### PR TITLE
MockitoAnnotations.initMocks() returns List of all created mocks

### DIFF
--- a/src/org/mockito/MockitoAnnotations.java
+++ b/src/org/mockito/MockitoAnnotations.java
@@ -18,6 +18,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Field;
+import java.util.List;
 
 import static java.lang.annotation.ElementType.FIELD;
 
@@ -86,7 +87,7 @@ public class MockitoAnnotations {
      * <p>
      * See examples in javadoc for {@link MockitoAnnotations} class.
      */
-    public static void initMocks(Object testClass) {
+    public static List<Object> initMocks(Object testClass) {
         if (testClass == null) {
             throw new MockitoException("testClass cannot be null. For info how to use @Mock annotations see examples in javadoc for MockitoAnnotations class");
         }
@@ -105,7 +106,7 @@ public class MockitoAnnotations {
         }
 
         //anyway act 'the new' way
-        annotationEngine.process(testClass.getClass(), testClass);
+        return annotationEngine.process(testClass.getClass(), testClass);
     }
 
     static void scanDeprecatedWay(AnnotationEngine annotationEngine, Object testClass, Class<?> clazz) {

--- a/src/org/mockito/configuration/AnnotationEngine.java
+++ b/src/org/mockito/configuration/AnnotationEngine.java
@@ -8,6 +8,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.util.List;
 
 /**
  * Configures mock creation logic behind &#064;Mock, &#064;Captor and &#064;Spy annotations
@@ -34,8 +35,11 @@ public interface AnnotationEngine {
      * <p>
      * See the implementation of this method to figure out what is it for.
      * 
-     * @param clazz Class where to extract field information, check implementation for details
-     * @param testInstance Test instance
+     * @param clazz
+     *            Class where to extract field information, check implementation for details
+     * @param testInstance
+     *            Test instance
+     * @return List of field values (mocks) from fields processed by this processor
      */
-    void process(Class<?> clazz, Object testInstance);
+    List<Object> process(Class<?> clazz, Object testInstance);
 }

--- a/src/org/mockito/internal/configuration/DefaultAnnotationEngine.java
+++ b/src/org/mockito/internal/configuration/DefaultAnnotationEngine.java
@@ -14,7 +14,9 @@ import org.mockito.internal.util.reflection.FieldSetter;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -58,7 +60,8 @@ public class DefaultAnnotationEngine implements AnnotationEngine {
         annotationProcessorMap.put(annotationClass, fieldAnnotationProcessor);
     }
 
-    public void process(Class<?> clazz, Object testInstance) {
+    public List<Object> process(Class<?> clazz, Object testInstance) {
+        List<Object> createdMocks = new ArrayList<Object>();
         Field[] fields = clazz.getDeclaredFields();
         for (Field field : fields) {
             boolean alreadyAssigned = false;
@@ -73,9 +76,11 @@ public class DefaultAnnotationEngine implements AnnotationEngine {
                         throw new MockitoException("Problems setting field " + field.getName() + " annotated with "
                                 + annotation, e);
                     }
+                    createdMocks.add(mock);
                 }        
             }
         }
+        return createdMocks;
     }
     
     void throwIfAlreadyAssigned(Field field, boolean alreadyAssigned) {

--- a/test/org/mockitousage/annotation/InitMocksReturnsMocksTest.java
+++ b/test/org/mockitousage/annotation/InitMocksReturnsMocksTest.java
@@ -1,0 +1,49 @@
+package org.mockitousage.annotation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+public class InitMocksReturnsMocksTest {
+
+    @Mock
+    List list;
+
+    @Mock
+    Set set;
+
+    @Spy
+    List list2 = new ArrayList();
+
+    @Test
+    public void shouldReturnMocks() {
+        List mocks = MockitoAnnotations.initMocks(this);
+
+        assertEquals(3, mocks.size());
+        assertTrue(mocks.contains(set));
+        assertTrue(mocks.contains(list));
+        assertTrue(mocks.contains(list2));
+    }
+
+    @Test
+    public void noMocksShouldReturnEmptyList() {
+        List mocks = MockitoAnnotations.initMocks(new NoMocksClass());
+
+        assertEquals(0, mocks.size());
+    }
+
+    @SuppressWarnings("unused")
+    private class NoMocksClass {
+        List list;
+
+    }
+}


### PR DESCRIPTION
- MockitoAnnotations.initMocks( .. ) returns List of all created mocks
- added simple tests for the new feature to InitMocksReturnsMocksTest class

This is a convenience feature that allows you to get a list of all mocks created when calling initMocks, so you can then push these mocks to for example test ApplicationContext in Spring unit tests or do some post processing for all the mocks.
