### PR TITLE
Improved MockitoTestNGListener by making it reset argument captors before each test

### DIFF
--- a/subprojects/testng/src/main/java/org/mockito/testng/MockitoBeforeTestNGMethod.java
+++ b/subprojects/testng/src/main/java/org/mockito/testng/MockitoBeforeTestNGMethod.java
@@ -46,7 +46,7 @@ public class MockitoBeforeTestNGMethod {
     private void initializeCaptors(Object instance) {
         List<InstanceField> instanceFields = Fields.allDeclaredFieldsOf(instance).filter(annotatedBy(Captor.class)).instanceFields();
         for (InstanceField instanceField : instanceFields) {
-            new CaptorAnnotationProcessor().process(instanceField.annotation(Captor.class), instanceField.jdkField());
+            instanceField.set(new CaptorAnnotationProcessor().process(instanceField.annotation(Captor.class), instanceField.jdkField()));
         }
     }
 

--- a/subprojects/testng/src/test/java/org/mockitousage/testng/CaptorAnnotatedFieldShouldBeClearedTest.java
+++ b/subprojects/testng/src/test/java/org/mockitousage/testng/CaptorAnnotatedFieldShouldBeClearedTest.java
@@ -14,13 +14,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @Listeners(MockitoTestNGListener.class)
-@Test(enabled = false, description = "not yet ready")
 public class CaptorAnnotatedFieldShouldBeClearedTest {
 
     @Captor ArgumentCaptor<String> captor;
     @Mock List<String> list;
 
-    @Test(enabled = false)
+    @Test
     public void first_test_method_that_uses_captor() throws Exception {
         list.add("a");
         list.add("b");
@@ -29,7 +28,7 @@ public class CaptorAnnotatedFieldShouldBeClearedTest {
         assertThat(captor.getAllValues()).containsOnly("a", "b");
     }
 
-    @Test(enabled = false)
+    @Test
     public void second_test_method_that_uses_captor() throws Exception {
         list.add("t");
         list.add("u");


### PR DESCRIPTION
Before each run of a TestNG test the Captor arguments need to be reset.
