### PR TITLE
Refactoring: Remove unused import

### DIFF
--- a/src/org/mockito/internal/stubbing/defaultanswers/ReturnsMocks.java
+++ b/src/org/mockito/internal/stubbing/defaultanswers/ReturnsMocks.java
@@ -8,7 +8,6 @@ import java.io.Serializable;
 
 import org.mockito.internal.MockitoCore;
 import org.mockito.internal.creation.MockSettingsImpl;
-import org.mockito.internal.creation.jmock.ClassImposterizer;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 


### PR DESCRIPTION
Hi,

ClassImposterizer is no longer used in ReturnsMocks; this patch allows us in the Android Open Source Project to build ReturnsMocks without building ClassImposterizer (which ultimately depends on cglib-and-asm, which we can't use.)

Thanks,
Ian
