### PR TITLE
ComponentUnderTest rule

### DIFF
--- a/src/org/mockito/rules/CGLibObjectCreationEngineImpl.java
+++ b/src/org/mockito/rules/CGLibObjectCreationEngineImpl.java
@@ -1,0 +1,32 @@
+package org.mockito.rules;
+
+import org.mockito.cglib.proxy.Enhancer;
+import org.mockito.cglib.proxy.NoOp;
+
+public final class CGLibObjectCreationEngineImpl implements ObjectCreationEngine {
+
+    private static class Holder {
+        public static final CGLibObjectCreationEngineImpl INSTANCE = new CGLibObjectCreationEngineImpl();
+    }
+
+    public static CGLibObjectCreationEngineImpl getInstance() {
+        return Holder.INSTANCE;
+    }
+
+    private CGLibObjectCreationEngineImpl() {
+
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T create(final Class<T> type) {
+        // Using CGLIB instead of e.g. type.newInstance() allows to
+        // construct objects with package scope constructors, yet maybe it is a
+        // bit of a overkill?
+        final Enhancer enhancer = new Enhancer();
+        enhancer.setCallback(NoOp.INSTANCE);
+        enhancer.setSuperclass(type);
+        return (T) enhancer.create();
+    }
+
+}

--- a/src/org/mockito/rules/ComponentUnderTestRule.java
+++ b/src/org/mockito/rules/ComponentUnderTestRule.java
@@ -1,0 +1,72 @@
+package org.mockito.rules;
+
+import java.lang.annotation.Annotation;
+
+import org.junit.rules.MethodRule;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+import org.mockito.rules.annotations.ComponentUnderTest;
+import org.mockito.rules.statement.ComponentUnderTestStatement;
+
+/**
+ * Allows easy stubbing of dependencies of tested components.
+ * <p/>
+ * Each tested component should declare its dependencies with package scope.
+ * <p/>
+ * Include this rule in you JUnit, annotate the tested component a
+ * {@link ComponentUnderTest} and all dependencies annotated with with the
+ * annotations specified in this rule constructor will be mocked. Example for a
+ * Spring component which uses autowired dependencies:
+ * 
+ * <pre>
+ * public class MyComponentTest {
+ *     &#064;Rule
+ *     public ComponentUnderTestRule rule = new ComponentUnderTestRule(Autowired.class);
+ * 
+ *     &#064;ComponentUnderTest
+ *     private MyComponent component; // instantiation is not necessary
+ * 
+ *     &#064;Test
+ *     public void shouldDoSomething() {
+ *       // given
+ *       given(component.dependency.foo()).willReturn(&quot;A&quot;);
+ *    
+ *       // when
+ *       Result result = component.bar();
+ *    
+ *       // then
+ *       assertThat(result).isEqualTo(...);
+ *     }
+ * }
+ * 
+ * </pre>
+ * <p/>
+ */
+public class ComponentUnderTestRule implements MethodRule { // Please note that
+                                                            // MethodRule is no
+                                                            // longer deprecated
+                                                            // in JUnit 4.11
+
+    private final MockEngine mockEngine;
+    private final ObjectCreationEngine objectCreationEngine;
+
+    private final Class<? extends Annotation>[] annotationsToMock;
+
+    public ComponentUnderTestRule(final Class<? extends Annotation>... annotationsToMock) {
+        this(MockitoMockEngine.getInstance(), CGLibObjectCreationEngineImpl.getInstance(), annotationsToMock);
+    }
+
+    public ComponentUnderTestRule(final MockEngine mockEngine, final ObjectCreationEngine objectCreationEngine,
+            final Class<? extends Annotation>... annotationsToMock) {
+        this.mockEngine = mockEngine;
+        this.annotationsToMock = annotationsToMock;
+        this.objectCreationEngine = objectCreationEngine;
+    }
+
+    @Override
+    public Statement apply(final Statement statement, final FrameworkMethod method, final Object testClass) {
+        return new ComponentUnderTestStatement(statement, testClass, annotationsToMock, mockEngine,
+                objectCreationEngine);
+    }
+
+}

--- a/src/org/mockito/rules/MockEngine.java
+++ b/src/org/mockito/rules/MockEngine.java
@@ -1,0 +1,7 @@
+package org.mockito.rules;
+
+public interface MockEngine {
+
+    <T> T mock(Class<T> type);
+
+}

--- a/src/org/mockito/rules/MockitoMockEngine.java
+++ b/src/org/mockito/rules/MockitoMockEngine.java
@@ -1,0 +1,24 @@
+package org.mockito.rules;
+
+import org.mockito.Mockito;
+
+public final class MockitoMockEngine implements MockEngine {
+
+    private static class Holder {
+        public static final MockitoMockEngine INSTANCE = new MockitoMockEngine();
+    }
+
+    public static MockitoMockEngine getInstance() {
+        return Holder.INSTANCE;
+    }
+
+    private MockitoMockEngine() {
+
+    }
+
+    @Override
+    public <T> T mock(final Class<T> type) {
+        return Mockito.mock(type);
+    }
+
+}

--- a/src/org/mockito/rules/ObjectCreationEngine.java
+++ b/src/org/mockito/rules/ObjectCreationEngine.java
@@ -1,0 +1,6 @@
+package org.mockito.rules;
+
+public interface ObjectCreationEngine {
+
+    <T> T create(Class<T> type);
+}

--- a/src/org/mockito/rules/annotations/ComponentUnderTest.java
+++ b/src/org/mockito/rules/annotations/ComponentUnderTest.java
@@ -1,0 +1,9 @@
+package org.mockito.rules.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ComponentUnderTest {
+
+}

--- a/src/org/mockito/rules/statement/ComponentUnderTestStatement.java
+++ b/src/org/mockito/rules/statement/ComponentUnderTestStatement.java
@@ -1,0 +1,124 @@
+package org.mockito.rules.statement;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.runners.model.Statement;
+import org.mockito.rules.MockEngine;
+import org.mockito.rules.ObjectCreationEngine;
+import org.mockito.rules.annotations.ComponentUnderTest;
+
+public final class ComponentUnderTestStatement extends Statement {
+
+    private static final Class<ComponentUnderTest> ANNOTATION_FOR_TESTED_COMPONENT = ComponentUnderTest.class;
+
+    private final Statement baseStatement;
+    private final Object testClass;
+    private final Class<? extends Annotation>[] annotationsToMock;
+    private final MockEngine mockEngine;
+    private final ObjectCreationEngine creationEngine;
+
+    public ComponentUnderTestStatement(final Statement statement, final Object testClass,
+            final Class<? extends Annotation>[] annotationsToMock, final MockEngine mockEngine,
+            final ObjectCreationEngine creationEngine) {
+        this.baseStatement = statement;
+        this.testClass = testClass;
+        this.annotationsToMock = annotationsToMock;
+        this.mockEngine = mockEngine;
+        this.creationEngine = creationEngine;
+    }
+
+    @Override
+    public void evaluate() throws Throwable {
+
+        injectMocks(testClass);
+
+        baseStatement.evaluate();
+    }
+
+    private Iterable<Field> getDependencies(final Class<?> clazz) {
+
+        final List<Field> dependencies = new LinkedList<Field>();
+
+        final Field[] allFields = clazz.getDeclaredFields();
+
+        for (final Field field : allFields) {
+            if (shouldMock(field)) {
+                dependencies.add(field);
+            }
+        }
+
+        return dependencies;
+    }
+
+    private void injectMocks(final Object testClass) throws IllegalArgumentException, IllegalAccessException {
+        final Field[] declaredFields = testClass.getClass().getDeclaredFields();
+
+        for (final Field field : declaredFields) {
+
+            field.setAccessible(true);
+
+            if (shouldInjectMock(field)) {
+                injectMocksInfoField(field, testClass);
+            }
+        }
+    }
+
+    private void injectMocksInfoField(final Field componentUnderTest, final Object testClass)
+            throws IllegalArgumentException, IllegalAccessException {
+
+        if (componentUnderTest.get(testClass) == null) {
+            tryCreate(componentUnderTest, testClass);
+        }
+
+        mockDependenciesForComponent(componentUnderTest.get(testClass));
+    }
+
+    private void mockAll(final Object fieldValue, final Iterable<Field> dependencies) throws IllegalAccessException {
+        for (final Field dependency : dependencies) {
+            dependency.setAccessible(true);
+            dependency.set(fieldValue, mockEngine.mock(dependency.getType()));
+        }
+    }
+
+    private void mockDependenciesForComponent(final Object componentUnderTestValue) throws IllegalAccessException {
+
+        Class<? extends Object> clazz = componentUnderTestValue.getClass();
+        do {
+            final Iterable<Field> dependnecies = getDependencies(clazz);
+            mockAll(componentUnderTestValue, dependnecies);
+
+            clazz = clazz.getSuperclass();
+
+        } while (clazz != Object.class); // Enum?
+    }
+
+    private boolean shouldInjectMock(final Field field) {
+        for (final Annotation foundAnnotation : field.getDeclaredAnnotations()) {
+            if (foundAnnotation.annotationType().equals(ANNOTATION_FOR_TESTED_COMPONENT)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private boolean shouldMock(final Field field) {
+        for (final Class<?> expectedAnnotation : annotationsToMock) {
+            for (final Annotation foundAnnotation : field.getDeclaredAnnotations()) {
+                if (expectedAnnotation.equals(foundAnnotation.annotationType())) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private void tryCreate(final Field componentUnderTest, final Object testClass) throws IllegalArgumentException,
+            IllegalAccessException {
+        componentUnderTest.set(testClass, creationEngine.create(componentUnderTest.getType()));
+    }
+}

--- a/test/org/mockito/rules/CGLibObjectCreationEngineImplTest.java
+++ b/test/org/mockito/rules/CGLibObjectCreationEngineImplTest.java
@@ -1,0 +1,26 @@
+package org.mockito.rules;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class CGLibObjectCreationEngineImplTest {
+
+    static class TestClass {
+
+    }
+
+    private final CGLibObjectCreationEngineImpl engine = CGLibObjectCreationEngineImpl.getInstance();
+
+    @Test
+    public void shouldCreateObject() {
+        // given
+
+        // when
+        final TestClass instance = engine.create(TestClass.class);
+
+        // then
+
+        assertThat(instance).isNotNull();
+    }
+}

--- a/test/org/mockito/rules/MockitoMockEngineTest.java
+++ b/test/org/mockito/rules/MockitoMockEngineTest.java
@@ -1,0 +1,26 @@
+package org.mockito.rules;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class MockitoMockEngineTest {
+
+    interface Intf {
+
+    }
+
+    private final MockitoMockEngine mockEngine = MockitoMockEngine.getInstance();
+
+    @Test
+    public void shouldMock() {
+        // given
+
+        // when
+        final Intf mock = mockEngine.mock(Intf.class);
+
+        // then
+        assertThat(mock).isNotNull(); // FIXME: better assertion?
+    }
+
+}

--- a/test/org/mockito/rules/it/ComponentUnderTestRuleIntegrationTest.java
+++ b/test/org/mockito/rules/it/ComponentUnderTestRuleIntegrationTest.java
@@ -1,0 +1,30 @@
+package org.mockito.rules.it;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+import org.mockito.rules.annotations.ComponentUnderTest;
+
+public class ComponentUnderTestRuleIntegrationTest extends TestBase {
+
+    @ComponentUnderTest
+    private TestComponent testComponent;
+
+    @Test
+    public void shouldCreateMocksAndStubMethod() {
+        // given
+        given(testComponent.returnDependency.bar()).willReturn("mock");
+        final int invocations = 10;
+
+        // when
+        final String foo = testComponent.foo(invocations);
+
+        // then
+        assertThat(foo).isEqualTo("mock");
+        verify(testComponent.countingDependency, times(invocations)).bar();
+    }
+
+}

--- a/test/org/mockito/rules/it/TestAutowired.java
+++ b/test/org/mockito/rules/it/TestAutowired.java
@@ -1,0 +1,9 @@
+package org.mockito.rules.it;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestAutowired {
+
+}

--- a/test/org/mockito/rules/it/TestAutowiredInjectingRule.java
+++ b/test/org/mockito/rules/it/TestAutowiredInjectingRule.java
@@ -1,0 +1,11 @@
+package org.mockito.rules.it;
+
+import org.mockito.rules.ComponentUnderTestRule;
+
+public class TestAutowiredInjectingRule extends ComponentUnderTestRule {
+
+    @SuppressWarnings("unchecked")
+    public TestAutowiredInjectingRule() {
+        super(TestAutowired.class);
+    }
+}

--- a/test/org/mockito/rules/it/TestBase.java
+++ b/test/org/mockito/rules/it/TestBase.java
@@ -1,0 +1,11 @@
+package org.mockito.rules.it;
+
+import org.junit.Rule;
+import org.mockito.rules.ComponentUnderTestRule;
+
+public abstract class TestBase {
+
+    @Rule
+    public final ComponentUnderTestRule rule = new TestAutowiredInjectingRule();
+
+}

--- a/test/org/mockito/rules/it/TestComponent.java
+++ b/test/org/mockito/rules/it/TestComponent.java
@@ -1,0 +1,18 @@
+package org.mockito.rules.it;
+
+class TestComponent {
+
+    @TestAutowired
+    TestDependency returnDependency;
+
+    @TestAutowired
+    TestDependency countingDependency;
+
+    public String foo(final int times) {
+        for (int i = 0; i < times; ++i) {
+            countingDependency.bar();
+        }
+
+        return returnDependency.bar();
+    }
+}

--- a/test/org/mockito/rules/it/TestDependency.java
+++ b/test/org/mockito/rules/it/TestDependency.java
@@ -1,0 +1,6 @@
+package org.mockito.rules.it;
+
+interface TestDependency {
+
+    String bar();
+}


### PR DESCRIPTION
Hi, 
   There is a feature I use a lot with my Spring projects where dependencies are injected based on annotations. The idea is to automate the creation of mocks and get rid of @Mock and @InjectMocks annotations. It could be used anywhere where dependencies are injected based on annotations.

As described in https://groups.google.com/forum/?fromgroups=#!topic/mockito/aBv81zqU-p8 (rather unnoticed ;))

 Please take a look at ComponentUnderTestRuleIntegrationTest for
documentation / sample.

What do you think?

Kornel