### PR TITLE
New "MockingDetails.getInvocations" method for inspecting what happened with the mock

### DIFF
--- a/src/org/mockito/MockingDetails.java
+++ b/src/org/mockito/MockingDetails.java
@@ -4,6 +4,10 @@
  */
 package org.mockito;
 
+import java.util.Collection;
+
+import org.mockito.invocation.Invocation;
+
 /**
  * Provides mocking information.
  * For example, you can identify whether a particular object is either a mock or a spy.
@@ -28,4 +32,13 @@ public interface MockingDetails {
      * @since 1.9.5
      */
     boolean isSpy();
+    
+    /**
+     * Provides a collection of methods indicating the invocations of the object
+     * @return collection of Invocation representing the invocations 
+     * for the object.
+     *
+     * @since 1.9.x
+     */
+    Collection<Invocation> getInvocations();
 }

--- a/src/org/mockito/internal/util/DefaultMockingDetails.java
+++ b/src/org/mockito/internal/util/DefaultMockingDetails.java
@@ -4,7 +4,14 @@
  */
 package org.mockito.internal.util;
 
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 import org.mockito.MockingDetails;
+import org.mockito.internal.stubbing.StubbedInvocationMatcher;
+import org.mockito.invocation.Invocation;
 
 /**
  * Class to inspect any object, and identify whether a particular object is either a mock or a spy.  This is
@@ -33,6 +40,10 @@ public class DefaultMockingDetails implements MockingDetails {
      */
     public boolean isSpy(){
         return delegate.isSpy( toInspect );
+    }
+    
+    public Collection<Invocation> getInvocations() {
+    	return delegate.getMockHandler(toInspect).getInvocationContainer().getInvocations();
     }
 }
 

--- a/test/org/mockito/MockingDetailsTest.java
+++ b/test/org/mockito/MockingDetailsTest.java
@@ -1,0 +1,47 @@
+package org.mockito;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Test;
+import org.mockito.internal.MockitoCore;
+import org.mockito.invocation.Invocation;
+
+import static org.mockito.Mockito.*;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MockingDetailsTest {
+	
+	@Test
+	public void testGetInvocations() {
+		List<String> methodsInvoked = new ArrayList<String>() {{
+			add("add");
+			add("remove");
+			add("clear");
+		}};
+		
+		List<String> mockedList = (List<String>) mock(List.class);
+		
+		mockedList.add("one");
+		mockedList.remove(0);
+		mockedList.clear();
+		
+		MockingDetails mockingDetails = new MockitoCore().mockingDetails(mockedList);
+		Collection<Invocation> invocations = mockingDetails.getInvocations();
+		
+		assertNotNull(invocations);
+		assertEquals(invocations.size(),3);
+		for (Invocation method : invocations) {
+			assertTrue(methodsInvoked.contains(method.getMethod().getName()));
+			if (method.getMethod().getName().equals("add")) {
+				assertEquals(method.getArguments().length,1);
+				assertEquals(method.getArguments()[0],"one");
+			}
+		}	
+	}
+}


### PR DESCRIPTION
A simple implementation for [Issue 178](https://code.google.com/p/mockito/issues/detail?can=2&start=0&num=100&q=&colspec=ID%20Type%20Status%20Priority%20Milestone%20Owner%20Summary&groupby=&sort=type&id=178)

Modified the MockingDetails API to expose a getInvocations() method. This uses the invocation container from the MockUtil object to return a collection of Invocations (which is in the org.mockito.invocation package). This enables users to debug and see invocations on a given mock and use the debugger (or code) to see arguments passed, the target method, etc. 
