### PR TITLE
Simplified 'thenReturn' interface to a single varargs method

### DIFF
--- a/src/org/mockito/BDDMockito.java
+++ b/src/org/mockito/BDDMockito.java
@@ -76,16 +76,16 @@ public class BDDMockito extends Mockito {
         BDDMyOngoingStubbing<T> will(Answer<?> answer);
 
         /**
-         * See original {@link OngoingStubbing#thenReturn(Object)}
+         * See original {@link OngoingStubbing#thenReturn(Object[])}
          * @since 1.8.0
          */
         BDDMyOngoingStubbing<T> willReturn(T value);
 
         /**
-         * See original {@link OngoingStubbing#thenReturn(Object, Object[])}
+         * See original {@link OngoingStubbing#thenReturn(Object[])}
          * @since 1.8.0
          */
-        BDDMyOngoingStubbing<T> willReturn(T value, T... values);
+        BDDMyOngoingStubbing<T> willReturn(T... values);
 
         /**
          * See original {@link OngoingStubbing#thenThrow(Throwable...)}
@@ -144,8 +144,8 @@ public class BDDMockito extends Mockito {
         /* (non-Javadoc)
          * @see BDDMockito.BDDMyOngoingStubbing#willReturn(java.lang.Object, T[])
          */
-        public BDDMyOngoingStubbing<T> willReturn(T value, T... values) {
-            return new BDDOngoingStubbingImpl<T>(mockitoOngoingStubbing.thenReturn(value, values));
+        public BDDMyOngoingStubbing<T> willReturn(T... values) {
+            return new BDDOngoingStubbingImpl<T>(mockitoOngoingStubbing.thenReturn(values));
         }
 
         /* (non-Javadoc)

--- a/src/org/mockito/internal/stubbing/BaseStubbing.java
+++ b/src/org/mockito/internal/stubbing/BaseStubbing.java
@@ -12,17 +12,14 @@ import org.mockito.stubbing.DeprecatedOngoingStubbing;
 import org.mockito.stubbing.OngoingStubbing;
 
 public abstract class BaseStubbing<T> implements OngoingStubbing<T>, DeprecatedOngoingStubbing<T> {
-    public OngoingStubbing<T> thenReturn(T value) {
-        return thenAnswer(new Returns(value));
-    }
-
-    public OngoingStubbing<T> thenReturn(T value, T... values) {
-        OngoingStubbing<T> stubbing = thenReturn(value);            
-        if (values == null) {
-            return stubbing.thenReturn(null);
+    public OngoingStubbing<T> thenReturn(T... values) {
+        if (values == null || values.length == 0) {
+            return thenAnswer(new Returns(null));
         }
+        OngoingStubbing<T> stubbing = null;
         for (T v: values) {
-            stubbing = stubbing.thenReturn(v);
+            if(stubbing == null) stubbing = thenAnswer(new Returns(v));
+            else stubbing.thenReturn(v);
         }
         return stubbing;
     }

--- a/src/org/mockito/stubbing/OngoingStubbing.java
+++ b/src/org/mockito/stubbing/OngoingStubbing.java
@@ -35,20 +35,6 @@ import org.mockito.internal.progress.IOngoingStubbing;
 public interface OngoingStubbing<T> extends IOngoingStubbing {
 
     /**
-     * Sets a return value to be returned when the method is called. E.g:
-     * <pre class="code"><code class="java">
-     * when(mock.someMethod()).thenReturn(10);
-     * </code></pre>
-     *
-     * See examples in javadoc for {@link Mockito#when}
-     *
-     * @param value return value
-     *
-     * @return iOngoingStubbing object that allows stubbing consecutive calls
-     */
-    OngoingStubbing<T> thenReturn(T value);
-
-    /**
      * Sets consecutive return values to be returned when the method is called. E.g:
      * <pre class="code"><code class="java">
      * when(mock.someMethod()).thenReturn(1, 2, 3);
@@ -58,12 +44,11 @@ public interface OngoingStubbing<T> extends IOngoingStubbing {
      * <p>
      * See examples in javadoc for {@link Mockito#when}
      *
-     * @param value first return value
-     * @param values next return values
+     * @param values return values
      *
      * @return iOngoingStubbing object that allows stubbing consecutive calls
      */
-    OngoingStubbing<T> thenReturn(T value, T... values);
+    OngoingStubbing<T> thenReturn(T... values);
 
     /**
      * Sets Throwable objects to be thrown when the method is called. E.g:


### PR DESCRIPTION
The 'thenReturn' interface was difficult to call with multiple values before as an array couldn't be easily passed.
