### PR TITLE
Refactoring: Fixes env var to TERM for readability purpose on travis log when building with gradle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jdk:
     - oraclejdk7
 
 env:
-    - env=dumb
+    - TERM=dumb
 
 before_install:
 # use Gradle 1.8 
@@ -25,7 +25,5 @@ script:
     - gradle build
 
 after_success:
-#    - cat build/test-results/*
     - gradle cobertura
-#    - cat build/reports/cobertura/coverage.xml
-    - gradle --info --debug coveralls
+    - gradle coveralls


### PR DESCRIPTION
Wrote `env` instead of `TERM`, also cleaned up the `.travis.yml` file
