### PR TITLE
Implemented support for InOrder evaluation of Timeout VerificationMode

### DIFF
--- a/src/org/mockito/Mockito.java
+++ b/src/org/mockito/Mockito.java
@@ -779,8 +779,6 @@ import org.mockito.verification.VerificationWithTimeout;
  * <p>
  * It feels this feature should be used rarely - figure out a better way of testing your multi-threaded system.
  * <p>
- * Not yet implemented to work with InOrder verification.
- * <p>
  * Examples:
  * <p>
  * <pre class="code"><code class="java">
@@ -2057,8 +2055,6 @@ public class Mockito extends Matchers {
      * times(2) failed, and then fail.
      * <p>
      * It feels this feature should be used rarely - figure out a better way of testing your multi-threaded system
-     * <p>
-     * Not yet implemented to work with InOrder verification.
      * <pre class="code"><code class="java">
      *   //passes when someMethod() is called within given time span 
      *   verify(mock, timeout(100)).someMethod();

--- a/src/org/mockito/internal/InOrderImpl.java
+++ b/src/org/mockito/internal/InOrderImpl.java
@@ -18,17 +18,19 @@ import org.mockito.internal.verification.api.InOrderContext;
 import org.mockito.internal.verification.api.VerificationInOrderMode;
 import org.mockito.invocation.Invocation;
 import org.mockito.verification.VerificationMode;
+import org.mockito.verification.VerificationWrapper;
+import org.mockito.verification.VerificationWrapperInOrderWrapper;
 
 /**
  * Allows verifying in order. This class should not be exposed, hence default access.
  */
 public class InOrderImpl implements InOrder, InOrderContext {
-    
+
     private final MockitoCore mockitoCore = new MockitoCore();
     private final Reporter reporter = new Reporter();
     private final List<Object> mocksToBeVerifiedInOrder = new LinkedList<Object>();
     private final InOrderContext inOrderContext = new InOrderContextImpl();
-    
+
     public List<Object> getMocksToBeVerifiedInOrder() {
         return mocksToBeVerifiedInOrder;
     }
@@ -40,10 +42,12 @@ public class InOrderImpl implements InOrder, InOrderContext {
     public <T> T verify(T mock) {
         return this.verify(mock, VerificationModeFactory.times(1));
     }
-    
+
     public <T> T verify(T mock, VerificationMode mode) {
         if (!mocksToBeVerifiedInOrder.contains(mock)) {
             reporter.inOrderRequiresFamiliarMock();
+        } else if (mode instanceof VerificationWrapper) {
+            return mockitoCore.verify(mock, new VerificationWrapperInOrderWrapper((VerificationWrapper) mode, this));
         } else if (!(mode instanceof VerificationInOrderMode)) {
             throw new MockitoException(mode.getClass().getSimpleName() + " is not implemented to work with InOrder");
         }

--- a/src/org/mockito/internal/verification/VerificationOverTimeImpl.java
+++ b/src/org/mockito/internal/verification/VerificationOverTimeImpl.java
@@ -104,5 +104,8 @@ public class VerificationOverTimeImpl implements VerificationMode {
     public VerificationMode getDelegate() {
         return delegate;
     }
-    
+
+    public boolean isReturnOnSuccess() {
+        return returnOnSuccess;
+    }
 }

--- a/src/org/mockito/verification/VerificationWrapperInOrderWrapper.java
+++ b/src/org/mockito/verification/VerificationWrapperInOrderWrapper.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.verification;
+
+import org.mockito.exceptions.base.MockitoException;
+import org.mockito.internal.InOrderImpl;
+import org.mockito.internal.verification.InOrderWrapper;
+import org.mockito.internal.verification.VerificationOverTimeImpl;
+import org.mockito.internal.verification.api.VerificationData;
+import org.mockito.internal.verification.api.VerificationInOrderMode;
+
+public class VerificationWrapperInOrderWrapper implements VerificationMode {
+
+    private final VerificationMode delegate;
+
+    public VerificationWrapperInOrderWrapper(VerificationWrapper<?> verificationWrapper, InOrderImpl inOrder) {
+        VerificationMode verificationMode = verificationWrapper.wrappedVerification;
+
+        VerificationMode inOrderWrappedVerificationMode = wrapInOrder(verificationWrapper, verificationMode, inOrder);
+
+        delegate = verificationWrapper.copySelfWithNewVerificationMode(inOrderWrappedVerificationMode);
+    }
+
+    public void verify(VerificationData data) {
+        delegate.verify(data);
+    }
+
+    private VerificationMode wrapInOrder(VerificationWrapper<?> verificationWrapper, VerificationMode verificationMode, InOrderImpl inOrder) {
+        if (verificationMode instanceof VerificationInOrderMode) {
+            final VerificationInOrderMode verificationInOrderMode = (VerificationInOrderMode)verificationMode;
+            return new InOrderWrapper(verificationInOrderMode, inOrder);
+        } else if (verificationMode instanceof VerificationOverTimeImpl) {
+            final VerificationOverTimeImpl verificationOverTime = (VerificationOverTimeImpl)verificationMode;
+            if (verificationOverTime.isReturnOnSuccess()) {
+                return new VerificationOverTimeImpl(verificationOverTime.getPollingPeriod(),
+                        verificationOverTime.getDuration(),
+                        wrapInOrder(verificationWrapper, verificationOverTime.getDelegate(), inOrder),
+                        verificationOverTime.isReturnOnSuccess());
+            }
+        }
+
+        throw new MockitoException(verificationMode.getClass().getSimpleName() +
+                " is not implemented to work with InOrder wrapped inside a " +
+                verificationWrapper.getClass().getSimpleName());
+    }
+}

--- a/test/org/mockitousage/verification/VerificationWithTimeoutTest.java
+++ b/test/org/mockitousage/verification/VerificationWithTimeoutTest.java
@@ -5,8 +5,10 @@
 
 package org.mockitousage.verification;
 
+import java.util.LinkedList;
+import java.util.List;
+
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mock;
@@ -15,11 +17,13 @@ import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockito.exceptions.verification.TooLittleActualInvocations;
 import org.mockitoutil.TestBase;
 
-import java.util.LinkedList;
-import java.util.List;
-
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class VerificationWithTimeoutTest extends TestBase {
 
@@ -134,8 +138,6 @@ public class VerificationWithTimeoutTest extends TestBase {
         } catch (NoInteractionsWanted e) {}
     }
     
-    //TODO not yet implemented
-    @Ignore
     @Test
     public void shouldAllowTimeoutVerificationInOrder() throws Exception {
         //given


### PR DESCRIPTION
Fixed for [issue 292](https://code.google.com/p/mockito/issues/detail?id=292)

Note that while the provided wrapping mechanism is generic enough to support both 'timeout' and 'after' usage, the current implementation of VerificationWithTimeoutTest.java prevents correct usage with 'after'. This is because it repeatedly verifies until the timeout has elapsed, thus marking all invocations that may have matched in the meantime as verified. This will of course 'exhaust' correct invocations and more often than not fail on the verification before the 'ager time' has elapsed.