### PR TITLE
Improved behavior of EqualsWithDelta with regards to null handling

### DIFF
--- a/src/org/mockito/internal/matchers/EqualsWithDelta.java
+++ b/src/org/mockito/internal/matchers/EqualsWithDelta.java
@@ -29,7 +29,7 @@ public class EqualsWithDelta extends ArgumentMatcher<Number> implements Serializ
             return false;
         }
 
-        if (wanted == null && actual == null) {
+        if (wanted == actual) {
             return true;
         }
 

--- a/test/org/mockitousage/bugs/EqualsWithDeltaTest.java
+++ b/test/org/mockitousage/bugs/EqualsWithDeltaTest.java
@@ -26,6 +26,14 @@ public class EqualsWithDeltaTest {
         assertThat(matcher.matches(null)).isTrue();
     }
 
+    @Test
+    public void testEqualsWithDelta_WhenActualAndExpectedAreTheSameObject() throws Exception {
+        Double expected = 1.0;
+        Double actual = expected;
+        Matcher<Number> matcher = equalsWithDelta(expected);
+        assertThat(matcher.matches(actual)).isTrue();
+    }
+
 	public Matcher<Number> equalsWithDelta(final Double expected) {
 		return new EqualsWithDelta(expected, .000001);
 	}


### PR DESCRIPTION
Added check to the EqualsWithDelta matcher
  If the actual and expected objects are the same.
