### PR TITLE
Improved the javadoc example of custom Answer implementation

### DIFF
--- a/src/org/mockito/stubbing/Answer.java
+++ b/src/org/mockito/stubbing/Answer.java
@@ -17,11 +17,11 @@ import org.mockito.invocation.InvocationOnMock;
  *     Object answer(InvocationOnMock invocation) {
  *         Object[] args = invocation.getArguments();
  *         Object mock = invocation.getMock();
- *         return "called with arguments: " + args;
+ *         return "called with arguments: " + Arrays.toString(args);
  *     }
  * });
  * 
- * //Following prints "called with arguments: foo"
+ * //Following prints "called with arguments: [foo]"
  * System.out.println(mock.someMethod("foo"));
  * </code></pre>
  * 


### PR DESCRIPTION
So a developer can just copy and paste code from javadocs' snippet to have the expected result.
