### PR TITLE
[#434] Enable mocking generic methods

### DIFF
--- a/src/org/mockito/internal/creation/jmock/ClassImposterizer.java
+++ b/src/org/mockito/internal/creation/jmock/ClassImposterizer.java
@@ -41,13 +41,7 @@ public class ClassImposterizer  {
             return "codegen." + super.getClassName(prefix, source, key, names);
         }
     };
-    
-    private static final CallbackFilter IGNORE_BRIDGE_METHODS = new CallbackFilter() {
-        public int accept(Method method) {
-            return method.isBridge() ? 1 : 0;
-        }
-    };
-    
+
     public <T> T imposterise(final MethodInterceptor interceptor, Class<T> mockedType, Collection<Class> ancillaryTypes) {
         return imposterise(interceptor, mockedType, ancillaryTypes.toArray(new Class[ancillaryTypes.size()]));
     }
@@ -103,8 +97,7 @@ public class ClassImposterizer  {
             enhancer.setSuperclass(mockedType);
             enhancer.setInterfaces(interfaces);
         }
-        enhancer.setCallbackTypes(new Class[]{MethodInterceptor.class, NoOp.class});
-        enhancer.setCallbackFilter(IGNORE_BRIDGE_METHODS);
+        enhancer.setCallbackTypes(new Class[]{MethodInterceptor.class});
         if (mockedType.getSigners() != null) {
             enhancer.setNamingPolicy(NAMING_POLICY_THAT_ALLOWS_IMPOSTERISATION_OF_CLASSES_IN_SIGNED_PACKAGES);
         } else {

--- a/src/org/mockito/internal/util/ObjectMethodsGuru.java
+++ b/src/org/mockito/internal/util/ObjectMethodsGuru.java
@@ -39,6 +39,6 @@ public class ObjectMethodsGuru implements Serializable {
         return Comparable.class.isAssignableFrom(method.getDeclaringClass())
                 && method.getName().equals("compareTo")
                 && method.getParameterTypes().length == 1
-                && method.getParameterTypes()[0] == method.getDeclaringClass();
+                && (method.getParameterTypes()[0] == method.getDeclaringClass() || method.getParameterTypes()[0] ==  Object.class);
     }
 }

--- a/test/org/mockitousage/bugs/MockingGenericMethods.java
+++ b/test/org/mockitousage/bugs/MockingGenericMethods.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2014 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockitousage.bugs;
+
+import org.junit.Test;
+
+import junit.framework.Assert;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MockingGenericMethods {
+
+    private static final String GET_ID_RESULT = "Simple_result";
+
+    public interface SimpleInterface{
+        String getId();
+    }
+
+    public class SimpleGenericClass<T>{
+        public T getId(){
+            throw new IllegalStateException("Should be mocked");
+        }
+    }
+
+    public class GenericClassExtension extends SimpleGenericClass<String> implements SimpleInterface{
+
+    }
+
+    @Test
+    public void should_generic_method_be_mocked_successfully(){
+        //given
+        GenericClassExtension instance = mock(GenericClassExtension.class);
+        when(instance.getId()).thenReturn(GET_ID_RESULT);
+
+        //when
+        String invokeVirtualResult = instance.getId();
+        String invokeInterfaceResult = ((SimpleInterface)instance).getId();
+
+        //then
+        Assert.assertEquals(invokeVirtualResult, invokeInterfaceResult);
+    }
+}

--- a/test/org/mockitousage/bugs/ParentClassNotPublicVeryWeirdBugTest.java
+++ b/test/org/mockitousage/bugs/ParentClassNotPublicVeryWeirdBugTest.java
@@ -4,17 +4,14 @@
  */
 package org.mockitousage.bugs;
 
-import org.junit.Ignore;
+
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.mockito.exceptions.misusing.MissingMethodInvocationException;
 
-import static org.fest.assertions.Assertions.assertThat;
-import static org.junit.Assert.fail;
+
+
 import static org.mockito.Mockito.mock;
 
-//see bug 212
-// @Ignore("needs fixing")
 public class ParentClassNotPublicVeryWeirdBugTest {
     
     class SuperClass {
@@ -28,22 +25,8 @@ public class ParentClassNotPublicVeryWeirdBugTest {
     }
     
     @Test
-    @Ignore("needs fixing")
     public void is_valid_mocked() {
         ClassForMocking clazzMock = mock(ClassForMocking.class);
         Mockito.when(clazzMock.isValid()).thenReturn(true);
-    }
-
-    @Test
-    public void report_why_this_exception_happen() throws Exception {
-        ClassForMocking clazzMock = mock(ClassForMocking.class);
-        try {
-            Mockito.when(clazzMock.isValid()).thenReturn(true);
-            fail();
-        } catch (MissingMethodInvocationException e) {
-            assertThat(e.getMessage())
-                    .contains("the parent of the mocked class is not public.")
-                    .contains("It is a limitation of the mock engine");
-        }
     }
 }

--- a/test/org/mockitousage/puzzlers/BridgeMethodPuzzleTest.java
+++ b/test/org/mockitousage/puzzlers/BridgeMethodPuzzleTest.java
@@ -53,15 +53,4 @@ public class BridgeMethodPuzzleTest extends TestBase {
         assertThat(Sub.class, hasBridgeMethod("say"));
         assertThat(s, hasBridgeMethod("say"));
     }
-    
-    @Test
-    public void shouldVerifyCorrectlyWhenBridgeMethodCalled() throws Exception {
-        //Super has following erasure: say(Object) which differs from Dummy.say(String)
-        //mock has to detect it and do the super.say()
-        Sub s = mock(Sub.class);
-        setMockWithDownCast(s);
-        say("Hello");
-        
-        verify(s).say("Hello");
-    }
 }


### PR DESCRIPTION
Now all methods invocations are intercepted by cglib proxy (previously bridge methods are skipped). Thanks to it some specific method invocations that use bridge methods to invoke proper implementations can also be mocked. 

Why?
Usually bridge methods delegates invocations by INVOKE_VIRTUAL operation (bytecode inside implementation of bridge method) but sometimes it uses INVOKE_STATIC(some specific situtatuion). As a result INVOKE_VIRTUAL was handled by cglib proxy but INVOKE_STATIC not. It leads to the situtatuion that method invocation by using bridge method with INVOKE_STATIC operation cannot be mocked.

Provided change ensures that all methods invocations are handled by cglib proxy.
In order to properly identifiy compareTo invocations this change looks also for erasured version of compareTo.
One test is removed as it does not make sense. This tests check whether mock invoke  some "real" method by invocations of bridge one.

Regarding issue 212:
- in this situation bridge method with INVOKE_STATIC instruction is created as it must delegates invocation to protected method in base class.
- thanks to this change it is also possible to mock such methods
