### PR TITLE
Refactoring: avoid static keyword in inner interface definition

### DIFF
--- a/src/org/mockito/BDDMockito.java
+++ b/src/org/mockito/BDDMockito.java
@@ -61,7 +61,7 @@ public class BDDMockito extends Mockito {
      * See original {@link OngoingStubbing}
      * @since 1.8.0
      */
-    public static interface BDDMyOngoingStubbing<T> {
+    public interface BDDMyOngoingStubbing<T> {
         
         /**
          * See original {@link OngoingStubbing#thenAnswer(Answer)}
@@ -182,7 +182,7 @@ public class BDDMockito extends Mockito {
      * See original {@link Stubber}
      * @since 1.8.0
      */
-    public static interface BDDStubber {
+    public interface BDDStubber {
         /**
          * See original {@link Stubber#doAnswer(Answer)}
          * @since 1.8.0

--- a/src/org/mockito/internal/creation/AcrossJVMSerializationFeature.java
+++ b/src/org/mockito/internal/creation/AcrossJVMSerializationFeature.java
@@ -411,7 +411,7 @@ public class AcrossJVMSerializationFeature implements Serializable {
      *
      * @see #enableSerializationAcrossJVM(org.mockito.mock.MockCreationSettings)
      */
-    public static interface AcrossJVMMockitoMockSerializable {
+    public interface AcrossJVMMockitoMockSerializable {
         public Object writeReplace() throws java.io.ObjectStreamException;
     }
 }

--- a/src/org/mockito/internal/util/collections/ListUtil.java
+++ b/src/org/mockito/internal/util/collections/ListUtil.java
@@ -20,7 +20,7 @@ public class ListUtil {
         return filtered;
     }
     
-    public static interface Filter<T> {
+    public interface Filter<T> {
         boolean isOut(T object);
     }
 }

--- a/src/org/mockito/internal/util/reflection/GenericMetadataSupport.java
+++ b/src/org/mockito/internal/util/reflection/GenericMetadataSupport.java
@@ -461,7 +461,7 @@ public abstract class GenericMetadataSupport implements Serializable {
      * @see WildCardBoundedType
      * @see <a href="http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues.html#4.5.1">http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues.html#4.5.1</a>
      */
-    public static interface BoundedType extends Type {
+    public interface BoundedType extends Type {
         Type firstBound();
 
         Type[] interfaceBounds();

--- a/test/org/mockito/internal/InvalidStateDetectionTest.java
+++ b/test/org/mockito/internal/InvalidStateDetectionTest.java
@@ -202,7 +202,7 @@ public class InvalidStateDetectionTest extends TestBase {
         verify(mock).simpleMethod();
     }
     
-    private static interface DetectsInvalidState {
+    private interface DetectsInvalidState {
         void detect(IMethods mock);
     }
     

--- a/test/org/mockito/internal/util/reflection/FieldInitializerTest.java
+++ b/test/org/mockito/internal/util/reflection/FieldInitializerTest.java
@@ -193,7 +193,7 @@ public class FieldInitializerTest {
         public AbstractStaticClass() {}
     }
 
-    static interface Interface {
+    interface Interface {
 
     }
 

--- a/test/org/mockitousage/bugs/ConcurrentModificationExceptionOnMultiThreadedVerificationTest.java
+++ b/test/org/mockitousage/bugs/ConcurrentModificationExceptionOnMultiThreadedVerificationTest.java
@@ -82,7 +82,7 @@ public class ConcurrentModificationExceptionOnMultiThreadedVerificationTest {
 		
 	}
 	
-	public static interface ITarget {
+	public interface ITarget {
 
 		public String targetMethod(String arg);
 	}

--- a/test/org/mockitousage/bugs/CovariantOverrideTest.java
+++ b/test/org/mockitousage/bugs/CovariantOverrideTest.java
@@ -13,11 +13,11 @@ import static org.mockito.Mockito.*;
 //see issue 101
 public class CovariantOverrideTest extends TestBase {
    
-    public static interface ReturnsObject {
+    public interface ReturnsObject {
         Object callMe();
     }
 
-    public static interface ReturnsString extends ReturnsObject {
+    public interface ReturnsString extends ReturnsObject {
         // Java 5 covariant override of method from parent interface
         String callMe();
     }

--- a/test/org/mockitousage/bugs/ShouldNotDeadlockAnswerExecutionTest.java
+++ b/test/org/mockitousage/bugs/ShouldNotDeadlockAnswerExecutionTest.java
@@ -107,7 +107,7 @@ public class ShouldNotDeadlockAnswerExecutionTest {
 
     }
 
-    static interface Service {
+    interface Service {
 
         String verySlowMethod();
 

--- a/test/org/mockitoutil/SimplePerRealmReloadingClassLoader.java
+++ b/test/org/mockitoutil/SimplePerRealmReloadingClassLoader.java
@@ -112,7 +112,7 @@ public class SimplePerRealmReloadingClassLoader extends URLClassLoader {
     }
 
 
-    public static interface ReloadClassPredicate {
+    public interface ReloadClassPredicate {
         boolean acceptReloadOf(String qualifiedName);
     }
 }


### PR DESCRIPTION
inner interfaces are implicitly static
