### PR TITLE
Allow calling real implementation of jdk8 extension methods

### DIFF
--- a/src/org/mockito/exceptions/Reporter.java
+++ b/src/org/mockito/exceptions/Reporter.java
@@ -580,12 +580,12 @@ public class Reporter {
         ));
     }
 
-    public void cannotCallRealMethodOnInterface() {
+    public void cannotCallAbstractRealMethod() {
         throw new MockitoException(join(
-                "Cannot call real method on java interface. Interface does not have any implementation!",
-                "Calling real methods is only possible when mocking concrete classes.",
+                "Cannot call abstract real method on java object!",
+                "Calling real methods is only possible when mocking non abstract method.",
                 "  //correct example:",
-                "  when(mockOfConcreteClass.doStuff()).thenCallRealMethod();"
+                "  when(mockOfConcreteClass.nonAbstractMethod()).thenCallRealMethod();"
         ));
     }
 

--- a/src/org/mockito/internal/creation/DelegatingMethod.java
+++ b/src/org/mockito/internal/creation/DelegatingMethod.java
@@ -5,6 +5,7 @@
 package org.mockito.internal.creation;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 
 import org.mockito.internal.invocation.MockitoMethod;
 
@@ -39,6 +40,11 @@ public class DelegatingMethod implements MockitoMethod {
 
     public boolean isVarArgs() {
         return method.isVarArgs();
+    }
+
+    @Override
+    public boolean isAbstract() {
+        return (method.getModifiers() & Modifier.ABSTRACT) != 0;
     }
     
     @Override

--- a/src/org/mockito/internal/invocation/AbstractAwareMethod.java
+++ b/src/org/mockito/internal/invocation/AbstractAwareMethod.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito.internal.invocation;
+
+public interface AbstractAwareMethod {
+    boolean isAbstract();
+}

--- a/src/org/mockito/internal/invocation/InvocationImpl.java
+++ b/src/org/mockito/internal/invocation/InvocationImpl.java
@@ -102,8 +102,8 @@ public class InvocationImpl implements Invocation, VerificationAwareInvocation {
     }
 
     public Object callRealMethod() throws Throwable {
-        if (this.getMethod().getDeclaringClass().isInterface()) {
-            new Reporter().cannotCallRealMethodOnInterface();
+        if (method.isAbstract()) {
+            new Reporter().cannotCallAbstractRealMethod();
         }
         return realMethod.invoke(mock, rawArguments);
     }

--- a/src/org/mockito/internal/invocation/MockitoMethod.java
+++ b/src/org/mockito/internal/invocation/MockitoMethod.java
@@ -6,7 +6,7 @@ package org.mockito.internal.invocation;
 
 import java.lang.reflect.Method;
 
-public interface MockitoMethod {
+public interface MockitoMethod extends AbstractAwareMethod {
 
     public String getName();
 

--- a/src/org/mockito/internal/invocation/SerializableMethod.java
+++ b/src/org/mockito/internal/invocation/SerializableMethod.java
@@ -6,6 +6,7 @@ package org.mockito.internal.invocation;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
 
 import org.mockito.exceptions.base.MockitoException;
@@ -20,6 +21,7 @@ public class SerializableMethod implements Serializable, MockitoMethod {
     private Class<?> returnType;
     private Class<?>[] exceptionTypes;
     private boolean isVarArgs;
+    private boolean isAbstract;
 
     public SerializableMethod(Method method) {
         declaringClass = method.getDeclaringClass();
@@ -28,6 +30,7 @@ public class SerializableMethod implements Serializable, MockitoMethod {
         returnType = method.getReturnType();
         exceptionTypes = method.getExceptionTypes();
         isVarArgs = method.isVarArgs();
+        isAbstract = (method.getModifiers() & Modifier.ABSTRACT) != 0;
     }
 
     public String getName() {
@@ -48,7 +51,12 @@ public class SerializableMethod implements Serializable, MockitoMethod {
 
     public boolean isVarArgs() {
         return isVarArgs;
-    }  
+    }
+
+    @Override
+    public boolean isAbstract() {
+        return isAbstract;
+    }
 
     public Method getJavaMethod() {
         try {
@@ -64,7 +72,7 @@ public class SerializableMethod implements Serializable, MockitoMethod {
                             "Please report this as a defect with an example of how to reproduce it.", declaringClass, methodName);
             throw new MockitoException(message, e);
         }
-    }    
+    }
 
     @Override
     public int hashCode() {

--- a/src/org/mockito/internal/stubbing/answers/AnswersValidator.java
+++ b/src/org/mockito/internal/stubbing/answers/AnswersValidator.java
@@ -49,8 +49,8 @@ public class AnswersValidator {
     }
 
     private void validateMockingConcreteClass(CallsRealMethods answer, MethodInfo methodInfo) {
-        if (methodInfo.isDeclaredOnInterface()) {
-            reporter.cannotCallRealMethodOnInterface();
+        if (methodInfo.isAbstract()) {
+            reporter.cannotCallAbstractRealMethod();
         }
     }
 

--- a/src/org/mockito/internal/stubbing/answers/MethodInfo.java
+++ b/src/org/mockito/internal/stubbing/answers/MethodInfo.java
@@ -4,15 +4,17 @@
  */
 package org.mockito.internal.stubbing.answers;
 
+import org.mockito.internal.invocation.AbstractAwareMethod;
 import org.mockito.internal.util.Primitives;
 import org.mockito.invocation.Invocation;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 
 /**
  * by Szczepan Faber, created at: 3/31/12
  */
-public class MethodInfo {
+public class MethodInfo implements AbstractAwareMethod {
 
     private Method method;
 
@@ -62,5 +64,10 @@ public class MethodInfo {
 
     public boolean isDeclaredOnInterface() {
         return method.getDeclaringClass().isInterface();
+    }
+
+    @Override
+    public boolean isAbstract() {
+        return (method.getModifiers() & Modifier.ABSTRACT) != 0;
     }
 }


### PR DESCRIPTION
See also the google code ticket: https://code.google.com/p/mockito/issues/detail?id=456

Enable calling real implementation on extensions method from jdk8
Additionally change add validation checking whether callRealMethod is invoked on abstract methods.
In fact resolving issue could be achieved by removing this validation because when someone do next thing:
1: when(someInteface.abstractMethod()).thanCallRealMethod();
2: someInteface.abstractMethod()
Exception will be throwned on second line informing that there were attempt to invoke abstract method
