### PR TITLE
New "getArgumentAt" method for convenient implementation of custom Answers

### DIFF
--- a/src/org/mockito/internal/invocation/InvocationImpl.java
+++ b/src/org/mockito/internal/invocation/InvocationImpl.java
@@ -61,6 +61,11 @@ public class InvocationImpl implements Invocation, VerificationAwareInvocation {
     public Object[] getArguments() {
         return arguments;
     }
+    
+    @Override
+    public <T> T getArgumentAt(int index, Class<T> clazz) {
+        return (T) arguments[index];
+    }
 
     public boolean isVerified() {
         return verified || isIgnoredForVerification;

--- a/src/org/mockito/invocation/InvocationOnMock.java
+++ b/src/org/mockito/invocation/InvocationOnMock.java
@@ -35,6 +35,15 @@ public interface InvocationOnMock extends Serializable {
      * @return arguments
      */
     Object[] getArguments();
+    
+    /**
+    * Returns casted argument using position
+    * @param index argument position
+    * @param clazz argument type
+    * @return casted argument on position
+    */
+    <T extends Object> T getArgumentAt(int index, Class<T> clazz);
+
 
     /**
      * calls real method

--- a/test/org/mockito/internal/invocation/InvocationImplTest.java
+++ b/test/org/mockito/internal/invocation/InvocationImplTest.java
@@ -147,4 +147,18 @@ public class InvocationImplTest extends TestBase {
             fail();
         } catch(MockitoException e) {}
     }
+    
+    @Test
+    public void shouldReturnCastedArgumentAt(){
+        //given
+        int argument = 42;
+        Invocation invocationOnInterface = new InvocationBuilder().method("twoArgumentMethod").
+            argTypes(int.class, int.class).args(1, argument).toInvocation();
+
+        //when
+        int secondArgument = invocationOnInterface.getArgumentAt(1, int.class);
+
+        //then
+        assertTrue(secondArgument == argument);
+    }
 }

--- a/test/org/mockito/internal/stubbing/answers/ReturnsArgumentAtTest.java
+++ b/test/org/mockito/internal/stubbing/answers/ReturnsArgumentAtTest.java
@@ -5,6 +5,8 @@
 package org.mockito.internal.stubbing.answers;
 
 import org.junit.Test;
+import org.mockito.internal.invocation.InvocationBuilder;
+import org.mockito.internal.invocation.InvocationImpl;
 import org.mockito.internal.stubbing.answers.ReturnsArgumentAt;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockitousage.IMethods;
@@ -53,29 +55,9 @@ public class ReturnsArgumentAtTest {
         }
     }
 
-	private static InvocationOnMock invocationWith(final String... parameters) {
-        return new InvocationOnMock() {
-
-            public Object getMock() {
-                return null;
-            }
-
-            public Method getMethod() {
-                try {
-                    return IMethods.class.getDeclaredMethod("varargsReturningString", Object[].class);
-                } catch (NoSuchMethodException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-
-            public Object[] getArguments() {
-                return parameters;
-            }
-
-            public Object callRealMethod() throws Throwable {
-                return null;
-            }
-        };
-    }
+	private static InvocationOnMock invocationWith(Object... parameters) {
+		return new InvocationBuilder().method("varargsReturningString").argTypes(Object[].class)
+ 			.args(parameters).toInvocation();
+	}
 
 }


### PR DESCRIPTION
The problem is when i need to use answers, I quite often need to cast these arguments.
I propose two methods in InvocationOnMock, so we can get two arguments of method typesafely, so this piece of code,

``` java
@SuppressWarnings("unchecked")
  doAnswer(new Answer() {
      public Object answer(InvocationOnMock invocation) {
          Object[] args = invocation.getArguments();
          int count  = (int)args[1];
         //do something
      }})
  .when(mock).someMethod();
```

will be better:

``` java
  doAnswer(new Answer() {
      public Object answer(InvocationOnMock invocation) {
           int count  = invocation.getArgumentAt(1, int.class);
         //do something
      }})
  .when(mock).someMethod();
```
