### PR TITLE
Follow best practice for OSGi bundle naming.

### DIFF
--- a/conf/mockito-all.bnd
+++ b/conf/mockito-all.bnd
@@ -4,7 +4,7 @@
 -versionpolicy=[${version;==;${@}},${version;+;${@}})
 
 Bundle-Name= Mockito Mock Library for Java. Hamcrest-core & Objenesis included in the bundle.
-Bundle-SymbolicName= org.mockito.mockito-all
+Bundle-SymbolicName= org.mockito.all
 Bundle-Version= ${version}
 
 Export-Package= !org.mockito.asm.*, \

--- a/conf/mockito-core.bnd
+++ b/conf/mockito-core.bnd
@@ -1,7 +1,7 @@
 -versionpolicy=[${version;==;${@}},${version;+;${@}})
 
 Bundle-Name= Mockito Mock Library for Java. Core bundle requires Hamcrest-core and Objenesis. 
-Bundle-SymbolicName= org.mockito.mockito-core
+Bundle-SymbolicName= org.mockito
 Bundle-Version= ${version}
 
 Export-Package= !org.mockito.asm.*, \

--- a/osgi.gradle
+++ b/osgi.gradle
@@ -9,7 +9,7 @@ afterEvaluate {
             instruction '-versionpolicy', '[${version;==;${@}},${version;+;${@}})'
 
             name = 'Mockito Mock Library for Java. Core bundle requires Hamcrest-core and Objenesis.'
-            symbolicName = 'org.mockito.mockito-core'
+            symbolicName = 'org.mockito'
             version = project.version
 
             instruction 'Export-Package',
@@ -41,7 +41,7 @@ afterEvaluate {
             instruction '-versionpolicy', '[${version;==;${@}},${version;+;${@}})'
 
             name = 'Mockito Mock Library for Java. Hamcrest-core and Objenesis included in the bundle.'
-            symbolicName = 'org.mockito.mockito-all'
+            symbolicName = 'org.mockito.all'
             version = project.version
 
             instruction 'Export-Package',


### PR DESCRIPTION
Following good practice guidelines for OSGi bundle naming [1], the Bundle Symbolic Name (BSN) only needs to be named after the module's "dominant" or root package -- this allows you to use the simplest possible BSN that uniquely identifies your module and removes the "mockito.mockito" duplication in the name.

[1] http://wiki.eclipse.org/Bundle_Naming
