### PR TITLE
Proposal to add packaging to mockito-testng with gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,9 @@
 import org.apache.xalan.xsltc.cmdline.Compile
 
-version = '1.9.8' //TODO duplicated with file
+Properties props = new Properties()
+props.load(new FileInputStream("${rootProject.projectDir}/version.properties"))
+
+version = props.version
 group = 'org.mockito'
 description = 'Core API and implementation.'
 
@@ -8,6 +11,7 @@ allprojects {
     apply plugin: 'java'
     apply plugin: 'eclipse'
     apply plugin: 'idea'
+    apply plugin: 'maven'
 
     repositories {
         mavenCentral()

--- a/subprojects/testng/testng.gradle
+++ b/subprojects/testng/testng.gradle
@@ -1,18 +1,52 @@
 description = "Mockito for TestNG"
 
+Properties props = new Properties()
+props.load(new FileInputStream("${rootProject.projectDir}/version.properties"))
+
 group = 'org.mockito'
 archivesBaseName = 'mockito-testng'
-version = '1.0' // TODO change version
+version = props['mockito.testng.version']
 
 repositories {
     mavenCentral()
 }
 
+jar {
+    manifest.attributes["Created-By"] =
+            "${System.getProperty("java.version")} (${System.getProperty("java.specification.vendor")})"
+    manifest.attributes["Implementation-Title"] = project.name
+    manifest.attributes["Implementation-Version"] = project.version
+
+    from("${rootProject.projectDir}") {
+        include "LICENSE"
+        include "NOTICE"
+        into "META-INF"
+        expand(copyright: new Date().format("yyyy"), version: project.version)
+    }
+
+}
+
+task sourcesJar(type: Jar, dependsOn:classes) {
+    classifier = "sources"
+    from sourceSets.main.allJava.srcDirs
+    include "**/*.java", "**/*.aj"
+}
+
+artifacts {
+    archives sourcesJar
+}
+
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            repository(url: "file://${rootProject.projectDir}/target/maven/repository")
+        }
+    }
+}
+
 dependencies {
     compile project.rootProject
-//    compile 'org.mockito:mockito-core:1.9.5'
     compile 'org.testng:testng:6.3.1'
-
     testCompile 'org.easytesting:fest-assert:1.4'
 }
 

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,2 @@
 version=1.9.8
+mockito.testng.version=1.0


### PR DESCRIPTION
This pull request was done while the Hackergarten event at devoxxFR.

This is a packaging proposal for mockito-testng module with gradle.
- 'grade build' create a 'mockito-testng-1.0.jar' and 'mockito-testng-1.0-sources.jar' in ROOT/subprojects/testng/build
- 'gradle uploadArchives' package mockito-testng as maven artifact (local repository in ROOT/target/maven/repository for now)

I've also loaded version.properties in gradles files (and deleted reltated TODO) to re-euse version number, and added mockito.testng.version in this file

I think it will need to be adapted to your build needs (build path(s) for example), but it provide a start.
It also currently miss the osgi repackaging. 
