### PR TITLE
timeout() should take a long as a parameter.

### DIFF
--- a/src/org/mockito/Mockito.java
+++ b/src/org/mockito/Mockito.java
@@ -2091,7 +2091,7 @@ public class Mockito extends Matchers {
      * 
      * @return verification mode
      */
-    public static VerificationWithTimeout timeout(int millis) {
+    public static VerificationWithTimeout timeout(long millis) {
         return new Timeout(millis, VerificationModeFactory.times(1));
     }
     

--- a/src/org/mockito/internal/verification/VerificationOverTimeImpl.java
+++ b/src/org/mockito/internal/verification/VerificationOverTimeImpl.java
@@ -17,7 +17,7 @@ import org.mockito.verification.VerificationMode;
 public class VerificationOverTimeImpl implements VerificationMode {
 
     private final int pollingPeriodMillis;
-    private final int durationMillis;
+    private final long durationMillis;
     private final VerificationMode delegate;
     private final boolean returnOnSuccess;
     
@@ -32,7 +32,7 @@ public class VerificationOverTimeImpl implements VerificationMode {
      *                        the delegate is satisfied and the full duration has passed (as in
      *                        {@link org.mockito.verification.VerificationAfterDelay}).
      */
-    public VerificationOverTimeImpl(int pollingPeriodMillis, int durationMillis, VerificationMode delegate, boolean returnOnSuccess) {
+    public VerificationOverTimeImpl(int pollingPeriodMillis, long durationMillis, VerificationMode delegate, boolean returnOnSuccess) {
         this.pollingPeriodMillis = pollingPeriodMillis;
         this.durationMillis = durationMillis;
         this.delegate = delegate;
@@ -105,7 +105,7 @@ public class VerificationOverTimeImpl implements VerificationMode {
         return pollingPeriodMillis;
     }
     
-    public int getDuration() {
+    public long getDuration() {
         return durationMillis;
     }
     

--- a/src/org/mockito/verification/After.java
+++ b/src/org/mockito/verification/After.java
@@ -16,11 +16,11 @@ public class After extends VerificationWrapper<VerificationOverTimeImpl> impleme
      * Typically, you won't use this class explicitly. Instead use timeout() method on Mockito class.
      * See javadoc for {@link VerificationWithTimeout}
      */
-    public After(int delayMillis, VerificationMode verificationMode) {
+    public After(long delayMillis, VerificationMode verificationMode) {
         this(10, delayMillis, verificationMode);
     }
     
-    public After(int pollingPeriod, int delayMillis, VerificationMode verificationMode) {
+    public After(int pollingPeriod, long delayMillis, VerificationMode verificationMode) {
         super(new VerificationOverTimeImpl(pollingPeriod, delayMillis, verificationMode, false));
     }
     

--- a/src/org/mockito/verification/Timeout.java
+++ b/src/org/mockito/verification/Timeout.java
@@ -20,14 +20,14 @@ public class Timeout extends VerificationWrapper<VerificationOverTimeImpl> imple
      * Typically, you won't use this class explicitly. Instead use timeout() method on Mockito class.
      * See javadoc for {@link VerificationWithTimeout}
      */
-    public Timeout(int millis, VerificationMode delegate) {
+    public Timeout(long millis, VerificationMode delegate) {
         this(10, millis, delegate);
     }
 
     /**
      * See the javadoc for {@link VerificationWithTimeout}
      */
-    Timeout(int pollingPeriodMillis, int millis, VerificationMode delegate) {
+    Timeout(int pollingPeriodMillis, long millis, VerificationMode delegate) {
         super(new VerificationOverTimeImpl(pollingPeriodMillis, millis, delegate, true));
     }
     

--- a/test/org/mockito/verification/TimeoutTest.java
+++ b/test/org/mockito/verification/TimeoutTest.java
@@ -81,7 +81,7 @@ public class TimeoutTest extends TestBase {
         assertTimeoutCorrectlyConfigured(t.only(), Timeout.class, 50, 25, Only.class);
     }
     
-    private void assertTimeoutCorrectlyConfigured(VerificationMode t, Class<?> expectedType, int expectedTimeout, int expectedPollingPeriod, Class<?> expectedDelegateType) {
+    private void assertTimeoutCorrectlyConfigured(VerificationMode t, Class<?> expectedType, long expectedTimeout, int expectedPollingPeriod, Class<?> expectedDelegateType) {
         assertEquals(expectedType, t.getClass());
         assertEquals(expectedTimeout, ((Timeout) t).wrappedVerification.getDuration());
         assertEquals(expectedPollingPeriod, ((Timeout) t).wrappedVerification.getPollingPeriod());


### PR DESCRIPTION
Generally libraries handle timeout milliseconds as longs for example TimeUnit.SECONDS.toMillis(1) returns a longs as well. I have to cast this value down to int every time I plan to use TimeUnit.
