### PR TITLE
An initial pass at throwing an exception for unstubbed invocations.

### DIFF
--- a/src/org/mockito/Answers.java
+++ b/src/org/mockito/Answers.java
@@ -9,6 +9,7 @@ import org.mockito.internal.stubbing.defaultanswers.GloballyConfiguredAnswer;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsDeepStubs;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsMocks;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsSmartNulls;
+import org.mockito.internal.stubbing.defaultanswers.ThrowsSmartNulls;
 import org.mockito.stubbing.Answer;
 
 /**
@@ -41,6 +42,15 @@ public enum Answers {
      * @see org.mockito.Mockito#RETURNS_SMART_NULLS
      */
     RETURNS_SMART_NULLS(new ReturnsSmartNulls()),
+
+    /**
+     * An answer that throws smart-nulls.
+     *
+     * <p>Please see the {@link org.mockito.Mockito#THROWS_SMART_NULLS} documentation for more details.</p>
+     *
+     * @see org.mockito.Mockito#THROWS_SMART_NULLS
+     */
+    THROWS_SMART_NULLS(new ThrowsSmartNulls()),
 
     /**
      * An answer that returns <strong>mocks</strong> (not stubs).

--- a/src/org/mockito/Mockito.java
+++ b/src/org/mockito/Mockito.java
@@ -984,6 +984,37 @@ public class Mockito extends Matchers {
      * </code></pre>
      */
     public static final Answer<Object> RETURNS_SMART_NULLS = Answers.RETURNS_SMART_NULLS.get();
+
+    /**
+     * Optional <code>Answer</code> to be used with {@link Mockito#mock(Class, Answer)}.
+     * <p>
+     * {@link Answer} can be used to define the return values of unstubbed invocations.
+     * <p>
+     * This implementation can be helpful when working with legacy code.
+     * Unstubbed methods often return null. If your code uses the object returned by an unstubbed call you get a NullPointerException.
+     * This implementation of Answer <b>returns SmartNull instead of null</b>.
+     * <code>SmartNull</code> gives nicer exception message than NPE because it points out the line where unstubbed method was called. You just click on the stack trace.
+     * <p>
+     * Unlike <code>ReturnsSmartNulls</code>, <code>ThrowsSmartNulls</code> does not try to return ordinary return values.
+     * <p>
+     * If the return type is a primitive or a final then a smart null exception is thrown.
+     * <p>
+     * Example:
+     * <pre class="code"><code class="java">
+     *   Foo mock = (Foo.class, RETURNS_SMART_NULLS);
+     *   
+     *   //calling unstubbed method here:
+     *   Stuff stuff = mock.getStuff();
+     *   
+     *   //using object returned by unstubbed call:
+     *   stuff.doSomething();
+     *   
+     *   //Above doesn't yield NullPointerException this time!
+     *   //Instead, SmartNullPointerException is thrown. 
+     *   //Exception's cause links to unstubbed <i>mock.getStuff()</i> - just click on the stack trace.  
+     * </code></pre>
+     */
+    public static final Answer<Object> THROWS_SMART_NULLS = Answers.THROWS_SMART_NULLS.get();
     
     /**
      * Optional <code>Answer</code> to be used with {@link Mockito#mock(Class, Answer)}

--- a/src/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNulls.java
+++ b/src/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNulls.java
@@ -8,11 +8,9 @@ import java.io.Serializable;
 import java.lang.reflect.Modifier;
 
 import org.mockito.Mockito;
-import org.mockito.exceptions.Reporter;
 import org.mockito.internal.debugging.LocationImpl;
-import org.mockito.invocation.Location;
-import org.mockito.internal.util.ObjectMethodsGuru;
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.invocation.Location;
 import org.mockito.stubbing.Answer;
 
 /**
@@ -35,7 +33,7 @@ import org.mockito.stubbing.Answer;
  */
 public class ReturnsSmartNulls implements Answer<Object>, Serializable {
 
-    private static final long serialVersionUID = 7618312406617949441L;
+    private static final long serialVersionUID = -7675347942814309907L;
 
     private final Answer<Object> delegate = new ReturnsMoreEmptyValues();
 
@@ -50,25 +48,5 @@ public class ReturnsSmartNulls implements Answer<Object>, Serializable {
             return Mockito.mock(type, new ThrowsSmartNullPointer(invocation, location));
         }
         return null;
-    }
-
-    private static class ThrowsSmartNullPointer implements Answer {
-        private final InvocationOnMock unstubbedInvocation;
-        private final Location location;
-
-        public ThrowsSmartNullPointer(InvocationOnMock unstubbedInvocation, Location location) {
-            this.unstubbedInvocation = unstubbedInvocation;
-            this.location = location;
-        }
-
-        public Object answer(InvocationOnMock currentInvocation) throws Throwable {
-            if (new ObjectMethodsGuru().isToString(currentInvocation.getMethod())) {
-                return "SmartNull returned by this unstubbed method call on a mock:\n" +
-                        unstubbedInvocation.toString();
-            }
-
-            new Reporter().smartNullPointerException(unstubbedInvocation.toString(), location);
-            return null;
-        }
     }
 }

--- a/src/org/mockito/internal/stubbing/defaultanswers/ThrowsSmartNullPointer.java
+++ b/src/org/mockito/internal/stubbing/defaultanswers/ThrowsSmartNullPointer.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2014 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.stubbing.defaultanswers;
+
+import org.mockito.exceptions.Reporter;
+import org.mockito.internal.util.ObjectMethodsGuru;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.invocation.Location;
+import org.mockito.stubbing.Answer;
+
+/**
+ * A package private class for throwing a smart null pointer exception reporting the unstubbed
+ * invocation and the location.
+ */
+class ThrowsSmartNullPointer implements Answer<Object> {
+    private final InvocationOnMock unstubbedInvocation;
+    private final Location location;
+
+    public ThrowsSmartNullPointer(InvocationOnMock unstubbedInvocation, Location location) {
+        this.unstubbedInvocation = unstubbedInvocation;
+        this.location = location;
+    }
+
+    public Object answer(InvocationOnMock currentInvocation) throws Throwable {
+        if (new ObjectMethodsGuru().isToString(currentInvocation.getMethod())) {
+            return "SmartNull returned by this unstubbed method call on a mock:\n" +
+                    unstubbedInvocation.toString();
+        }
+
+        new Reporter().smartNullPointerException(unstubbedInvocation.toString(), location);
+        return null;
+    }
+}

--- a/src/org/mockito/internal/stubbing/defaultanswers/ThrowsSmartNulls.java
+++ b/src/org/mockito/internal/stubbing/defaultanswers/ThrowsSmartNulls.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.stubbing.defaultanswers;
+
+import java.io.Serializable;
+import java.lang.reflect.Modifier;
+
+import org.mockito.Mockito;
+import org.mockito.exceptions.Reporter;
+import org.mockito.internal.debugging.LocationImpl;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.invocation.Location;
+import org.mockito.stubbing.Answer;
+
+/**
+ * Optional Answer that can be used with
+ * {@link Mockito#mock(Class, Answer)}
+ * <p>
+ * This implementation can be helpful when working with legacy code. Unstubbed
+ * methods often return null. If your code uses the object returned by an
+ * unstubbed call you get a NullPointerException. This implementation of
+ * Answer returns SmartNulls instead of nulls.
+ * SmartNull gives nicer exception message than NPE because it points out the
+ * line where unstubbed method was called. You just click on the stack trace.
+ * <p>
+ * Unlike ReturnsSmartNulls, ThrowsSmartNulls does <b>not</b> try to return ordinary return values
+ * before it tries to return SmartNull.
+ *
+ * If the return type is not mockable (e.g. a primitive or final) then a smart null exception is
+ * thrown immediately.
+ */
+public class ThrowsSmartNulls implements Answer<Object>, Serializable {
+
+    private static final long serialVersionUID = 7144947647279773153L;
+
+    public Object answer(final InvocationOnMock unstubbedInvocation) throws Throwable {
+        Class<?> type = unstubbedInvocation.getMethod().getReturnType();
+        final Location location = new LocationImpl();
+        if (type.isPrimitive() || Modifier.isFinal(type.getModifiers())) {
+            new Reporter().smartNullPointerException(unstubbedInvocation.toString(), location);
+        } else {
+            return Mockito.mock(type, new ThrowsSmartNullPointer(unstubbedInvocation, location));
+        }
+        return null;
+    }
+}

--- a/test/org/mockito/internal/stubbing/defaultanswers/ThrowsSmartNullsTest.java
+++ b/test/org/mockito/internal/stubbing/defaultanswers/ThrowsSmartNullsTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.stubbing.defaultanswers;
+
+import java.lang.reflect.Method;
+
+import org.junit.Test;
+import org.mockito.exceptions.verification.SmartNullPointerException;
+import org.mockito.stubbing.Answer;
+import org.mockitoutil.TestBase;
+
+public class ThrowsSmartNullsTest extends TestBase {
+    private Answer<Object> answer = new ThrowsSmartNulls();
+
+    interface Foo {
+        Foo get();
+
+        Foo withArgs(String oneArg, String otherArg);
+    }
+
+    @Test
+    public void should_return_an_object_that_fails_on_any_method_invocation_for_non_primitives() throws Throwable {
+        Foo smartNull = (Foo) answer.answer(invocationOf(Foo.class, "get"));
+
+        try {
+            smartNull.get();
+            fail();
+        } catch (SmartNullPointerException expected) {
+        }
+    }
+
+    @Test
+    public void should_throw_an_exception_on_any_method_invocation_returning_primitives() throws Throwable {
+        Method[] declaredMethods = HasPrimitiveMethods.class.getDeclaredMethods();
+        assertNotEquals(0, declaredMethods.length);
+        for (Method method : declaredMethods) {
+            try {
+                answer.answer(invocationOf(HasPrimitiveMethods.class, method.getName()));
+                fail();
+            } catch (SmartNullPointerException expected) {
+            }
+        }
+    }
+
+    @Test
+    public void should_return_an_object_that_allows_object_methods() throws Throwable {
+        Foo smartNull = (Foo) answer.answer(invocationOf(Foo.class, "get"));
+
+        assertContains("SmartNull returned by", smartNull + "");
+        assertContains("foo.get()", smartNull + "");
+    }
+
+    @Test
+    public void should_print_the_parameters_when_calling_a_method_with_args() throws Throwable {
+        Foo smartNull = (Foo) answer.answer(invocationOf(Foo.class, "withArgs", "oompa", "lumpa"));
+
+        assertContains("foo.withArgs", smartNull + "");
+        assertContains("oompa", smartNull + "");
+        assertContains("lumpa", smartNull + "");
+    }
+
+    @Test
+    public void should_print_the_parameters_on_SmartNullPointerException_message() throws Throwable {
+        Foo smartNull = (Foo) answer.answer(invocationOf(Foo.class, "withArgs", "oompa", "lumpa"));
+
+        try {
+            smartNull.get();
+            fail();
+        } catch (SmartNullPointerException e) {
+            assertContains("oompa", e.getMessage());
+            assertContains("lumpa", e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
This is an initial solution for https://code.google.com/p/mockito/issues/detail?id=346

It doesn't solve all the use cases on that issue but may be a good enough solution for now.

FYI, I moved ThrowsSmartNullPointer out of ReturnsSmartNulls into its own package private class so it could be reused by the new ThrowsSmartNulls class.

Please let me know if the name of the new ThrowsSmartNulls class could be improved, however I felt that keeping "SmartNulls" as part of the name made sense, since it is
a) still returning smart null objects for unstubbed methods that return non-primitive and non-final types (the smart null objects throw smart null exceptions on access via method calls, except for toString() calls), and
b) now throwing smart null exceptions immediately for methods that return primitive or final types.