### PR TITLE
@emir-hasanbegovic Removed pulling of dependencies into jar so that mave...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,8 +64,8 @@ dependencies {
 
     testUtil sourceSets.test.output
 
-//    compile 'org.objenesis:objenesis:2.1'
-//    compile 'org.hamcrest:hamcrest-core:1.1'
+    compile 'org.objenesis:objenesis:2.1'
+    compile 'org.hamcrest:hamcrest-core:1.1'
 
 }
 
@@ -113,10 +113,6 @@ task allJar(type: Jar) {
     baseName = 'mockito-all'
 
     with commonJarContent
-
-
-    from(zipTree("lib/run/objenesis-2.1.jar")) { exclude "META-INF/maven/**" }
-    from(zipTree("lib/run/com.springsource.org.hamcrest.core-1.1.0.jar")) { exclude "LICENSE.txt" }
 
     //classes
     from(sourceSets.main.output)


### PR DESCRIPTION
Removed pulling of dependencies into jar so that maven applications can manage their dependencies if they happen to bring in the same ones

Should add 

``` xml
<dependency>
    <groupId>org.objenesis</groupId>
    <artifactId>objenesis</artifactId>
    <version>2.1</version>
</dependency>
```

and 

``` xml
<dependency>
    <groupId>org.hamcrest</groupId>
    <artifactId>hamcrest-core</artifactId>
    <version>[1.3,)</version>
</dependency>
```

To the pom file to match changes and let people have easier access to compiling with mockito
