### PR TITLE
Adding "getRealClass()" method to MockingDetails and DefaultMockingDetails

### DIFF
--- a/src/org/mockito/MockingDetails.java
+++ b/src/org/mockito/MockingDetails.java
@@ -41,4 +41,13 @@ public interface MockingDetails {
      * @since 1.9.x
      */
     Collection<Invocation> getInvocations();
+    
+    /**
+     * Returns the "real" or "original" class of the object, or the type originally passed to
+     * the "mock()" or "spy()" function, or referenced by an annotation.  This works even if
+     * the object is not a mock or a spy.
+     * 
+     * @return Real or "original" class of the object
+     */
+    Class<?>    getRealClass();
 }

--- a/src/org/mockito/internal/util/DefaultMockingDetails.java
+++ b/src/org/mockito/internal/util/DefaultMockingDetails.java
@@ -49,7 +49,6 @@ public class DefaultMockingDetails implements MockingDetails {
      * 
      * @return Real or "original" class of the object
      */
-    @Override
     public Class<?> getRealClass() {
         return new MockUtil().getMockHandler(toInspect).getMockSettings().getTypeToMock();
     }

--- a/src/org/mockito/internal/util/DefaultMockingDetails.java
+++ b/src/org/mockito/internal/util/DefaultMockingDetails.java
@@ -41,5 +41,17 @@ public class DefaultMockingDetails implements MockingDetails {
     public Collection<Invocation> getInvocations() {
     	return delegate.getMockHandler(toInspect).getInvocationContainer().getInvocations();
     }
+    
+    /**
+     * Returns the "real" or "original" class of the object, or the type originally passed to
+     * the "mock()" or "spy()" function, or referenced by an annotation. If the object is a plain
+     * object, then it will just return the class of the object.
+     * 
+     * @return Real or "original" class of the object
+     */
+    @Override
+    public Class<?> getRealClass() {
+        return new MockUtil().getMockHandler(toInspect).getMockSettings().getTypeToMock();
+    }
 }
 

--- a/test/org/mockito/internal/util/DefaultMockingDetailsTest.java
+++ b/test/org/mockito/internal/util/DefaultMockingDetailsTest.java
@@ -1,0 +1,63 @@
+package org.mockito.internal.util;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultMockingDetailsTest {
+
+	@Mock
+	private Foo	foo;
+	@Mock
+	private Bar bar;
+	@Spy
+	private Gork gork;
+	private Foo anotherFoo	= new Foo();
+
+	@Test
+	public void testMockIsMock() throws Exception {
+		assertEquals(true, Mockito.mockingDetails(foo).isMock());
+		assertEquals(true, Mockito.mockingDetails(bar).isMock());
+		assertEquals(true, Mockito.mockingDetails(gork).isMock());
+	}
+	
+	@Test
+	public void testNotMockIsNotMock() throws Exception {
+		assertEquals(false, Mockito.mockingDetails(anotherFoo).isMock());
+	}
+	
+	@Test
+	public void testSpyIsSpy() throws Exception {
+		assertEquals(true, Mockito.mockingDetails(gork).isSpy());
+	}
+	
+	@Test
+	public void testNotSpyIsNotSpy() throws Exception {
+		assertEquals(false, Mockito.mockingDetails(foo).isSpy());
+		assertEquals(false, Mockito.mockingDetails(bar).isSpy());
+		assertEquals(false, Mockito.mockingDetails(anotherFoo).isSpy());
+	}
+	
+	@Test
+	public void testGetRealClassNotInterface() throws Exception {
+		assertEquals(Foo.class, Mockito.mockingDetails(foo).getRealClass());
+	}
+
+	@Test
+	public void testGetRealClassInterface() throws Exception {
+		assertEquals(Bar.class, Mockito.mockingDetails(bar).getRealClass());
+	}
+
+	public static class Foo { }
+
+	public static interface Bar { }
+	
+	public static class Gork { }
+}


### PR DESCRIPTION
In some situations, it's useful to get from a mock object the original class object that was mocked to produce the mocked class. The logical place to provide this information is in the MockingDetails interface, and in the DefaultMockingDetails implementation. The method that provides this information should return a reasonable result if the object is either a mock, a spy, or neither.

This change adds the method to the interface and implementation, and also adds a unit test for DefaultMockingDetails which includes tests for this new method and some tests for some of the existing methods in the class.