### PR TITLE
Fix flaky test: TimeoutTest

### DIFF
--- a/src/org/mockito/internal/verification/DurationChecker.java
+++ b/src/org/mockito/internal/verification/DurationChecker.java
@@ -1,5 +1,0 @@
-package org.mockito.internal.verification;
-
-public interface DurationChecker {
-    boolean isVerificationStillInProgress(long startTime);
-}

--- a/src/org/mockito/internal/verification/Timer.java
+++ b/src/org/mockito/internal/verification/Timer.java
@@ -1,14 +1,14 @@
 package org.mockito.internal.verification;
 
-public class DurationCheckerImpl implements DurationChecker {
+public class Timer {
 
     private final long durationMillis;
 
-    public DurationCheckerImpl(long durationMillis) {
+    public Timer(long durationMillis) {
         this.durationMillis = durationMillis;
     }
 
-    public boolean isVerificationStillInProgress(long startTime) {
+    public boolean isUp(long startTime) {
         return System.currentTimeMillis() - startTime <= durationMillis;
     }
 }

--- a/src/org/mockito/internal/verification/VerificationOverTimeImpl.java
+++ b/src/org/mockito/internal/verification/VerificationOverTimeImpl.java
@@ -20,7 +20,7 @@ public class VerificationOverTimeImpl implements VerificationMode {
     private final long durationMillis;
     private final VerificationMode delegate;
     private final boolean returnOnSuccess;
-    private final DurationChecker durationChecker;
+    private final Timer timer;
     
     /**
      * Create this verification mode, to be used to verify invocation ongoing data later.
@@ -38,7 +38,7 @@ public class VerificationOverTimeImpl implements VerificationMode {
         this.durationMillis = durationMillis;
         this.delegate = delegate;
         this.returnOnSuccess = returnOnSuccess;
-        this.durationChecker = new DurationCheckerImpl(durationMillis);
+        this.timer = new Timer(durationMillis);
     }
 
     /**
@@ -51,14 +51,14 @@ public class VerificationOverTimeImpl implements VerificationMode {
      *                        {@link org.mockito.verification.VerificationWithTimeout}, or to only return once
      *                        the delegate is satisfied and the full duration has passed (as in
      *                        {@link org.mockito.verification.VerificationAfterDelay}).
-     * @param durationChecker Checker of whether the duration of the verification is still acceptable
+     * @param timer Checker of whether the duration of the verification is still acceptable
      */
-    public VerificationOverTimeImpl(long pollingPeriodMillis, long durationMillis, VerificationMode delegate, boolean returnOnSuccess, DurationChecker durationChecker) {
+    public VerificationOverTimeImpl(long pollingPeriodMillis, long durationMillis, VerificationMode delegate, boolean returnOnSuccess, Timer timer) {
         this.pollingPeriodMillis = pollingPeriodMillis;
         this.durationMillis = durationMillis;
         this.delegate = delegate;
         this.returnOnSuccess = returnOnSuccess;
-        this.durationChecker = durationChecker;
+        this.timer = timer;
     }
 
     /**
@@ -80,7 +80,7 @@ public class VerificationOverTimeImpl implements VerificationMode {
         AssertionError error = null;
         
         long startTime = System.currentTimeMillis();
-        while (durationChecker.isVerificationStillInProgress(startTime)) {
+        while (timer.isUp(startTime)) {
             try {
                 delegate.verify(data);
                 

--- a/src/org/mockito/verification/Timeout.java
+++ b/src/org/mockito/verification/Timeout.java
@@ -5,8 +5,7 @@
 package org.mockito.verification;
 
 import org.mockito.exceptions.Reporter;
-import org.mockito.internal.verification.DurationChecker;
-import org.mockito.internal.verification.DurationCheckerImpl;
+import org.mockito.internal.verification.Timer;
 import org.mockito.internal.verification.VerificationOverTimeImpl;
 /**
  * See the javadoc for {@link VerificationWithTimeout}
@@ -36,8 +35,8 @@ public class Timeout extends VerificationWrapper<VerificationOverTimeImpl> imple
     /**
      * See the javadoc for {@link VerificationWithTimeout}
      */
-    Timeout(long pollingPeriodMillis, long millis, VerificationMode delegate, DurationChecker durationChecker) {
-        super(new VerificationOverTimeImpl(pollingPeriodMillis, millis, delegate, true, durationChecker));
+    Timeout(long pollingPeriodMillis, long millis, VerificationMode delegate, Timer timer) {
+        super(new VerificationOverTimeImpl(pollingPeriodMillis, millis, delegate, true, timer));
     }
     
     @Override

--- a/test/org/mockito/internal/verification/TimerTest.java
+++ b/test/org/mockito/internal/verification/TimerTest.java
@@ -1,0 +1,36 @@
+package org.mockito.internal.verification;
+
+import org.junit.Test;
+import org.mockitoutil.TestBase;
+
+import static org.hamcrest.CoreMatchers.is;
+
+public class TimerTest extends TestBase {
+
+    @Test
+    public void should_return_true_if_task_is_in_acceptable_time_bounds() {
+        long duration = 10000L;
+        long now = System.currentTimeMillis();
+        Timer timer = new Timer(duration);
+
+        boolean isTimeUp = timer.isUp(now);
+
+        assertThat(isTimeUp, is(true));
+    }
+
+    @Test
+    public void should_return_false_if_task_is_outside_the_acceptable_time_bounds() {
+        long duration = 0L;
+        Timer timer = new Timer(duration);
+        long timeFromPast = generate_time_from_past();
+
+        boolean isTimeUp = timer.isUp(timeFromPast);
+
+        assertThat(isTimeUp, is(false));
+    }
+
+    long generate_time_from_past() {
+        return System.currentTimeMillis() - 10000L;
+    }
+
+}

--- a/test/org/mockito/verification/TimeoutTest.java
+++ b/test/org/mockito/verification/TimeoutTest.java
@@ -16,22 +16,24 @@ public class TimeoutTest extends TestBase {
     
     @Mock VerificationMode mode;
     @Mock VerificationDataImpl data;
-    @Mock DurationChecker durationChecker;
+    @Mock Timer timer;
     MockitoAssertionError error = new MockitoAssertionError(""); 
 
     @Test
     public void should_pass_when_verification_passes() {
-        Timeout t = new Timeout(1, 3, mode);
-        
+        Timeout t = new Timeout(1, 3, mode, timer);
+
+        when(timer.isUp(anyLong())).thenReturn(true, true, true, false);
         doNothing().when(mode).verify(data);
-        
+
         t.verify(data);
     }
     
     @Test
     public void should_fail_because_verification_fails() {
-        Timeout t = new Timeout(1, 2, mode);
-        
+        Timeout t = new Timeout(1, 2, mode, timer);
+
+        when(timer.isUp(anyLong())).thenReturn(true, true, true, false);
         doThrow(error).
         doThrow(error).
         doThrow(error).
@@ -45,8 +47,9 @@ public class TimeoutTest extends TestBase {
     
     @Test
     public void should_pass_even_if_first_verification_fails() {
-        Timeout t = new Timeout(1, 5, mode);
-        
+        Timeout t = new Timeout(1, 5, mode, timer);
+
+        when(timer.isUp(anyLong())).thenReturn(true, true, true, false);
         doThrow(error).
         doThrow(error).
         doNothing().
@@ -57,10 +60,10 @@ public class TimeoutTest extends TestBase {
 
     @Test
     public void should_try_to_verify_correct_number_of_times() {
-        Timeout t = new Timeout(10, 50, mode, durationChecker);
+        Timeout t = new Timeout(10, 50, mode, timer);
         
         doThrow(error).when(mode).verify(data);
-        when(durationChecker.isVerificationStillInProgress(anyLong())).thenReturn(true, true, true, true, true, false);
+        when(timer.isUp(anyLong())).thenReturn(true, true, true, true, true, false);
 
         try {
             t.verify(data);
@@ -72,7 +75,7 @@ public class TimeoutTest extends TestBase {
     
     @Test
     public void should_create_correctly_configured_timeout() {
-        Timeout t = new Timeout(25, 50, mode);
+        Timeout t = new Timeout(25, 50, mode, timer);
         
         assertTimeoutCorrectlyConfigured(t.atLeastOnce(), Timeout.class, 50, 25, AtLeast.class);
         assertTimeoutCorrectlyConfigured(t.atLeast(5), Timeout.class, 50, 25, AtLeast.class);


### PR DESCRIPTION
The discussion about the flickering test is present here - https://groups.google.com/forum/#!topic/mockito-dev/lDbmq9X622Y

Just as a reminder:

> Hey 
> 
> Build failed due to a fluke I think: 
> 
> org.mockito.verification.TimeoutTest > 
> should_try_to_verify_correct_number_of_times FAILED 
> 
> ```
> org.mockito.exceptions.verification.TooManyActualInvocations at 
> ```
> 
> TimeoutTest.java:71 
> 
> The test seems to be flaky? 
> 
> If someone can push DUMMY_COMMIT.txt to force the build and make it 
> green again; and take a look into the test and make it more stable 
> that would be most awesome :) 
> ## Cheers! 
> 
> Szczepan Faber 
