### PR TITLE
bdd mockito cleanup

### DIFF
--- a/src/org/mockito/BDDMockito.java
+++ b/src/org/mockito/BDDMockito.java
@@ -127,6 +127,9 @@ public class BDDMockito extends Mockito {
         <M> M getMock();
     }
 
+    /**
+     * @deprecated not part of the public API, use {@link BDDMyOngoingStubbing} instead.
+     */
     public static class BDDOngoingStubbingImpl<T> implements BDDMyOngoingStubbing<T> {
 
         private final OngoingStubbing<T> mockitoOngoingStubbing;
@@ -226,6 +229,7 @@ public class BDDMockito extends Mockito {
 
         /**
          * @see #verify(Object)
+         * @since 1.10.5
          */
         public T should() {
             return verify(mock);
@@ -233,6 +237,7 @@ public class BDDMockito extends Mockito {
 
         /**
          * @see #verify(Object, VerificationMode)
+         * @since 1.10.5
          */
         public T should(VerificationMode mode) {
             return verify(mock, mode);
@@ -287,6 +292,9 @@ public class BDDMockito extends Mockito {
         <T> T given(T mock);
     }
 
+    /**
+     * @deprecated not part of the public API, use {@link BDDStubber} instead.
+     */
     public static class BDDStubberImpl implements BDDStubber {
 
         private final Stubber mockitoStubber;


### PR DESCRIPTION
> I'd love a PR with: 
> 1. New feature highlighted on the main Mockito class (add an item to the bottom of the list, for example: "(new) Fluent BDD alias for verification"). 
> 2. Deprecate 'Then' class. Introduce 'Then' interface (you can create a new package org.mockito.bdd) that the 'Then' class can implement for now. 
> 3. Extra credit: also deprecate other concrete classes that leak from the top level BDDMockito 
> 4. Javadoc for deprecate class includes a deprecation reason 
> 5. Ensure new API that you have introduced contains @since information.
1. has already been solved in the original pull request.
   I haven't introduced the Then interface yet. How are other interfaces going to be solved?
