### PR TITLE
Fixes issue #99 : RETURNS_DEEP_STUBS automatically tries to create serializable mocks

### DIFF
--- a/test/org/mockitousage/bugs/DeepStubsWronglyReportsSerializationProblemsTest.java
+++ b/test/org/mockitousage/bugs/DeepStubsWronglyReportsSerializationProblemsTest.java
@@ -1,0 +1,32 @@
+package org.mockitousage.bugs;
+
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+
+/**
+ * In GH issue 99 : https://github.com/mockito/mockito/issues/99
+ */
+public class DeepStubsWronglyReportsSerializationProblemsTest {
+
+    @Test
+    public void should_not_raise_a_mockito_exception_about_serialization_when_accessing_deep_stub() {
+        NotSerializableShouldBeMocked the_deep_stub = mock(ToBeDeepStubbed.class, RETURNS_DEEP_STUBS).getSomething();
+        assertThat(the_deep_stub).isNotNull();
+    }
+
+    public static class ToBeDeepStubbed {
+        public ToBeDeepStubbed() { }
+
+        public NotSerializableShouldBeMocked getSomething() {
+            return null;
+        }
+    }
+
+    public static class NotSerializableShouldBeMocked {
+        NotSerializableShouldBeMocked(String mandatory_param) { }
+    }
+
+}


### PR DESCRIPTION
See issue #99 

What it does is propagating the serializing mode of the parent, upon each mock creation when deep stubbing.

Before each mock created where made serializable by default. Which is not an issue when the types have a default no arg constructor, but may become problematic when the type didn't have one, Mockito would report an error explaining that it couldn't mock this type.
