### PR TITLE
Improved exception handling of AdditionalAnswers#delegatesTo

### DIFF
--- a/src/org/mockito/internal/stubbing/defaultanswers/ForwardsInvocations.java
+++ b/src/org/mockito/internal/stubbing/defaultanswers/ForwardsInvocations.java
@@ -8,6 +8,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.io.Serializable;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 /**
@@ -28,6 +29,11 @@ public class ForwardsInvocations implements Answer<Object>, Serializable {
 	public Object answer(InvocationOnMock invocation) throws Throwable {
 		Method method = invocation.getMethod() ;
 
-        return method.invoke(delegatedObject, invocation.getArguments());
-	}
+        try {
+            return method.invoke(delegatedObject, invocation.getArguments());
+        } catch (InvocationTargetException e) {
+            // propagate the original exception from the delegate
+            throw e.getCause();
+        }
+    }
 }

--- a/test/org/mockitousage/stubbing/StubbingWithDelegate.java
+++ b/test/org/mockitousage/stubbing/StubbingWithDelegate.java
@@ -74,4 +74,22 @@ public class StubbingWithDelegate {
             assertThat(e.toString()).doesNotContain("org.mockito");
         }
     }
+
+    @Test
+    public void exception_should_be_propagated_from_delegate() throws Exception {
+        final RuntimeException failure = new RuntimeException("angry-method");
+        IMethods methods = mock(IMethods.class, delegatesTo(new MethodsImpl() {
+            @Override
+            public String simpleMethod() {
+                throw failure;
+            }
+        }));
+
+        try {
+            methods.simpleMethod(); // delegate throws an exception
+            fail();
+        } catch (RuntimeException e) {
+            assertThat(e).isEqualTo(failure);
+        }
+    }
 }


### PR DESCRIPTION
When using the AdditionalAnswers#delegatesTo method, exceptions thrown by the delegate are wrapped in InvocationTargetException due to invocation via Method.
Instead, the original exception from the delegate should be propagated to the caller.
