### PR TITLE
Allow delegateTo to delegate to any class that has the required methods

### DIFF
--- a/src/org/mockito/exceptions/Reporter.java
+++ b/src/org/mockito/exceptions/Reporter.java
@@ -22,12 +22,11 @@ import org.mockito.invocation.Invocation;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.invocation.Location;
 import org.mockito.listeners.InvocationListener;
-
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
 import static org.mockito.internal.reporting.Pluralizer.pluralize;
 import static org.mockito.internal.util.StringJoiner.join;
 
@@ -767,4 +766,24 @@ public class Reporter {
                 ""
         ));
     }
+    
+    public void delegatedMethodHasWrongReturnType(Method mockMethod, Method delegateMethod, Object mock, Object delegate) {
+    	throw new MockitoException(join(
+    	        "Methods called on delegated instance must have compatible return types with the mock.",
+    	        "When calling: " + mockMethod + " on mock: " + new MockUtil().getMockName(mock),
+    	        "return type should be: " + mockMethod.getReturnType().getSimpleName() + ", but was: " + delegateMethod.getReturnType().getSimpleName(),
+    	        "Check that the instance passed to delegatesTo() is of the correct type or contains compatible methods",
+    	        "(delegate instance had type: " + delegate.getClass().getSimpleName() + ")"
+    	));
+    }
+
+	public void delegatedMethodDoesNotExistOnDelegate(Method mockMethod, Object mock, Object delegate) {
+		throw new MockitoException(join(
+    	        "Methods called on mock must exist in delegated instance.",
+    	        "When calling: " + mockMethod + " on mock: " + new MockUtil().getMockName(mock),
+    	        "no such method was found.",
+    	        "Check that the instance passed to delegatesTo() is of the correct type or contains compatible methods",
+    	        "(delegate instance had type: " + delegate.getClass().getSimpleName() + ")"
+    	));
+	}
 }

--- a/test/org/mockitousage/stubbing/StubbingWithDelegate.java
+++ b/test/org/mockitousage/stubbing/StubbingWithDelegate.java
@@ -132,7 +132,7 @@ public class StubbingWithDelegate {
             mock.isEmpty();
             fail();
         } catch (MockitoException e) {
-            assertThat(e.toString()).contains("Method not found on delegate");
+            assertThat(e.toString()).contains("Methods called on mock must exist");
         }
     }
     
@@ -144,7 +144,7 @@ public class StubbingWithDelegate {
             mock.size();
             fail();
         } catch (MockitoException e) {
-            assertThat(e.toString()).contains("Incompatible return type on delegate method");
+            assertThat(e.toString()).contains("Methods called on delegated instance must have compatible return type");
         }
     }
     
@@ -156,9 +156,9 @@ public class StubbingWithDelegate {
             mock.subList(0, 0);
             fail();
         } catch (MockitoException e) {
-            assertThat(e.toString()).contains("Incompatible return type on delegate method");
+            assertThat(e.toString()).contains("Methods called on delegated instance must have compatible return type");
         }
-	}
+    }
 
     @Test
     public void exception_should_be_propagated_from_delegate() throws Exception {


### PR DESCRIPTION
This allows using `delegatesTo` with instances that are not instances of the mocked class, as long as they have methods of the required signatures. This allows the creation of fake objects of classes that contain many unneeded methods (Issue #112).
