### PR TITLE
Calling real methods automatically deals with abstract methods

### DIFF
--- a/src/org/mockito/internal/stubbing/answers/CallsRealMethods.java
+++ b/src/org/mockito/internal/stubbing/answers/CallsRealMethods.java
@@ -5,7 +5,9 @@
 package org.mockito.internal.stubbing.answers;
 
 import java.io.Serializable;
+import java.lang.reflect.Modifier;
 
+import org.mockito.internal.stubbing.defaultanswers.GloballyConfiguredAnswer;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -33,6 +35,9 @@ public class CallsRealMethods implements Answer<Object>, Serializable {
     private static final long serialVersionUID = 9057165148930624087L;
 
     public Object answer(InvocationOnMock invocation) throws Throwable {
+    	if (Modifier.isAbstract(invocation.getMethod().getModifiers())) {
+    		return new GloballyConfiguredAnswer().answer(invocation);
+    	}
         return invocation.callRealMethod();
     }
 }

--- a/test/org/mockitousage/constructor/CreatingMocksWithConstructorTest.java
+++ b/test/org/mockitousage/constructor/CreatingMocksWithConstructorTest.java
@@ -1,6 +1,7 @@
 package org.mockitousage.constructor;
 
-import org.junit.Ignore;
+import java.util.List;
+
 import org.junit.Test;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.mock.SerializableMode;
@@ -97,5 +98,31 @@ public class CreatingMocksWithConstructorTest extends TestBase {
         } catch (MockitoException e) {
             assertEquals("Mocks instantiated with constructor cannot be combined with " + SerializableMode.ACROSS_CLASSLOADERS + " serialization mode.", e.getMessage());
         }
+    }
+
+    static abstract class AbstractThing {
+    	abstract String name();
+    	String fullName() {
+    		return "abstract " + name();
+    	}
+    }
+    
+    @Test
+    public void abstractMethodReturnsDefault() {
+    	AbstractThing thing = spy(AbstractThing.class);
+    	assertEquals("abstract null", thing.fullName());
+    }
+    
+    @Test
+    public void abstractMethodStubbed() {
+    	AbstractThing thing = spy(AbstractThing.class);
+    	when(thing.name()).thenReturn("me");
+    	assertEquals("abstract me", thing.fullName());
+    }
+ 
+    @Test
+    public void testCallsRealInterfaceMethod() {
+    	List<String> list = mock(List.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+    	assertNull(list.get(1));
     }
 }


### PR DESCRIPTION
As discussed previously, changing CALLS_REAL_METHOD to delegate to default answer when the method is abstract. This makes spy() more useful.
