### PR TITLE
Fix anyX() methods to not match nulls

### DIFF
--- a/src/org/mockito/Matchers.java
+++ b/src/org/mockito/Matchers.java
@@ -50,13 +50,6 @@ import java.util.Set;
  * This implementation is due static type safety imposed by java compiler.
  * The consequence is that you cannot use <code>anyObject()</code>, <code>eq()</code> methods outside of verified/stubbed method.
  *
- * <p>
- * <b>Warning 2:</b>
- * <p>
- * The any family methods <b>*don't do any type checks*</b>, those are only here to avoid casting
- * in your code. If you want to perform type checks use the {@link #isA(Class)} method.
- * This <b>might</b> however change (type checks could be added) in a future major release.
- *
  * <h1>Custom Argument Matchers</h1>
  * 
  * Use {@link Matchers#argThat} method and pass an instance of hamcrest {@link Matcher}.
@@ -107,11 +100,7 @@ public class Matchers {
     private static final MockingProgress MOCKING_PROGRESS = new ThreadSafeMockingProgress();
 
     /**
-     * Any <code>boolean</code>, <code>Boolean</code> or <code>null</code>.
-     * <p>
-     * This method <b>*don't do any type checks*</b>, it is only there to avoid casting
-     * in your code. This might however change (type checks could be added) in a
-     * future major release.
+     * Any <code>boolean</code> or non-null <code>Boolean</code>
      * <p>
      * See examples in javadoc for {@link Matchers} class
      * 
@@ -122,11 +111,7 @@ public class Matchers {
     }
 
     /**
-     * Any <code>byte</code>, <code>Byte</code> or <code>null</code>.
-     * <p>
-     * This method <b>*don't do any type checks*</b>, it is only there to avoid casting
-     * in your code. This might however change (type checks could be added) in a
-     * future major release.
+     * Any <code>byte</code> or non-null <code>Byte</code>.
      * <p>
      * See examples in javadoc for {@link Matchers} class
      * 
@@ -137,11 +122,7 @@ public class Matchers {
     }
 
     /**
-     * Any <code>char</code>, <code>Character</code> or <code>null</code>.
-     * <p>
-     * This method <b>*don't do any type checks*</b>, it is only there to avoid casting
-     * in your code. This might however change (type checks could be added) in a
-     * future major release.
+     * Any <code>char</code> or non-null <code>Character</code>.
      * <p>
      * See examples in javadoc for {@link Matchers} class
      * 
@@ -152,11 +133,7 @@ public class Matchers {
     }
 
     /**
-     * Any int, Integer or <code>null</code>.
-     * <p>
-     * This method <b>*don't do any type checks*</b>, it is only there to avoid casting
-     * in your code. This might however change (type checks could be added) in a
-     * future major release.
+     * Any int or non-null Integer.
      * <p>
      * See examples in javadoc for {@link Matchers} class
      * 
@@ -167,11 +144,7 @@ public class Matchers {
     }
 
     /**
-     * Any <code>long</code>, <code>Long</code> or <code>null</code>.
-     * <p>
-     * This method <b>*don't do any type checks*</b>, it is only there to avoid casting
-     * in your code. This might however change (type checks could be added) in a
-     * future major release.
+     * Any <code>long</code> or non-null <code>Long</code>.
      * <p>
      * See examples in javadoc for {@link Matchers} class
      * 
@@ -182,11 +155,7 @@ public class Matchers {
     }
 
     /**
-     * Any <code>float</code>, <code>Float</code> or <code>null</code>.
-     * <p>
-     * This method <b>*don't do any type checks*</b>, it is only there to avoid casting
-     * in your code. This might however change (type checks could be added) in a
-     * future major release.
+     * Any <code>float</code> or non-null <code>Float</code>.
      * <p>
      * See examples in javadoc for {@link Matchers} class
      * 
@@ -197,11 +166,7 @@ public class Matchers {
     }
 
     /**
-     * Any <code>double</code>, <code>Double</code> or <code>null</code>.
-     * <p>
-     * This method <b>*don't do any type checks*</b>, it is only there to avoid casting
-     * in your code. This might however change (type checks could be added) in a
-     * future major release.
+     * Any <code>double</code> or non-null <code>Double</code>.
      * <p>
      * See examples in javadoc for {@link Matchers} class
      * 
@@ -212,11 +177,7 @@ public class Matchers {
     }
 
     /**
-     * Any <code>short</code>, <code>Short</code> or <code>null</code>.
-     * <p>
-     * This method <b>*don't do any type checks*</b>, it is only there to avoid casting
-     * in your code. This might however change (type checks could be added) in a
-     * future major release.
+     * Any <code>short</code> or non-null <code>Short</code>.
      * <p>
      * See examples in javadoc for {@link Matchers} class
      * 
@@ -227,13 +188,9 @@ public class Matchers {
     }
 
     /**
-     * Any <code>Object</code> or <code>null</code>.
+     * Matches anything, including null.
      * <p>
-     * This method <b>*don't do any type checks*</b>, it is only there to avoid casting
-     * in your code. This might however change (type checks could be added) in a
-     * future major release.
-     * <p>
-     * Has aliases: {@link #any()} and {@link #any(Class clazz)}
+     * This is an alias of: {@link #any()} and {@link #any(java.lang.Class)}
      * <p>
      * See examples in javadoc for {@link Matchers} class
      * 
@@ -271,20 +228,16 @@ public class Matchers {
     }
     
     /**
-     * Any kind object, not necessary of the given class.
-     * The class argument is provided only to avoid casting.
+     * Matches any object, including nulls
      * <p>
-     * Sometimes looks better than <code>anyObject()</code> - especially when explicit casting is required
-     * <p>
-     * Alias to {@link Matchers#anyObject()}
-     * <p>
-     * This method <b>*don't do any type checks*</b>, it is only there to avoid casting
-     * in your code. This might however change (type checks could be added) in a
-     * future major release.
+     * This method doesn't do type checks with the given parameter, it is only there
+     * to avoid casting in your code. This might however change (type checks could
+     * be added) in a future major release.
      * <p>
      * See examples in javadoc for {@link Matchers} class
-     * 
-     * @param clazz The type to avoid casting
+     * <p>
+     * This is an alias of: {@link #any()} and {@link #anyObject()}
+     * <p>
      * @return <code>null</code>.
      */
     public static <T> T any(Class<T> clazz) {
@@ -292,16 +245,14 @@ public class Matchers {
     }
     
     /**
-     * Any object or <code>null</code>.
+     * Matches anything, including nulls
      * <p>
      * Shorter alias to {@link Matchers#anyObject()}
      * <p>
-     * This method <b>*don't do any type checks*</b>, it is only there to avoid casting
-     * in your code. This might however change (type checks could be added) in a
-     * future major release.
-     * <p>
      * See examples in javadoc for {@link Matchers} class
-     * 
+     * <p>
+     * This is an alias of: {@link #anyObject()} and {@link #any(java.lang.Class)}
+     * <p>
      * @return <code>null</code>.
      */
     public static <T> T any() {
@@ -309,11 +260,7 @@ public class Matchers {
     }
 
     /**
-     * Any <code>String</code> or <code>null</code>.
-     * <p>
-     * This method <b>*don't do any type checks*</b>, it is only there to avoid casting
-     * in your code. This might however change (type checks could be added) in a
-     * future major release.
+     * Any non-null <code>String</code>
      * <p>
      * See examples in javadoc for {@link Matchers} class
      * 
@@ -324,11 +271,7 @@ public class Matchers {
     }
     
     /**
-     * Any <code>List</code> or <code>null</code>.
-     * <p>
-     * This method <b>*don't do any type checks*</b>, it is only there to avoid casting
-     * in your code. This might however change (type checks could be added) in a
-     * future major release.
+     * Any non-null <code>List</code>.
      * <p>
      * See examples in javadoc for {@link Matchers} class
      * 
@@ -336,17 +279,17 @@ public class Matchers {
      */
     public static List anyList() {
         return reportMatcher(new InstanceOf(List.class)).returnList();
-    }    
+    }
     
     /**
      * Generic friendly alias to {@link Matchers#anyList()}.
      * It's an alternative to &#064;SuppressWarnings("unchecked") to keep code clean of compiler warnings.
      * <p>
-     * Any <code>List</code> or <code>null</code>.
+     * Any non-null <code>List</code>.
      * <p>
-     * This method <b>*don't do any type checks*</b>, it is only there to avoid casting
-     * in your code. This might however change (type checks could be added) in a
-     * future major release.
+     * This method doesn't do type checks with the given parameter, it is only there
+     * to avoid casting in your code. This might however change (type checks could
+     * be added) in a future major release.
      * <p>
      * See examples in javadoc for {@link Matchers} class
      * 
@@ -355,14 +298,10 @@ public class Matchers {
      */
     public static <T> List<T> anyListOf(Class<T> clazz) {
         return anyList();
-    }    
+    }
     
     /**
-     * Any <code>Set</code> or <code>null</code>.
-     * <p>
-     * This method <b>*don't do any type checks*</b>, it is only there to avoid casting
-     * in your code. This might however change (type checks could be added) in a
-     * future major release.
+     * Any non-null <code>Set</code>.
      * <p>
      * See examples in javadoc for {@link Matchers} class
      *
@@ -376,11 +315,11 @@ public class Matchers {
      * Generic friendly alias to {@link Matchers#anySet()}.
      * It's an alternative to &#064;SuppressWarnings("unchecked") to keep code clean of compiler warnings.
      * <p>
-     * Any <code>Set</code> or <code>null</code>
+     * Any non-null <code>Set</code>.
      * <p>
-     * This method <b>*don't do any type checks*</b>, it is only there to avoid casting
-     * in your code. This might however change (type checks could be added) in a
-     * future major release.
+     * This method doesn't do type checks with the given parameter, it is only there
+     * to avoid casting in your code. This might however change (type checks could
+     * be added) in a future major release.
      * <p>
      * See examples in javadoc for {@link Matchers} class
      *
@@ -392,11 +331,7 @@ public class Matchers {
     }
 
     /**
-     * Any <code>Map</code> or <code>null</code>.
-     * <p>
-     * This method <b>*don't do any type checks*</b>, it is only there to avoid casting
-     * in your code. This might however change (type checks could be added) in a
-     * future major release.
+     * Any non-null <code>Map</code>.
      * <p>
      * See examples in javadoc for {@link Matchers} class
      * 
@@ -410,11 +345,11 @@ public class Matchers {
      * Generic friendly alias to {@link Matchers#anyMap()}.
      * It's an alternative to &#064;SuppressWarnings("unchecked") to keep code clean of compiler warnings.
      * <p>
-     * Any <code>Map</code> or <code>null</code>
+     * Any non-null <code>Map</code>.
      * <p>
-     * This method <b>*don't do any type checks*</b>, it is only there to avoid casting
-     * in your code. This might however change (type checks could be added) in a
-     * future major release.
+     * This method doesn't do type checks with the given parameter, it is only there
+     * to avoid casting in your code. This might however change (type checks could
+     * be added) in a future major release.
      * <p>
      * See examples in javadoc for {@link Matchers} class
      *
@@ -427,11 +362,7 @@ public class Matchers {
     }
     
     /**
-     * Any <code>Collection</code> or <code>null</code>.
-     * <p>
-     * This method <b>*don't do any type checks*</b>, it is only there to avoid casting
-     * in your code. This might however change (type checks could be added) in a
-     * future major release.
+     * Any non-null <code>Collection</code>.
      * <p>
      * See examples in javadoc for {@link Matchers} class
      * 
@@ -443,13 +374,13 @@ public class Matchers {
     
     /**
      * Generic friendly alias to {@link Matchers#anyCollection()}.
-     * It's an alternative to &#064;SuppressWarnings("unchecked") to keep code clean of compiler warnings.     
+     * It's an alternative to &#064;SuppressWarnings("unchecked") to keep code clean of compiler warnings.
      * <p>
-     * Any <code>Collection</code> or <code>null</code>.
+     * Any non-null <code>Collection</code>.
      * <p>
-     * This method <b>*don't do any type checks*</b>, it is only there to avoid casting
-     * in your code. This might however change (type checks could be added) in a
-     * future major release.
+     * This method doesn't do type checks with the given parameter, it is only there
+     * to avoid casting in your code. This might however change (type checks could
+     * be added) in a future major release.
      * <p>
      * See examples in javadoc for {@link Matchers} class
      * 

--- a/src/org/mockito/Matchers.java
+++ b/src/org/mockito/Matchers.java
@@ -5,7 +5,6 @@
 package org.mockito;
 
 import org.hamcrest.Matcher;
-import org.hamcrest.core.IsNull;
 import org.mockito.internal.matchers.*;
 import org.mockito.internal.matchers.apachecommons.ReflectionEquals;
 import org.mockito.internal.progress.HandyReturnValues;
@@ -241,7 +240,7 @@ public class Matchers {
      * @return <code>null</code>.
      */
     public static <T> T anyObject() {
-        return (T) reportMatcher(new InstanceOf(Object.class)).returnNull();
+        return (T) reportMatcher(Any.ANY).returnNull();
     }
 
     /**
@@ -289,7 +288,7 @@ public class Matchers {
      * @return <code>null</code>.
      */
     public static <T> T any(Class<T> clazz) {
-        return (T) reportMatcher(new InstanceOf(clazz)).returnFor(clazz);
+        return (T) reportMatcher(Any.ANY).returnFor(clazz);
     }
     
     /**
@@ -306,7 +305,7 @@ public class Matchers {
      * @return <code>null</code>.
      */
     public static <T> T any() {
-        return (T) reportMatcher(Any.ANY).returnNull();
+        return anyObject();
     }
 
     /**

--- a/src/org/mockito/Matchers.java
+++ b/src/org/mockito/Matchers.java
@@ -5,6 +5,7 @@
 package org.mockito;
 
 import org.hamcrest.Matcher;
+import org.hamcrest.core.IsNull;
 import org.mockito.internal.matchers.*;
 import org.mockito.internal.matchers.apachecommons.ReflectionEquals;
 import org.mockito.internal.progress.HandyReturnValues;
@@ -118,7 +119,7 @@ public class Matchers {
      * @return <code>false</code>.
      */
     public static boolean anyBoolean() {
-        return reportMatcher(Any.ANY).returnFalse();
+        return reportMatcher(new InstanceOf(Boolean.class)).returnFalse();
     }
 
     /**
@@ -133,7 +134,7 @@ public class Matchers {
      * @return <code>0</code>.
      */
     public static byte anyByte() {
-        return reportMatcher(Any.ANY).returnZero();
+        return reportMatcher(new InstanceOf(Byte.class)).returnZero();
     }
 
     /**
@@ -148,7 +149,7 @@ public class Matchers {
      * @return <code>0</code>.
      */
     public static char anyChar() {
-        return reportMatcher(Any.ANY).returnChar();
+        return reportMatcher(new InstanceOf(Character.class)).returnChar();
     }
 
     /**
@@ -163,7 +164,7 @@ public class Matchers {
      * @return <code>0</code>.
      */
     public static int anyInt() {
-        return reportMatcher(Any.ANY).returnZero();
+        return reportMatcher(new InstanceOf(Integer.class)).returnZero();
     }
 
     /**
@@ -178,7 +179,7 @@ public class Matchers {
      * @return <code>0</code>.
      */
     public static long anyLong() {
-        return reportMatcher(Any.ANY).returnZero();
+        return reportMatcher(new InstanceOf(Long.class)).returnZero();
     }
 
     /**
@@ -193,7 +194,7 @@ public class Matchers {
      * @return <code>0</code>.
      */
     public static float anyFloat() {
-        return reportMatcher(Any.ANY).returnZero();
+        return reportMatcher(new InstanceOf(Float.class)).returnZero();
     }
 
     /**
@@ -208,7 +209,7 @@ public class Matchers {
      * @return <code>0</code>.
      */
     public static double anyDouble() {
-        return reportMatcher(Any.ANY).returnZero();
+        return reportMatcher(new InstanceOf(Double.class)).returnZero();
     }
 
     /**
@@ -223,7 +224,7 @@ public class Matchers {
      * @return <code>0</code>.
      */
     public static short anyShort() {
-        return reportMatcher(Any.ANY).returnZero();
+        return reportMatcher(new InstanceOf(Short.class)).returnZero();
     }
 
     /**
@@ -240,7 +241,7 @@ public class Matchers {
      * @return <code>null</code>.
      */
     public static <T> T anyObject() {
-        return (T) reportMatcher(Any.ANY).returnNull();
+        return (T) reportMatcher(new InstanceOf(Object.class)).returnNull();
     }
 
     /**
@@ -288,7 +289,7 @@ public class Matchers {
      * @return <code>null</code>.
      */
     public static <T> T any(Class<T> clazz) {
-        return (T) reportMatcher(Any.ANY).returnFor(clazz);
+        return (T) reportMatcher(new InstanceOf(clazz)).returnFor(clazz);
     }
     
     /**
@@ -305,7 +306,7 @@ public class Matchers {
      * @return <code>null</code>.
      */
     public static <T> T any() {
-        return (T) anyObject();
+        return (T) reportMatcher(Any.ANY).returnNull();
     }
 
     /**
@@ -320,7 +321,7 @@ public class Matchers {
      * @return empty String ("")
      */
     public static String anyString() {
-        return reportMatcher(Any.ANY).returnString();
+        return reportMatcher(new InstanceOf(String.class)).returnString();
     }
     
     /**
@@ -335,7 +336,7 @@ public class Matchers {
      * @return empty List.
      */
     public static List anyList() {
-        return reportMatcher(Any.ANY).returnList();
+        return reportMatcher(new InstanceOf(List.class)).returnList();
     }    
     
     /**
@@ -354,7 +355,7 @@ public class Matchers {
      * @return empty List.
      */
     public static <T> List<T> anyListOf(Class<T> clazz) {
-        return (List) reportMatcher(Any.ANY).returnList();
+        return anyList();
     }    
     
     /**
@@ -369,7 +370,7 @@ public class Matchers {
      * @return empty Set
      */
     public static Set anySet() {
-        return reportMatcher(Any.ANY).returnSet();
+        return reportMatcher(new InstanceOf(Set.class)).returnSet();
     }
     
     /**
@@ -388,7 +389,7 @@ public class Matchers {
      * @return empty Set
      */
     public static <T> Set<T> anySetOf(Class<T> clazz) {
-        return (Set) reportMatcher(Any.ANY).returnSet();
+        return anySet();
     }
 
     /**
@@ -403,7 +404,7 @@ public class Matchers {
      * @return empty Map.
      */
     public static Map anyMap() {
-        return reportMatcher(Any.ANY).returnMap();
+        return reportMatcher(new InstanceOf(Map.class)).returnMap();
     }
 
     /**
@@ -423,7 +424,7 @@ public class Matchers {
      * @return empty Map.
      */
     public static <K, V>  Map<K, V> anyMapOf(Class<K> keyClazz, Class<V> valueClazz) {
-        return reportMatcher(Any.ANY).returnMap();
+        return anyMap();
     }
     
     /**
@@ -438,7 +439,7 @@ public class Matchers {
      * @return empty Collection.
      */
     public static Collection anyCollection() {
-        return reportMatcher(Any.ANY).returnList();
+        return reportMatcher(new InstanceOf(Collection.class)).returnList();
     }    
     
     /**
@@ -457,7 +458,7 @@ public class Matchers {
      * @return empty Collection.
      */
     public static <T> Collection<T> anyCollectionOf(Class<T> clazz) {
-        return (Collection) reportMatcher(Any.ANY).returnList();
+        return anyCollection();
     }    
 
     /**

--- a/src/org/mockito/internal/matchers/Any.java
+++ b/src/org/mockito/internal/matchers/Any.java
@@ -14,7 +14,7 @@ import org.mockito.ArgumentMatcher;
 public class Any extends ArgumentMatcher implements Serializable {
 
     private static final long serialVersionUID = -4062420125651019029L;
-    public static final Any ANY = new Any();    
+    public static final Any ANY = new Any();
     
     private Any() {}
     

--- a/test/org/mockitousage/IMethods.java
+++ b/test/org/mockitousage/IMethods.java
@@ -219,4 +219,6 @@ public interface IMethods {
     int toIntPrimitive(Integer i);
 
     Integer toIntWrapper(int i);
+
+    String forObject(Object object);
 }

--- a/test/org/mockitousage/MethodsImpl.java
+++ b/test/org/mockitousage/MethodsImpl.java
@@ -418,4 +418,8 @@ public class MethodsImpl implements IMethods {
     public Integer toIntWrapper(int i) {
         return null;
     }
+
+    public String forObject(Object object) {
+        return null;
+    }
 }

--- a/test/org/mockitousage/matchers/AnyXMatchersAcceptNullsTest.java
+++ b/test/org/mockitousage/matchers/AnyXMatchersAcceptNullsTest.java
@@ -41,7 +41,7 @@ public class AnyXMatchersAcceptNullsTest extends TestBase {
     }
     
     @Test
-    public void shouldAnyPrimiteWraperMatchersAcceptNull() {
+    public void shouldAcceptNullsInAllPrimitiveWrapperAnyMatchers() {
         when(mock.forInteger(anyInt())).thenReturn("0");
         when(mock.forCharacter(anyChar())).thenReturn("1");
         when(mock.forShort(anyShort())).thenReturn("2");

--- a/test/org/mockitousage/matchers/AnyXMatchersAcceptNullsTest.java
+++ b/test/org/mockitousage/matchers/AnyXMatchersAcceptNullsTest.java
@@ -24,13 +24,26 @@ public class AnyXMatchersAcceptNullsTest extends TestBase {
     }
 
     @Test
+    public void shouldAcceptNullsInAnyMatcher() {
+        when(mock.oneArg(any())).thenReturn("matched");
+
+        assertEquals(null, mock.forObject(null));
+    }
+
+    @Test
+    public void shouldAcceptNullsInAnyObjectMatcher() {
+        when(mock.oneArg(anyObject())).thenReturn("matched");
+
+        assertEquals(null, mock.forObject(null));
+    }
+
+    @Test
     public void shouldNotAcceptNullInAnyXMatchers() {
-        when(mock.oneArg(anyObject())).thenReturn("0");
-        when(mock.oneArg(anyString())).thenReturn("1");
-        when(mock.forList(anyList())).thenReturn("2");
-        when(mock.forMap(anyMap())).thenReturn("3");
-        when(mock.forCollection(anyCollection())).thenReturn("4");
-        when(mock.forSet(anySet())).thenReturn("5");
+        when(mock.oneArg(anyString())).thenReturn("0");
+        when(mock.forList(anyList())).thenReturn("1");
+        when(mock.forMap(anyMap())).thenReturn("2");
+        when(mock.forCollection(anyCollection())).thenReturn("3");
+        when(mock.forSet(anySet())).thenReturn("4");
         
         assertEquals(null, mock.oneArg((Object) null));
         assertEquals(null, mock.oneArg((String) null));

--- a/test/org/mockitousage/matchers/AnyXMatchersAcceptNullsTest.java
+++ b/test/org/mockitousage/matchers/AnyXMatchersAcceptNullsTest.java
@@ -24,7 +24,7 @@ public class AnyXMatchersAcceptNullsTest extends TestBase {
     }
 
     @Test
-    public void shouldAnyXMatchersAcceptNull() {
+    public void shouldNotAcceptNullInAnyXMatchers() {
         when(mock.oneArg(anyObject())).thenReturn("0");
         when(mock.oneArg(anyString())).thenReturn("1");
         when(mock.forList(anyList())).thenReturn("2");
@@ -32,16 +32,16 @@ public class AnyXMatchersAcceptNullsTest extends TestBase {
         when(mock.forCollection(anyCollection())).thenReturn("4");
         when(mock.forSet(anySet())).thenReturn("5");
         
-        assertEquals("0", mock.oneArg((Object) null));
-        assertEquals("1", mock.oneArg((String) null));
-        assertEquals("2", mock.forList(null));
-        assertEquals("3", mock.forMap(null));
-        assertEquals("4", mock.forCollection(null));
-        assertEquals("5", mock.forSet(null));
+        assertEquals(null, mock.oneArg((Object) null));
+        assertEquals(null, mock.oneArg((String) null));
+        assertEquals(null, mock.forList(null));
+        assertEquals(null, mock.forMap(null));
+        assertEquals(null, mock.forCollection(null));
+        assertEquals(null, mock.forSet(null));
     }
     
     @Test
-    public void shouldAcceptNullsInAllPrimitiveWrapperAnyMatchers() {
+    public void shouldNotAcceptNullInAllAnyPrimitiveWrapperMatchers() {
         when(mock.forInteger(anyInt())).thenReturn("0");
         when(mock.forCharacter(anyChar())).thenReturn("1");
         when(mock.forShort(anyShort())).thenReturn("2");
@@ -51,13 +51,13 @@ public class AnyXMatchersAcceptNullsTest extends TestBase {
         when(mock.forFloat(anyFloat())).thenReturn("6");
         when(mock.forDouble(anyDouble())).thenReturn("7");
         
-        assertEquals("0", mock.forInteger(null));
-        assertEquals("1", mock.forCharacter(null));
-        assertEquals("2", mock.forShort(null));
-        assertEquals("3", mock.forByte(null));
-        assertEquals("4", mock.forBoolean(null));
-        assertEquals("5", mock.forLong(null));
-        assertEquals("6", mock.forFloat(null));
-        assertEquals("7", mock.forDouble(null));
+        assertEquals(null, mock.forInteger(null));
+        assertEquals(null, mock.forCharacter(null));
+        assertEquals(null, mock.forShort(null));
+        assertEquals(null, mock.forByte(null));
+        assertEquals(null, mock.forBoolean(null));
+        assertEquals(null, mock.forLong(null));
+        assertEquals(null, mock.forFloat(null));
+        assertEquals(null, mock.forDouble(null));
     }
 }

--- a/test/org/mockitousage/matchers/MatchersTest.java
+++ b/test/org/mockitousage/matchers/MatchersTest.java
@@ -225,15 +225,25 @@ public class MatchersTest extends TestBase {
     
     @Test
     public void anyStringMatcher() {
-        when(mock.oneArg(anyString())).thenReturn("1");
+        when(mock.oneArg(anyString())).thenReturn("matched");
         
-        assertEquals("1", mock.oneArg(""));
-        assertEquals("1", mock.oneArg("any string"));
-        assertEquals(null, mock.oneArg((Object) null));
+        assertEquals("matched", mock.oneArg(""));
+        assertEquals("matched", mock.oneArg("any string"));
+        assertEquals(null, mock.oneArg((String) null));
     }
 
     @Test
     public void anyMatcher() {
+        when(mock.forObject(any())).thenReturn("matched");
+
+        assertEquals("matched", mock.forObject(123));
+        assertEquals("matched", mock.forObject("any string"));
+        assertEquals("matched", mock.forObject("any string"));
+        assertEquals("matched", mock.forObject((Object) null));
+    }
+
+    @Test
+    public void anyXMatcher() {
         when(mock.oneArg(anyBoolean())).thenReturn("0");
         when(mock.oneArg(anyByte())).thenReturn("1");
         when(mock.oneArg(anyChar())).thenReturn("2");

--- a/test/org/mockitousage/matchers/NewMatchersTest.java
+++ b/test/org/mockitousage/matchers/NewMatchersTest.java
@@ -29,41 +29,41 @@ public class NewMatchersTest extends TestBase {
 
     @Test
     public void shouldAllowAnyList() {
-        when(mock.forList(anyList())).thenReturn("x");
+        when(mock.forList(anyList())).thenReturn("matched");
         
-        assertEquals("x", mock.forList(null));
-        assertEquals("x", mock.forList(Arrays.asList("x", "y")));
-        
-        verify(mock, times(2)).forList(anyList());
+        assertEquals("matched", mock.forList(Arrays.asList("x", "y")));
+        assertEquals(null, mock.forList(null));
+
+        verify(mock, times(1)).forList(anyList());
     }
     
     @Test
     public void shouldAllowAnyCollection() {
-        when(mock.forCollection(anyCollection())).thenReturn("x");
+        when(mock.forCollection(anyCollection())).thenReturn("matched");
         
-        assertEquals("x", mock.forCollection(null));
-        assertEquals("x", mock.forCollection(Arrays.asList("x", "y")));
-        
-        verify(mock, times(2)).forCollection(anyCollection());
+        assertEquals("matched", mock.forCollection(Arrays.asList("x", "y")));
+        assertEquals(null, mock.forCollection(null));
+
+        verify(mock, times(1)).forCollection(anyCollection());
     }
     
     @Test
     public void shouldAllowAnyMap() {
-        when(mock.forMap(anyMap())).thenReturn("x");
+        when(mock.forMap(anyMap())).thenReturn("matched");
         
-        assertEquals("x", mock.forMap(null));
-        assertEquals("x", mock.forMap(new HashMap<String, String>()));
-        
-        verify(mock, times(2)).forMap(anyMap());
+        assertEquals("matched", mock.forMap(new HashMap<String, String>()));
+        assertEquals(null, mock.forMap(null));
+
+        verify(mock, times(1)).forMap(anyMap());
     }
     
     @Test
     public void shouldAllowAnySet() {
-        when(mock.forSet(anySet())).thenReturn("x");
+        when(mock.forSet(anySet())).thenReturn("matched");
         
-        assertEquals("x", mock.forSet(null));
-        assertEquals("x", mock.forSet(new HashSet<String>()));
-        
-        verify(mock, times(2)).forSet(anySet());
+        assertEquals("matched", mock.forSet(new HashSet<String>()));
+        assertEquals(null, mock.forSet(null));
+
+        verify(mock, times(1)).forSet(anySet());
     }
 }

--- a/test/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
+++ b/test/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
@@ -239,7 +239,10 @@ public class DescriptiveMessagesWhenVerificationFailsTest extends TestBase {
                 "\n" +
                 "Wanted but not invoked:" +
                 "\n" +
-                "iMethods.twoArgumentMethod(<any>, 100);";
+                "iMethods.twoArgumentMethod(\n" +
+                "    isA(java.lang.Integer),\n" +
+                "    100\n" +
+                ");";
             assertContains(expectedMessage, actualMessage);
         }
     }

--- a/test/org/mockitousage/verification/PrintingVerboseTypesWithArgumentsTest.java
+++ b/test/org/mockitousage/verification/PrintingVerboseTypesWithArgumentsTest.java
@@ -65,12 +65,12 @@ public class PrintingVerboseTypesWithArgumentsTest extends TestBase {
         
         try {
             //when
-            verify(boo).withLongAndInt(eq(100), anyInt());
+            verify(boo).withLongAndInt(eq(100), any(Integer.class));
             fail();
         } catch (ArgumentsAreDifferent e) {
             //then
             assertContains("withLongAndInt((Long) 100, 200)", e.getMessage());
-            assertContains("withLongAndInt((Integer) 100, <any>)", e.getMessage());
+            assertContains("withLongAndInt((Integer) 100, <any>", e.getMessage());
         }
     }
     

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-version=1.10.17
+version=2.0.0-beta
 mockito.testng.version=1.0


### PR DESCRIPTION
This fixes #134. To be specific:

`anyX()` - matches all instances of X (Integer, String, List), but not nulls.
`anyList(X.class)`, `anySet(X.class)`, etc - matches all list/set/map instances, ignoring the X parameter entirely (just used to fix generic type hassle). Doesn't match null.
`any()`, `anyObject()` - matches anything, including null.
`any(X.class)` - matches anything, including null, but with a more convenient return type.

We might want to take this further and deprecate some of these, or make the suggested API slightly clearer, but this is a good start.

Since this is definitely not backward compatible, I've now bumped to 2.0.0-beta!