### PR TITLE
enum Answers implements now Answer<Object>

### DIFF
--- a/src/org/mockito/Answers.java
+++ b/src/org/mockito/Answers.java
@@ -24,7 +24,6 @@ import org.mockito.stubbing.Answer;
  * <b>This is not the full list</b> of Answers available in Mockito. Some interesting answers can be found in org.mockito.stubbing.answers package.
  */
 public enum Answers implements Answer<Object>{
-
     /**
      * The default configured answer of every mock.
      *
@@ -76,6 +75,15 @@ public enum Answers implements Answer<Object>{
 
     private Answers(Answer<Object> implementation) {
         this.implementation = implementation;
+    }
+
+    /**
+     * @deprecated Use the enum-constant directly, instead of this getter.<br> 
+     * E.g. instead of <code>Answers.CALLS_REAL_METHODS.get()</code> use <code>Answers.CALLS_REAL_METHODS</code> .
+     */
+    @Deprecated
+    public Answer<Object> get() {
+        return this;
     }
 
 	public Object answer(InvocationOnMock invocation) throws Throwable {

--- a/src/org/mockito/Answers.java
+++ b/src/org/mockito/Answers.java
@@ -9,6 +9,7 @@ import org.mockito.internal.stubbing.defaultanswers.GloballyConfiguredAnswer;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsDeepStubs;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsMocks;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsSmartNulls;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 /**
@@ -22,7 +23,7 @@ import org.mockito.stubbing.Answer;
  * </code></pre>
  * <b>This is not the full list</b> of Answers available in Mockito. Some interesting answers can be found in org.mockito.stubbing.answers package.
  */
-public enum Answers {
+public enum Answers implements Answer<Object>{
 
     /**
      * The default configured answer of every mock.
@@ -77,7 +78,9 @@ public enum Answers {
         this.implementation = implementation;
     }
 
-    public Answer<Object> get() {
-        return implementation;
-    }
+	public Object answer(InvocationOnMock invocation) throws Throwable {
+		return implementation.answer(invocation);
+	}
+
+   
 }

--- a/src/org/mockito/Answers.java
+++ b/src/org/mockito/Answers.java
@@ -78,7 +78,7 @@ public enum Answers implements Answer<Object>{
     }
 
     /**
-     * @deprecated Use the enum-constant directly, instead of this getter.<br> 
+     * @deprecated Use the enum-constant directly, instead of this getter. This method will be removed in a future release<br> 
      * E.g. instead of <code>Answers.CALLS_REAL_METHODS.get()</code> use <code>Answers.CALLS_REAL_METHODS</code> .
      */
     @Deprecated

--- a/src/org/mockito/Mockito.java
+++ b/src/org/mockito/Mockito.java
@@ -983,7 +983,7 @@ public class Mockito extends Matchers {
      * This implementation first tries the global configuration.
      * If there is no global configuration then it uses {@link ReturnsEmptyValues} (returns zeros, empty collections, nulls, etc.)
      */
-    public static final Answer<Object> RETURNS_DEFAULTS = Answers.RETURNS_DEFAULTS.get();
+    public static final Answer<Object> RETURNS_DEFAULTS = Answers.RETURNS_DEFAULTS;
 
     /**
      * Optional <code>Answer</code> to be used with {@link Mockito#mock(Class, Answer)}.
@@ -1015,7 +1015,7 @@ public class Mockito extends Matchers {
      *   //Exception's cause links to unstubbed <i>mock.getStuff()</i> - just click on the stack trace.
      * </code></pre>
      */
-    public static final Answer<Object> RETURNS_SMART_NULLS = Answers.RETURNS_SMART_NULLS.get();
+    public static final Answer<Object> RETURNS_SMART_NULLS = Answers.RETURNS_SMART_NULLS;
 
     /**
      * Optional <code>Answer</code> to be used with {@link Mockito#mock(Class, Answer)}
@@ -1028,7 +1028,7 @@ public class Mockito extends Matchers {
      * then it tries to return mocks. If the return type cannot be mocked (e.g. is final) then plain null is returned.
      * <p>
      */
-    public static final Answer<Object> RETURNS_MOCKS = Answers.RETURNS_MOCKS.get();
+    public static final Answer<Object> RETURNS_MOCKS = Answers.RETURNS_MOCKS;
 
     /**
      * Optional <code>Answer</code> to be used with {@link Mockito#mock(Class, Answer)}.
@@ -1115,7 +1115,7 @@ public class Mockito extends Matchers {
      * (for example: is a primitive or a final class). This is because of java type system.
      * </p>
      */
-    public static final Answer<Object> RETURNS_DEEP_STUBS = Answers.RETURNS_DEEP_STUBS.get();
+    public static final Answer<Object> RETURNS_DEEP_STUBS = Answers.RETURNS_DEEP_STUBS;
 
     /**
      * Optional <code>Answer</code> to be used with {@link Mockito#mock(Class, Answer)}
@@ -1149,8 +1149,7 @@ public class Mockito extends Matchers {
      * value = mock.getSomething();
      * </code></pre>
      */
-    public static final Answer<Object> CALLS_REAL_METHODS = Answers.CALLS_REAL_METHODS.get();
-
+    public static final Answer<Object> CALLS_REAL_METHODS = Answers.CALLS_REAL_METHODS;
     /**
      * Creates mock object of given class or interface.
      * <p>

--- a/src/org/mockito/internal/configuration/MockAnnotationProcessor.java
+++ b/src/org/mockito/internal/configuration/MockAnnotationProcessor.java
@@ -29,7 +29,7 @@ public class MockAnnotationProcessor implements FieldAnnotationProcessor<Mock> {
         }
 
         // see @Mock answer default value
-        mockSettings.defaultAnswer(annotation.answer().get());
+        mockSettings.defaultAnswer(annotation.answer());
         return Mockito.mock(field.getType(), mockSettings);
     }
 }

--- a/src/org/mockito/internal/stubbing/answers/CallsRealMethods.java
+++ b/src/org/mockito/internal/stubbing/answers/CallsRealMethods.java
@@ -4,7 +4,8 @@
  */
 package org.mockito.internal.stubbing.answers;
 
-import org.mockito.Answers;
+import static org.mockito.Answers.RETURNS_DEFAULTS;
+
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -36,7 +37,7 @@ public class CallsRealMethods implements Answer<Object>, Serializable {
 
     public Object answer(InvocationOnMock invocation) throws Throwable {
     	if (Modifier.isAbstract(invocation.getMethod().getModifiers())) {
-    		return Answers.RETURNS_DEFAULTS.get().answer(invocation);
+    		return RETURNS_DEFAULTS.answer(invocation);
     	}
         return invocation.callRealMethod();
     }


### PR DESCRIPTION
The enum type Answers implements now the Answer interface. This allows us to use the enum values in `Mockito.mock(Class,Answer)`. This is handy when you have to test legacy code with PowerMockito and want to use both `@Mock` and `Mockito.mock(..)`.

```java
@Mock(answers=RETURNS_DEEP_STUBS) 
ClassA a;
ClassB b;

public void setUp(){
  b= mock(ClassB,Mockito.RETURNS_DEEP_STUBS)   //<< static import is not possible here, but with this pull request we can use RETURNS_DEEP_STUBS we used in @Mock.
}
```