### PR TITLE
[#157] Source files should not be put in binary JAR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ def licenseFiles = copySpec {
 
 jar {
     baseName = 'mockito-core'
-    from(sourceSets.main.allSource)
+    from(sourceSets.main.output)
     from(zipTree("lib/repackaged/cglib-and-asm-1.0.jar")) {
         exclude 'META-INF/MANIFEST.MF'
     }


### PR DESCRIPTION
It stupefies IntelliJ Idea to show decompiled file even when source jar is available.

Fix #157.