### PR TITLE
GitHubIssues fetcher is now aware of GitHub pagination

### DIFF
--- a/buildSrc/src/main/groovy/org/mockito/release/notes/improvements/DefaultImprovements.java
+++ b/buildSrc/src/main/groovy/org/mockito/release/notes/improvements/DefaultImprovements.java
@@ -22,4 +22,8 @@ class DefaultImprovements implements ImprovementSet {
     public void add(Improvement improvement) {
         improvements.add(improvement);
     }
+
+    public void addAll(List<Improvement> improvements) {
+        this.improvements.addAll(improvements);
+    }
 }

--- a/buildSrc/src/main/groovy/org/mockito/release/notes/improvements/GitHubTicketFetcher.java
+++ b/buildSrc/src/main/groovy/org/mockito/release/notes/improvements/GitHubTicketFetcher.java
@@ -9,10 +9,14 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.net.URLConnection;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
+import java.util.PriorityQueue;
+import java.util.Queue;
 
 class GitHubTicketFetcher {
 
@@ -23,38 +27,182 @@ class GitHubTicketFetcher {
             return;
         }
         LOG.info("Querying GitHub API for {} tickets", ticketIds.size());
-        String url = "https://api.github.com/repos/mockito/mockito/issues?access_token=" + authToken;
-        url += "&state=closed&filter=all";
 
-        Set<Long> tickets = new HashSet<Long>();
-        for (String id : ticketIds) {
-            tickets.add(Long.parseLong(id));
-        }
+        Queue<Long> tickets = queuedTicketNumbers(ticketIds);
 
         try {
-            fetch(tickets, improvements, url);
+            GitHubIssues issues = GitHubIssues.authenticatingWith(authToken)
+                    .state("closed")
+                    .filter("all")
+                    .direction("desc")
+                    .browse();
+
+            while (!tickets.isEmpty() && issues.hasNextPage()) {
+                List<JSONObject> page = issues.nextPage();
+
+                improvements.addAll(wantedImprovements(
+                        dropTicketsAboveMaxInPage(tickets, page),
+                        page));
+            }
         } catch (Exception e) {
             throw new RuntimeException("Problems fetching " + ticketIds.size() + " from GitHub", e);
         }
     }
 
-    private void fetch(Set<Long> tickets, DefaultImprovements improvements, String url) throws IOException {
-        InputStream response = new URL(url).openStream();
-        String content = IOUtil.readFully(response);
-        LOG.info("GitHub API responded successfully.");
-        List<JSONObject> issues = (List) JSONValue.parse(content);
-        LOG.info("GitHub API returned {} issues.", issues.size());
+    private Queue<Long> dropTicketsAboveMaxInPage(Queue<Long> tickets, List<JSONObject> page) {
+        if (page.isEmpty()) {
+            return tickets;
+        }
+        Long highestId = (Long) page.get(0).get("number");
+        while (tickets.peek() > highestId) {
+            tickets.poll();
+        }
+        return tickets;
+    }
+
+    private Queue<Long> queuedTicketNumbers(Collection<String> ticketIds) {
+        List<Long> tickets = new ArrayList<>();
+        for (String id : ticketIds) {
+            tickets.add(Long.parseLong(id));
+        }
+        Collections.sort(tickets);
+        PriorityQueue<Long> longs = new PriorityQueue<>(tickets.size(), Collections.reverseOrder());
+        longs.addAll(tickets);
+        return longs;
+    }
+
+    private List<Improvement> wantedImprovements(Collection<Long> tickets, List<JSONObject> issues) {
+        ArrayList<Improvement> pagedImprovements = new ArrayList<>();
 
         for (JSONObject issue : issues) {
             long id = (Long) issue.get("number");
             if (tickets.remove(id)) {
                 String issueUrl = (String) issue.get("html_url");
                 String title = (String) issue.get("title");
-                improvements.add(new Improvement(id, title, issueUrl, new HashSet()));
+                pagedImprovements.add(new Improvement(id, title, issueUrl, new HashSet<String>()));
 
                 if (tickets.isEmpty()) {
-                    return;
+                    return pagedImprovements;
                 }
+            }
+        }
+        return pagedImprovements;
+    }
+
+
+    private static class GitHubIssues {
+        public static final String RELATIVE_LINK_NOT_FOUND = "none";
+        private String nextPageUrl;
+
+        private GitHubIssues(String authToken, String state, String filter, String direction) {
+            // see API doc : https://developer.github.com/v3/issues/
+            nextPageUrl = String.format("%s%s%s%s%s",
+                    "https://api.github.com/repos/mockito/mockito/issues?access_token=" + authToken,
+                    state == null ? "" : "&state=" + state,
+                    filter == null ? "" : "&filter=" + filter,
+                    direction == null ? "" : "&direction=" + direction,
+                    "&page=1"
+            );
+        }
+
+
+        public GitHubIssues init() throws IOException {
+            URLConnection urlConnection = new URL(nextPageUrl).openConnection();
+            nextPageUrl = extractRelativeLink(urlConnection.getHeaderField("Link"), "next");
+            return this;
+        }
+
+        public boolean hasNextPage() {
+            return !RELATIVE_LINK_NOT_FOUND.equals(nextPageUrl);
+        }
+
+        public List<JSONObject> nextPage() throws IOException {
+            if(RELATIVE_LINK_NOT_FOUND.equals(nextPageUrl)) {
+                throw new IllegalStateException("GitHub API no more issues to fetch");
+            }
+            URL url = new URL(nextPageUrl);
+            LOG.info("GitHub API querying issue page {}", queryParamValue(url, "page"));
+            URLConnection urlConnection = url.openConnection();
+
+            LOG.info("GitHub API rate info => Remaining : {}, Limit : {}",
+                    urlConnection.getHeaderField("X-RateLimit-Remaining"),
+                    urlConnection.getHeaderField("X-RateLimit-Limit")
+            );
+            nextPageUrl = extractRelativeLink(urlConnection.getHeaderField("Link"), "next");
+
+            return parseJsonFrom(urlConnection);
+        }
+
+        private String queryParamValue(URL url, String page) {
+            String query = url.getQuery();
+            for (String param : query.split("&")) {
+                if(param.startsWith(page)) {
+                    return param.substring(param.indexOf('=') + 1, param.length());
+                }
+            }
+            return "N/A";
+        }
+
+        private List<JSONObject> parseJsonFrom(URLConnection urlConnection) throws IOException {
+            InputStream response = urlConnection.getInputStream();
+
+            String content = IOUtil.readFully(response);
+            LOG.info("GitHub API responded successfully.");
+            List<JSONObject> issues = (List<JSONObject>) JSONValue.parse(content);
+            LOG.info("GitHub API returned {} issues.", issues.size());
+            return issues;
+        }
+
+
+        private String extractRelativeLink(String linkHeader, final String relativeType) {
+            if (linkHeader == null) {
+                return null;
+            }
+
+            // See GitHub API doc : https://developer.github.com/guides/traversing-with-pagination/
+            // Link: <https://api.github.com/repositories/6207167/issues?access_token=a0a4c0f41c200f7c653323014d6a72a127764e17&state=closed&filter=all&page=2>; rel="next",
+            //       <https://api.github.com/repositories/62207167/issues?access_token=a0a4c0f41c200f7c653323014d6a72a127764e17&state=closed&filter=all&page=4>; rel="last"
+            for (String linkRel : linkHeader.split(",")) {
+                if (linkRel.contains("rel=\"" + relativeType + "\"")) {
+                    return linkRel.substring(
+                            linkRel.indexOf("http"),
+                            linkRel.indexOf(">; rel=\"" + relativeType + "\""));
+                }
+            }
+            return RELATIVE_LINK_NOT_FOUND;
+        }
+
+        public static GitHubIssuesBuilder authenticatingWith(String authToken) {
+            return new GitHubIssuesBuilder(authToken);
+        }
+
+        private static class GitHubIssuesBuilder {
+            private String authToken;
+            private String state;
+            private String filter;
+            private String direction;
+
+            public GitHubIssuesBuilder(String authToken) {
+                this.authToken = authToken;
+            }
+
+            public GitHubIssuesBuilder state(String state) {
+                this.state = state;
+                return this;
+            }
+
+            public GitHubIssuesBuilder filter(String filter) {
+                this.filter = filter;
+                return this;
+            }
+
+            public GitHubIssuesBuilder direction(String direction) {
+                this.direction = direction;
+                return this;
+            }
+
+            public GitHubIssues browse() {
+                return new GitHubIssues(authToken, state, filter, direction);
             }
         }
     }


### PR DESCRIPTION
On each build, the build script is tested, and the `GitHubTicketFetcherTest` failed because GitHb issues API is paginated. Over time with new issues/pull request added, the first page did not contain issue number the test expected to find, leading to this failed assertion.

```
Condition not satisfied:

impr.toText() == """* Improvements: 2 * Allow instances of other classes in AdditionalAnswers.delegatesTo [(#112)](https://github.com/mockito/mockito/issues/112) * Clarify Spy vs Mock CALLS_REAL_METHODS [(#108)](https://github.com/mockito/mockito/issues/108)"""
|    |        |
|    |        false
|    |        100 differences (58% similarity)
|    |        * Improvements: (1)\n  * Allow instances of other classes in AdditionalAnswers.delegatesTo [(#112)](https://github.com/mockito/mockito/issues/112)(-~--------------------------------------------------------------------------------------------------)
|    |        * Improvements: (2)\n  * Allow instances of other classes in AdditionalAnswers.delegatesTo [(#112)](https://github.com/mockito/mockito/issues/112)(\n  * Clarify Spy vs Mock CALLS_REAL_METHODS [(#108)](https://github.com/mockito/mockito/issues/108))
|    * Improvements: 1
|      * Allow instances of other classes in AdditionalAnswers.delegatesTo [(#112)](https://github.com/mockito/mockito/issues/112)
org.mockito.release.notes.improvements.DefaultImprovements@1ed22788

	at org.mockito.release.notes.improvements.GitHubTicketFetcherTest.fetches improvements from GitHub(GitHubTicketFetcherTest.groovy:19)
```


Github pagination is documented here : https://developer.github.com/guides/traversing-with-pagination/