### PR TITLE
Upgrade coveralls plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ script:
 - ./gradlew ciBuild
 after_success:
 - ./gradlew release
-- ./gradlew cobertura coveralls
+- ./gradlew --debug --stacktrace cobertura coveralls

--- a/build.gradle
+++ b/build.gradle
@@ -4,13 +4,11 @@ buildscript {
     }
 
     dependencies {
-        classpath 'net.saliman:gradle-cobertura-plugin:2.0.0' // coveralls plugin depends on cobertura plugin
-        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:0.6.1'
+        classpath 'net.saliman:gradle-cobertura-plugin:2.2.5' // coveralls plugin depends on cobertura plugin
+        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.1.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.0' //publishing to bintray
         classpath 'org.codehaus.groovy.modules.http-builder:http-builder:0.5.2' //rest calls to bintray api
     }
-
-    configurations.classpath.exclude group: 'com.android.tools.build', module: 'gradle'
 }
 
 apply plugin: 'maven-publish'

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ test {
     include "**/*Test.class"
     testLogging {
         exceptionFormat = 'full'
+        showCauses true
     }
 }
 

--- a/gradle/coverage.gradle
+++ b/gradle/coverage.gradle
@@ -1,13 +1,6 @@
 apply plugin: 'cobertura'
-//apply plugin: 'jacoco'
 apply plugin: 'com.github.kt3k.coveralls'
 cobertura.coverageFormats = ['html', 'xml'] // coveralls plugin depends on xml format report
 //cobertura.coverageIgnoreTrivial = true
-coveralls.sourceDirs = ['src']  //workaround for https://github.com/stevesaliman/gradle-cobertura-plugin/issues/53
 
-//jacocoTestReport {
-//    reports {
-//        xml.enabled = true // coveralls plugin depends on xml format report
-//        html.enabled = true
-//    }
-//}
+//coveralls.sourceDirs = ['src']  //workaround for https://github.com/stevesaliman/gradle-cobertura-plugin/issues/53

--- a/gradle/coverage.gradle
+++ b/gradle/coverage.gradle
@@ -3,4 +3,4 @@ apply plugin: 'com.github.kt3k.coveralls'
 cobertura.coverageFormats = ['html', 'xml'] // coveralls plugin depends on xml format report
 //cobertura.coverageIgnoreTrivial = true
 
-//coveralls.sourceDirs = ['src']  //workaround for https://github.com/stevesaliman/gradle-cobertura-plugin/issues/53
+coveralls.sourceDirs = ['src/']  //workaround for https://github.com/stevesaliman/gradle-cobertura-plugin/issues/53

--- a/gradle/coverage.gradle
+++ b/gradle/coverage.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'cobertura'
 apply plugin: 'com.github.kt3k.coveralls'
+cobertura.coverageDirs = ['build/classes/main']
 cobertura.coverageFormats = ['html', 'xml'] // coveralls plugin depends on xml format report
 //cobertura.coverageIgnoreTrivial = true
 
-coveralls.sourceDirs = ['src/']  //workaround for https://github.com/stevesaliman/gradle-cobertura-plugin/issues/53
+coveralls.sourceDirs = ['src']  //workaround for https://github.com/stevesaliman/gradle-cobertura-plugin/issues/53

--- a/gradle/coverage.gradle
+++ b/gradle/coverage.gradle
@@ -3,6 +3,7 @@ apply plugin: 'cobertura'
 apply plugin: 'com.github.kt3k.coveralls'
 cobertura.coverageFormats = ['html', 'xml'] // coveralls plugin depends on xml format report
 //cobertura.coverageIgnoreTrivial = true
+coveralls.sourceDirs = ['src']  //workaround for https://github.com/stevesaliman/gradle-cobertura-plugin/issues/53
 
 //jacocoTestReport {
 //    reports {

--- a/gradle/coverage.gradle
+++ b/gradle/coverage.gradle
@@ -1,5 +1,12 @@
 apply plugin: 'cobertura'
-apply plugin: 'coveralls'
+//apply plugin: 'jacoco'
+apply plugin: 'com.github.kt3k.coveralls'
 cobertura.coverageFormats = ['html', 'xml'] // coveralls plugin depends on xml format report
 //cobertura.coverageIgnoreTrivial = true
-coveralls.sourceDirs = ['src']  //workaround for https://github.com/stevesaliman/gradle-cobertura-plugin/issues/53
+
+//jacocoTestReport {
+//    reports {
+//        xml.enabled = true // coveralls plugin depends on xml format report
+//        html.enabled = true
+//    }
+//}

--- a/subprojects/testng/src/main/java/org/mockito/testng/MockitoAfterTestNGMethod.java
+++ b/subprojects/testng/src/main/java/org/mockito/testng/MockitoAfterTestNGMethod.java
@@ -33,7 +33,7 @@ public class MockitoAfterTestNGMethod {
 
     @SuppressWarnings({"deprecation", "unchecked"})
     private Collection<Object> instanceMocksOf(Object instance) {
-        return Fields.allDeclaredFieldsOf(instance)
+        return Fields.allDeclaredInstanceFieldsOf(instance)
                                             .filter(annotatedBy(Mock.class,
                                                                 Spy.class,
                                                                 MockitoAnnotations.Mock.class))

--- a/subprojects/testng/src/main/java/org/mockito/testng/MockitoBeforeTestNGMethod.java
+++ b/subprojects/testng/src/main/java/org/mockito/testng/MockitoBeforeTestNGMethod.java
@@ -44,7 +44,7 @@ public class MockitoBeforeTestNGMethod {
     }
 
     private void initializeCaptors(Object instance) {
-        List<InstanceField> instanceFields = Fields.allDeclaredFieldsOf(instance).filter(annotatedBy(Captor.class)).instanceFields();
+        List<InstanceField> instanceFields = Fields.allDeclaredInstanceFieldsOf(instance).filter(annotatedBy(Captor.class)).instanceFields();
         for (InstanceField instanceField : instanceFields) {
             instanceField.set(new CaptorAnnotationProcessor().process(instanceField.annotation(Captor.class), instanceField.jdkField()));
         }

--- a/test/org/mockito/internal/util/reflection/FieldsTest.java
+++ b/test/org/mockito/internal/util/reflection/FieldsTest.java
@@ -14,25 +14,27 @@ public class FieldsTest {
 
     @Test
     public void fields_should_return_all_declared_fields_in_hierarchy() throws Exception {
-        assertThat(Fields.allDeclaredFieldsOf(new HierarchyOfClasses()).names())
-                .containsOnly("a", "b", "static_a", "static_b");
+        assertThat(Fields.allDeclaredInstanceFieldsOf(new HierarchyOfClasses()).names())
+                .containsOnly("a", "b")
+                .excludes("static_a", "static_b");
     }
 
     @Test
-    public void fields_should_return_declared_fields() throws Exception {
-        assertThat(Fields.declaredFieldsOf(new HierarchyOfClasses()).names())
-                .containsOnly("b", "static_b");
+    public void fields_should_return_declared_instance_fields() throws Exception {
+        assertThat(Fields.declaredInstanceFieldsOf(new HierarchyOfClasses()).names())
+                .containsOnly("b")
+                .excludes("static_b");
     }
 
     @Test
     public void can_filter_not_null_fields() throws Exception {
-        assertThat(Fields.declaredFieldsOf(new NullOrNotNullFields()).notNull().names())
+        assertThat(Fields.declaredInstanceFieldsOf(new NullOrNotNullFields()).notNull().names())
                 .containsOnly("c");
     }
 
     @Test
     public void can_get_values_of_instance_fields() throws Exception {
-        assertThat(Fields.declaredFieldsOf(new ValuedFields()).assignedValues())
+        assertThat(Fields.declaredInstanceFieldsOf(new ValuedFields()).assignedValues())
                 .containsOnly("a", "b");
     }
 
@@ -41,7 +43,7 @@ public class FieldsTest {
     public void can_get_list_of_InstanceField() throws Exception {
         ValuedFields instance = new ValuedFields();
 
-        assertThat(Fields.declaredFieldsOf(instance).instanceFields())
+        assertThat(Fields.declaredInstanceFieldsOf(instance).instanceFields())
                 .containsOnly(new InstanceField(field("a", instance), instance),
                               new InstanceField(field("b", instance), instance)
                 );

--- a/test/org/mockitointegration/NoJUnitDependenciesTest.java
+++ b/test/org/mockitointegration/NoJUnitDependenciesTest.java
@@ -4,36 +4,75 @@ import org.hamcrest.Matcher;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.cglib.proxy.Enhancer;
+import org.mockito.junit.MockitoJUnit;
 import org.mockitoutil.ClassLoaders;
 import org.objenesis.Objenesis;
 
 import java.util.Set;
 
+import static org.fest.assertions.Assertions.assertThat;
+
 public class NoJUnitDependenciesTest {
+
     @Test
-    public void pure_mockito_should_not_depend_JUnit() throws Exception {
+    public void pure_mockito_should_not_depend_JUnit() throws Throwable {
         ClassLoader classLoader_without_JUnit = ClassLoaders.excludingClassLoader()
                 .withCodeSourceUrlOf(
                         Mockito.class,
                         Matcher.class,
                         Enhancer.class,
-                        Objenesis.class
+                        Objenesis.class,
+                        hackToPossiblyIncludeCobertura()
                 )
                 .without("junit", "org.junit")
                 .build();
 
-        Set<String> pureMockitoAPIClasses = ClassLoaders.in(classLoader_without_JUnit).omit("runners", "junit", "JUnit").listOwnedClasses();
+        Set<String> pureMockitoAPIClasses = ClassLoaders.in(classLoader_without_JUnit)
+                .omit("runners", "junit", "JUnit")
+                .listOwnedClasses();
 
         for (String pureMockitoAPIClass : pureMockitoAPIClasses) {
             checkDependency(classLoader_without_JUnit, pureMockitoAPIClass);
         }
     }
 
-    private void checkDependency(ClassLoader classLoader_without_JUnit, String pureMockitoAPIClass) throws ClassNotFoundException {
+    @Test
+    public void verify_failure() throws Throwable {
+        ClassLoader classLoader_without_JUnit = ClassLoaders.excludingClassLoader()
+                .withCodeSourceUrlOf(
+                        Mockito.class,
+                        Matcher.class,
+                        Enhancer.class,
+                        Objenesis.class,
+                        hackToPossiblyIncludeCobertura()
+                )
+                .without("junit", "org.junit")
+                .build();
+
         try {
-            Class.forName(pureMockitoAPIClass, true, classLoader_without_JUnit);
+            checkDependency(classLoader_without_JUnit, MockitoJUnit.class.getName());
+        } catch (AssertionError e) {
+            assertThat(e.getCause()).isInstanceOf(NoClassDefFoundError.class);
+            assertThat(e.getCause().getMessage()).contains("junit");
+        }
+    }
+
+    private void checkDependency(ClassLoader classLoader_without_JUnit, String pureMockitoAPIClass) throws Throwable {
+        try {
+            Class.forName(pureMockitoAPIClass, true, classLoader_without_JUnit).getDeclaredFields();
         } catch (Throwable e) {
-            throw new AssertionError(String.format("'%s' has some dependency to JUnit", pureMockitoAPIClass), e);
+            if(e instanceof NoClassDefFoundError) {
+                throw new AssertionError(String.format("'%s' has some unwanted class dependency", pureMockitoAPIClass), e);
+            }
+            throw e;
+        }
+    }
+
+    private Class<?> hackToPossiblyIncludeCobertura() throws ClassNotFoundException {
+        try {
+            return Class.forName("net.sourceforge.cobertura.coveragedata.TouchCollector");
+        } catch (ClassNotFoundException ignored) {
+            return null;
         }
     }
 }

--- a/test/org/mockitoutil/ClassLoaders.java
+++ b/test/org/mockitoutil/ClassLoaders.java
@@ -123,7 +123,7 @@ public abstract class ClassLoaders {
 
         public ExcludingURLClassLoaderBuilder withCodeSourceUrlOf(Class<?>... classes) {
             for (Class<?> clazz : classes) {
-                codeSourceUrls.add(obtainClassPathOf(clazz.getName()));
+                if(clazz != null) codeSourceUrls.add(obtainClassPathOf(clazz.getName()));
             }
             return this;
         }


### PR DESCRIPTION
Should have been just changing numbers, but it isn't. This PR contains several fixes in the source code in order to fix the coverage reports.

However with the last version there's still a pretty big issue in the travis logs, cobertura fails with some classes hence the lower coverage result (I suspect it is related to the missing dependency, but I'm not sure...)

* Replacing Cobertura with Jacoco, make Gradle fail with obscure stacktraces

  ```gradle
apply plugin : 'jacoco'
apply plugin: 'com.github.kt3k.coveralls'

  jacocoTestReport {
      reports {
          xml.enabled = true // coveralls plugin depends on xml format report
          html.enabled = true
      }
}
```

  ```
  Failed to notify ProjectEvaluationListener.afterEvaluate(), but primary configuration failure takes precedence.
  java.lang.NullPointerException: Cannot get property 'plus' on null object
  	at org.codehaus.groovy.runtime.NullObject.getProperty(NullObject.java:57)
    ...

* Where:
Script '/Users/brice/work/opensource/mockito/gradle/coverage.gradle' line: 4

* What went wrong:
A problem occurred evaluating script.
> Could not find method jacocoTestReport() for arguments [coverage_bz56tm90of2yklk5dd11r2maq$_run_closure1@aca79de] on root project 'mockito'.
```

  ... yet it is documented like that here : http://gradle.org/docs/current/userguide/jacoco_plugin.html#N138AF

  I don't get what I'm missing there.

* Updated Cobertura / Coveralls plugin, however the coverage phase fails to instrument classes, for a unknown reason at this moment. 
