### PR TITLE
Fixes #169

### DIFF
--- a/src/org/mockito/internal/configuration/injection/scanner/InjectMocksScanner.java
+++ b/src/org/mockito/internal/configuration/injection/scanner/InjectMocksScanner.java
@@ -4,10 +4,7 @@
  */
 package org.mockito.internal.configuration.injection.scanner;
 
-import org.mockito.Captor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.*;
 import org.mockito.exceptions.Reporter;
 
 import java.lang.reflect.Field;
@@ -50,7 +47,7 @@ public class InjectMocksScanner {
         Field[] fields = clazz.getDeclaredFields();
         for (Field field : fields) {
             if (null != field.getAnnotation(InjectMocks.class)) {
-                assertNoAnnotations(field, Mock.class, MockitoAnnotations.Mock.class, Captor.class);
+                assertNoAnnotations(field, Mock.class, MockitoAnnotations.Mock.class, Captor.class, Spy.class);
                 mockDependentFields.add(field);
             }
         }

--- a/test/org/mockitousage/annotation/WrongSetOfAnnotationsTest.java
+++ b/test/org/mockitousage/annotation/WrongSetOfAnnotationsTest.java
@@ -29,14 +29,14 @@ public class WrongSetOfAnnotationsTest extends TestBase {
     @Test(expected=MockitoException.class)
     public void shouldNotAllowSpyAndInjectMock() throws Exception {
         MockitoAnnotations.initMocks(new Object() {
-            @InjectMocks @Spy List mock;
+            @InjectMocks @Spy WrongSetOfAnnotationsTest mock;
         });
     }
     
     @Test(expected=MockitoException.class)
     public void shouldNotAllowMockAndInjectMock() throws Exception {
         MockitoAnnotations.initMocks(new Object() {
-            @InjectMocks @Mock List mock;
+            @InjectMocks @Mock WrongSetOfAnnotationsTest mock;
         });
     }
     


### PR DESCRIPTION
First fixed the test so that it doesn't try to instantiate an interface, then added the Spy annotation to the set of not allowed together with InjectMocks. Assumed the behavior should be same as for InjectMocks + Mock combination.