### PR TITLE
Fixes #172: Updated hamcrest-core from version 1.1 to 1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ tasks.withType(JavaCompile) {
 //TODO we should remove all dependencies to checked-in jars
 dependencies {
     provided "junit:junit:4.10"
-    compile "org.hamcrest:hamcrest-core:1.1", "org.objenesis:objenesis:2.1"
+    compile "org.hamcrest:hamcrest-core:1.3", "org.objenesis:objenesis:2.1"
     compile fileTree('lib/repackaged') { exclude '*.txt'}
 
     testCompile fileTree("lib/test")

--- a/src/org/mockito/internal/matchers/LocalizedMatcher.java
+++ b/src/org/mockito/internal/matchers/LocalizedMatcher.java
@@ -64,6 +64,10 @@ public class LocalizedMatcher implements Matcher, ContainsExtraTypeInformation, 
         }
     }
 
+    public void describeMismatch(Object argument, Description description) {
+        actualMatcher.describeMismatch(argument, description);
+    }
+
     //TODO: refactor other 'delegated interfaces' to use the MatcherDecorator feature
     public Matcher getActualMatcher() {
         return actualMatcher;

--- a/test/org/mockito/internal/runners/RunnerFactoryTest.java
+++ b/test/org/mockito/internal/runners/RunnerFactoryTest.java
@@ -37,7 +37,7 @@ public class RunnerFactoryTest extends TestBase {
         RunnerImpl runner = factory.create(RunnerFactoryTest.class);
         
         //then
-        assertThat(runner, is(JUnit44RunnerImpl.class));
+        assertThat(runner, instanceOf(JUnit44RunnerImpl.class));
     }
     
     @Test
@@ -54,7 +54,7 @@ public class RunnerFactoryTest extends TestBase {
         RunnerImpl runner = factory.create(RunnerFactoryTest.class);
         
         //then
-        assertThat(runner, is(JUnit45AndHigherRunnerImpl.class));
+        assertThat(runner, instanceOf(JUnit45AndHigherRunnerImpl.class));
     }
     
     @Test

--- a/test/org/mockitousage/basicapi/MocksCreationTest.java
+++ b/test/org/mockitousage/basicapi/MocksCreationTest.java
@@ -16,7 +16,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.mockito.Mockito.*;
 
 @SuppressWarnings("unchecked")
@@ -62,7 +62,7 @@ public class MocksCreationTest extends TestBase {
         //then
         assertContains("great mockie", name);
         //and
-        assertThat(mock, is(List.class));
+        assertThat(mock, instanceOf(List.class));
     }
     
     @Test

--- a/test/org/mockitoutil/ExtraMatchers.java
+++ b/test/org/mockitoutil/ExtraMatchers.java
@@ -133,7 +133,7 @@ public class ExtraMatchers {
         };
     }
     
-    public static org.hamcrest.Matcher<java.lang.Object> clazz(java.lang.Class<?> type) {
+    public static <T> org.hamcrest.Matcher<T> clazz(java.lang.Class<T> type) {
         return CoreMatchers.is(type);
     }
 


### PR DESCRIPTION
Updated the `hamcrest-core` version to `1.3`.

Therefore I needed to add a new method to the `LocalizedMatcher` and change all usages of `assertThat(<interface>, is(<interfaceImpl>))`. IMHO `instanceOf` is fine in the unit tests.

In the ExtraMatchers class, `is` could also be replaced by `instanceOf`. I decided to change the signature of the method. But maybe it is safer (and more user-friendly) to leave the public signature as it is and just change the logic.

Could you please review my solution and give me feedback? Thank you!