### PR TITLE
Make PropertyAndSetterInjection field sorting consistent

### DIFF
--- a/src/org/mockito/internal/configuration/injection/PropertyAndSetterInjection.java
+++ b/src/org/mockito/internal/configuration/injection/PropertyAndSetterInjection.java
@@ -14,6 +14,7 @@ import org.mockito.internal.configuration.injection.filter.TypeBasedCandidateFil
 import org.mockito.internal.util.collections.ListUtil;
 import org.mockito.internal.util.reflection.FieldInitializationReport;
 import org.mockito.internal.util.reflection.FieldInitializer;
+import org.mockito.internal.util.reflection.SuperTypesLastSorter;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -124,45 +125,6 @@ public class PropertyAndSetterInjection extends MockInjectionStrategy {
         List<Field> declaredFields = Arrays.asList(awaitingInjectionClazz.getDeclaredFields());
         declaredFields = ListUtil.filter(declaredFields, notFinalOrStatic);
 
-        sortSuperTypesLast(declaredFields);
-
-        return declaredFields;
+        return new SuperTypesLastSorter().sort(declaredFields);
     }
-
-    /**
-     * Sort first by name, then move any fields after their supertypes.
-     */
-    static void sortSuperTypesLast(List<Field> fields) {
-        Collections.sort(fields, compareFieldsByName);
-
-        int i = 0;
-
-        while (i < fields.size() - 1) {
-            Field f = fields.get(i);
-            Class<?> ft = f.getType();
-            int newPos = i;
-            for (int j = i + 1; j < fields.size(); j++) {
-                Class<?> t = fields.get(j).getType();
-
-                if (ft != t && ft.isAssignableFrom(t)) {
-                    newPos = j;
-                }
-            }
-
-            if (newPos == i) {
-                i++;
-            } else {
-                fields.remove(i);
-                fields.add(newPos, f);
-            }
-        }
-    }
-
-    private static Comparator<Field> compareFieldsByName = new Comparator<Field>()
-    {
-        public int compare(Field o1, Field o2)
-        {
-            return o1.getName().compareTo(o2.getName());
-        }
-    };
 }

--- a/src/org/mockito/internal/util/reflection/SuperTypesLastSorter.java
+++ b/src/org/mockito/internal/util/reflection/SuperTypesLastSorter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2015 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito.internal.util.reflection;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Sort fields in an order suitable for injection, by name with superclasses
+ * moved after their subclasses.
+ */
+public class SuperTypesLastSorter
+{
+    /**
+     * Return a new collection with the fields sorted first by name,
+     * then with any fields moved after their supertypes.
+     */
+    public List<Field> sort(Collection<? extends Field> unsortedFields)
+    {
+        List<Field> fields = new ArrayList<Field>(unsortedFields);
+
+        Collections.sort(fields, compareFieldsByName);
+
+        int i = 0;
+
+        while (i < fields.size() - 1) {
+            Field f = fields.get(i);
+            Class<?> ft = f.getType();
+            int newPos = i;
+            for (int j = i + 1; j < fields.size(); j++) {
+                Class<?> t = fields.get(j).getType();
+
+                if (ft != t && ft.isAssignableFrom(t)) {
+                    newPos = j;
+                }
+            }
+
+            if (newPos == i) {
+                i++;
+            } else {
+                fields.remove(i);
+                fields.add(newPos, f);
+            }
+        }
+
+        return fields;
+    }
+
+
+    private static Comparator<Field> compareFieldsByName = new Comparator<Field>()
+    {
+        public int compare(Field o1, Field o2)
+        {
+            return o1.getName().compareTo(o2.getName());
+        }
+    };
+}

--- a/test/org/mockito/internal/configuration/injection/FieldTypeAndNameComparatorTest.java
+++ b/test/org/mockito/internal/configuration/injection/FieldTypeAndNameComparatorTest.java
@@ -5,12 +5,15 @@ import org.junit.Test;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import static org.fest.assertions.Assertions.assertThat;
 
 @SuppressWarnings("unused")
 public class FieldTypeAndNameComparatorTest {
+
+    private static Comparator<Field> cmp = new PropertyAndSetterInjection.FieldTypeAndNameComparator();
 
     private Object objectA;
     private Object objectB;
@@ -23,15 +26,15 @@ public class FieldTypeAndNameComparatorTest {
 
     @Test
     public void when_same_type_the_order_is_based_on_field_name() throws Exception {
-        assertThat(new PropertyAndSetterInjection.FieldTypeAndNameComparator().compare(field("objectA"), field("objectB"))).isEqualTo(-1);
-        assertThat(new PropertyAndSetterInjection.FieldTypeAndNameComparator().compare(field("objectB"), field("objectA"))).isEqualTo(1);
-        assertThat(new PropertyAndSetterInjection.FieldTypeAndNameComparator().compare(field("objectB"), field("objectB"))).isEqualTo(0);
+        assertThat(cmp.compare(field("objectA"), field("objectB"))).isEqualTo(-1);
+        assertThat(cmp.compare(field("objectB"), field("objectA"))).isEqualTo(1);
+        assertThat(cmp.compare(field("objectB"), field("objectB"))).isEqualTo(0);
     }
 
     @Test
     public void when_type_is_different_the_supertype_comes_last() throws Exception {
-        assertThat(new PropertyAndSetterInjection.FieldTypeAndNameComparator().compare(field("numberA"), field("objectB"))).isEqualTo(-1);
-        assertThat(new PropertyAndSetterInjection.FieldTypeAndNameComparator().compare(field("objectB"), field("numberA"))).isEqualTo(1);
+        assertThat(cmp.compare(field("numberA"), field("objectB"))).isEqualTo(-1);
+        assertThat(cmp.compare(field("objectB"), field("numberA"))).isEqualTo(1);
     }
 
     @Test
@@ -45,7 +48,7 @@ public class FieldTypeAndNameComparatorTest {
                 field("integerA")
         );
 
-        Collections.sort(unsortedFields, new PropertyAndSetterInjection.FieldTypeAndNameComparator());
+        Collections.sort(unsortedFields, cmp);
 
         assertThat(unsortedFields).containsSequence(
                 field("integerA"),
@@ -65,7 +68,7 @@ public class FieldTypeAndNameComparatorTest {
                 field("objectA")
         );
 
-        Collections.sort(unsortedFields, new PropertyAndSetterInjection.FieldTypeAndNameComparator());
+        Collections.sort(unsortedFields, cmp);
 
         assertThat(unsortedFields).containsSequence(
                 field("objectA"),

--- a/test/org/mockito/internal/configuration/injection/FieldTypeAndNameComparatorTest.java
+++ b/test/org/mockito/internal/configuration/injection/FieldTypeAndNameComparatorTest.java
@@ -3,17 +3,40 @@ package org.mockito.internal.configuration.injection;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.fest.assertions.Assertions.assertThat;
 
 @SuppressWarnings("unused")
 public class FieldTypeAndNameComparatorTest {
+    /**
+     * A Comparator that behaves like the old one, so the existing tests
+     * continue to work.
+     */
+    private static Comparator<Field> cmp = new Comparator<Field>()
+    {
+        public int compare(Field o1, Field o2)
+        {
+            if (o1.equals(o2)) {
+                return 0;
+            }
 
-    private static Comparator<Field> cmp = new PropertyAndSetterInjection.FieldTypeAndNameComparator();
+            List<Field> l = new ArrayList<Field>(Arrays.asList(o1, o2));
+            PropertyAndSetterInjection.sortSuperTypesLast(l);
+
+            if (l.get(0) == o1) {
+                return -1;
+            } else {
+                return 1;
+            }
+        }
+    };
 
     private Object objectA;
     private Object objectB;
@@ -23,6 +46,13 @@ public class FieldTypeAndNameComparatorTest {
 
     private Integer integerA;
     private Integer integerB;
+
+    private Iterable<?> iterableA;
+
+    private Number xNumber;
+    private Iterable<?> yIterable;
+    private Integer zInteger;
+
 
     @Test
     public void when_same_type_the_order_is_based_on_field_name() throws Exception {
@@ -48,7 +78,7 @@ public class FieldTypeAndNameComparatorTest {
                 field("integerA")
         );
 
-        Collections.sort(unsortedFields, cmp);
+        PropertyAndSetterInjection.sortSuperTypesLast(unsortedFields);
 
         assertThat(unsortedFields).containsSequence(
                 field("integerA"),
@@ -74,6 +104,45 @@ public class FieldTypeAndNameComparatorTest {
                 field("objectA"),
                 field("objectB")
         );
+    }
+
+    @Test
+    public void fields_sort_consistently_when_interfaces_are_included() throws NoSuchFieldException
+    {
+        assertSortConsistently(field("iterableA"), field("numberA"), field("integerA"));
+    }
+
+    @Test
+    public void fields_sort_consistently_when_names_and_type_indicate_different_order() throws NoSuchFieldException
+    {
+        assertSortConsistently(field("xNumber"), field("yIterable"), field("zInteger"));
+    }
+
+    /**
+     * Assert that these fields sort in the same order no matter which order
+     * they start in.
+     */
+    private static void assertSortConsistently(Field a, Field b, Field c)
+    {
+        Field[][] initialOrderings = {
+                {a, b, c},
+                {a, c, b},
+                {b, a, c},
+                {b, c, a},
+                {c, a, b},
+                {c, b, a}
+        };
+
+        Set<List<Field>> results = new HashSet<List<Field>>();
+
+        for (Field[] o : initialOrderings) {
+            List<Field> l = new ArrayList<Field>(Arrays.asList(o));
+
+            PropertyAndSetterInjection.sortSuperTypesLast(l);
+            results.add(l);
+        }
+
+        assertThat(results).hasSize(1);
     }
 
     private Field field(String field) throws NoSuchFieldException {

--- a/test/org/mockito/internal/configuration/injection/PropertyAndSetterInjectionTest.java
+++ b/test/org/mockito/internal/configuration/injection/PropertyAndSetterInjectionTest.java
@@ -14,7 +14,7 @@ import java.util.Set;
 import static org.fest.assertions.Assertions.assertThat;
 
 @SuppressWarnings("unused")
-public class FieldTypeAndNameComparatorTest {
+public class PropertyAndSetterInjectionTest {
     /**
      * A Comparator that behaves like the old one, so the existing tests
      * continue to work.

--- a/test/org/mockito/internal/util/reflection/SuperTypesLastSorterTest.java
+++ b/test/org/mockito/internal/util/reflection/SuperTypesLastSorterTest.java
@@ -1,6 +1,8 @@
-package org.mockito.internal.configuration.injection;
+package org.mockito.internal.util.reflection;
 
+import org.fest.assertions.Condition;
 import org.junit.Test;
+import org.mockito.internal.util.reflection.SuperTypesLastSorter;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -14,7 +16,7 @@ import java.util.Set;
 import static org.fest.assertions.Assertions.assertThat;
 
 @SuppressWarnings("unused")
-public class PropertyAndSetterInjectionTest {
+public class SuperTypesLastSorterTest {
     /**
      * A Comparator that behaves like the old one, so the existing tests
      * continue to work.
@@ -27,8 +29,7 @@ public class PropertyAndSetterInjectionTest {
                 return 0;
             }
 
-            List<Field> l = new ArrayList<Field>(Arrays.asList(o1, o2));
-            PropertyAndSetterInjection.sortSuperTypesLast(l);
+            List<Field> l = new SuperTypesLastSorter().sort(Arrays.asList(o1, o2));
 
             if (l.get(0) == o1) {
                 return -1;
@@ -78,9 +79,9 @@ public class PropertyAndSetterInjectionTest {
                 field("integerA")
         );
 
-        PropertyAndSetterInjection.sortSuperTypesLast(unsortedFields);
+        List<Field> sortedFields = new SuperTypesLastSorter().sort(unsortedFields);
 
-        assertThat(unsortedFields).containsSequence(
+        assertThat(sortedFields).containsSequence(
                 field("integerA"),
                 field("integerB"),
                 field("numberA"),
@@ -136,10 +137,7 @@ public class PropertyAndSetterInjectionTest {
         Set<List<Field>> results = new HashSet<List<Field>>();
 
         for (Field[] o : initialOrderings) {
-            List<Field> l = new ArrayList<Field>(Arrays.asList(o));
-
-            PropertyAndSetterInjection.sortSuperTypesLast(l);
-            results.add(l);
+            results.add(new SuperTypesLastSorter().sort(Arrays.asList(o)));
         }
 
         assertThat(results).hasSize(1);


### PR DESCRIPTION
#155 is caused by calling `Collections.sort` with a comparator that isn't always transitive, as in the case where sorting by name and sorting by type hierarchy imply different orders.

For example, with fields of type `[Iterable, Integer, Number]`, it gives `Iterable == Integer` and `Iterable == Number`, but also an inconsistent `Integer < Number`.

I'm not sure it's possible to sort consistently with a stateless `Comparator`, so this change switches to a `sortSuperTypesLast` method that first sorts by name and then shuffles any subclasses to after their superclasses. It's slower, but should be deterministic. The existing tests are preserved by leaving behind a dummy `Comparator` that uses the new sort method. New tests make sure that the sorted ordering doesn't depend on the original order.

Fixes #155.