### PR TITLE
Comparison Should Use Equals Method Instead of ==

### DIFF
--- a/src/org/mockito/internal/handler/MockHandlerImpl.java
+++ b/src/org/mockito/internal/handler/MockHandlerImpl.java
@@ -67,7 +67,7 @@ class MockHandlerImpl<T> implements InternalMockHandler<T> {
         if (verificationMode != null) {
             // We need to check if verification was started on the correct mock
             // - see VerifyingWithAnExtraCallToADifferentMockTest (bug 138)
-            if (((MockAwareVerificationMode) verificationMode).getMock() == invocation.getMock()) {
+            if (((MockAwareVerificationMode) verificationMode).getMock().equals(invocation.getMock())) {
                 VerificationDataImpl data = createVerificationData(invocationContainerImpl, invocationMatcher);
                 verificationMode.verify(data);
                 return null;


### PR DESCRIPTION
I am writing framework that relies on Mockito which requires proxying mocks during concurrent test runs. The comparison operator in MockHandlerImpl does not give me the opportunity to intercept equality check during the verification process. I would like to propose changing the test from == to equals() which would give me the opportunity to intercept calls to equals() and to do a proper comparison with my proxy's underlying mock instance.