### PR TITLE
Added a default answer for java.util.Optional

### DIFF
--- a/src/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValues.java
+++ b/src/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValues.java
@@ -5,14 +5,9 @@
 
 package org.mockito.internal.stubbing.defaultanswers;
 
-import org.mockito.internal.util.MockUtil;
-import org.mockito.internal.util.ObjectMethodsGuru;
-import org.mockito.internal.util.Primitives;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.mock.MockName;
-import org.mockito.stubbing.Answer;
-
 import java.io.Serializable;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -27,6 +22,15 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+
+import org.mockito.internal.creation.instance.InstantiationException;
+import org.mockito.internal.util.JavaEightUtil;
+import org.mockito.internal.util.MockUtil;
+import org.mockito.internal.util.ObjectMethodsGuru;
+import org.mockito.internal.util.Primitives;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.mock.MockName;
+import org.mockito.stubbing.Answer;
 
 /**
  * Default answer of every Mockito mock.
@@ -45,6 +49,9 @@ import java.util.TreeSet;
  * </li>
  * <li>
  *  Returns zero if references are equals otherwise non-zero for Comparable#compareTo(T other) method (see issue 184)
+ * </li>
+ * <li>
+ *  Returns an {@link java.util.Optional#empty() empty Optional} for Optional (see issue 191).
  * </li>
  * <li>
  *  Returns null for everything else
@@ -116,8 +123,11 @@ public class ReturnsEmptyValues implements Answer<Object>, Serializable {
         }
         // TODO return empty Iterable ; see issue 175
 
+        if ("java.util.Optional".equals(type.getName())) {
+        	return JavaEightUtil.emptyOptional();
+        }
+        
         //Let's not care about the rest of collections.
         return null;
     }
-
 }

--- a/src/org/mockito/internal/util/JavaEightUtil.java
+++ b/src/org/mockito/internal/util/JavaEightUtil.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2015 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.util;
+
+import java.lang.reflect.Method;
+
+import org.mockito.internal.creation.instance.InstantiationException;
+
+/**
+ * Helper class to work with features that were introduced in Java versions after 1.5.
+ * This class uses reflection in most places to avoid coupling with a newer JDK.
+ */
+public final class JavaEightUtil {
+	private static Object emptyOptional;
+	
+	private JavaEightUtil() {
+		// utility class
+	}
+	
+	/**
+	 * Creates an empty Optional using reflection to stay backwards-compatible with older
+	 * JDKs (see issue 191).
+	 * 
+	 * @return an empty Optional.
+	 */
+	public static Object emptyOptional() {
+		// no need for double-checked locking
+		if (emptyOptional != null) {
+			return emptyOptional;
+		}
+		
+		try {
+			final Class<?> optionalClass = Class.forName("java.util.Optional");
+			final Method emptyMethod = optionalClass.getMethod("empty");
+			
+			return emptyOptional = emptyMethod.invoke(null);
+			// any exception is really unexpected since the type name has
+			// already been verified to be java.util.Optional
+		} catch (Exception e) {
+			throw new InstantiationException("Could not create java.util.Optional#empty(): " + e, e);
+		}
+	}
+}


### PR DESCRIPTION
I've introduced a new default answer for `java.util.Optional` that returns an empty optional.

The code uses reflection, so it should compile and run cleanly in older versions than Java 8.

--------------------------------------
**EDIT by mockito team** : fixes #191 