### PR TITLE
Fixes #200 : ArgumentCaptor.forClass is more friendly with generic types

### DIFF
--- a/src/org/mockito/ArgumentCaptor.java
+++ b/src/org/mockito/ArgumentCaptor.java
@@ -65,7 +65,7 @@ public class ArgumentCaptor<T> {
     HandyReturnValues handyReturnValues = new HandyReturnValues();
 
     private final CapturingMatcher<T> capturingMatcher = new CapturingMatcher<T>();
-    private final Class<T> clazz;
+    private final Class<? extends T> clazz;
 
     /**
      * @deprecated
@@ -87,7 +87,7 @@ public class ArgumentCaptor<T> {
         this.clazz = null;
     }
 
-    ArgumentCaptor(Class<T> clazz) {
+    private ArgumentCaptor(Class<? extends T> clazz) {
         this.clazz = clazz;
     }
 
@@ -163,10 +163,11 @@ public class ArgumentCaptor<T> {
      * future major release.
      *
      * @param clazz Type matching the parameter to be captured.
-     * @param <T> Type of clazz
+     * @param <S> Type of clazz
+     * @param <U> Type of object captured by the newly built ArgumentCaptor
      * @return A new ArgumentCaptor
      */
-    public static <T> ArgumentCaptor<T> forClass(Class<T> clazz) {
-        return new ArgumentCaptor<T>(clazz);
+    public static <U,S extends U> ArgumentCaptor<U> forClass(Class<S> clazz) {
+        return new ArgumentCaptor<U>(clazz);
     }
 }

--- a/test/org/mockitousage/matchers/CapturingArgumentsTest.java
+++ b/test/org/mockitousage/matchers/CapturingArgumentsTest.java
@@ -14,6 +14,7 @@ import org.mockito.exceptions.verification.WantedButNotInvoked;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.mockito.Matchers.any;
@@ -123,6 +124,18 @@ public class CapturingArgumentsTest extends TestBase {
         ArgumentCaptor<Person> argument = ArgumentCaptor.forClass(Person.class);
         verify(emailService).sendEmailTo(argument.capture());
         assertEquals(null, argument.getValue());
+    }
+
+    @Test
+    public void should_allow_construction_of_captor_for_parameterized_type_in_a_convenient_way()  {
+        //the test passes if this expression compiles
+        ArgumentCaptor<List<Person>> argument = ArgumentCaptor.forClass(List.class);
+    }
+
+    @Test
+    public void should_allow_construction_of_captor_for_a_more_specific_type()  {
+        //the test passes if this expression compiles
+        ArgumentCaptor<List> argument = ArgumentCaptor.forClass(ArrayList.class);
     }
     
     @Test


### PR DESCRIPTION
We modify the signature of `ArgumentCaptor.fromClass(Class<T>)` to better express the type relationship between the argument and the return type.  There is no change to the behavior of the method.  This change is to allow expressions such as:

```java
ArgumentCaptor<Consumer<String>> captor = ArgumentCaptor.fromClass(Consumer.class)
```

to type check, which is desirable as a convenience to users of `ArgumentCaptor`.

We also add two tests to document this extension to the api, both of which fail to compile without this change to `ArgumentCaptor.fromClass`.  These tests are unusual in that they make no assertions; this is justified because the change which they test is a change to the formal, or compile-time, properties of `ArgumentCaptor`, not its behavior.