### PR TITLE
Better protection against incompatible returned value of default answer, and get safely mock name

### DIFF
--- a/src/org/mockito/exceptions/Reporter.java
+++ b/src/org/mockito/exceptions/Reporter.java
@@ -8,7 +8,13 @@ package org.mockito.exceptions;
 import org.mockito.exceptions.base.MockitoAssertionError;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.exceptions.misusing.*;
-import org.mockito.exceptions.verification.*;
+import org.mockito.exceptions.verification.NeverWantedButInvoked;
+import org.mockito.exceptions.verification.NoInteractionsWanted;
+import org.mockito.exceptions.verification.SmartNullPointerException;
+import org.mockito.exceptions.verification.TooLittleActualInvocations;
+import org.mockito.exceptions.verification.TooManyActualInvocations;
+import org.mockito.exceptions.verification.VerificationInOrderFailure;
+import org.mockito.exceptions.verification.WantedButNotInvoked;
 import org.mockito.internal.debugging.LocationImpl;
 import org.mockito.internal.exceptions.MockitoLimitations;
 import org.mockito.internal.exceptions.VerificationAwareInvocation;
@@ -232,7 +238,7 @@ public class Reporter {
     public void invalidUseOfMatchers(int expectedMatchersCount, List<LocalizedMatcher> recordedMatchers) {
         throw new InvalidUseOfMatchersException(join(
                 "Invalid use of argument matchers!",
-                expectedMatchersCount + " matchers expected, " + recordedMatchers.size()+ " recorded:" +
+                expectedMatchersCount + " matchers expected, " + recordedMatchers.size() + " recorded:" +
                         locationsOf(recordedMatchers),
                 "",
                 "This exception may occur if matchers are combined with raw values:",
@@ -388,7 +394,7 @@ public class Reporter {
     private String createTooLittleInvocationsMessage(org.mockito.internal.reporting.Discrepancy discrepancy, DescribedInvocation wanted,
                                                      Location lastActualInvocation) {
         String ending =
-                (lastActualInvocation != null)? lastActualInvocation + "\n" : "\n";
+                (lastActualInvocation != null) ? lastActualInvocation + "\n" : "\n";
 
         String message = join(
                 wanted.toString(),
@@ -642,7 +648,7 @@ public class Reporter {
 
     public void fieldInitialisationThrewException(Field field, Throwable details) {
         throw new MockitoException(join(
-                "Cannot instantiate @InjectMocks field named '" + field.getName() + "' of type '" + field.getType() +  "'.",
+                "Cannot instantiate @InjectMocks field named '" + field.getName() + "' of type '" + field.getType() + "'.",
                 "You haven't provided the instance at field declaration so I tried to construct the instance.",
                 "However the constructor or the initialization block threw an exception : " + details.getMessage(),
                 ""), details);
@@ -694,7 +700,7 @@ public class Reporter {
     public void spyAndDelegateAreMutuallyExclusive() {
         throw new MockitoException(join(
                 "Settings should not define a spy instance and a delegated instance at the same time."
-        )) ;
+        ));
     }
 
     public void invalidArgumentRangeAtIdentityAnswerCreationTime() {
@@ -775,24 +781,24 @@ public class Reporter {
     }
 
     public void delegatedMethodHasWrongReturnType(Method mockMethod, Method delegateMethod, Object mock, Object delegate) {
-    	throw new MockitoException(join(
-    	        "Methods called on delegated instance must have compatible return types with the mock.",
-    	        "When calling: " + mockMethod + " on mock: " + safelyGetMockName(mock),
-    	        "return type should be: " + mockMethod.getReturnType().getSimpleName() + ", but was: " + delegateMethod.getReturnType().getSimpleName(),
-    	        "Check that the instance passed to delegatesTo() is of the correct type or contains compatible methods",
-    	        "(delegate instance had type: " + delegate.getClass().getSimpleName() + ")"
-    	));
+        throw new MockitoException(join(
+                "Methods called on delegated instance must have compatible return types with the mock.",
+                "When calling: " + mockMethod + " on mock: " + safelyGetMockName(mock),
+                "return type should be: " + mockMethod.getReturnType().getSimpleName() + ", but was: " + delegateMethod.getReturnType().getSimpleName(),
+                "Check that the instance passed to delegatesTo() is of the correct type or contains compatible methods",
+                "(delegate instance had type: " + delegate.getClass().getSimpleName() + ")"
+        ));
     }
 
-	public void delegatedMethodDoesNotExistOnDelegate(Method mockMethod, Object mock, Object delegate) {
-		throw new MockitoException(join(
-    	        "Methods called on mock must exist in delegated instance.",
-    	        "When calling: " + mockMethod + " on mock: " + safelyGetMockName(mock),
-    	        "no such method was found.",
-    	        "Check that the instance passed to delegatesTo() is of the correct type or contains compatible methods",
-    	        "(delegate instance had type: " + delegate.getClass().getSimpleName() + ")"
-    	));
-	}
+    public void delegatedMethodDoesNotExistOnDelegate(Method mockMethod, Object mock, Object delegate) {
+        throw new MockitoException(join(
+                "Methods called on mock must exist in delegated instance.",
+                "When calling: " + mockMethod + " on mock: " + safelyGetMockName(mock),
+                "no such method was found.",
+                "Check that the instance passed to delegatesTo() is of the correct type or contains compatible methods",
+                "(delegate instance had type: " + delegate.getClass().getSimpleName() + ")"
+        ));
+    }
 
     public void usingConstructorWithFancySerializable(SerializableMode mode) {
         throw new MockitoException("Mocks instantiated with constructor cannot be combined with " + mode + " serialization mode.");

--- a/src/org/mockito/exceptions/Reporter.java
+++ b/src/org/mockito/exceptions/Reporter.java
@@ -496,6 +496,18 @@ public class Reporter {
         ));
     }
 
+    public void wrongTypeReturnedByDefaultAnswer(Object mock, String expectedType, String actualType, String methodName) {
+        throw new WrongTypeOfReturnValue(join(
+                "Default answer returned a result with the wrong type:",
+                actualType + " cannot be returned by " + methodName + "()",
+                methodName + "() should return " + expectedType,
+                "",
+                "The default answer of " + safelyGetMockName(mock) + " that was configured on the mock is probably incorrectly implemented.",
+                ""
+        ));
+    }
+
+
     public void wantedAtMostX(int maxNumberOfInvocations, int foundSize) {
         throw new MockitoAssertionError(join("Wanted at most " + pluralize(maxNumberOfInvocations) + " but was " + foundSize));
     }

--- a/src/org/mockito/internal/handler/MockHandlerImpl.java
+++ b/src/org/mockito/internal/handler/MockHandlerImpl.java
@@ -10,7 +10,12 @@ import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockito.internal.invocation.MatchersBinder;
 import org.mockito.internal.progress.MockingProgress;
 import org.mockito.internal.progress.ThreadSafeMockingProgress;
-import org.mockito.internal.stubbing.*;
+import org.mockito.internal.stubbing.InvocationContainer;
+import org.mockito.internal.stubbing.InvocationContainerImpl;
+import org.mockito.internal.stubbing.OngoingStubbingImpl;
+import org.mockito.internal.stubbing.StubbedInvocationMatcher;
+import org.mockito.internal.stubbing.VoidMethodStubbableImpl;
+import org.mockito.internal.stubbing.answers.AnswersValidator;
 import org.mockito.internal.verification.MockAwareVerificationMode;
 import org.mockito.internal.verification.VerificationDataImpl;
 import org.mockito.invocation.Invocation;
@@ -23,9 +28,8 @@ import java.util.List;
 
 /**
  * Invocation handler set on mock objects.
- * 
- * @param <T>
- *            type of mock object to handle
+ *
+ * @param <T> type of mock object to handle
  */
 class MockHandlerImpl<T> implements InternalMockHandler<T> {
 
@@ -45,7 +49,7 @@ class MockHandlerImpl<T> implements InternalMockHandler<T> {
     }
 
     public Object handle(Invocation invocation) throws Throwable {
-		if (invocationContainerImpl.hasAnswersForStubbing()) {
+        if (invocationContainerImpl.hasAnswersForStubbing()) {
             // stubbing voids with stubVoid() or doAnswer() style
             InvocationMatcher invocationMatcher = matchersBinder.bindMatchers(
                     mockingProgress.getArgumentMatcherStorage(),
@@ -90,7 +94,8 @@ class MockHandlerImpl<T> implements InternalMockHandler<T> {
             stubbedInvocation.captureArgumentsFrom(invocation);
             return stubbedInvocation.answer(invocation);
         } else {
-             Object ret = mockSettings.getDefaultAnswer().answer(invocation);
+            Object ret = mockSettings.getDefaultAnswer().answer(invocation);
+            new AnswersValidator().validateDefaultAnswerReturnedValue(invocation, ret);
 
             // redo setting invocation for potential stubbing in case of partial
             // mocks / spies.
@@ -100,7 +105,7 @@ class MockHandlerImpl<T> implements InternalMockHandler<T> {
             invocationContainerImpl.resetInvocationForPotentialStubbing(invocationMatcher);
             return ret;
         }
-	}
+    }
 
     public VoidMethodStubbable<T> voidMethodStubbable(T mock) {
         return new VoidMethodStubbableImpl<T>(mock, invocationContainerImpl);

--- a/src/org/mockito/internal/invocation/InvocationImpl.java
+++ b/src/org/mockito/internal/invocation/InvocationImpl.java
@@ -105,6 +105,10 @@ public class InvocationImpl implements Invocation, VerificationAwareInvocation {
         return this.rawArguments;
     }
 
+    public Class<?> getRawReturnType() {
+        return method.getReturnType();
+    }
+
     public Object callRealMethod() throws Throwable {
         if (method.isAbstract()) {
             new Reporter().cannotCallAbstractRealMethod();

--- a/src/org/mockito/internal/stubbing/answers/AnswersValidator.java
+++ b/src/org/mockito/internal/stubbing/answers/AnswersValidator.java
@@ -11,21 +11,21 @@ import org.mockito.stubbing.Answer;
 public class AnswersValidator {
 
     private final Reporter reporter = new Reporter();
-    
+
     public void validate(Answer<?> answer, Invocation invocation) {
         MethodInfo methodInfo = new MethodInfo(invocation);
         if (answer instanceof ThrowsException) {
             validateException((ThrowsException) answer, methodInfo);
         }
-        
+
         if (answer instanceof Returns) {
             validateReturnValue((Returns) answer, methodInfo);
         }
-        
+
         if (answer instanceof DoesNothing) {
             validateDoNothing((DoesNothing) answer, methodInfo);
         }
-        
+
         if (answer instanceof CallsRealMethods) {
             validateMockingConcreteClass((CallsRealMethods) answer, methodInfo);
         }
@@ -42,8 +42,8 @@ public class AnswersValidator {
         MethodInfo methodInfo = new MethodInfo(invocation);
         if (!methodInfo.isValidReturnType(returnsArgumentAt.returnedTypeOnSignature(invocation))) {
             new Reporter().wrongTypeOfArgumentToReturn(invocation, methodInfo.printMethodReturnType(),
-                                                       returnsArgumentAt.returnedTypeOnSignature(invocation),
-                                                       returnsArgumentAt.wantedArgumentPosition());
+                    returnsArgumentAt.returnedTypeOnSignature(invocation),
+                    returnsArgumentAt.wantedArgumentPosition());
         }
 
     }
@@ -64,10 +64,10 @@ public class AnswersValidator {
         if (methodInfo.isVoid()) {
             reporter.cannotStubVoidMethodWithAReturnValue(methodInfo.getMethodName());
         }
-        
+
         if (answer.returnsNull() && methodInfo.returnsPrimitive()) {
             reporter.wrongTypeOfReturnValue(methodInfo.printMethodReturnType(), "null", methodInfo.getMethodName());
-        } 
+        }
 
         if (!answer.returnsNull() && !methodInfo.isValidReturnType(answer.getReturnType())) {
             reporter.wrongTypeOfReturnValue(methodInfo.printMethodReturnType(), answer.printReturnType(), methodInfo.getMethodName());
@@ -79,13 +79,24 @@ public class AnswersValidator {
         if (throwable == null) {
             reporter.cannotStubWithNullThrowable();
         }
-        
+
         if (throwable instanceof RuntimeException || throwable instanceof Error) {
             return;
         }
-        
+
         if (!methodInfo.isValidException(throwable)) {
             reporter.checkedExceptionInvalid(throwable);
+        }
+    }
+
+    public void validateDefaultAnswerReturnedValue(Invocation invocation, Object returnedValue) {
+        MethodInfo methodInfo = new MethodInfo(invocation);
+        if (returnedValue != null && !methodInfo.isValidReturnType(returnedValue.getClass())) {
+            reporter.wrongTypeReturnedByDefaultAnswer(
+                    invocation.getMock(),
+                    methodInfo.printMethodReturnType(),
+                    returnedValue.getClass().getSimpleName(),
+                    methodInfo.getMethodName());
         }
     }
 }

--- a/src/org/mockito/invocation/Invocation.java
+++ b/src/org/mockito/invocation/Invocation.java
@@ -42,6 +42,14 @@ public interface Invocation extends InvocationOnMock, DescribedInvocation {
     Object[] getRawArguments();
 
     /**
+     * Returns unprocessed arguments whereas {@link #getArguments()} returns
+     * arguments already processed (e.g. varargs expended, etc.).
+     *
+     * @return unprocessed arguments, exactly as provided to this invocation.
+     */
+    Class getRawReturnType();
+
+    /**
      * Marks this invocation as verified so that it will not cause verification error at
      * {@link org.mockito.Mockito#verifyNoMoreInteractions(Object...)}
      */

--- a/test/org/mockito/exceptions/ReporterTest.java
+++ b/test/org/mockito/exceptions/ReporterTest.java
@@ -6,21 +6,81 @@
 package org.mockito.exceptions;
 
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.mockito.exceptions.base.MockitoException;
+import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockito.exceptions.verification.TooLittleActualInvocations;
+import org.mockito.exceptions.verification.VerificationInOrderFailure;
+import org.mockito.internal.exceptions.VerificationAwareInvocation;
 import org.mockito.internal.invocation.InvocationBuilder;
-import org.mockito.internal.reporting.*;
+import org.mockito.internal.stubbing.answers.Returns;
+import org.mockito.invocation.Invocation;
+import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+
+import static org.mockito.Mockito.mock;
 
 public class ReporterTest extends TestBase {
 
-    @Test(expected=TooLittleActualInvocations.class)
-    public void shouldLetPassingNullLastActualStackTrace() throws Exception {
+    @Test(expected = TooLittleActualInvocations.class)
+    public void should_let_passing_null_last_actual_stack_trace() throws Exception {
         new Reporter().tooLittleActualInvocations(new org.mockito.internal.reporting.Discrepancy(1, 2), new InvocationBuilder().toInvocation(), null);
     }
-    
-    @Test(expected=MockitoException.class)
-    public void shouldThrowCorrectExceptionForNullInvocationListener() throws Exception {
-    	new Reporter().invocationListenerDoesNotAcceptNullParameters();
+
+    @Test(expected = MockitoException.class)
+    public void should_throw_correct_exception_for_null_invocation_listener() throws Exception {
+        new Reporter().invocationListenerDoesNotAcceptNullParameters();
     }
+
+    @Test(expected = NoInteractionsWanted.class)
+    public void can_use_mock_name_even_when_mock_bogus_default_answer_and_when_reporting_no_more_interaction_wanted() throws Exception {
+        Invocation invocation_with_bogus_default_answer = new InvocationBuilder().mock(mock(IMethods.class, new Returns(false))).toInvocation();
+        new Reporter().noMoreInteractionsWanted(invocation_with_bogus_default_answer, Collections.<VerificationAwareInvocation>emptyList());
+    }
+
+    @Test(expected = VerificationInOrderFailure.class)
+    public void can_use_print_mock_name_even_when_mock_bogus_default_answer_and_when_reporting_no_more_interaction_wanted_in_order() throws Exception {
+        Invocation invocation_with_bogus_default_answer = new InvocationBuilder().mock(mock(IMethods.class, new Returns(false))).toInvocation();
+        new Reporter().noMoreInteractionsWantedInOrder(invocation_with_bogus_default_answer);
+    }
+
+    @Test(expected = MockitoException.class)
+    public void can_use_print_mock_name_even_when_mock_bogus_default_answer_and_when_reporting_invalid_argument_position() throws Exception {
+        Invocation invocation_with_bogus_default_answer = new InvocationBuilder().mock(mock(IMethods.class, new Returns(false))).toInvocation();
+        new Reporter().invalidArgumentPositionRangeAtInvocationTime(invocation_with_bogus_default_answer, true, 0);
+    }
+
+    @Test(expected = MockitoException.class)
+    public void can_use_print_mock_name_even_when_mock_bogus_default_answer_and_when_reporting_wrong_argument_to_return() throws Exception {
+        Invocation invocation_with_bogus_default_answer = new InvocationBuilder().mock(mock(IMethods.class, new Returns(false))).toInvocation();
+        new Reporter().wrongTypeOfArgumentToReturn(invocation_with_bogus_default_answer, "", String.class, 0);
+    }
+
+    @Test(expected = MockitoException.class)
+    public void can_use_print_mock_name_even_when_mock_bogus_default_answer_and_when_reporting_delegate_method_dont_exists() throws Exception {
+        Invocation dumb_invocation = new InvocationBuilder().toInvocation();
+        IMethods mock_with_bogus_default_answer = mock(IMethods.class, new Returns(false));
+        new Reporter().delegatedMethodDoesNotExistOnDelegate(dumb_invocation.getMethod(), mock_with_bogus_default_answer, String.class);
+    }
+
+    @Test(expected = MockitoException.class)
+    public void can_use_print_mock_name_even_when_mock_bogus_default_answer_and_when_reporting_delegate_method_has_wrong_return_type() throws Exception {
+        Invocation dumb_invocation = new InvocationBuilder().toInvocation();
+        IMethods mock_with_bogus_default_answer = mock(IMethods.class, new Returns(false));
+        new Reporter().delegatedMethodHasWrongReturnType(dumb_invocation.getMethod(), dumb_invocation.getMethod(), mock_with_bogus_default_answer, String.class);
+    }
+
+    @Test(expected = MockitoException.class)
+    public void can_use_print_mock_name_even_when_mock_bogus_default_answer_and_when_reporting_injection_failure() throws Exception {
+        IMethods mock_with_bogus_default_answer = mock(IMethods.class, new Returns(false));
+        new Reporter().cannotInjectDependency(someField(), mock_with_bogus_default_answer, new Exception());
+    }
+
+    private Field someField() {
+        return Mockito.class.getDeclaredFields()[0];
+    }
+
 }

--- a/test/org/mockito/internal/handler/MockHandlerImplTest.java
+++ b/test/org/mockito/internal/handler/MockHandlerImplTest.java
@@ -29,79 +29,73 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
-@SuppressWarnings({ "unchecked", "serial" })
+@SuppressWarnings({"unchecked", "serial"})
 public class MockHandlerImplTest extends TestBase {
 
-	private StubbedInvocationMatcher stubbedInvocationMatcher = mock(StubbedInvocationMatcher.class);
-	private Invocation invocation = mock(InvocationImpl.class);
+    private StubbedInvocationMatcher stubbedInvocationMatcher = mock(StubbedInvocationMatcher.class);
+    private Invocation invocation = mock(InvocationImpl.class);
 
 
-	@Test
-	public void shouldRemoveVerificationModeEvenWhenInvalidMatchers() throws Throwable {
-		// given
-		Invocation invocation = new InvocationBuilder().toInvocation();
-		@SuppressWarnings("rawtypes")
+    @Test
+    public void should_remove_verification_mode_even_when_invalid_matchers() throws Throwable {
+        // given
+        Invocation invocation = new InvocationBuilder().toInvocation();
+        @SuppressWarnings("rawtypes")
         MockHandlerImpl<?> handler = new MockHandlerImpl(new MockSettingsImpl());
-		handler.mockingProgress.verificationStarted(VerificationModeFactory.atLeastOnce());
-		handler.matchersBinder = new MatchersBinder() {
-			public InvocationMatcher bindMatchers(ArgumentMatcherStorage argumentMatcherStorage, Invocation invocation) {
-				throw new InvalidUseOfMatchersException();
-			}
-		};
+        handler.mockingProgress.verificationStarted(VerificationModeFactory.atLeastOnce());
+        handler.matchersBinder = new MatchersBinder() {
+            public InvocationMatcher bindMatchers(ArgumentMatcherStorage argumentMatcherStorage, Invocation invocation) {
+                throw new InvalidUseOfMatchersException();
+            }
+        };
 
-		try {
-			// when
-			handler.handle(invocation);
+        try {
+            // when
+            handler.handle(invocation);
 
-			// then
-			fail();
-		} catch (InvalidUseOfMatchersException e) {
-		}
+            // then
+            fail();
+        } catch (InvalidUseOfMatchersException ignored) {
+        }
 
-		assertNull(handler.mockingProgress.pullVerificationMode());
-	}
-
-
+        assertNull(handler.mockingProgress.pullVerificationMode());
+    }
 
 
-	@Test(expected = MockitoException.class)
-	public void shouldThrowMockitoExceptionWhenInvocationHandlerThrowsAnything() throws Throwable {
-		// given
-		InvocationListener throwingListener = mock(InvocationListener.class);
-		doThrow(new Throwable()).when(throwingListener).reportInvocation(any(MethodInvocationReport.class));
-		MockHandlerImpl<?> handler = createCorrectlyStubbedHandler(throwingListener);
+    @Test(expected = MockitoException.class)
+    public void should_throw_mockito_exception_when_invocation_handler_throws_anything() throws Throwable {
+        // given
+        InvocationListener throwingListener = mock(InvocationListener.class);
+        doThrow(new Throwable()).when(throwingListener).reportInvocation(any(MethodInvocationReport.class));
+        MockHandlerImpl<?> handler = create_correctly_stubbed_handler(throwingListener);
 
-		// when
-		handler.handle(invocation);
-	}
-
-
-
-	private MockHandlerImpl<?> createCorrectlyStubbedHandler(InvocationListener throwingListener) {
-		MockHandlerImpl<?> handler = createHandlerWithListeners(throwingListener);
-		stubOrdinaryInvocationWithGivenReturnValue(handler);
-		return handler;
-	}
-
-	private void stubOrdinaryInvocationWithGivenReturnValue(MockHandlerImpl<?> handler) {
-		stubOrdinaryInvocationWithInvocationMatcher(handler, stubbedInvocationMatcher);
-	}
+        // when
+        handler.handle(invocation);
+    }
 
 
+    private MockHandlerImpl<?> create_correctly_stubbed_handler(InvocationListener throwingListener) {
+        MockHandlerImpl<?> handler = create_handler_with_listeners(throwingListener);
+        stub_ordinary_invocation_with_given_return_value(handler);
+        return handler;
+    }
 
-	private void stubOrdinaryInvocationWithInvocationMatcher(MockHandlerImpl<?> handler, StubbedInvocationMatcher value) {
-		handler.invocationContainerImpl = mock(InvocationContainerImpl.class);
-		given(handler.invocationContainerImpl.findAnswerFor(any(InvocationImpl.class))).willReturn(value);
-	}
+    private void stub_ordinary_invocation_with_given_return_value(MockHandlerImpl<?> handler) {
+        stub_ordinary_invocation_with_invocation_matcher(handler, stubbedInvocationMatcher);
+    }
 
 
+    private void stub_ordinary_invocation_with_invocation_matcher(MockHandlerImpl<?> handler, StubbedInvocationMatcher value) {
+        handler.invocationContainerImpl = mock(InvocationContainerImpl.class);
+        given(handler.invocationContainerImpl.findAnswerFor(any(InvocationImpl.class))).willReturn(value);
+    }
 
 
-	private MockHandlerImpl<?> createHandlerWithListeners(InvocationListener... listener) {
-		@SuppressWarnings("rawtypes")
+    private MockHandlerImpl<?> create_handler_with_listeners(InvocationListener... listener) {
+        @SuppressWarnings("rawtypes")
         MockHandlerImpl<?> handler = new MockHandlerImpl(mock(MockSettingsImpl.class));
-		handler.matchersBinder = mock(MatchersBinder.class);
-		given(handler.getMockSettings().getInvocationListeners()).willReturn(Arrays.asList(listener));
-		return handler;
-	}
+        handler.matchersBinder = mock(MatchersBinder.class);
+        given(handler.getMockSettings().getInvocationListeners()).willReturn(Arrays.asList(listener));
+        return handler;
+    }
 }

--- a/test/org/mockito/internal/handler/MockHandlerImplTest.java
+++ b/test/org/mockito/internal/handler/MockHandlerImplTest.java
@@ -8,6 +8,7 @@ package org.mockito.internal.handler;
 import org.junit.Test;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.exceptions.misusing.InvalidUseOfMatchersException;
+import org.mockito.exceptions.misusing.WrongTypeOfReturnValue;
 import org.mockito.internal.creation.MockSettingsImpl;
 import org.mockito.internal.invocation.InvocationBuilder;
 import org.mockito.internal.invocation.InvocationImpl;
@@ -16,6 +17,7 @@ import org.mockito.internal.invocation.MatchersBinder;
 import org.mockito.internal.progress.ArgumentMatcherStorage;
 import org.mockito.internal.stubbing.InvocationContainerImpl;
 import org.mockito.internal.stubbing.StubbedInvocationMatcher;
+import org.mockito.internal.stubbing.answers.Returns;
 import org.mockito.internal.verification.VerificationModeFactory;
 import org.mockito.invocation.Invocation;
 import org.mockito.listeners.InvocationListener;
@@ -73,6 +75,17 @@ public class MockHandlerImplTest extends TestBase {
         handler.handle(invocation);
     }
 
+    @Test(expected = WrongTypeOfReturnValue.class)
+    public void should_report_bogus_default_answer() throws Throwable {
+        MockSettingsImpl mockSettings = mock(MockSettingsImpl.class);
+        MockHandlerImpl<?> handler = new MockHandlerImpl(mockSettings);
+        given(mockSettings.getDefaultAnswer()).willReturn(new Returns(AWrongType.WRONG_TYPE));
+
+        @SuppressWarnings("unused") // otherwise cast is not done
+        String there_should_not_be_a_CCE_here = (String) handler.handle(
+                new InvocationBuilder().method(Object.class.getDeclaredMethod("toString")).toInvocation()
+        );
+    }
 
     private MockHandlerImpl<?> create_correctly_stubbed_handler(InvocationListener throwingListener) {
         MockHandlerImpl<?> handler = create_handler_with_listeners(throwingListener);
@@ -97,5 +110,9 @@ public class MockHandlerImplTest extends TestBase {
         handler.matchersBinder = mock(MatchersBinder.class);
         given(handler.getMockSettings().getInvocationListeners()).willReturn(Arrays.asList(listener));
         return handler;
+    }
+
+    private static class AWrongType {
+        public static final AWrongType WRONG_TYPE = new AWrongType();
     }
 }

--- a/test/org/mockito/internal/verification/NoMoreInteractionsTest.java
+++ b/test/org/mockito/internal/verification/NoMoreInteractionsTest.java
@@ -4,8 +4,6 @@
  */
 package org.mockito.internal.verification;
 
-import static java.util.Arrays.*;
-
 import org.fest.assertions.Assertions;
 import org.junit.Test;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
@@ -17,19 +15,23 @@ import org.mockito.internal.progress.ThreadSafeMockingProgress;
 import org.mockito.internal.stubbing.InvocationContainerImpl;
 import org.mockito.internal.verification.api.VerificationDataInOrderImpl;
 import org.mockito.invocation.Invocation;
+import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
+
+import static java.util.Arrays.asList;
+import static org.mockito.Mockito.mock;
 
 public class NoMoreInteractionsTest extends TestBase {
 
     InOrderContextImpl context = new InOrderContextImpl();
-    
+
     @Test
     public void shouldVerifyInOrder() {
         //given
         NoMoreInteractions n = new NoMoreInteractions();
         Invocation i = new InvocationBuilder().toInvocation();
         assertFalse(context.isVerified(i));
-        
+
         try {
             //when
             n.verifyInOrder(new VerificationDataInOrderImpl(context, asList(i), null));
@@ -37,7 +39,7 @@ public class NoMoreInteractionsTest extends TestBase {
             fail();
         } catch(VerificationInOrderFailure e) {}
     }
-    
+
     @Test
     public void shouldVerifyInOrderAndPass() {
         //given
@@ -45,12 +47,12 @@ public class NoMoreInteractionsTest extends TestBase {
         Invocation i = new InvocationBuilder().toInvocation();
         context.markVerified(i);
         assertTrue(context.isVerified(i));
-        
+
         //when
         n.verifyInOrder(new VerificationDataInOrderImpl(context, asList(i), null));
         //then no exception is thrown
     }
-    
+
     @Test
     public void shouldVerifyInOrderMultipleInvoctions() {
         //given
@@ -83,7 +85,7 @@ public class NoMoreInteractionsTest extends TestBase {
     public void noMoreInteractionsExceptionMessageShouldDescribeMock() {
         //given
         NoMoreInteractions n = new NoMoreInteractions();
-        String mock = "a mock";
+        IMethods mock = mock(IMethods.class, "a mock");
         InvocationMatcher i = new InvocationBuilder().mock(mock).toInvocationMatcher();
 
         InvocationContainerImpl invocations =
@@ -104,7 +106,7 @@ public class NoMoreInteractionsTest extends TestBase {
     public void noMoreInteractionsInOrderExceptionMessageShouldDescribeMock() {
         //given
         NoMoreInteractions n = new NoMoreInteractions();
-        String mock = "a mock";
+        IMethods mock = mock(IMethods.class, "a mock");
         Invocation i = new InvocationBuilder().mock(mock).toInvocation();
 
         try {

--- a/test/org/mockitousage/bugs/ClassCastExOnVerifyZeroInteractionsTest.java
+++ b/test/org/mockitousage/bugs/ClassCastExOnVerifyZeroInteractionsTest.java
@@ -1,0 +1,26 @@
+package org.mockitousage.bugs;
+
+import org.junit.Test;
+import org.mockito.exceptions.verification.NoInteractionsWanted;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+public class ClassCastExOnVerifyZeroInteractionsTest {
+    public interface TestMock {
+        boolean m1();
+    }
+
+    @Test(expected = NoInteractionsWanted.class)
+    public void should_not_throw_a_ClassCastException() {
+        TestMock test = mock(TestMock.class, new Answer() {
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                return false;
+            }
+        });
+        test.m1();
+        verifyZeroInteractions(test);
+    }
+}

--- a/test/org/mockitousage/bugs/ClassCastExOnVerifyZeroInteractionsTest.java
+++ b/test/org/mockitousage/bugs/ClassCastExOnVerifyZeroInteractionsTest.java
@@ -1,6 +1,7 @@
 package org.mockitousage.bugs;
 
 import org.junit.Test;
+import org.mockito.exceptions.misusing.WrongTypeOfReturnValue;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -14,7 +15,7 @@ public class ClassCastExOnVerifyZeroInteractionsTest {
     }
 
     @Test(expected = NoInteractionsWanted.class)
-    public void should_not_throw_a_ClassCastException() {
+    public void should_not_throw_ClassCastException_when_mock_verification_fails() {
         TestMock test = mock(TestMock.class, new Answer() {
             public Object answer(InvocationOnMock invocation) throws Throwable {
                 return false;
@@ -22,5 +23,16 @@ public class ClassCastExOnVerifyZeroInteractionsTest {
         });
         test.m1();
         verifyZeroInteractions(test);
+    }
+
+    @Test(expected = WrongTypeOfReturnValue.class)
+    public void should_report_bogus_default_answer() throws Exception {
+        TestMock test = mock(TestMock.class, new Answer() {
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                return false;
+            }
+        });
+
+        test.toString();
     }
 }

--- a/test/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
+++ b/test/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
@@ -33,7 +33,7 @@ public class DescriptiveMessagesWhenVerificationFailsTest extends TestBase {
 
     @Before
     public void setup() {
-        mock = Mockito.mock(IMethods.class);
+        mock = Mockito.mock(IMethods.class, "iMethods");
     }
 
     @Test
@@ -85,8 +85,8 @@ public class DescriptiveMessagesWhenVerificationFailsTest extends TestBase {
                     "iMethods.varargs(1, 1000);";
 
             assertContains(wanted, e.getMessage());
-            
-            String actual = 
+
+            String actual =
                     "\n" +
                     "Actual invocation has different arguments:" +
                     "\n" +
@@ -95,7 +95,7 @@ public class DescriptiveMessagesWhenVerificationFailsTest extends TestBase {
             assertContains(actual, e.getMessage());
         }
     }
-    
+
     @Test
     public void should_print_actual_and_wanted_in_multiple_lines() {
         mock.varargs("this is very long string", "this is another very long string");
@@ -296,11 +296,11 @@ public class DescriptiveMessagesWhenVerificationFailsTest extends TestBase {
             assertContains("simpleMethod(null, null);", e.getMessage());
         }
     }
-    
+
     @Test
     public void should_say_never_wanted_but_invoked() throws Exception {
         mock.simpleMethod(1);
-    
+
         verify(mock, never()).simpleMethod(2);
         try {
             verify(mock, never()).simpleMethod(1);
@@ -310,12 +310,12 @@ public class DescriptiveMessagesWhenVerificationFailsTest extends TestBase {
             assertContains("But invoked here:", e.getMessage());
         }
     }
-    
+
     @Test
     public void should_show_right_actual_method() throws Exception {
         mock.simpleMethod(9191);
         mock.simpleMethod("foo");
-    
+
         try {
             verify(mock).simpleMethod("bar");
             fail();
@@ -326,11 +326,11 @@ public class DescriptiveMessagesWhenVerificationFailsTest extends TestBase {
     }
 
     @Mock private IMethods iHavefunkyName;
-    
+
     @Test
     public void should_print_field_name_when_annotations_used() throws Exception {
         iHavefunkyName.simpleMethod(10);
-    
+
         try {
             verify(iHavefunkyName).simpleMethod(20);
             fail();
@@ -339,12 +339,12 @@ public class DescriptiveMessagesWhenVerificationFailsTest extends TestBase {
             assertContains("iHavefunkyName.simpleMethod(10)", e.getMessage());
         }
     }
-    
+
     @Test
     public void should_print_interactions_on_mock_when_ordinary_verification_fail() throws Exception {
         mock.otherMethod();
         mock.booleanReturningMethod();
-        
+
         try {
             verify(mock).simpleMethod();
             fail();
@@ -353,8 +353,8 @@ public class DescriptiveMessagesWhenVerificationFailsTest extends TestBase {
         }
     }
 
-    @Mock private IMethods veeeeeeeeeeeeeeeeeeeeeeeerylongNameMock; 
-    
+    @Mock private IMethods veeeeeeeeeeeeeeeeeeeeeeeerylongNameMock;
+
     @Test
     public void should_never_break_method_string_when_no_args_in_method() throws Exception {
         try {
@@ -430,5 +430,4 @@ public class DescriptiveMessagesWhenVerificationFailsTest extends TestBase {
     public interface AnInterface {
         void foo(int i);
     }
-    
 }


### PR DESCRIPTION
Fixes issue #187


The value returned by the default answer is now validated to make sure there won't be a `ClassCastException` if the default value is incompatible with return type.

Reporter now fetch in safer way the mock name, in case the default answer is incorrectly implemented. This avoid a `ClassCastException` when reporting a verification issue.