### PR TITLE
Improves InjectMocks behavior when injectee has multiple fields of the same type

### DIFF
--- a/src/org/mockito/internal/configuration/injection/PropertyAndSetterInjection.java
+++ b/src/org/mockito/internal/configuration/injection/PropertyAndSetterInjection.java
@@ -111,7 +111,7 @@ public class PropertyAndSetterInjection extends MockInjectionStrategy {
     private boolean injectMockCandidatesOnFields(Set<Object> mocks, Object instance, boolean injectionOccurred, List<Field> orderedInstanceFields) {
         for (Iterator<Field> it = orderedInstanceFields.iterator(); it.hasNext(); ) {
             Field field = it.next();
-            Object injected = mockCandidateFilter.filterCandidate(mocks, field, instance).thenInject();
+            Object injected = mockCandidateFilter.filterCandidate(mocks, field, orderedInstanceFields, instance).thenInject();
             if (injected != null) {
                 injectionOccurred |= true;
                 mocks.remove(injected);

--- a/src/org/mockito/internal/configuration/injection/filter/FinalMockCandidateFilter.java
+++ b/src/org/mockito/internal/configuration/injection/filter/FinalMockCandidateFilter.java
@@ -10,6 +10,7 @@ import org.mockito.internal.util.reflection.FieldSetter;
 
 import java.lang.reflect.Field;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * This node returns an actual injecter which will be either :
@@ -20,7 +21,7 @@ import java.util.Collection;
  * </ul>
  */
 public class FinalMockCandidateFilter implements MockCandidateFilter {
-    public OngoingInjecter filterCandidate(final Collection<Object> mocks, final Field field, final Object fieldInstance) {
+    public OngoingInjecter filterCandidate(final Collection<Object> mocks, final Field field, List<Field> fields, final Object fieldInstance) {
         if(mocks.size() == 1) {
             final Object matchingMock = mocks.iterator().next();
 

--- a/src/org/mockito/internal/configuration/injection/filter/MockCandidateFilter.java
+++ b/src/org/mockito/internal/configuration/injection/filter/MockCandidateFilter.java
@@ -6,13 +6,14 @@ package org.mockito.internal.configuration.injection.filter;
 
 import java.lang.reflect.Field;
 import java.util.Collection;
+import java.util.List;
 
 public interface MockCandidateFilter {
 
     OngoingInjecter filterCandidate(
             Collection<Object> mocks,
             Field fieldToBeInjected,
-            Object fieldInstance
+            List<Field> fields, Object instance
     );
 
 }

--- a/src/org/mockito/internal/configuration/injection/filter/NameBasedCandidateFilter.java
+++ b/src/org/mockito/internal/configuration/injection/filter/NameBasedCandidateFilter.java
@@ -12,23 +12,50 @@ import java.util.Collection;
 import java.util.List;
 
 public class NameBasedCandidateFilter implements MockCandidateFilter {
-    private final MockCandidateFilter next;
-    private final MockUtil mockUtil = new MockUtil();
+	private final MockCandidateFilter next;
+	private final MockUtil mockUtil = new MockUtil();
 
-    public NameBasedCandidateFilter(MockCandidateFilter next) {
-        this.next = next;
-    }
+	public NameBasedCandidateFilter(MockCandidateFilter next) {
+		this.next = next;
+	}
 
-    public OngoingInjecter filterCandidate(Collection<Object> mocks, Field field, Object fieldInstance) {
-        List<Object> mockNameMatches = new ArrayList<Object>();
-        if(mocks.size() > 1) {
-            for (Object mock : mocks) {
-                if (field.getName().equals(mockUtil.getMockName(mock).toString())) {
-                    mockNameMatches.add(mock);
-                }
-            }
-            return next.filterCandidate(mockNameMatches, field, fieldInstance);
-        }
-        return next.filterCandidate(mocks, field, fieldInstance);
-    }
+	public OngoingInjecter filterCandidate(Collection<Object> mocks,
+			Field field, List<Field> fields, Object fieldInstance) {
+		List<Object> mockNameMatches = new ArrayList<Object>();
+		if (mocks.size() > 1) {
+			for (Object mock : mocks) {
+				if (field.getName().equals(mockUtil.getMockName(mock).toString())) {
+					mockNameMatches.add(mock);
+				}
+			}
+			return next.filterCandidate(mockNameMatches, field, fields,
+					fieldInstance);
+			/*
+			 * In this case we have to check whether we have conflicting naming
+			 * fields. E.g. 2 fields of the same type, but we have to make sure
+			 * we match on the correct name.
+			 * 
+			 * Therefore we have to go through all other fields and make sure
+			 * whenever we find a field that does match its name with the mock
+			 * name, we should take that field instead.
+			 */
+		} else if (mocks.size() == 1) {
+			String mockName = mockUtil.getMockName(mocks.iterator().next())
+					.toString();
+
+			for (Field otherField : fields) {
+				if (!otherField.equals(field)
+						&& otherField.getType().equals(field.getType())
+						&& otherField.getName().equals(mockName)) {
+
+					return new OngoingInjecter() {
+						public Object thenInject() {
+							return null;
+						}
+					};
+				}
+			}
+		}
+		return next.filterCandidate(mocks, field, fields, fieldInstance);
+	}
 }

--- a/src/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
+++ b/src/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
@@ -17,7 +17,7 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
         this.next = next;
     }
 
-    public OngoingInjecter filterCandidate(Collection<Object> mocks, Field field, Object fieldInstance) {
+    public OngoingInjecter filterCandidate(Collection<Object> mocks, Field field, List<Field> fields, Object fieldInstance) {
         List<Object> mockTypeMatches = new ArrayList<Object>();
         for (Object mock : mocks) {
             if (field.getType().isAssignableFrom(mock.getClass())) {
@@ -25,6 +25,6 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
             }
         }
 
-        return next.filterCandidate(mockTypeMatches, field, fieldInstance);
+        return next.filterCandidate(mockTypeMatches, field, fields, fieldInstance);
     }
 }

--- a/test/org/mockitousage/annotation/MockInjectionUsingSetterOrPropertyTest.java
+++ b/test/org/mockitousage/annotation/MockInjectionUsingSetterOrPropertyTest.java
@@ -4,6 +4,9 @@
  */
 package org.mockitousage.annotation;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import org.fest.assertions.Assertions;
 import org.junit.Before;
 import org.junit.Test;
@@ -28,6 +31,7 @@ public class MockInjectionUsingSetterOrPropertyTest extends TestBase {
     @InjectMocks private BaseUnderTesting baseUnderTest = new BaseUnderTesting();
     @InjectMocks private SubUnderTesting subUnderTest = new SubUnderTesting();
     @InjectMocks private OtherBaseUnderTesting otherBaseUnderTest = new OtherBaseUnderTesting();
+    @InjectMocks private OtherSuperUnderTesting otherSuperUnderTesting = new OtherSuperUnderTesting();
 
     private BaseUnderTesting baseUnderTestingInstance = new BaseUnderTesting();
     @InjectMocks private BaseUnderTesting initializedBase = baseUnderTestingInstance;
@@ -40,6 +44,8 @@ public class MockInjectionUsingSetterOrPropertyTest extends TestBase {
     @Mock private List list;
     @Mock private Set histogram1;
     @Mock private Set histogram2;
+    @Mock private A candidate2;
+    
     @Spy private TreeSet searchTree = new TreeSet();
     private MockUtil mockUtil = new MockUtil();
 
@@ -102,6 +108,13 @@ public class MockInjectionUsingSetterOrPropertyTest extends TestBase {
         MockitoAnnotations.initMocks(this);
         assertSame(searchTree, otherBaseUnderTest.getSearchTree());
     }
+    
+    @Test
+	public void shouldInsertFieldWithCorrectNameWhenMultipleTypesAvailable() {
+		MockitoAnnotations.initMocks(this);
+		assertNull(otherSuperUnderTesting.candidate1);
+		assertNotNull(otherSuperUnderTesting.candidate2);
+	}
     
     @Test
     public void shouldInstantiateInjectMockFieldIfPossible() throws Exception {
@@ -168,4 +181,15 @@ public class MockInjectionUsingSetterOrPropertyTest extends TestBase {
             return histogram2;
         }
     }
+    
+    static class OtherSuperUnderTesting {
+		private A candidate1;
+
+		private A candidate2;
+	}
+
+	interface A {
+	}
+
+    
 }


### PR DESCRIPTION
Fix to @InjectMocks which injected incorrectly when multiple fields
of the same type could be injected into, but only supplying 1 mock.
This makes sure that whenever there are multiple type candidates,
it will hold off injecting if it finds a different field which has the correct matching name.