### PR TITLE
Add .gitattributes to enforce LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Allow gradle.bat to retain CRLF
+gradlew.bat text eol=crlf


### PR DESCRIPTION
Noticed the massive https://github.com/mockito/mockito/commit/d26f5db9023b6b7cd331017551ea4353fff0ef91.

This allows you to let git handle it.

It seems some files are still wrong. See here for a way to fix all https://help.github.com/articles/dealing-with-line-endings/

There might be a valid reason for not doing this, if so just close it :smile: 