### PR TITLE
[#206] Fix issue related to windows path

### DIFF
--- a/test/org/mockitoutil/ClassLoaders.java
+++ b/test/org/mockitoutil/ClassLoaders.java
@@ -358,7 +358,8 @@ public abstract class ClassLoaders {
         }
 
         private String classNameFor(File root, File file) {
-            String temp = file.getAbsolutePath().substring(root.getAbsolutePath().length() + 1).replace('/', '.');
+            String temp = file.getAbsolutePath().substring(root.getAbsolutePath().length() + 1).
+                    replace(File.separatorChar, '.');
             return temp.subSequence(0, temp.indexOf(".class")).toString();
         }
 


### PR DESCRIPTION
Problem was caused by file separator. Replacing hardcoded char '/' by File.seperatorChar solves issue. In the same file there is second occurence of this character but it is used with getResource(path) method -  in such case '/' is only acceptable separator.