### PR TITLE
Fixed over one thousand warnings

### DIFF
--- a/.checkstyle
+++ b/.checkstyle
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fileset-config file-format-version="1.2.0" simple-config="false">
-    <local-check-config name="mockito-code" location="conf/checkstyle-code.xml" type="project" description="">
-        <additional-data name="protect-config-file" value="false"/>
-    </local-check-config>
-    <local-check-config name="mockito-test" location="conf/checkstyle-test.xml" type="project" description="">
-        <additional-data name="protect-config-file" value="false"/>
-    </local-check-config>
-    <fileset name="mockito-code" enabled="true" check-config-name="mockito-code" local="true">
-        <file-match-pattern match-pattern="^src[/\\].*java$" include-pattern="true"/>
-    </fileset>
-    <fileset name="mockito-test" enabled="true" check-config-name="mockito-test" local="true">
-        <file-match-pattern match-pattern="^test[/\\].*java$" include-pattern="true"/>
-    </fileset>
+
+<fileset-config file-format-version="1.2.0" simple-config="false" sync-formatter="false">
+  <local-check-config name="mockito-code" location="conf/checkstyle-code.xml" type="project" description="">
+    <additional-data name="protect-config-file" value="false"/>
+  </local-check-config>
+  <local-check-config name="mockito-test" location="conf/checkstyle-test.xml" type="project" description="">
+    <additional-data name="protect-config-file" value="false"/>
+  </local-check-config>
+  <fileset name="mockito-test" enabled="true" check-config-name="mockito-test" local="true">
+    <file-match-pattern match-pattern="^test[/\\].*java$" include-pattern="true"/>
+  </fileset>
+  <fileset name="mockito-code" enabled="true" check-config-name="mockito-code" local="true">
+    <file-match-pattern match-pattern="^src[/\\].*java$" include-pattern="true"/>
+  </fileset>
 </fileset-config>

--- a/conf/checkstyle-code.xml
+++ b/conf/checkstyle-code.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
 <!--
     This configuration file was written by the eclipse-cs plugin configuration editor
 -->
@@ -6,130 +8,117 @@
     Checkstyle-Configuration: mockito-code
     Description: none
 -->
-<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 <module name="Checker">
-    <property name="severity" value="warning"/>
-    <module name="TreeWalker">
-        <property name="tabWidth" value="4"/>
-        <module name="JavadocMethod">
-            <property name="severity" value="ignore"/>
-            <property name="logLoadErrors" value="true"/>
-            <property name="suppressLoadErrors" value="true"/>
-        </module>
-        <module name="JavadocType">
-            <property name="severity" value="ignore"/>
-        </module>
-        <module name="JavadocVariable">
-            <property name="severity" value="ignore"/>
-        </module>
-        <module name="JavadocStyle">
-            <property name="checkFirstSentence" value="false"/>
-        </module>
-        <module name="ConstantName"/>
-        <module name="LocalFinalVariableName"/>
-        <module name="LocalVariableName"/>
-        <module name="MemberName"/>
-        <module name="MethodName">
-            <property name="severity" value="ignore"/>
-        </module>
-        <module name="PackageName"/>
-        <module name="ParameterName"/>
-        <module name="StaticVariableName"/>
-        <module name="TypeName"/>
-        <module name="AvoidStarImport"/>
-        <module name="IllegalImport"/>
-        <module name="RedundantImport"/>
-        <module name="UnusedImports">
-            <property name="severity" value="ignore"/>
-        </module>
-        <module name="FileLength"/>
-        <module name="LineLength">
-            <property name="severity" value="ignore"/>
-        </module>
-        <module name="MethodLength"/>
-        <module name="ParameterNumber"/>
-        <module name="EmptyForIteratorPad"/>
-        <module name="MethodParamPad"/>
-        <module name="NoWhitespaceAfter">
-            <property name="tokens" value="BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
-        </module>
-        <module name="NoWhitespaceBefore"/>
-        <module name="OperatorWrap">
-            <property name="tokens" value="BAND,BOR,BSR,BXOR,COLON,DIV,EQUAL,GE,GT,LAND,LE,LITERAL_INSTANCEOF,LOR,LT,MINUS,MOD,NOT_EQUAL,QUESTION,SL,SR,STAR"/>
-        </module>
-        <module name="ParenPad">
-            <property name="severity" value="ignore"/>
-            <property name="tokens" value="CTOR_CALL,METHOD_CALL,SUPER_CTOR_CALL"/>
-        </module>
-        <module name="TypecastParenPad"/>
-        <module name="TabCharacter"/>
-        <module name="WhitespaceAfter"/>
-        <module name="WhitespaceAround">
-            <property name="severity" value="ignore"/>
-            <property name="tokens" value="ASSIGN,BAND,BAND_ASSIGN,BOR,BOR_ASSIGN,BSR,BSR_ASSIGN,BXOR,BXOR_ASSIGN,COLON,DIV,DIV_ASSIGN,EQUAL,GE,GT,LAND,LE,LITERAL_ASSERT,LITERAL_CATCH,LITERAL_DO,LITERAL_ELSE,LITERAL_FINALLY,LITERAL_FOR,LITERAL_IF,LITERAL_RETURN,LITERAL_SYNCHRONIZED,LITERAL_TRY,LITERAL_WHILE,LOR,LT,MINUS,MINUS_ASSIGN,MOD,MOD_ASSIGN,NOT_EQUAL,PLUS,PLUS_ASSIGN,QUESTION,SL,SLIST,SL_ASSIGN,SR,SR_ASSIGN,STAR,STAR_ASSIGN,LITERAL_ASSERT,TYPE_EXTENSION_AND"/>
-        </module>
-        <module name="ModifierOrder"/>
-        <module name="RedundantModifier"/>
-        <module name="AvoidNestedBlocks"/>
-        <module name="EmptyBlock">
-            <property name="severity" value="ignore"/>
-        </module>
-        <module name="LeftCurly"/>
-        <module name="NeedBraces"/>
-        <module name="RightCurly"/>
-        <module name="AvoidInlineConditionals">
-            <property name="severity" value="ignore"/>
-        </module>
-        <module name="DoubleCheckedLocking"/>
-        <module name="EmptyStatement"/>
-        <module name="EqualsHashCode"/>
-        <module name="HiddenField">
-            <property name="severity" value="ignore"/>
-        </module>
-        <module name="IllegalInstantiation"/>
-        <module name="InnerAssignment"/>
-        <module name="MagicNumber">
-            <property name="severity" value="ignore"/>
-        </module>
-        <module name="MissingSwitchDefault"/>
-        <module name="RedundantThrows">
-            <property name="logLoadErrors" value="true"/>
-            <property name="suppressLoadErrors" value="true"/>
-        </module>
-        <module name="SimplifyBooleanExpression">
-            <property name="severity" value="ignore"/>
-        </module>
-        <module name="SimplifyBooleanReturn"/>
-        <module name="DesignForExtension">
-            <property name="severity" value="ignore"/>
-        </module>
-        <module name="FinalClass">
-            <property name="severity" value="ignore"/>
-        </module>
-        <module name="HideUtilityClassConstructor">
-            <property name="severity" value="ignore"/>
-        </module>
-        <module name="InterfaceIsType"/>
-        <module name="VisibilityModifier">
-            <property name="severity" value="ignore"/>
-            <property name="packageAllowed" value="true"/>
-            <property name="protectedAllowed" value="true"/>
-        </module>
-        <module name="ArrayTypeStyle"/>
-        <module name="FinalParameters">
-            <property name="severity" value="ignore"/>
-        </module>
-        <module name="GenericIllegalRegexp">
-            <property name="severity" value="ignore"/>
-            <property name="format" value="\s+$"/>
-            <property name="message" value="Line has trailing spaces."/>
-        </module>
-        <module name="TodoComment"/>
-        <module name="UpperEll"/>
+  <property name="severity" value="warning"/>
+  <module name="TreeWalker">
+    <property name="tabWidth" value="4"/>
+    <module name="JavadocMethod">
+      <property name="severity" value="ignore"/>
+      <property name="suppressLoadErrors" value="true"/>
     </module>
-    <module name="PackageHtml"/>
-    <module name="NewlineAtEndOfFile">
-        <property name="severity" value="ignore"/>
+    <module name="JavadocType">
+      <property name="severity" value="ignore"/>
     </module>
-    <module name="Translation"/>
+    <module name="JavadocVariable">
+      <property name="severity" value="ignore"/>
+    </module>
+    <module name="JavadocStyle">
+      <property name="checkFirstSentence" value="false"/>
+    </module>
+    <module name="ConstantName"/>
+    <module name="LocalFinalVariableName"/>
+    <module name="LocalVariableName"/>
+    <module name="MemberName"/>
+    <module name="MethodName">
+      <property name="severity" value="ignore"/>
+    </module>
+    <module name="PackageName"/>
+    <module name="ParameterName"/>
+    <module name="StaticVariableName"/>
+    <module name="TypeName"/>
+    <module name="AvoidStarImport"/>
+    <module name="IllegalImport"/>
+    <module name="RedundantImport"/>
+    <module name="UnusedImports">
+      <property name="severity" value="ignore"/>
+    </module>
+    <module name="MethodLength"/>
+    <module name="ParameterNumber"/>
+    <module name="EmptyForIteratorPad"/>
+    <module name="MethodParamPad"/>
+    <module name="NoWhitespaceAfter">
+      <property name="tokens" value="BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
+    </module>
+    <module name="NoWhitespaceBefore"/>
+    <module name="OperatorWrap">
+      <property name="tokens" value="BAND,BOR,BSR,BXOR,COLON,DIV,EQUAL,GE,GT,LAND,LE,LITERAL_INSTANCEOF,LOR,LT,MINUS,MOD,NOT_EQUAL,QUESTION,SL,SR,STAR"/>
+    </module>
+    <module name="ParenPad">
+      <property name="severity" value="ignore"/>
+      <property name="tokens" value="CTOR_CALL,METHOD_CALL,SUPER_CTOR_CALL"/>
+    </module>
+    <module name="TypecastParenPad"/>
+    <module name="WhitespaceAfter"/>
+    <module name="WhitespaceAround">
+      <property name="severity" value="ignore"/>
+      <property name="tokens" value="ASSIGN,BAND,BAND_ASSIGN,BOR,BOR_ASSIGN,BSR,BSR_ASSIGN,BXOR,BXOR_ASSIGN,COLON,DIV,DIV_ASSIGN,EQUAL,GE,GT,LAND,LE,LITERAL_ASSERT,LITERAL_CATCH,LITERAL_DO,LITERAL_ELSE,LITERAL_FINALLY,LITERAL_FOR,LITERAL_IF,LITERAL_RETURN,LITERAL_SYNCHRONIZED,LITERAL_TRY,LITERAL_WHILE,LOR,LT,MINUS,MINUS_ASSIGN,MOD,MOD_ASSIGN,NOT_EQUAL,PLUS,PLUS_ASSIGN,QUESTION,SL,SLIST,SL_ASSIGN,SR,SR_ASSIGN,STAR,STAR_ASSIGN,LITERAL_ASSERT,TYPE_EXTENSION_AND"/>
+    </module>
+    <module name="ModifierOrder"/>
+    <module name="RedundantModifier"/>
+    <module name="AvoidNestedBlocks"/>
+    <module name="EmptyBlock">
+      <property name="severity" value="ignore"/>
+    </module>
+    <module name="LeftCurly"/>
+    <module name="NeedBraces"/>
+    <module name="RightCurly"/>
+    <module name="AvoidInlineConditionals">
+      <property name="severity" value="ignore"/>
+    </module>
+    <module name="EmptyStatement"/>
+    <module name="EqualsHashCode"/>
+    <module name="HiddenField">
+      <property name="severity" value="ignore"/>
+    </module>
+    <module name="IllegalInstantiation"/>
+    <module name="InnerAssignment"/>
+    <module name="MagicNumber">
+      <property name="severity" value="ignore"/>
+    </module>
+    <module name="MissingSwitchDefault"/>
+    <module name="SimplifyBooleanExpression">
+      <property name="severity" value="ignore"/>
+    </module>
+    <module name="SimplifyBooleanReturn"/>
+    <module name="DesignForExtension">
+      <property name="severity" value="ignore"/>
+    </module>
+    <module name="FinalClass">
+      <property name="severity" value="ignore"/>
+    </module>
+    <module name="HideUtilityClassConstructor">
+      <property name="severity" value="ignore"/>
+    </module>
+    <module name="InterfaceIsType"/>
+    <module name="VisibilityModifier">
+      <property name="severity" value="ignore"/>
+      <property name="packageAllowed" value="true"/>
+      <property name="protectedAllowed" value="true"/>
+    </module>
+    <module name="ArrayTypeStyle"/>
+    <module name="FinalParameters">
+      <property name="severity" value="ignore"/>
+    </module>
+    <module name="GenericIllegalRegexp">
+      <property name="severity" value="ignore"/>
+    </module>
+    <module name="TodoComment"/>
+    <module name="UpperEll"/>
+  </module>
+  <module name="FileLength"/>
+  <module name="FileTabCharacter"/>
+  <module name="NewlineAtEndOfFile">
+    <property name="severity" value="ignore"/>
+  </module>
+  <module name="Translation"/>
 </module>

--- a/conf/checkstyle-test.xml
+++ b/conf/checkstyle-test.xml
@@ -42,7 +42,6 @@
         <module name="UnusedImports">
             <property name="severity" value="ignore"/>
         </module>
-        <module name="FileLength"/>
         <module name="LineLength">
             <property name="severity" value="ignore"/>
         </module>
@@ -62,7 +61,6 @@
             <property name="tokens" value="CTOR_CALL,METHOD_CALL,SUPER_CTOR_CALL"/>
         </module>
         <module name="TypecastParenPad"/>
-        <module name="TabCharacter"/>
         <module name="WhitespaceAfter"/>
         <module name="WhitespaceAround">
             <property name="severity" value="ignore"/>
@@ -80,7 +78,6 @@
         <module name="AvoidInlineConditionals">
             <property name="severity" value="ignore"/>
         </module>
-        <module name="DoubleCheckedLocking"/>
         <module name="EmptyStatement"/>
         <module name="EqualsHashCode"/>
         <module name="HiddenField">
@@ -92,10 +89,6 @@
             <property name="severity" value="ignore"/>
         </module>
         <module name="MissingSwitchDefault"/>
-        <module name="RedundantThrows">
-            <property name="logLoadErrors" value="true"/>
-            <property name="suppressLoadErrors" value="true"/>
-        </module>
         <module name="SimplifyBooleanExpression">
             <property name="severity" value="ignore"/>
         </module>
@@ -127,6 +120,8 @@
         <module name="TodoComment"/>
         <module name="UpperEll"/>
     </module>
+    <module name="FileLength"/>
+    <module name="FileTabCharacter"/>
     <module name="NewlineAtEndOfFile">
         <property name="severity" value="ignore"/>
     </module>

--- a/conf/checkstyle-test.xml
+++ b/conf/checkstyle-test.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
 <!--
     This configuration file was written by the eclipse-cs plugin configuration editor
 -->
@@ -6,124 +8,132 @@
     Checkstyle-Configuration: mockito-test
     Description: none
 -->
-<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 <module name="Checker">
-    <property name="severity" value="warning"/>
-    <module name="TreeWalker">
-        <property name="tabWidth" value="4"/>
-        <module name="JavadocMethod">
-            <property name="severity" value="ignore"/>
-            <property name="logLoadErrors" value="true"/>
-            <property name="suppressLoadErrors" value="true"/>
-        </module>
-        <module name="JavadocType">
-            <property name="severity" value="ignore"/>
-        </module>
-        <module name="JavadocVariable">
-            <property name="severity" value="ignore"/>
-        </module>
-        <module name="JavadocStyle">
-            <property name="checkFirstSentence" value="false"/>
-        </module>
-        <module name="ConstantName"/>
-        <module name="LocalFinalVariableName"/>
-        <module name="LocalVariableName"/>
-        <module name="MemberName"/>
-        <module name="MethodName">
-            <property name="severity" value="ignore"/>
-        </module>
-        <module name="PackageName"/>
-        <module name="ParameterName"/>
-        <module name="StaticVariableName"/>
-        <module name="TypeName"/>
-        <module name="AvoidStarImport"/>
-        <module name="IllegalImport"/>
-        <module name="RedundantImport"/>
-        <module name="UnusedImports">
-            <property name="severity" value="ignore"/>
-        </module>
-        <module name="LineLength">
-            <property name="severity" value="ignore"/>
-        </module>
-        <module name="MethodLength"/>
-        <module name="ParameterNumber"/>
-        <module name="EmptyForIteratorPad"/>
-        <module name="MethodParamPad"/>
-        <module name="NoWhitespaceAfter">
-            <property name="tokens" value="BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
-        </module>
-        <module name="NoWhitespaceBefore"/>
-        <module name="OperatorWrap">
-            <property name="tokens" value="BAND,BOR,BSR,BXOR,COLON,DIV,EQUAL,GE,GT,LAND,LE,LITERAL_INSTANCEOF,LOR,LT,MINUS,MOD,NOT_EQUAL,QUESTION,SL,SR,STAR"/>
-        </module>
-        <module name="ParenPad">
-            <property name="severity" value="ignore"/>
-            <property name="tokens" value="CTOR_CALL,METHOD_CALL,SUPER_CTOR_CALL"/>
-        </module>
-        <module name="TypecastParenPad"/>
-        <module name="WhitespaceAfter"/>
-        <module name="WhitespaceAround">
-            <property name="severity" value="ignore"/>
-            <property name="tokens" value="ASSIGN,BAND,BAND_ASSIGN,BOR,BOR_ASSIGN,BSR,BSR_ASSIGN,BXOR,BXOR_ASSIGN,COLON,DIV,DIV_ASSIGN,EQUAL,GE,GT,LAND,LE,LITERAL_ASSERT,LITERAL_CATCH,LITERAL_DO,LITERAL_ELSE,LITERAL_FINALLY,LITERAL_FOR,LITERAL_IF,LITERAL_RETURN,LITERAL_SYNCHRONIZED,LITERAL_TRY,LITERAL_WHILE,LOR,LT,MINUS,MINUS_ASSIGN,MOD,MOD_ASSIGN,NOT_EQUAL,PLUS,PLUS_ASSIGN,QUESTION,SL,SLIST,SL_ASSIGN,SR,SR_ASSIGN,STAR,STAR_ASSIGN,LITERAL_ASSERT,TYPE_EXTENSION_AND"/>
-        </module>
-        <module name="ModifierOrder"/>
-        <module name="RedundantModifier"/>
-        <module name="AvoidNestedBlocks"/>
-        <module name="EmptyBlock">
-            <property name="severity" value="ignore"/>
-        </module>
-        <module name="LeftCurly"/>
-        <module name="NeedBraces"/>
-        <module name="RightCurly"/>
-        <module name="AvoidInlineConditionals">
-            <property name="severity" value="ignore"/>
-        </module>
-        <module name="EmptyStatement"/>
-        <module name="EqualsHashCode"/>
-        <module name="HiddenField">
-            <property name="severity" value="ignore"/>
-        </module>
-        <module name="IllegalInstantiation"/>
-        <module name="InnerAssignment"/>
-        <module name="MagicNumber">
-            <property name="severity" value="ignore"/>
-        </module>
-        <module name="MissingSwitchDefault"/>
-        <module name="SimplifyBooleanExpression">
-            <property name="severity" value="ignore"/>
-        </module>
-        <module name="SimplifyBooleanReturn"/>
-        <module name="DesignForExtension">
-            <property name="severity" value="ignore"/>
-        </module>
-        <module name="FinalClass">
-            <property name="severity" value="ignore"/>
-        </module>
-        <module name="HideUtilityClassConstructor">
-            <property name="severity" value="ignore"/>
-        </module>
-        <module name="InterfaceIsType"/>
-        <module name="VisibilityModifier">
-            <property name="severity" value="ignore"/>
-            <property name="packageAllowed" value="true"/>
-            <property name="protectedAllowed" value="true"/>
-        </module>
-        <module name="ArrayTypeStyle"/>
-        <module name="FinalParameters">
-            <property name="severity" value="ignore"/>
-        </module>
-        <module name="GenericIllegalRegexp">
-            <property name="severity" value="ignore"/>
-            <property name="format" value="\s+$"/>
-            <property name="message" value="Line has trailing spaces."/>
-        </module>
-        <module name="TodoComment"/>
-        <module name="UpperEll"/>
+  <property name="severity" value="warning"/>
+  <module name="TreeWalker">
+    <property name="tabWidth" value="4"/>
+    <module name="JavadocMethod">
+      <property name="severity" value="ignore"/>
+      <property name="suppressLoadErrors" value="true"/>
     </module>
-    <module name="FileLength"/>
-    <module name="FileTabCharacter"/>
-    <module name="NewlineAtEndOfFile">
-        <property name="severity" value="ignore"/>
+    <module name="JavadocType">
+      <property name="severity" value="ignore"/>
     </module>
-    <module name="Translation"/>
+    <module name="JavadocVariable">
+      <property name="severity" value="ignore"/>
+    </module>
+    <module name="JavadocStyle">
+      <property name="checkFirstSentence" value="false"/>
+    </module>
+    <module name="ConstantName"/>
+    <module name="LocalFinalVariableName">
+      <property name="format" value="^[a-z][_a-zA-Z0-9]*$"/>
+    </module>
+    <module name="LocalVariableName">
+      <property name="format" value="^[a-z][_a-zA-Z0-9]*$"/>
+    </module>
+    <module name="MemberName">
+      <property name="format" value="^[a-z][_a-zA-Z0-9]*$"/>
+    </module>
+    <module name="MethodName">
+      <property name="severity" value="ignore"/>
+    </module>
+    <module name="PackageName"/>
+    <module name="ParameterName">
+      <property name="format" value="^[a-z][_a-zA-Z0-9]*$"/>
+    </module>
+    <module name="StaticVariableName">
+      <property name="format" value="^[a-z][_a-zA-Z0-9]*$"/>
+    </module>
+    <module name="TypeName">
+      <property name="format" value="^[a-zA-Z][_a-zA-Z0-9]*$"/>
+    </module>
+    <module name="AvoidStarImport"/>
+    <module name="IllegalImport"/>
+    <module name="RedundantImport"/>
+    <module name="UnusedImports">
+      <property name="severity" value="ignore"/>
+    </module>
+    <module name="LineLength">
+      <property name="severity" value="ignore"/>
+    </module>
+    <module name="MethodLength"/>
+    <module name="ParameterNumber"/>
+    <module name="EmptyForIteratorPad"/>
+    <module name="MethodParamPad"/>
+    <module name="NoWhitespaceAfter">
+      <property name="tokens" value="BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
+    </module>
+    <module name="NoWhitespaceBefore"/>
+    <module name="OperatorWrap">
+      <property name="tokens" value="BAND,BOR,BSR,BXOR,COLON,DIV,EQUAL,GE,GT,LAND,LE,LITERAL_INSTANCEOF,LOR,LT,MINUS,MOD,NOT_EQUAL,QUESTION,SL,SR,STAR"/>
+    </module>
+    <module name="ParenPad">
+      <property name="severity" value="ignore"/>
+      <property name="tokens" value="CTOR_CALL,METHOD_CALL,SUPER_CTOR_CALL"/>
+    </module>
+    <module name="TypecastParenPad"/>
+    <module name="WhitespaceAfter"/>
+    <module name="WhitespaceAround">
+      <property name="severity" value="ignore"/>
+      <property name="tokens" value="ASSIGN,BAND,BAND_ASSIGN,BOR,BOR_ASSIGN,BSR,BSR_ASSIGN,BXOR,BXOR_ASSIGN,COLON,DIV,DIV_ASSIGN,EQUAL,GE,GT,LAND,LE,LITERAL_ASSERT,LITERAL_CATCH,LITERAL_DO,LITERAL_ELSE,LITERAL_FINALLY,LITERAL_FOR,LITERAL_IF,LITERAL_RETURN,LITERAL_SYNCHRONIZED,LITERAL_TRY,LITERAL_WHILE,LOR,LT,MINUS,MINUS_ASSIGN,MOD,MOD_ASSIGN,NOT_EQUAL,PLUS,PLUS_ASSIGN,QUESTION,SL,SLIST,SL_ASSIGN,SR,SR_ASSIGN,STAR,STAR_ASSIGN,LITERAL_ASSERT,TYPE_EXTENSION_AND"/>
+    </module>
+    <module name="ModifierOrder"/>
+    <module name="RedundantModifier"/>
+    <module name="AvoidNestedBlocks"/>
+    <module name="EmptyBlock">
+      <property name="severity" value="ignore"/>
+    </module>
+    <module name="LeftCurly"/>
+    <module name="NeedBraces"/>
+    <module name="RightCurly"/>
+    <module name="AvoidInlineConditionals">
+      <property name="severity" value="ignore"/>
+    </module>
+    <module name="EmptyStatement"/>
+    <module name="EqualsHashCode"/>
+    <module name="HiddenField">
+      <property name="severity" value="ignore"/>
+    </module>
+    <module name="IllegalInstantiation"/>
+    <module name="InnerAssignment"/>
+    <module name="MagicNumber">
+      <property name="severity" value="ignore"/>
+    </module>
+    <module name="MissingSwitchDefault"/>
+    <module name="SimplifyBooleanExpression">
+      <property name="severity" value="ignore"/>
+    </module>
+    <module name="SimplifyBooleanReturn"/>
+    <module name="DesignForExtension">
+      <property name="severity" value="ignore"/>
+    </module>
+    <module name="FinalClass">
+      <property name="severity" value="ignore"/>
+    </module>
+    <module name="HideUtilityClassConstructor">
+      <property name="severity" value="ignore"/>
+    </module>
+    <module name="InterfaceIsType"/>
+    <module name="VisibilityModifier">
+      <property name="severity" value="ignore"/>
+      <property name="packageAllowed" value="true"/>
+      <property name="protectedAllowed" value="true"/>
+    </module>
+    <module name="ArrayTypeStyle"/>
+    <module name="FinalParameters">
+      <property name="severity" value="ignore"/>
+    </module>
+    <module name="GenericIllegalRegexp">
+      <property name="severity" value="ignore"/>
+    </module>
+    <module name="TodoComment"/>
+    <module name="UpperEll"/>
+  </module>
+  <module name="FileLength"/>
+  <module name="FileTabCharacter"/>
+  <module name="NewlineAtEndOfFile">
+    <property name="severity" value="ignore"/>
+  </module>
+  <module name="Translation"/>
 </module>

--- a/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMaker.java
+++ b/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMaker.java
@@ -1,6 +1,7 @@
 package org.mockito.internal.creation.bytebuddy;
 
 import static org.mockito.internal.util.StringJoiner.join;
+
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.InternalMockHandler;
 import org.mockito.internal.creation.instance.Instantiator;
@@ -10,6 +11,7 @@ import org.mockito.mock.MockCreationSettings;
 import org.mockito.mock.SerializableMode;
 import org.mockito.plugins.MockMaker;
 
+@SuppressWarnings("rawtypes")
 public class ByteBuddyMockMaker implements MockMaker {
 
     private final CachingMockBytecodeGenerator cachingMockBytecodeGenerator;
@@ -18,18 +20,18 @@ public class ByteBuddyMockMaker implements MockMaker {
         cachingMockBytecodeGenerator = new CachingMockBytecodeGenerator();
     }
 
-    public <T> T createMock(MockCreationSettings<T> settings, MockHandler handler) {
-        Class<T> mockedProxyType = createProxyClass(mockWithFeaturesFrom(settings));
+    public <T> T createMock(final MockCreationSettings<T> settings, final MockHandler handler) {
+        final Class<T> mockedProxyType = createProxyClass(mockWithFeaturesFrom(settings));
 
-        Instantiator instantiator = new InstantiatorProvider().getInstantiator(settings);
+        final Instantiator instantiator = new InstantiatorProvider().getInstantiator(settings);
         T mockInstance = null;
         try {
             mockInstance = instantiator.newInstance(mockedProxyType);
-            MockMethodInterceptor.MockAccess mockAccess = (MockMethodInterceptor.MockAccess) mockInstance;
+            final MockMethodInterceptor.MockAccess mockAccess = (MockMethodInterceptor.MockAccess) mockInstance;
             mockAccess.setMockitoInterceptor(new MockMethodInterceptor(asInternalMockHandler(handler), settings));
 
             return ensureMockIsAssignableToMockedType(settings, mockInstance);
-        } catch (ClassCastException cce) {
+        } catch (final ClassCastException cce) {
             throw new MockitoException(join(
                     "ClassCastException occurred while creating the mockito mock :",
                     "  class to mock : " + describeClass(mockedProxyType),
@@ -40,17 +42,17 @@ public class ByteBuddyMockMaker implements MockMaker {
                     "You might experience classloading issues, please ask the mockito mailing-list.",
                     ""
             ),cce);
-        } catch (org.mockito.internal.creation.instance.InstantiationException e) {
+        } catch (final org.mockito.internal.creation.instance.InstantiationException e) {
             throw new MockitoException("Unable to create mock instance of type '" + mockedProxyType.getSuperclass().getSimpleName() + "'", e);
         }
     }
 
-    <T> Class<T> createProxyClass(MockFeatures<T> mockFeatures) {
+    <T> Class<T> createProxyClass(final MockFeatures<T> mockFeatures) {
         return cachingMockBytecodeGenerator.get(mockFeatures);
     }
 
 
-    private <T> MockFeatures<T> mockWithFeaturesFrom(MockCreationSettings<T> settings) {
+    private <T> MockFeatures<T> mockWithFeaturesFrom(final MockCreationSettings<T> settings) {
         return MockFeatures.withMockFeatures(
                 settings.getTypeToMock(),
                 settings.getExtraInterfaces(),
@@ -58,36 +60,36 @@ public class ByteBuddyMockMaker implements MockMaker {
         );
     }
 
-    private <T> T ensureMockIsAssignableToMockedType(MockCreationSettings<T> settings, T mock) {
+    private <T> T ensureMockIsAssignableToMockedType(final MockCreationSettings<T> settings, final T mock) {
         // Force explicit cast to mocked type here, instead of
         // relying on the JVM to implicitly cast on the client call site.
         // This allows us to catch the ClassCastException earlier
-        Class<T> typeToMock = settings.getTypeToMock();
+        final Class<T> typeToMock = settings.getTypeToMock();
         return typeToMock.cast(mock);
     }
 
-    private static String describeClass(Class type) {
+    private static String describeClass(final Class type) {
         return type == null ? "null" : "'" + type.getCanonicalName() + "', loaded by classloader : '" + type.getClassLoader() + "'";
     }
 
-    private static String describeClass(Object instance) {
+    private static String describeClass(final Object instance) {
         return instance == null ? "null" : describeClass(instance.getClass());
     }
 
-    public MockHandler getHandler(Object mock) {
+    public MockHandler getHandler(final Object mock) {
         if (!(mock instanceof MockMethodInterceptor.MockAccess)) {
             return null;
         }
         return ((MockMethodInterceptor.MockAccess) mock).getMockitoInterceptor().getMockHandler();
     }
 
-    public void resetMock(Object mock, MockHandler newHandler, MockCreationSettings settings) {
+    public void resetMock(final Object mock, final MockHandler newHandler, final MockCreationSettings settings) {
         ((MockMethodInterceptor.MockAccess) mock).setMockitoInterceptor(
                 new MockMethodInterceptor(asInternalMockHandler(newHandler), settings)
         );
     }
 
-    private static InternalMockHandler asInternalMockHandler(MockHandler handler) {
+    private static InternalMockHandler asInternalMockHandler(final MockHandler handler) {
         if (!(handler instanceof InternalMockHandler)) {
             throw new MockitoException(join(
                     "At the moment you cannot provide own implementations of MockHandler.",

--- a/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/CachingMockBytecodeGenerator.java
+++ b/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/CachingMockBytecodeGenerator.java
@@ -1,6 +1,7 @@
 package org.mockito.internal.creation.bytebuddy;
 
 import static org.mockito.internal.util.StringJoiner.join;
+
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Modifier;
 import java.util.HashSet;
@@ -9,8 +10,10 @@ import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+
 import org.mockito.exceptions.base.MockitoException;
 
+@SuppressWarnings({"unchecked", "rawtypes"})
 class CachingMockBytecodeGenerator {
 
     private final Lock avoidingClassLeakCacheLock = new ReentrantLock();
@@ -19,7 +22,7 @@ class CachingMockBytecodeGenerator {
 
     private final MockBytecodeGenerator mockBytecodeGenerator = new MockBytecodeGenerator();
 
-    public <T> Class<T> get(MockFeatures<T> params) {
+	public <T> Class<T> get(MockFeatures<T> params) {
         // TODO improves locking behavior with ReentrantReadWriteLock ?
         avoidingClassLeakCacheLock.lock();
         try {

--- a/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/InterceptedInvocation.java
+++ b/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/InterceptedInvocation.java
@@ -16,6 +16,7 @@ import org.mockito.invocation.Invocation;
 import org.mockito.invocation.Location;
 import org.mockito.invocation.StubInfo;
 
+@SuppressWarnings("rawtypes")
 class InterceptedInvocation implements Invocation, VerificationAwareInvocation {
 
     private static final long serialVersionUID = 475027563923510472L;

--- a/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/InterceptedInvocation.java
+++ b/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/InterceptedInvocation.java
@@ -1,5 +1,10 @@
 package org.mockito.internal.creation.bytebuddy;
 
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.concurrent.Callable;
+
 import org.mockito.exceptions.Reporter;
 import org.mockito.internal.debugging.LocationImpl;
 import org.mockito.internal.exceptions.VerificationAwareInvocation;
@@ -10,11 +15,6 @@ import org.mockito.internal.reporting.PrintSettings;
 import org.mockito.invocation.Invocation;
 import org.mockito.invocation.Location;
 import org.mockito.invocation.StubInfo;
-
-import java.io.Serializable;
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.concurrent.Callable;
 
 class InterceptedInvocation implements Invocation, VerificationAwareInvocation {
 
@@ -33,11 +33,11 @@ class InterceptedInvocation implements Invocation, VerificationAwareInvocation {
     private boolean isIgnoredForVerification;
     private StubInfo stubInfo;
 
-    public InterceptedInvocation(Object mock,
-                                 MockitoMethod mockitoMethod,
-                                 Object[] arguments,
-                                 SuperMethod superMethod,
-                                 int sequenceNumber) {
+    public InterceptedInvocation(final Object mock,
+                                 final MockitoMethod mockitoMethod,
+                                 final Object[] arguments,
+                                 final SuperMethod superMethod,
+                                 final int sequenceNumber) {
         this.mock = mock;
         this.mockitoMethod = mockitoMethod;
         this.arguments = ArgumentsProcessor.expandVarArgs(mockitoMethod.isVarArgs(), arguments);
@@ -47,78 +47,78 @@ class InterceptedInvocation implements Invocation, VerificationAwareInvocation {
         location = new LocationImpl();
     }
 
-    @Override
+    
     public boolean isVerified() {
         return verified || isIgnoredForVerification;
     }
 
-    @Override
+    
     public int getSequenceNumber() {
         return sequenceNumber;
     }
 
-    @Override
+    
     public Location getLocation() {
         return location;
     }
 
-    @Override
+    
     public Object[] getRawArguments() {
         return rawArguments;
     }
 
-    @Override
+    
     public Class getRawReturnType() {
         return mockitoMethod.getReturnType();
     }
 
-    @Override
+    
     public void markVerified() {
         verified = true;
     }
 
-    @Override
+    
     public StubInfo stubInfo() {
         return stubInfo;
     }
 
-    @Override
-    public void markStubbed(StubInfo stubInfo) {
+    
+    public void markStubbed(final StubInfo stubInfo) {
         this.stubInfo = stubInfo;
     }
 
-    @Override
+    
     public boolean isIgnoredForVerification() {
         return isIgnoredForVerification;
     }
 
-    @Override
+    
     public void ignoreForVerification() {
         isIgnoredForVerification = true;
     }
 
-    @Override
+    
     public Object getMock() {
         return mock;
     }
 
-    @Override
+    
     public Method getMethod() {
         return mockitoMethod.getJavaMethod();
     }
 
-    @Override
+    
     public Object[] getArguments() {
         return arguments;
     }
 
-    @Override
+    
     @SuppressWarnings("unchecked")
-    public <T> T getArgumentAt(int index, Class<T> clazz) {
+    public <T> T getArgumentAt(final int index, final Class<T> clazz) {
         return (T) arguments[index];
     }
 
-    @Override
+    
     public Object callRealMethod() throws Throwable {
         if (!superMethod.isInvokable()) {
             new Reporter().cannotCallAbstractRealMethod();
@@ -126,23 +126,23 @@ class InterceptedInvocation implements Invocation, VerificationAwareInvocation {
         return superMethod.invoke();
     }
 
-    @Override
+    
     public int hashCode() {
         return 1;
     }
 
-    @Override
-    public boolean equals(Object o) {
+    
+    public boolean equals(final Object o) {
         if (o == null || !o.getClass().equals(this.getClass())) {
             return false;
         }
-        InterceptedInvocation other = (InterceptedInvocation) o;
+        final InterceptedInvocation other = (InterceptedInvocation) o;
         return this.mock.equals(other.mock)
                 && this.mockitoMethod.equals(other.mockitoMethod)
                 && this.equalArguments(other.arguments);
     }
 
-    private boolean equalArguments(Object[] arguments) {
+    private boolean equalArguments(final Object[] arguments) {
         return Arrays.equals(arguments, this.arguments);
     }
 
@@ -157,12 +157,12 @@ class InterceptedInvocation implements Invocation, VerificationAwareInvocation {
 
             INSTANCE;
 
-            @Override
+            
             public boolean isInvokable() {
                 return false;
             }
 
-            @Override
+            
             public Object invoke() {
                 throw new IllegalStateException();
             }
@@ -174,20 +174,20 @@ class InterceptedInvocation implements Invocation, VerificationAwareInvocation {
 
             private final Callable<?> callable;
 
-            public FromCallable(Callable<?> callable) {
+            public FromCallable(final Callable<?> callable) {
                 this.callable = callable;
             }
 
-            @Override
+            
             public boolean isInvokable() {
                 return true;
             }
 
-            @Override
+            
             public Object invoke() throws Throwable {
                 try {
                     return callable.call();
-                } catch (Throwable t) {
+                } catch (final Throwable t) {
                     new ConditionalStackTraceFilter().filter(t);
                     throw t;
                 }

--- a/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/MockFeatures.java
+++ b/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/MockFeatures.java
@@ -3,18 +3,19 @@ package org.mockito.internal.creation.bytebuddy;
 import java.util.Collections;
 import java.util.Set;
 
+@SuppressWarnings("rawtypes")
 class MockFeatures<T> {
     final Class<T> mockedType;
     final Set<Class> interfaces;
     final boolean crossClassLoaderSerializable;
 
-    private MockFeatures(Class<T> mockedType, Set<Class> interfaces, boolean crossClassLoaderSerializable) {
+    private MockFeatures(final Class<T> mockedType, final Set<Class> interfaces, final boolean crossClassLoaderSerializable) {
         this.mockedType = mockedType;
         this.interfaces = Collections.unmodifiableSet(interfaces);
         this.crossClassLoaderSerializable = crossClassLoaderSerializable;
     }
 
-    public static <T> MockFeatures<T> withMockFeatures(Class<T> mockedType, Set<Class> interfaces, boolean crossClassLoaderSerializable) {
+    public static <T> MockFeatures<T> withMockFeatures(final Class<T> mockedType, final Set<Class> interfaces, final boolean crossClassLoaderSerializable) {
         return new MockFeatures<T>(mockedType, interfaces, crossClassLoaderSerializable);
     }
 }

--- a/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/MockMethodInterceptor.java
+++ b/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/MockMethodInterceptor.java
@@ -4,13 +4,7 @@ import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.concurrent.Callable;
-import org.mockito.internal.InternalMockHandler;
-import org.mockito.internal.creation.DelegatingMethod;
-import org.mockito.internal.invocation.MockitoMethod;
-import org.mockito.internal.invocation.SerializableMethod;
-import org.mockito.internal.progress.SequenceNumber;
-import org.mockito.invocation.MockHandler;
-import org.mockito.mock.MockCreationSettings;
+
 import net.bytebuddy.implementation.bind.annotation.AllArguments;
 import net.bytebuddy.implementation.bind.annotation.Argument;
 import net.bytebuddy.implementation.bind.annotation.BindingPriority;
@@ -20,6 +14,15 @@ import net.bytebuddy.implementation.bind.annotation.RuntimeType;
 import net.bytebuddy.implementation.bind.annotation.SuperCall;
 import net.bytebuddy.implementation.bind.annotation.This;
 
+import org.mockito.internal.InternalMockHandler;
+import org.mockito.internal.creation.DelegatingMethod;
+import org.mockito.internal.invocation.MockitoMethod;
+import org.mockito.internal.invocation.SerializableMethod;
+import org.mockito.internal.progress.SequenceNumber;
+import org.mockito.invocation.MockHandler;
+import org.mockito.mock.MockCreationSettings;
+
+@SuppressWarnings("rawtypes")
 public class MockMethodInterceptor implements Serializable {
 
     private static final long serialVersionUID = 7152947254057253027L;
@@ -29,7 +32,7 @@ public class MockMethodInterceptor implements Serializable {
 
     private final ByteBuddyCrossClassLoaderSerializationSupport serializationSupport;
 
-    public MockMethodInterceptor(InternalMockHandler handler, MockCreationSettings mockCreationSettings) {
+    public MockMethodInterceptor(final InternalMockHandler handler, final MockCreationSettings mockCreationSettings) {
         this.handler = handler;
         this.mockCreationSettings = mockCreationSettings;
         serializationSupport = new ByteBuddyCrossClassLoaderSerializationSupport();
@@ -37,10 +40,10 @@ public class MockMethodInterceptor implements Serializable {
 
     @RuntimeType
     @BindingPriority(BindingPriority.DEFAULT * 3)
-    public Object interceptSuperCallable(@This Object mock,
-                                         @Origin(cache = true) Method invokedMethod,
-                                         @AllArguments Object[] arguments,
-                                         @SuperCall(serializableProxy = true) Callable<?> superCall) throws Throwable {
+    public Object interceptSuperCallable(@This final Object mock,
+                                         @Origin(cache = true) final Method invokedMethod,
+                                         @AllArguments final Object[] arguments,
+                                         @SuperCall(serializableProxy = true) final Callable<?> superCall) throws Throwable {
         return doIntercept(
                 mock,
                 invokedMethod,
@@ -51,10 +54,10 @@ public class MockMethodInterceptor implements Serializable {
 
     @RuntimeType
     @BindingPriority(BindingPriority.DEFAULT * 2)
-    public Object interceptDefaultCallable(@This Object mock,
-                                           @Origin(cache = true) Method invokedMethod,
-                                           @AllArguments Object[] arguments,
-                                           @DefaultCall(serializableProxy = true) Callable<?> superCall) throws Throwable {
+    public Object interceptDefaultCallable(@This final Object mock,
+                                           @Origin(cache = true) final Method invokedMethod,
+                                           @AllArguments final Object[] arguments,
+                                           @DefaultCall(serializableProxy = true) final Callable<?> superCall) throws Throwable {
         return doIntercept(
                 mock,
                 invokedMethod,
@@ -64,9 +67,9 @@ public class MockMethodInterceptor implements Serializable {
     }
 
     @RuntimeType
-    public Object interceptAbstract(@This Object mock,
-                                    @Origin(cache = true) Method invokedMethod,
-                                    @AllArguments Object[] arguments) throws Throwable {
+    public Object interceptAbstract(@This final Object mock,
+                                    @Origin(cache = true) final Method invokedMethod,
+                                    @AllArguments final Object[] arguments) throws Throwable {
         return doIntercept(
                 mock,
                 invokedMethod,
@@ -75,10 +78,10 @@ public class MockMethodInterceptor implements Serializable {
         );
     }
 
-    private Object doIntercept(Object mock,
-                               Method invokedMethod,
-                               Object[] arguments,
-                               InterceptedInvocation.SuperMethod superMethod) throws Throwable {
+    private Object doIntercept(final Object mock,
+                               final Method invokedMethod,
+                               final Object[] arguments,
+                               final InterceptedInvocation.SuperMethod superMethod) throws Throwable {
         return handler.handle(new InterceptedInvocation(
                 mock,
                 createMockitoMethod(invokedMethod),
@@ -88,7 +91,7 @@ public class MockMethodInterceptor implements Serializable {
         ));
     }
 
-    private MockitoMethod createMockitoMethod(Method method) {
+    private MockitoMethod createMockitoMethod(final Method method) {
         if (mockCreationSettings.isSerializable()) {
             return new SerializableMethod(method);
         } else {
@@ -105,25 +108,25 @@ public class MockMethodInterceptor implements Serializable {
     }
 
     public static class ForHashCode {
-        public static int doIdentityHashCode(@This Object thiz) {
+        public static int doIdentityHashCode(@This final Object thiz) {
             return System.identityHashCode(thiz);
         }
     }
 
     public static class ForEquals {
-        public static boolean doIdentityEquals(@This Object thiz, @Argument(0) Object other) {
+        public static boolean doIdentityEquals(@This final Object thiz, @Argument(0) final Object other) {
             return thiz == other;
         }
     }
 
     public static class ForWriteReplace {
-        public static Object doWriteReplace(@This MockAccess thiz) throws ObjectStreamException {
+        public static Object doWriteReplace(@This final MockAccess thiz) throws ObjectStreamException {
             return thiz.getMockitoInterceptor().getSerializationSupport().writeReplace(thiz);
         }
     }
 
     public static interface MockAccess {
         MockMethodInterceptor getMockitoInterceptor();
-        void setMockitoInterceptor(MockMethodInterceptor mockMethodInterceptor);
+        void setMockitoInterceptor(final MockMethodInterceptor mockMethodInterceptor);
     }
 }

--- a/mockmaker/bytebuddy/test/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMakerTest.java
+++ b/mockmaker/bytebuddy/test/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMakerTest.java
@@ -2,7 +2,11 @@ package org.mockito.internal.creation.bytebuddy;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.fail;
+
 import java.util.List;
+
+import net.bytebuddy.ByteBuddy;
+
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -17,26 +21,26 @@ import org.mockito.plugins.MockMaker;
 import org.mockito.stubbing.VoidMethodStubbable;
 import org.mockitoutil.ClassLoaders;
 import org.objenesis.ObjenesisStd;
-import net.bytebuddy.ByteBuddy;
 
+@SuppressWarnings("rawtypes")
 public class ByteBuddyMockMakerTest {
 
     MockMaker mockMaker = new ByteBuddyMockMaker();
 
     @Test
     public void should_create_mock_from_interface() throws Exception {
-        SomeInterface proxy = mockMaker.createMock(settingsFor(SomeInterface.class), dummyH());
+        final SomeInterface proxy = mockMaker.createMock(settingsFor(SomeInterface.class), dummyH());
 
-        Class superClass = proxy.getClass().getSuperclass();
+        final Class superClass = proxy.getClass().getSuperclass();
         assertThat(superClass).isEqualTo(Object.class);
     }
 
 
     @Test
     public void should_create_mock_from_class() throws Exception {
-        ClassWithoutConstructor proxy = mockMaker.createMock(settingsFor(ClassWithoutConstructor.class), dummyH());
+        final ClassWithoutConstructor proxy = mockMaker.createMock(settingsFor(ClassWithoutConstructor.class), dummyH());
 
-        Class superClass = proxy.getClass().getSuperclass();
+        final Class superClass = proxy.getClass().getSuperclass();
         assertThat(superClass).isEqualTo(ClassWithoutConstructor.class);
     }
 
@@ -45,19 +49,19 @@ public class ByteBuddyMockMakerTest {
         try {
             new ClassWithDodgyConstructor();
             fail();
-        } catch (Exception expected) {}
+        } catch (final Exception expected) {}
 
-        ClassWithDodgyConstructor mock = mockMaker.createMock(settingsFor(ClassWithDodgyConstructor.class), dummyH());
+        final ClassWithDodgyConstructor mock = mockMaker.createMock(settingsFor(ClassWithDodgyConstructor.class), dummyH());
         assertThat(mock).isNotNull();
     }
 
     @Test
     public void should_mocks_have_different_interceptors() throws Exception {
-        SomeClass mockOne = mockMaker.createMock(settingsFor(SomeClass.class), dummyH());
-        SomeClass mockTwo = mockMaker.createMock(settingsFor(SomeClass.class), dummyH());
+        final SomeClass mockOne = mockMaker.createMock(settingsFor(SomeClass.class), dummyH());
+        final SomeClass mockTwo = mockMaker.createMock(settingsFor(SomeClass.class), dummyH());
 
-        MockAccess interceptorOne = (MockAccess) mockOne;
-        MockAccess interceptorTwo = (MockAccess) mockTwo;
+        final MockAccess interceptorOne = (MockAccess) mockOne;
+        final MockAccess interceptorTwo = (MockAccess) mockTwo;
 
 
         assertThat(interceptorOne.getMockitoInterceptor())
@@ -66,14 +70,14 @@ public class ByteBuddyMockMakerTest {
 
     @Test
     public void should_use_ancillary_Types() {
-        SomeClass mock = mockMaker.createMock(settingsFor(SomeClass.class, SomeInterface.class), dummyH());
+        final SomeClass mock = mockMaker.createMock(settingsFor(SomeClass.class, SomeInterface.class), dummyH());
 
         assertThat(mock).isInstanceOf(SomeInterface.class);
     }
 
     @Test
     public void should_create_class_by_constructor() {
-        OtherClass mock = mockMaker.createMock(settingsWithConstructorFor(OtherClass.class), dummyH());
+        final OtherClass mock = mockMaker.createMock(settingsWithConstructorFor(OtherClass.class), dummyH());
         assertThat(mock).isNotNull();
     }
 
@@ -93,13 +97,13 @@ public class ByteBuddyMockMakerTest {
     @Ignore("missing objenesis reporting removed")
     public void report_issue_when_trying_to_load_objenesis() throws Exception {
         // given
-        ClassLoader classpath_without_objenesis = ClassLoaders.excludingClassLoader()
+        final ClassLoader classpath_without_objenesis = ClassLoaders.excludingClassLoader()
                 .withCodeSourceUrlOf(Mockito.class, ByteBuddy.class)
                 .without("org.objenesis")
                 .build();
-        boolean initialize_class = true;
+        final boolean initialize_class = true;
 
-        Class<?> mock_maker_class_loaded_fine_until = Class.forName(
+        final Class<?> mock_maker_class_loaded_fine_until = Class.forName(
                 "org.mockito.internal.creation.bytebuddy.ByteBuddyMockMaker",
                 initialize_class,
                 classpath_without_objenesis
@@ -110,7 +114,7 @@ public class ByteBuddyMockMakerTest {
         try {
             mock_maker_class_loaded_fine_until.newInstance();
             fail();
-        } catch (Throwable e) {
+        } catch (final Throwable e) {
             // then
             assertThat(e).isInstanceOf(IllegalStateException.class);
             assertThat(e.getMessage()).containsIgnoringCase("objenesis").contains("missing");
@@ -120,12 +124,12 @@ public class ByteBuddyMockMakerTest {
     @Test
     public void instantiate_fine_when_objenesis_on_the_classpath() throws Exception {
         // given
-        ClassLoader classpath_with_objenesis = ClassLoaders.excludingClassLoader()
+        final ClassLoader classpath_with_objenesis = ClassLoaders.excludingClassLoader()
                 .withCodeSourceUrlOf(Mockito.class, ByteBuddy.class, ObjenesisStd.class)
                 .build();
-        boolean initialize_class = true;
+        final boolean initialize_class = true;
 
-        Class<?> mock_maker_class_loaded_fine_until = Class.forName(
+        final Class<?> mock_maker_class_loaded_fine_until = Class.forName(
                 "org.mockito.internal.creation.bytebuddy.ByteBuddyMockMaker",
                 initialize_class,
                 classpath_with_objenesis
@@ -137,15 +141,17 @@ public class ByteBuddyMockMakerTest {
         // then everything went fine
     }
 
-    private static <T> MockCreationSettings<T> settingsFor(Class<T> type, Class... extraInterfaces) {
-        MockSettingsImpl<T> mockSettings = new MockSettingsImpl<T>();
+    private static <T> MockCreationSettings<T> settingsFor(final Class<T> type, final Class... extraInterfaces) {
+        final MockSettingsImpl<T> mockSettings = new MockSettingsImpl<T>();
         mockSettings.setTypeToMock(type);
-        if(extraInterfaces.length > 0) mockSettings.extraInterfaces(extraInterfaces);
+        if(extraInterfaces.length > 0) {
+            mockSettings.extraInterfaces(extraInterfaces);
+        }
         return mockSettings;
     }
 
-    private static <T> MockCreationSettings<T> settingsWithConstructorFor(Class<T> type) {
-        MockSettingsImpl<T> mockSettings = new MockSettingsImpl<T>();
+    private static <T> MockCreationSettings<T> settingsWithConstructorFor(final Class<T> type) {
+        final MockSettingsImpl<T> mockSettings = new MockSettingsImpl<T>();
         mockSettings.setTypeToMock(type);
         return mockSettings;
     }
@@ -155,10 +161,13 @@ public class ByteBuddyMockMakerTest {
     }
 
     private static class DummyMockHandler implements InternalMockHandler {
-        public Object handle(Invocation invocation) throws Throwable { return null; }
+
+        private static final long serialVersionUID = -1442610162820687609L;
+        
+        public Object handle(final Invocation invocation) throws Throwable { return null; }
         public MockCreationSettings getMockSettings() { return null; }
-        public VoidMethodStubbable voidMethodStubbable(Object mock) { return null; }
+        public VoidMethodStubbable voidMethodStubbable(final Object mock) { return null; }
         public InvocationContainer getInvocationContainer() { return null; }
-        public void setAnswersForStubbing(List list) { }
+        public void setAnswersForStubbing(final List list) { }
     }
 }

--- a/mockmaker/bytebuddy/test/java/org/mockito/internal/creation/bytebuddy/CachingMockBytecodeGeneratorTest.java
+++ b/mockmaker/bytebuddy/test/java/org/mockito/internal/creation/bytebuddy/CachingMockBytecodeGeneratorTest.java
@@ -5,14 +5,17 @@ import static org.junit.Assume.assumeTrue;
 import static org.mockito.internal.creation.bytebuddy.MockFeatures.withMockFeatures;
 import static org.mockitoutil.ClassLoaders.inMemoryClassLoader;
 import static org.mockitoutil.SimpleClassGenerator.makeMarkerInterface;
+
 import java.lang.management.ManagementFactory;
 import java.lang.ref.WeakReference;
 import java.util.Collections;
 import java.util.List;
 import java.util.WeakHashMap;
+
 import org.junit.Before;
 import org.junit.Test;
 
+@SuppressWarnings("rawtypes")
 public class CachingMockBytecodeGeneratorTest {
 
     @Before
@@ -27,7 +30,8 @@ public class CachingMockBytecodeGeneratorTest {
                 .withClassDefinition("foo.Bar", makeMarkerInterface("foo.Bar"))
                 .build();
 
-        CachingMockBytecodeGenerator cachingMockBytecodeGenerator = new CachingMockBytecodeGenerator();
+        final CachingMockBytecodeGenerator cachingMockBytecodeGenerator = new CachingMockBytecodeGenerator();
+        @SuppressWarnings("unused")
         Class<?> the_mock_type = cachingMockBytecodeGenerator.get(withMockFeatures(
                         classloader_with_life_shorter_than_cache.loadClass("foo.Bar"),
                         Collections.<Class>emptySet(),
@@ -50,7 +54,7 @@ public class CachingMockBytecodeGeneratorTest {
     @Test
     public void validate_simple_code_idea_where_weakhashmap_with_classloader_as_key_get_GCed_when_no_more_references() throws Exception {
         // given
-        WeakHashMap<ClassLoader, Object> cache = new WeakHashMap<ClassLoader, Object>();
+        final WeakHashMap<ClassLoader, Object> cache = new WeakHashMap<ClassLoader, Object>();
         ClassLoader short_lived_classloader = inMemoryClassLoader()
                 .withClassDefinition("foo.Bar", makeMarkerInterface("foo.Bar"))
                 .build();
@@ -72,7 +76,7 @@ public class CachingMockBytecodeGeneratorTest {
     static class HoldingAReference {
         final WeakReference<Class> a;
 
-        HoldingAReference(WeakReference<Class> a) {
+        HoldingAReference(final WeakReference<Class> a) {
             this.a = a;
         }
     }
@@ -83,8 +87,8 @@ public class CachingMockBytecodeGeneratorTest {
     }
 
     private static boolean explicitGCEnabled() {
-        List<String> inputArguments = ManagementFactory.getRuntimeMXBean().getInputArguments();
-        for (String inputArgument : inputArguments) {
+        final List<String> inputArguments = ManagementFactory.getRuntimeMXBean().getInputArguments();
+        for (final String inputArgument : inputArguments) {
             if (inputArgument.contains("-XX:+DisableExplicitGC")) {
                 return false;
             }

--- a/src/org/mockito/Answers.java
+++ b/src/org/mockito/Answers.java
@@ -68,8 +68,7 @@ public enum Answers implements Answer<Object>{
      *
      * @see org.mockito.Mockito#CALLS_REAL_METHODS
      */
-    CALLS_REAL_METHODS(new CallsRealMethods())
-    ;
+    CALLS_REAL_METHODS(new CallsRealMethods());
 
     private final Answer<Object> implementation;
 

--- a/src/org/mockito/ArgumentCaptor.java
+++ b/src/org/mockito/ArgumentCaptor.java
@@ -4,10 +4,10 @@
  */
 package org.mockito;
 
+import java.util.List;
+
 import org.mockito.internal.matchers.CapturingMatcher;
 import org.mockito.internal.progress.HandyReturnValues;
-
-import java.util.List;
 
 /**
  * Use it to capture argument values for further assertions.
@@ -87,7 +87,7 @@ public class ArgumentCaptor<T> {
         this.clazz = null;
     }
 
-    private ArgumentCaptor(Class<? extends T> clazz) {
+    private ArgumentCaptor(final Class<? extends T> clazz) {
         this.clazz = clazz;
     }
 
@@ -124,7 +124,7 @@ public class ArgumentCaptor<T> {
      * When varargs method was called multiple times, this method returns merged list of all values from all invocations.
      * <p>
      * Example: 
-     * <pre class="code"><code class="java">
+     * <pre class="code">
      *   mock.doSomething(new Person("John");
      *   mock.doSomething(new Person("Jane");
      *
@@ -167,7 +167,7 @@ public class ArgumentCaptor<T> {
      * @param <U> Type of object captured by the newly built ArgumentCaptor
      * @return A new ArgumentCaptor
      */
-    public static <U,S extends U> ArgumentCaptor<U> forClass(Class<S> clazz) {
+    public static <U, S extends U> ArgumentCaptor<U> forClass(final Class<S> clazz) {
         return new ArgumentCaptor<U>(clazz);
     }
 }

--- a/src/org/mockito/ArgumentMatcher.java
+++ b/src/org/mockito/ArgumentMatcher.java
@@ -59,8 +59,6 @@ import org.mockito.internal.util.Decamelizer;
  */
 public abstract class ArgumentMatcher<T> extends BaseMatcher<T> {
 
-    private static final long serialVersionUID = -2145234737829370369L;
-
     /**
      * Returns whether this matcher accepts the given argument.
      * <p>
@@ -85,8 +83,8 @@ public abstract class ArgumentMatcher<T> extends BaseMatcher<T> {
      * @param description the description to which the matcher description is
      * appended.
      */
-    public void describeTo(Description description) {
-        String className = getClass().getSimpleName();
+    public void describeTo(final Description description) {
+        final String className = getClass().getSimpleName();
         description.appendText(Decamelizer.decamelizeMatcher(className));
     }
 }

--- a/src/org/mockito/BDDMockito.java
+++ b/src/org/mockito/BDDMockito.java
@@ -76,7 +76,7 @@ import org.mockito.verification.VerificationMode;
  *
  * @since 1.8.0
  */
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class BDDMockito extends Mockito {
 
     /**
@@ -89,37 +89,37 @@ public class BDDMockito extends Mockito {
          * See original {@link OngoingStubbing#thenAnswer(Answer)}
          * @since 1.8.0
          */
-        BDDMyOngoingStubbing<T> willAnswer(Answer<?> answer);
+        BDDMyOngoingStubbing<T> willAnswer(final Answer<?> answer);
 
         /**
          * See original {@link OngoingStubbing#then(Answer)}
          * @since 1.9.0
          */
-        BDDMyOngoingStubbing<T> will(Answer<?> answer);
+        BDDMyOngoingStubbing<T> will(final Answer<?> answer);
 
         /**
          * See original {@link OngoingStubbing#thenReturn(Object)}
          * @since 1.8.0
          */
-        BDDMyOngoingStubbing<T> willReturn(T value);
+        BDDMyOngoingStubbing<T> willReturn(final T value);
 
         /**
          * See original {@link OngoingStubbing#thenReturn(Object, Object[])}
          * @since 1.8.0
          */
-        BDDMyOngoingStubbing<T> willReturn(T value, T... values);
+        BDDMyOngoingStubbing<T> willReturn(final T value, final T... values);
 
         /**
          * See original {@link OngoingStubbing#thenThrow(Throwable...)}
          * @since 1.8.0
          */
-        BDDMyOngoingStubbing<T> willThrow(Throwable... throwables);
+        BDDMyOngoingStubbing<T> willThrow(final Throwable... throwables);
 
         /**
          * See original {@link OngoingStubbing#thenThrow(Class[])}
          * @since 1.9.0
          */
-        BDDMyOngoingStubbing<T> willThrow(Class<? extends Throwable>... throwableClasses);
+        BDDMyOngoingStubbing<T> willThrow(final Class<? extends Throwable>... throwableClasses);
 
         /**
          * See original {@link OngoingStubbing#thenCallRealMethod()}
@@ -142,31 +142,31 @@ public class BDDMockito extends Mockito {
 
         private final OngoingStubbing<T> mockitoOngoingStubbing;
 
-        public BDDOngoingStubbingImpl(OngoingStubbing<T> ongoingStubbing) {
+        public BDDOngoingStubbingImpl(final OngoingStubbing<T> ongoingStubbing) {
             this.mockitoOngoingStubbing = ongoingStubbing;
         }
 
-        public BDDMyOngoingStubbing<T> willAnswer(Answer<?> answer) {
+        public BDDMyOngoingStubbing<T> willAnswer(final Answer<?> answer) {
             return new BDDOngoingStubbingImpl<T>(mockitoOngoingStubbing.thenAnswer(answer));
         }
 
-        public BDDMyOngoingStubbing<T> will(Answer<?> answer) {
+        public BDDMyOngoingStubbing<T> will(final Answer<?> answer) {
             return new BDDOngoingStubbingImpl<T>(mockitoOngoingStubbing.then(answer));
         }
 
-        public BDDMyOngoingStubbing<T> willReturn(T value) {
+        public BDDMyOngoingStubbing<T> willReturn(final T value) {
             return new BDDOngoingStubbingImpl<T>(mockitoOngoingStubbing.thenReturn(value));
         }
 
-        public BDDMyOngoingStubbing<T> willReturn(T value, T... values) {
+        public BDDMyOngoingStubbing<T> willReturn(final T value, final T... values) {
             return new BDDOngoingStubbingImpl<T>(mockitoOngoingStubbing.thenReturn(value, values));
         }
 
-        public BDDMyOngoingStubbing<T> willThrow(Throwable... throwables) {
+        public BDDMyOngoingStubbing<T> willThrow(final Throwable... throwables) {
             return new BDDOngoingStubbingImpl<T>(mockitoOngoingStubbing.thenThrow(throwables));
         }
 
-        public BDDMyOngoingStubbing<T> willThrow(Class<? extends Throwable>... throwableClasses) {
+        public BDDMyOngoingStubbing<T> willThrow(final Class<? extends Throwable>... throwableClasses) {
             return new BDDOngoingStubbingImpl<T>(mockitoOngoingStubbing.thenThrow(throwableClasses));
         }
 
@@ -183,7 +183,7 @@ public class BDDMockito extends Mockito {
      * see original {@link Mockito#when(Object)}
      * @since 1.8.0
      */
-    public static <T> BDDMyOngoingStubbing<T> given(T methodCall) {
+    public static <T> BDDMyOngoingStubbing<T> given(final T methodCall) {
         return new BDDOngoingStubbingImpl<T>(Mockito.when(methodCall));
     }
 
@@ -201,7 +201,7 @@ public class BDDMockito extends Mockito {
      * @see #verify(Object, VerificationMode)
      * @since 1.10.0
      */
-    public static <T> Then<T> then(T mock) {
+    public static <T> Then<T> then(final T mock) {
         return new ThenImpl<T>(mock);
     }
 
@@ -224,19 +224,19 @@ public class BDDMockito extends Mockito {
          * @see #verify(Object, VerificationMode)
          * @since 1.10.5
          */
-        T should(VerificationMode mode);
+        T should(final VerificationMode mode);
 
         /**
          * @see InOrder#verify(Object)
          * @since 2.0
          */
-        T should(InOrder inOrder);
+        T should(final InOrder inOrder);
 
         /**
          * @see InOrder#verify(Object, VerificationMode)
          * @since 2.0
          */
-        T should(InOrder inOrder, VerificationMode mode);
+        T should(final InOrder inOrder, final VerificationMode mode);
 
         /**
          * @see #verifyZeroInteractions(Object...)
@@ -253,7 +253,7 @@ public class BDDMockito extends Mockito {
 
         private final T mock;
 
-        ThenImpl(T mock) {
+        ThenImpl(final T mock) {
             this.mock = mock;
         }
 
@@ -269,7 +269,7 @@ public class BDDMockito extends Mockito {
          * @see #verify(Object, VerificationMode)
          * @since 1.10.5
          */
-        public T should(VerificationMode mode) {
+        public T should(final VerificationMode mode) {
             return verify(mock, mode);
         }
 
@@ -277,7 +277,7 @@ public class BDDMockito extends Mockito {
          * @see InOrder#verify(Object)
          * @since 2.0
          */
-        public T should(InOrder inOrder) {
+        public T should(final InOrder inOrder) {
             return inOrder.verify(mock);
         }
 
@@ -285,7 +285,7 @@ public class BDDMockito extends Mockito {
          * @see InOrder#verify(Object, VerificationMode)
          * @since 2.0
          */
-        public T should(InOrder inOrder, VerificationMode mode) {
+        public T should(final InOrder inOrder, final VerificationMode mode) {
             return inOrder.verify(mock, mode);
         }
 
@@ -307,7 +307,7 @@ public class BDDMockito extends Mockito {
          * See original {@link Stubber#doAnswer(Answer)}
          * @since 1.8.0
          */
-        BDDStubber willAnswer(Answer answer);
+        BDDStubber willAnswer(final Answer answer);
 
         /**
          * See original {@link Stubber#doNothing()}
@@ -319,19 +319,19 @@ public class BDDMockito extends Mockito {
          * See original {@link Stubber#doReturn(Object)}
          * @since 1.8.0
          */
-        BDDStubber willReturn(Object toBeReturned);
+        BDDStubber willReturn(final Object toBeReturned);
 
         /**
          * See original {@link Stubber#doThrow(Throwable)}
          * @since 1.8.0
          */
-        BDDStubber willThrow(Throwable toBeThrown);
+        BDDStubber willThrow(final Throwable toBeThrown);
 
         /**
          * See original {@link Stubber#doThrow(Class)}
          * @since 1.9.0
          */
-        BDDStubber willThrow(Class<? extends Throwable> toBeThrown);
+        BDDStubber willThrow(final Class<? extends Throwable> toBeThrown);
 
         /**
          * See original {@link Stubber#doCallRealMethod()}
@@ -343,7 +343,7 @@ public class BDDMockito extends Mockito {
          * See original {@link Stubber#when(Object)}
          * @since 1.8.0
          */
-        <T> T given(T mock);
+        <T> T given(final T mock);
     }
 
     /**
@@ -354,15 +354,15 @@ public class BDDMockito extends Mockito {
 
         private final Stubber mockitoStubber;
 
-        public BDDStubberImpl(Stubber mockitoStubber) {
+        public BDDStubberImpl(final Stubber mockitoStubber) {
             this.mockitoStubber = mockitoStubber;
         }
 
-        public <T> T given(T mock) {
+        public <T> T given(final T mock) {
             return mockitoStubber.when(mock);
         }
 
-        public BDDStubber willAnswer(Answer answer) {
+        public BDDStubber willAnswer(final Answer answer) {
             return new BDDStubberImpl(mockitoStubber.doAnswer(answer));
         }
 
@@ -370,15 +370,15 @@ public class BDDMockito extends Mockito {
             return new BDDStubberImpl(mockitoStubber.doNothing());
         }
 
-        public BDDStubber willReturn(Object toBeReturned) {
+        public BDDStubber willReturn(final Object toBeReturned) {
             return new BDDStubberImpl(mockitoStubber.doReturn(toBeReturned));
         }
 
-        public BDDStubber willThrow(Throwable toBeThrown) {
+        public BDDStubber willThrow(final Throwable toBeThrown) {
             return new BDDStubberImpl(mockitoStubber.doThrow(toBeThrown));
         }
 
-        public BDDStubber willThrow(Class<? extends Throwable> toBeThrown) {
+        public BDDStubber willThrow(final Class<? extends Throwable> toBeThrown) {
             return new BDDStubberImpl(mockitoStubber.doThrow(toBeThrown));
         }
 
@@ -391,7 +391,7 @@ public class BDDMockito extends Mockito {
      * see original {@link Mockito#doThrow(Throwable)}
      * @since 1.8.0
      */
-    public static BDDStubber willThrow(Throwable toBeThrown) {
+    public static BDDStubber willThrow(final Throwable toBeThrown) {
         return new BDDStubberImpl(Mockito.doThrow(toBeThrown));
     }
 
@@ -399,7 +399,7 @@ public class BDDMockito extends Mockito {
      * see original {@link Mockito#doThrow(Throwable)}
      * @since 1.9.0
      */
-    public static BDDStubber willThrow(Class<? extends Throwable> toBeThrown) {
+    public static BDDStubber willThrow(final Class<? extends Throwable> toBeThrown) {
         return new BDDStubberImpl(Mockito.doThrow(toBeThrown));
     }
 
@@ -407,7 +407,7 @@ public class BDDMockito extends Mockito {
      * see original {@link Mockito#doAnswer(Answer)}
      * @since 1.8.0
      */
-    public static BDDStubber willAnswer(Answer answer) {
+    public static BDDStubber willAnswer(final Answer answer) {
         return new BDDStubberImpl(Mockito.doAnswer(answer));
     }
 
@@ -423,7 +423,7 @@ public class BDDMockito extends Mockito {
      * see original {@link Mockito#doReturn(Object)}
      * @since 1.8.0
      */
-    public static BDDStubber willReturn(Object toBeReturned) {
+    public static BDDStubber willReturn(final Object toBeReturned) {
         return new BDDStubberImpl(Mockito.doReturn(toBeReturned));
     }
 

--- a/src/org/mockito/Captor.java
+++ b/src/org/mockito/Captor.java
@@ -4,7 +4,11 @@
  */
 package org.mockito;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * Allows shorthand {@link org.mockito.ArgumentCaptor} creation on fields.

--- a/src/org/mockito/InjectMocks.java
+++ b/src/org/mockito/InjectMocks.java
@@ -4,12 +4,12 @@
  */
 package org.mockito;
 
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Mark a field on which injection should be performed.
@@ -131,7 +131,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *       }
  *   }
  * </code></pre>
- * </p>
  *
  *
  * <p>

--- a/src/org/mockito/Matchers.java
+++ b/src/org/mockito/Matchers.java
@@ -104,7 +104,7 @@ import org.mockito.internal.progress.ThreadSafeMockingProgress;
  * For example, if custom argument matcher is not likely to be reused
  * or you just need it to assert on argument values to complete verification of behavior.
  */
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class Matchers {
     
     private static final MockingProgress MOCKING_PROGRESS = new ThreadSafeMockingProgress();

--- a/src/org/mockito/Matchers.java
+++ b/src/org/mockito/Matchers.java
@@ -4,17 +4,27 @@
  */
 package org.mockito;
 
-import org.hamcrest.Matcher;
-import org.mockito.internal.matchers.*;
-import org.mockito.internal.matchers.apachecommons.ReflectionEquals;
-import org.mockito.internal.progress.HandyReturnValues;
-import org.mockito.internal.progress.MockingProgress;
-import org.mockito.internal.progress.ThreadSafeMockingProgress;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.hamcrest.Matcher;
+import org.mockito.internal.matchers.Any;
+import org.mockito.internal.matchers.AnyVararg;
+import org.mockito.internal.matchers.Contains;
+import org.mockito.internal.matchers.EndsWith;
+import org.mockito.internal.matchers.Equals;
+import org.mockito.internal.matchers.InstanceOf;
+import org.mockito.internal.matchers.Matches;
+import org.mockito.internal.matchers.NotNull;
+import org.mockito.internal.matchers.Null;
+import org.mockito.internal.matchers.Same;
+import org.mockito.internal.matchers.StartsWith;
+import org.mockito.internal.matchers.apachecommons.ReflectionEquals;
+import org.mockito.internal.progress.HandyReturnValues;
+import org.mockito.internal.progress.MockingProgress;
+import org.mockito.internal.progress.ThreadSafeMockingProgress;
 
 /**
  * Allow flexible verification or stubbing. See also {@link AdditionalMatchers}.
@@ -240,8 +250,8 @@ public class Matchers {
      * <p>
      * @return <code>null</code>.
      */
-    public static <T> T any(Class<T> clazz) {
-        return (T) reportMatcher(Any.ANY).returnFor(clazz);
+    public static <T> T any(final Class<T> clazz) {
+        return reportMatcher(Any.ANY).returnFor(clazz);
     }
     
     /**
@@ -296,7 +306,7 @@ public class Matchers {
      * @param clazz Type owned by the list to avoid casting
      * @return empty List.
      */
-    public static <T> List<T> anyListOf(Class<T> clazz) {
+    public static <T> List<T> anyListOf(final Class<T> clazz) {
         return anyList();
     }
     
@@ -326,7 +336,7 @@ public class Matchers {
      * @param clazz Type owned by the Set to avoid casting
      * @return empty Set
      */
-    public static <T> Set<T> anySetOf(Class<T> clazz) {
+    public static <T> Set<T> anySetOf(final Class<T> clazz) {
         return anySet();
     }
 
@@ -357,7 +367,7 @@ public class Matchers {
      * @param valueClazz Type of the value to avoid casting
      * @return empty Map.
      */
-    public static <K, V>  Map<K, V> anyMapOf(Class<K> keyClazz, Class<V> valueClazz) {
+    public static <K, V>  Map<K, V> anyMapOf(final Class<K> keyClazz, final Class<V> valueClazz) {
         return anyMap();
     }
     
@@ -387,7 +397,7 @@ public class Matchers {
      * @param clazz Type owned by the collection to avoid casting
      * @return empty Collection.
      */
-    public static <T> Collection<T> anyCollectionOf(Class<T> clazz) {
+    public static <T> Collection<T> anyCollectionOf(final Class<T> clazz) {
         return anyCollection();
     }    
 
@@ -402,7 +412,7 @@ public class Matchers {
      *            the class of the accepted type.
      * @return <code>null</code>.
      */
-    public static <T> T isA(Class<T> clazz) {
+    public static <T> T isA(final Class<T> clazz) {
         return reportMatcher(new InstanceOf(clazz)).<T>returnFor(clazz);
     }
 
@@ -415,7 +425,7 @@ public class Matchers {
      *            the given value.
      * @return <code>0</code>.
      */
-    public static boolean eq(boolean value) {
+    public static boolean eq(final boolean value) {
         return reportMatcher(new Equals(value)).returnFalse();
     }
 
@@ -428,7 +438,7 @@ public class Matchers {
      *            the given value.
      * @return <code>0</code>.
      */
-    public static byte eq(byte value) {
+    public static byte eq(final byte value) {
         return reportMatcher(new Equals(value)).returnZero();
     }
 
@@ -441,7 +451,7 @@ public class Matchers {
      *            the given value.
      * @return <code>0</code>.
      */
-    public static char eq(char value) {
+    public static char eq(final char value) {
         return reportMatcher(new Equals(value)).returnChar();
     }
 
@@ -454,7 +464,7 @@ public class Matchers {
      *            the given value.
      * @return <code>0</code>.
      */
-    public static double eq(double value) {
+    public static double eq(final double value) {
         return reportMatcher(new Equals(value)).returnZero();
     }
 
@@ -467,7 +477,7 @@ public class Matchers {
      *            the given value.
      * @return <code>0</code>.
      */
-    public static float eq(float value) {
+    public static float eq(final float value) {
         return reportMatcher(new Equals(value)).returnZero();
     }
     
@@ -480,7 +490,7 @@ public class Matchers {
      *            the given value.
      * @return <code>0</code>.
      */
-    public static int eq(int value) {
+    public static int eq(final int value) {
         return reportMatcher(new Equals(value)).returnZero();
     }
 
@@ -493,7 +503,7 @@ public class Matchers {
      *            the given value.
      * @return <code>0</code>.
      */
-    public static long eq(long value) {
+    public static long eq(final long value) {
         return reportMatcher(new Equals(value)).returnZero();
     }
 
@@ -506,7 +516,7 @@ public class Matchers {
      *            the given value.
      * @return <code>0</code>.
      */
-    public static short eq(short value) {
+    public static short eq(final short value) {
         return reportMatcher(new Equals(value)).returnZero();
     }
 
@@ -519,8 +529,8 @@ public class Matchers {
      *            the given value.
      * @return <code>null</code>.
      */
-    public static <T> T eq(T value) {
-        return (T) reportMatcher(new Equals(value)).<T>returnFor(value);
+    public static <T> T eq(final T value) {
+        return reportMatcher(new Equals(value)).<T>returnFor(value);
     }
 
     /**
@@ -543,7 +553,7 @@ public class Matchers {
      *            fields to exclude, if field does not exist it is ignored.
      * @return <code>null</code>.
      */
-    public static <T> T refEq(T value, String... excludeFields) {
+    public static <T> T refEq(final T value, final String... excludeFields) {
         return reportMatcher(new ReflectionEquals(value, excludeFields)).<T>returnNull();
     }
     
@@ -558,8 +568,8 @@ public class Matchers {
      *            the given value.
      * @return <code>null</code>.
      */
-    public static <T> T same(T value) {
-        return (T) reportMatcher(new Same(value)).<T>returnFor(value);
+    public static <T> T same(final T value) {
+        return reportMatcher(new Same(value)).<T>returnFor(value);
     }
 
     /**
@@ -582,7 +592,7 @@ public class Matchers {
      * @param clazz Type to avoid casting
      * @return <code>null</code>.
      */
-    public static <T> T isNull(Class<T> clazz) {
+    public static <T> T isNull(final Class<T> clazz) {
         return (T) reportMatcher(Null.NULL).returnNull();
     }
 
@@ -610,7 +620,7 @@ public class Matchers {
      * @param clazz Type to avoid casting
      * @return <code>null</code>.
      */
-    public static <T> T notNull(Class<T> clazz) {
+    public static <T> T notNull(final Class<T> clazz) {
         return (T) reportMatcher(NotNull.NOT_NULL).returnNull();
     }
     
@@ -638,7 +648,7 @@ public class Matchers {
      * @param clazz Type to avoid casting
      * @return <code>null</code>.
      */
-    public static <T> T isNotNull(Class<T> clazz) {
+    public static <T> T isNotNull(final Class<T> clazz) {
         return notNull(clazz);
     }
 
@@ -651,7 +661,7 @@ public class Matchers {
      *            the substring.
      * @return empty String ("").
      */
-    public static String contains(String substring) {
+    public static String contains(final String substring) {
         return reportMatcher(new Contains(substring)).returnString();
     }
 
@@ -664,7 +674,7 @@ public class Matchers {
      *            the regular expression.
      * @return empty String ("").
      */
-    public static String matches(String regex) {
+    public static String matches(final String regex) {
         return reportMatcher(new Matches(regex)).returnString();
     }
 
@@ -677,7 +687,7 @@ public class Matchers {
      *            the suffix.
      * @return empty String ("").
      */
-    public static String endsWith(String suffix) {
+    public static String endsWith(final String suffix) {
         return reportMatcher(new EndsWith(suffix)).returnString();
     }
 
@@ -690,7 +700,7 @@ public class Matchers {
      *            the prefix.
      * @return empty String ("").
      */
-    public static String startsWith(String prefix) {
+    public static String startsWith(final String prefix) {
         return reportMatcher(new StartsWith(prefix)).returnString();
     }
 
@@ -705,7 +715,7 @@ public class Matchers {
      * @param matcher decides whether argument matches
      * @return <code>null</code>.
      */
-    public static <T> T argThat(Matcher<T> matcher) {
+    public static <T> T argThat(final Matcher<T> matcher) {
         return reportMatcher(matcher).<T>returnNull();
     }
     
@@ -717,7 +727,7 @@ public class Matchers {
      * @param matcher decides whether argument matches
      * @return <code>0</code>.
      */
-    public static char charThat(Matcher<Character> matcher) {
+    public static char charThat(final Matcher<Character> matcher) {
         return reportMatcher(matcher).returnChar();
     }
     
@@ -729,7 +739,7 @@ public class Matchers {
      * @param matcher decides whether argument matches
      * @return <code>false</code>.
      */
-    public static boolean booleanThat(Matcher<Boolean> matcher) {
+    public static boolean booleanThat(final Matcher<Boolean> matcher) {
         return reportMatcher(matcher).returnFalse();
     }
     
@@ -741,7 +751,7 @@ public class Matchers {
      * @param matcher decides whether argument matches
      * @return <code>0</code>.
      */
-    public static byte byteThat(Matcher<Byte> matcher) {
+    public static byte byteThat(final Matcher<Byte> matcher) {
         return reportMatcher(matcher).returnZero();
     }
     
@@ -753,7 +763,7 @@ public class Matchers {
      * @param matcher decides whether argument matches
      * @return <code>0</code>.
      */
-    public static short shortThat(Matcher<Short> matcher) {
+    public static short shortThat(final Matcher<Short> matcher) {
         return reportMatcher(matcher).returnZero();
     }
     
@@ -765,7 +775,7 @@ public class Matchers {
      * @param matcher decides whether argument matches
      * @return <code>0</code>.
      */
-    public static int intThat(Matcher<Integer> matcher) {
+    public static int intThat(final Matcher<Integer> matcher) {
         return reportMatcher(matcher).returnZero();
     }
 
@@ -777,7 +787,7 @@ public class Matchers {
      * @param matcher decides whether argument matches
      * @return <code>0</code>.
      */
-    public static long longThat(Matcher<Long> matcher) {
+    public static long longThat(final Matcher<Long> matcher) {
         return reportMatcher(matcher).returnZero();
     }
     
@@ -789,7 +799,7 @@ public class Matchers {
      * @param matcher decides whether argument matches
      * @return <code>0</code>.
      */
-    public static float floatThat(Matcher<Float> matcher) {
+    public static float floatThat(final Matcher<Float> matcher) {
         return reportMatcher(matcher).returnZero();
     }
     
@@ -801,11 +811,11 @@ public class Matchers {
      * @param matcher decides whether argument matches
      * @return <code>0</code>.
      */
-    public static double doubleThat(Matcher<Double> matcher) {
+    public static double doubleThat(final Matcher<Double> matcher) {
         return reportMatcher(matcher).returnZero();
     }
 
-    private static HandyReturnValues reportMatcher(Matcher<?> matcher) {
+    private static HandyReturnValues reportMatcher(final Matcher<?> matcher) {
         return MOCKING_PROGRESS.getArgumentMatcherStorage().reportMatcher(matcher);
     }
 }

--- a/src/org/mockito/MockSettings.java
+++ b/src/org/mockito/MockSettings.java
@@ -4,11 +4,11 @@
  */
 package org.mockito;
 
+import java.io.Serializable;
+
 import org.mockito.listeners.InvocationListener;
 import org.mockito.mock.SerializableMode;
 import org.mockito.stubbing.Answer;
-
-import java.io.Serializable;
 
 /**
  * Allows mock creation with additional mock settings.
@@ -58,7 +58,7 @@ public interface MockSettings extends Serializable {
      * @param interfaces extra interfaces the should implement.
      * @return settings instance so that you can fluently specify other settings
      */
-    MockSettings extraInterfaces(Class<?>... interfaces);
+    MockSettings extraInterfaces(final Class<?>... interfaces);
 
     /**
      * Specifies mock name. Naming mocks can be helpful for debugging - the name is used in all verification errors.
@@ -78,7 +78,7 @@ public interface MockSettings extends Serializable {
      * @param name the name of the mock, later used in all verification errors
      * @return settings instance so that you can fluently specify other settings
      */
-    MockSettings name(String name);
+    MockSettings name(final String name);
 
     /**
      * Specifies the instance to spy on. Makes sense only for spies/partial mocks.
@@ -120,7 +120,7 @@ public interface MockSettings extends Serializable {
      * @param instance to spy on
      * @return settings instance so that you can fluently specify other settings
      */
-    MockSettings spiedInstance(Object instance);
+    MockSettings spiedInstance(final Object instance);
 
     /**
      * Specifies default answers to interactions.
@@ -140,8 +140,7 @@ public interface MockSettings extends Serializable {
      * @param defaultAnswer default answer to be used by mock when not stubbed
      * @return settings instance so that you can fluently specify other settings
      */
-    @SuppressWarnings("unchecked")
-    MockSettings defaultAnswer(Answer defaultAnswer);
+    MockSettings defaultAnswer(final Answer defaultAnswer);
 
     /**
      * Configures the mock to be serializable. With this feature you can use a mock in a place that requires dependencies to be serializable.
@@ -178,7 +177,7 @@ public interface MockSettings extends Serializable {
      * @return settings instance so that you can fluently specify other settings
      * @since 1.10.0
      */
-    MockSettings serializable(SerializableMode mode);
+    MockSettings serializable(final SerializableMode mode);
 
     /**
      * Enables real-time logging of method invocations on this mock. Can be used
@@ -215,7 +214,7 @@ public interface MockSettings extends Serializable {
      * @param listeners The invocation listeners to add. May not be null.
      * @return settings instance so that you can fluently specify other settings
      */
-    MockSettings invocationListeners(InvocationListener... listeners);
+    MockSettings invocationListeners(final InvocationListener... listeners);
 
     /**
      * A stub-only mock does not record method
@@ -265,5 +264,5 @@ public interface MockSettings extends Serializable {
      * @since 1.10.12
      */
     @Incubating
-    MockSettings outerInstance(Object outerClassInstance);
+    MockSettings outerInstance(final Object outerClassInstance);
 }

--- a/src/org/mockito/MockSettings.java
+++ b/src/org/mockito/MockSettings.java
@@ -36,6 +36,7 @@ import org.mockito.stubbing.Answer;
  * Firstly, to make it easy to add another mock setting when the demand comes.
  * Secondly, to enable combining together different mock settings without introducing zillions of overloaded mock() methods.
  */
+@SuppressWarnings("rawtypes")
 public interface MockSettings extends Serializable {
 
     /**
@@ -106,7 +107,7 @@ public interface MockSettings extends Serializable {
      * About stubbing for a partial mock, as it is a spy it will always call the real method, unless you use the
      * <code>doReturn</code>|<code>Throw</code>|<code>Answer</code>|<code>CallRealMethod</code> stubbing style. Example:
      *
-     * <pre class="code"><code class="java">
+     * <code class="java">
      *   List list = new LinkedList();
      *   List spy = spy(list);
      *

--- a/src/org/mockito/MockingDetails.java
+++ b/src/org/mockito/MockingDetails.java
@@ -4,10 +4,10 @@
  */
 package org.mockito;
 
-import org.mockito.invocation.Invocation;
-
 import java.util.Collection;
 import java.util.Set;
+
+import org.mockito.invocation.Invocation;
 
 /**
  * Provides mocking information.
@@ -15,6 +15,7 @@ import java.util.Set;
  *
  * @since 1.9.5
  */
+@SuppressWarnings("rawtypes")
 public interface MockingDetails {
     
     /**

--- a/src/org/mockito/Mockito.java
+++ b/src/org/mockito/Mockito.java
@@ -7,15 +7,29 @@ package org.mockito;
 import org.mockito.internal.MockitoCore;
 import org.mockito.internal.creation.MockSettingsImpl;
 import org.mockito.internal.debugging.MockitoDebuggerImpl;
-import org.mockito.internal.stubbing.answers.*;
+import org.mockito.internal.stubbing.answers.AnswerReturnValuesAdapter;
+import org.mockito.internal.stubbing.answers.CallsRealMethods;
+import org.mockito.internal.stubbing.answers.DoesNothing;
+import org.mockito.internal.stubbing.answers.Returns;
+import org.mockito.internal.stubbing.answers.ThrowsException;
+import org.mockito.internal.stubbing.answers.ThrowsExceptionClass;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsEmptyValues;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsMoreEmptyValues;
 import org.mockito.internal.verification.VerificationModeFactory;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.mockito.mock.SerializableMode;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.mockito.stubbing.*;
-import org.mockito.verification.*;
-import org.mockito.junit.*;
+import org.mockito.stubbing.Answer;
+import org.mockito.stubbing.DeprecatedOngoingStubbing;
+import org.mockito.stubbing.OngoingStubbing;
+import org.mockito.stubbing.Stubber;
+import org.mockito.stubbing.VoidMethodStubbable;
+import org.mockito.verification.After;
+import org.mockito.verification.Timeout;
+import org.mockito.verification.VerificationAfterDelay;
+import org.mockito.verification.VerificationMode;
+import org.mockito.verification.VerificationWithTimeout;
 
 /**
  * <p align="left"><img src="logo.png" srcset="logo@2x.png 2x" alt="Mockito logo"/></p>
@@ -1252,7 +1266,7 @@ public class Mockito extends Matchers {
      * @param classToMock class or interface to mock
      * @return mock object
      */
-    public static <T> T mock(Class<T> classToMock) {
+    public static <T> T mock(final Class<T> classToMock) {
         return mock(classToMock, withSettings().defaultAnswer(RETURNS_DEFAULTS));
     }
 
@@ -1271,7 +1285,7 @@ public class Mockito extends Matchers {
      * @param name of the mock
      * @return mock object
      */
-    public static <T> T mock(Class<T> classToMock, String name) {
+    public static <T> T mock(final Class<T> classToMock, final String name) {
         return mock(classToMock, withSettings()
                 .name(name)
                 .defaultAnswer(RETURNS_DEFAULTS));
@@ -1289,7 +1303,7 @@ public class Mockito extends Matchers {
      * @return A {@link org.mockito.MockingDetails} instance.
      * @since 1.9.5
      */
-    public static MockingDetails mockingDetails(Object toInspect) {
+    public static MockingDetails mockingDetails(final Object toInspect) {
         return MOCKITO_CORE.mockingDetails(toInspect);
     }
 
@@ -1324,7 +1338,7 @@ public class Mockito extends Matchers {
      * @deprecated <b>Please use mock(Foo.class, defaultAnswer);</b>
      */
     @Deprecated
-    public static <T> T mock(Class<T> classToMock, ReturnValues returnValues) {
+    public static <T> T mock(final Class<T> classToMock, final ReturnValues returnValues) {
         return mock(classToMock, withSettings().defaultAnswer(new AnswerReturnValuesAdapter(returnValues)));
     }
 
@@ -1347,7 +1361,7 @@ public class Mockito extends Matchers {
      *
      * @return mock object
      */
-    public static <T> T mock(Class<T> classToMock, Answer defaultAnswer) {
+    public static <T> T mock(final Class<T> classToMock, final Answer defaultAnswer) {
         return mock(classToMock, withSettings().defaultAnswer(defaultAnswer));
     }
 
@@ -1374,7 +1388,7 @@ public class Mockito extends Matchers {
      * @param mockSettings additional mock settings
      * @return mock object
      */
-    public static <T> T mock(Class<T> classToMock, MockSettings mockSettings) {
+    public static <T> T mock(final Class<T> classToMock, final MockSettings mockSettings) {
         return MOCKITO_CORE.mock(classToMock, mockSettings);
     }
 
@@ -1457,7 +1471,7 @@ public class Mockito extends Matchers {
      *            to spy on
      * @return a spy of the real object
      */
-    public static <T> T spy(T object) {
+    public static <T> T spy(final T object) {
         return MOCKITO_CORE.mock((Class<T>) object.getClass(), withSettings()
                 .spiedInstance(object)
                 .defaultAnswer(CALLS_REAL_METHODS));
@@ -1491,7 +1505,7 @@ public class Mockito extends Matchers {
      * @since 1.10.12
      */
     @Incubating
-    public static <T> T spy(Class<T> classToSpy) {
+    public static <T> T spy(final Class<T> classToSpy) {
         return MOCKITO_CORE.mock(classToSpy, withSettings()
                 .useConstructor()
                 .defaultAnswer(CALLS_REAL_METHODS));
@@ -1546,7 +1560,7 @@ public class Mockito extends Matchers {
      *            method call
      * @return DeprecatedOngoingStubbing object to set stubbed value/exception
      */
-    public static <T> DeprecatedOngoingStubbing<T> stub(T methodCall) {
+    public static <T> DeprecatedOngoingStubbing<T> stub(final T methodCall) {
         return MOCKITO_CORE.stub(methodCall);
     }
 
@@ -1612,7 +1626,7 @@ public class Mockito extends Matchers {
      * @return OngoingStubbing object used to stub fluently.
      *         <strong>Do not</strong> create a reference to this returned object.
      */
-    public static <T> OngoingStubbing<T> when(T methodCall) {
+    public static <T> OngoingStubbing<T> when(final T methodCall) {
         return MOCKITO_CORE.when(methodCall);
     }
 
@@ -1643,7 +1657,7 @@ public class Mockito extends Matchers {
      * @param mock to be verified
      * @return mock object itself
      */
-    public static <T> T verify(T mock) {
+    public static <T> T verify(final T mock) {
         return MOCKITO_CORE.verify(mock, times(1));
     }
 
@@ -1669,7 +1683,7 @@ public class Mockito extends Matchers {
      *
      * @return mock object itself
      */
-    public static <T> T verify(T mock, VerificationMode mode) {
+    public static <T> T verify(final T mock, final VerificationMode mode) {
         return MOCKITO_CORE.verify(mock, mode);
     }
 
@@ -1700,7 +1714,7 @@ public class Mockito extends Matchers {
      * @param <T> The Type of the mocks
      * @param mocks to be reset
      */
-    public static <T> void reset(T ... mocks) {
+    public static <T> void reset(final T ... mocks) {
         MOCKITO_CORE.reset(mocks);
     }
 
@@ -1745,7 +1759,7 @@ public class Mockito extends Matchers {
      *
      * @param mocks to be verified
      */
-    public static void verifyNoMoreInteractions(Object... mocks) {
+    public static void verifyNoMoreInteractions(final Object... mocks) {
         MOCKITO_CORE.verifyNoMoreInteractions(mocks);
     }
 
@@ -1764,7 +1778,7 @@ public class Mockito extends Matchers {
      *
      * @param mocks to be verified
      */
-    public static void verifyZeroInteractions(Object... mocks) {
+    public static void verifyZeroInteractions(final Object... mocks) {
         MOCKITO_CORE.verifyNoMoreInteractions(mocks);
     }
 
@@ -1800,7 +1814,8 @@ public class Mockito extends Matchers {
      *            to stub
      * @return stubbable object that allows stubbing with throwable
      */
-    public static <T> VoidMethodStubbable<T> stubVoid(T mock) {
+    @Deprecated
+    public static <T> VoidMethodStubbable<T> stubVoid(final T mock) {
         return MOCKITO_CORE.stubVoid(mock);
     }
 
@@ -1818,7 +1833,7 @@ public class Mockito extends Matchers {
      * @param toBeThrown to be thrown when the stubbed method is called
      * @return stubber - to select a method for stubbing
      */
-    public static Stubber doThrow(Throwable toBeThrown) {
+    public static Stubber doThrow(final Throwable toBeThrown) {
         return MOCKITO_CORE.doAnswer(new ThrowsException(toBeThrown));
     }
 
@@ -1839,7 +1854,7 @@ public class Mockito extends Matchers {
      * @return stubber - to select a method for stubbing
      * @since 1.9.0
      */
-    public static Stubber doThrow(Class<? extends Throwable> toBeThrown) {
+    public static Stubber doThrow(final Class<? extends Throwable> toBeThrown) {
         return MOCKITO_CORE.doAnswer(new ThrowsExceptionClass(toBeThrown));
     }
 
@@ -1901,7 +1916,7 @@ public class Mockito extends Matchers {
      * @param answer to answer when the stubbed method is called
      * @return stubber - to select a method for stubbing
      */
-    public static Stubber doAnswer(Answer answer) {
+    public static Stubber doAnswer(final Answer answer) {
         return MOCKITO_CORE.doAnswer(answer);
     }
 
@@ -1993,7 +2008,7 @@ public class Mockito extends Matchers {
      * @param toBeReturned to be returned when the stubbed method is called
      * @return stubber - to select a method for stubbing
      */
-    public static Stubber doReturn(Object toBeReturned) {
+    public static Stubber doReturn(final Object toBeReturned) {
         return MOCKITO_CORE.doAnswer(new Returns(toBeReturned));
     }
 
@@ -2024,7 +2039,7 @@ public class Mockito extends Matchers {
      *
      * @return InOrder object to be used to verify in order
      */
-    public static InOrder inOrder(Object... mocks) {
+    public static InOrder inOrder(final Object... mocks) {
         return MOCKITO_CORE.inOrder(mocks);
     }
 
@@ -2091,7 +2106,7 @@ public class Mockito extends Matchers {
      * @param mocks input mocks that will be changed
      * @return the same mocks that were passed in as parameters
      */
-    public static Object[] ignoreStubs(Object... mocks) {
+    public static Object[] ignoreStubs(final Object... mocks) {
         return MOCKITO_CORE.ignoreStubs(mocks);
     }
 
@@ -2107,7 +2122,7 @@ public class Mockito extends Matchers {
      *
      * @return verification mode
      */
-    public static VerificationMode times(int wantedNumberOfInvocations) {
+    public static VerificationMode times(final int wantedNumberOfInvocations) {
         return VerificationModeFactory.times(wantedNumberOfInvocations);
     }
 
@@ -2159,7 +2174,7 @@ public class Mockito extends Matchers {
      *
      * @return verification mode
      */
-    public static VerificationMode atLeast(int minNumberOfInvocations) {
+    public static VerificationMode atLeast(final int minNumberOfInvocations) {
         return VerificationModeFactory.atLeast(minNumberOfInvocations);
     }
 
@@ -2175,7 +2190,7 @@ public class Mockito extends Matchers {
      *
      * @return verification mode
      */
-    public static VerificationMode atMost(int maxNumberOfInvocations) {
+    public static VerificationMode atMost(final int maxNumberOfInvocations) {
         return VerificationModeFactory.atMost(maxNumberOfInvocations);
     }
 
@@ -2192,7 +2207,7 @@ public class Mockito extends Matchers {
      * @param wantedNumberOfInvocations number of invocations to verify
      * @return  verification mode
      */
-    public static VerificationMode calls( int wantedNumberOfInvocations ){
+    public static VerificationMode calls( final int wantedNumberOfInvocations ){
         return VerificationModeFactory.calls( wantedNumberOfInvocations );
     }
 
@@ -2253,7 +2268,7 @@ public class Mockito extends Matchers {
      *
      * @return verification mode
      */
-    public static VerificationWithTimeout timeout(long millis) {
+    public static VerificationWithTimeout timeout(final long millis) {
         return new Timeout(millis, VerificationModeFactory.times(1));
     }
 
@@ -2293,7 +2308,7 @@ public class Mockito extends Matchers {
      *
      * @return verification mode
      */
-    public static VerificationAfterDelay after(long millis) {
+    public static VerificationAfterDelay after(final long millis) {
         return new After(millis, VerificationModeFactory.times(1));
     }
 

--- a/src/org/mockito/Mockito.java
+++ b/src/org/mockito/Mockito.java
@@ -72,8 +72,8 @@ import org.mockito.verification.VerificationWithTimeout;
  *      <a href="#28">28. <code>MockMaker</code> API (Since 1.9.5)</a><br/>
  *      <a href="#29">29. (new) BDD style verification (Since 1.10.0)</a><br/>
  *      <a href="#30">30. (new) Spying or mocking abstract classes (Since 1.10.12)</a><br/>
- *      <a href="#31">31. (new) Mockito mocks can be <em>serialized</em> / <em>deserialized</em> across classloaders (Since 1.10.0)</a></h3>
- *      <a href="#32">32. (new) Better generic support with deep stubs (Since 1.10.0)</a></h3>
+ *      <a href="#31">31. (new) Mockito mocks can be <em>serialized</em> / <em>deserialized</em> across classloaders (Since 1.10.0)</a>
+ *      <a href="#32">32. (new) Better generic support with deep stubs (Since 1.10.0)</a>
  *      <a href="#32">33. (new) Mockito JUnit rule (Since 1.10.17)</a><br/>
  *      <a href="#34">34. (new) Switch <em>on</em> or <em>off</em> plugins (Since 1.10.15)</a><br/>
  * </b>
@@ -1077,7 +1077,7 @@ import org.mockito.verification.VerificationWithTimeout;
  *
  *
  */
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class Mockito extends Matchers {
 
     static final MockitoCore MOCKITO_CORE = new MockitoCore();

--- a/src/org/mockito/exceptions/PrintableInvocation.java
+++ b/src/org/mockito/exceptions/PrintableInvocation.java
@@ -5,7 +5,6 @@
 
 package org.mockito.exceptions;
 
-import org.mockito.invocation.DescribedInvocation;
 import org.mockito.invocation.Location;
 
 @Deprecated

--- a/src/org/mockito/exceptions/Reporter.java
+++ b/src/org/mockito/exceptions/Reporter.java
@@ -60,6 +60,7 @@ import org.mockito.mock.SerializableMode;
  * Generally, exception messages are full of line breaks to make them easy to
  * read (xunit plugins take only fraction of screen on modern IDEs).
  */
+@SuppressWarnings("rawtypes")
 public class Reporter {
 
     public void checkedExceptionInvalid(final Throwable t) {

--- a/src/org/mockito/exceptions/Reporter.java
+++ b/src/org/mockito/exceptions/Reporter.java
@@ -5,9 +5,27 @@
 
 package org.mockito.exceptions;
 
+import static org.mockito.internal.reporting.Pluralizer.pluralize;
+import static org.mockito.internal.util.StringJoiner.join;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 import org.mockito.exceptions.base.MockitoAssertionError;
 import org.mockito.exceptions.base.MockitoException;
-import org.mockito.exceptions.misusing.*;
+import org.mockito.exceptions.misusing.CannotStubVoidMethodWithReturnValue;
+import org.mockito.exceptions.misusing.CannotVerifyStubOnlyMock;
+import org.mockito.exceptions.misusing.FriendlyReminderException;
+import org.mockito.exceptions.misusing.InvalidUseOfMatchersException;
+import org.mockito.exceptions.misusing.MissingMethodInvocationException;
+import org.mockito.exceptions.misusing.NotAMockException;
+import org.mockito.exceptions.misusing.NullInsteadOfMockException;
+import org.mockito.exceptions.misusing.UnfinishedStubbingException;
+import org.mockito.exceptions.misusing.UnfinishedVerificationException;
+import org.mockito.exceptions.misusing.WrongTypeOfReturnValue;
 import org.mockito.exceptions.verification.NeverWantedButInvoked;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockito.exceptions.verification.SmartNullPointerException;
@@ -31,15 +49,6 @@ import org.mockito.listeners.InvocationListener;
 import org.mockito.mock.MockName;
 import org.mockito.mock.SerializableMode;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
-import static org.mockito.internal.reporting.Pluralizer.pluralize;
-import static org.mockito.internal.util.StringJoiner.join;
-
 /**
  * Reports verification and misusing errors.
  * <p>
@@ -53,7 +62,7 @@ import static org.mockito.internal.util.StringJoiner.join;
  */
 public class Reporter {
 
-    public void checkedExceptionInvalid(Throwable t) {
+    public void checkedExceptionInvalid(final Throwable t) {
         throw new MockitoException(join(
                 "Checked exception is invalid for this method!",
                 "Invalid: " + t
@@ -67,7 +76,7 @@ public class Reporter {
 
     }
 
-    public void unfinishedStubbing(Location location) {
+    public void unfinishedStubbing(final Location location) {
         throw new UnfinishedStubbingException(join(
                 "Unfinished stubbing detected here:",
                 location,
@@ -113,8 +122,8 @@ public class Reporter {
         ));
     }
 
-    public void unfinishedVerificationException(Location location) {
-        UnfinishedVerificationException exception = new UnfinishedVerificationException(join(
+    public void unfinishedVerificationException(final Location location) {
+        final UnfinishedVerificationException exception = new UnfinishedVerificationException(join(
                 "Missing method call for verify(mock) here:",
                 location,
                 "",
@@ -130,7 +139,7 @@ public class Reporter {
         throw exception;
     }
 
-    public void notAMockPassedToVerify(Class type) {
+    public void notAMockPassedToVerify(final Class type) {
         throw new NotAMockException(join(
                 "Argument passed to verify() is of type " + type.getSimpleName() + " and is not a mock!",
                 "Make sure you place the parenthesis correctly!",
@@ -235,7 +244,7 @@ public class Reporter {
         ));
     }
 
-    public void invalidUseOfMatchers(int expectedMatchersCount, List<LocalizedMatcher> recordedMatchers) {
+    public void invalidUseOfMatchers(final int expectedMatchersCount, final List<LocalizedMatcher> recordedMatchers) {
         throw new InvalidUseOfMatchersException(join(
                 "Invalid use of argument matchers!",
                 expectedMatchersCount + " matchers expected, " + recordedMatchers.size() + " recorded:" +
@@ -254,7 +263,7 @@ public class Reporter {
         ));
     }
 
-    public void incorrectUseOfAdditionalMatchers(String additionalMatcherName, int expectedSubMatchersCount, Collection<LocalizedMatcher> matcherStack) {
+    public void incorrectUseOfAdditionalMatchers(final String additionalMatcherName, final int expectedSubMatchersCount, final Collection<LocalizedMatcher> matcherStack) {
         throw new InvalidUseOfMatchersException(join(
                 "Invalid use of argument matchers inside additional matcher " + additionalMatcherName + " !",
                 new LocationImpl(),
@@ -282,7 +291,7 @@ public class Reporter {
         ));
     }
 
-    public void reportNoSubMatchersFound(String additionalMatcherName) {
+    public void reportNoSubMatchersFound(final String additionalMatcherName) {
         throw new InvalidUseOfMatchersException(join(
                 "No matchers found for additional matcher " + additionalMatcherName,
                 new LocationImpl(),
@@ -291,15 +300,16 @@ public class Reporter {
     }
 
 
-    private Object locationsOf(Collection<LocalizedMatcher> matchers) {
-        List<String> description = new ArrayList<String>();
-        for (LocalizedMatcher matcher : matchers)
+    private Object locationsOf(final Collection<LocalizedMatcher> matchers) {
+        final List<String> description = new ArrayList<String>();
+        for (final LocalizedMatcher matcher : matchers) {
             description.add(matcher.getLocation().toString());
+        }
         return join(description.toArray());
     }
 
-    public void argumentsAreDifferent(String wanted, String actual, Location actualLocation) {
-        String message = join("Argument(s) are different! Wanted:",
+    public void argumentsAreDifferent(final String wanted, final String actual, final Location actualLocation) {
+        final String message = join("Argument(s) are different! Wanted:",
                 wanted,
                 new LocationImpl(),
                 "Actual invocation has different arguments:",
@@ -311,17 +321,17 @@ public class Reporter {
         throw JUnitTool.createArgumentsAreDifferentException(message, wanted, actual);
     }
 
-    public void wantedButNotInvoked(DescribedInvocation wanted) {
+    public void wantedButNotInvoked(final DescribedInvocation wanted) {
         throw new WantedButNotInvoked(createWantedButNotInvokedMessage(wanted));
     }
 
-    public void wantedButNotInvoked(DescribedInvocation wanted, List<? extends DescribedInvocation> invocations) {
+    public void wantedButNotInvoked(final DescribedInvocation wanted, final List<? extends DescribedInvocation> invocations) {
         String allInvocations;
         if (invocations.isEmpty()) {
             allInvocations = "Actually, there were zero interactions with this mock.\n";
         } else {
-            StringBuilder sb = new StringBuilder("\nHowever, there were other interactions with this mock:\n");
-            for (DescribedInvocation i : invocations) {
+            final StringBuilder sb = new StringBuilder("\nHowever, there were other interactions with this mock:\n");
+            for (final DescribedInvocation i : invocations) {
                 sb.append(i.toString())
                         .append("\n")
                         .append(i.getLocation())
@@ -330,11 +340,11 @@ public class Reporter {
             allInvocations = sb.toString();
         }
 
-        String message = createWantedButNotInvokedMessage(wanted);
+        final String message = createWantedButNotInvokedMessage(wanted);
         throw new WantedButNotInvoked(message + allInvocations);
     }
 
-    private String createWantedButNotInvokedMessage(DescribedInvocation wanted) {
+    private String createWantedButNotInvokedMessage(final DescribedInvocation wanted) {
         return join(
                 "Wanted but not invoked:",
                 wanted.toString(),
@@ -343,7 +353,7 @@ public class Reporter {
         );
     }
 
-    public void wantedButNotInvokedInOrder(DescribedInvocation wanted, DescribedInvocation previous) {
+    public void wantedButNotInvokedInOrder(final DescribedInvocation wanted, final DescribedInvocation previous) {
         throw new VerificationInOrderFailure(join(
                 "Verification in order failure",
                 "Wanted but not invoked:",
@@ -356,13 +366,13 @@ public class Reporter {
         ));
     }
 
-    public void tooManyActualInvocations(int wantedCount, int actualCount, DescribedInvocation wanted, Location firstUndesired) {
-        String message = createTooManyInvocationsMessage(wantedCount, actualCount, wanted, firstUndesired);
+    public void tooManyActualInvocations(final int wantedCount, final int actualCount, final DescribedInvocation wanted, final Location firstUndesired) {
+        final String message = createTooManyInvocationsMessage(wantedCount, actualCount, wanted, firstUndesired);
         throw new TooManyActualInvocations(message);
     }
 
-    private String createTooManyInvocationsMessage(int wantedCount, int actualCount, DescribedInvocation wanted,
-                                                   Location firstUndesired) {
+    private String createTooManyInvocationsMessage(final int wantedCount, final int actualCount, final DescribedInvocation wanted,
+                                                   final Location firstUndesired) {
         return join(
                 wanted.toString(),
                 "Wanted " + pluralize(wantedCount) + ":",
@@ -373,7 +383,7 @@ public class Reporter {
         );
     }
 
-    public void neverWantedButInvoked(DescribedInvocation wanted, Location firstUndesired) {
+    public void neverWantedButInvoked(final DescribedInvocation wanted, final Location firstUndesired) {
         throw new NeverWantedButInvoked(join(
                 wanted.toString(),
                 "Never wanted here:",
@@ -384,19 +394,19 @@ public class Reporter {
         ));
     }
 
-    public void tooManyActualInvocationsInOrder(int wantedCount, int actualCount, DescribedInvocation wanted, Location firstUndesired) {
-        String message = createTooManyInvocationsMessage(wantedCount, actualCount, wanted, firstUndesired);
+    public void tooManyActualInvocationsInOrder(final int wantedCount, final int actualCount, final DescribedInvocation wanted, final Location firstUndesired) {
+        final String message = createTooManyInvocationsMessage(wantedCount, actualCount, wanted, firstUndesired);
         throw new VerificationInOrderFailure(join(
                 "Verification in order failure:" + message
         ));
     }
 
-    private String createTooLittleInvocationsMessage(org.mockito.internal.reporting.Discrepancy discrepancy, DescribedInvocation wanted,
-                                                     Location lastActualInvocation) {
-        String ending =
+    private String createTooLittleInvocationsMessage(final org.mockito.internal.reporting.Discrepancy discrepancy, final DescribedInvocation wanted,
+                                                     final Location lastActualInvocation) {
+        final String ending =
                 (lastActualInvocation != null) ? lastActualInvocation + "\n" : "\n";
 
-        String message = join(
+        final String message = join(
                 wanted.toString(),
                 "Wanted " + discrepancy.getPluralizedWantedCount() + ":",
                 new LocationImpl(),
@@ -406,23 +416,23 @@ public class Reporter {
         return message;
     }
 
-    public void tooLittleActualInvocations(org.mockito.internal.reporting.Discrepancy discrepancy, DescribedInvocation wanted, Location lastActualLocation) {
-        String message = createTooLittleInvocationsMessage(discrepancy, wanted, lastActualLocation);
+    public void tooLittleActualInvocations(final org.mockito.internal.reporting.Discrepancy discrepancy, final DescribedInvocation wanted, final Location lastActualLocation) {
+        final String message = createTooLittleInvocationsMessage(discrepancy, wanted, lastActualLocation);
 
         throw new TooLittleActualInvocations(message);
     }
 
-    public void tooLittleActualInvocationsInOrder(org.mockito.internal.reporting.Discrepancy discrepancy, DescribedInvocation wanted, Location lastActualLocation) {
-        String message = createTooLittleInvocationsMessage(discrepancy, wanted, lastActualLocation);
+    public void tooLittleActualInvocationsInOrder(final org.mockito.internal.reporting.Discrepancy discrepancy, final DescribedInvocation wanted, final Location lastActualLocation) {
+        final String message = createTooLittleInvocationsMessage(discrepancy, wanted, lastActualLocation);
 
         throw new VerificationInOrderFailure(join(
                 "Verification in order failure:" + message
         ));
     }
 
-    public void noMoreInteractionsWanted(Invocation undesired, List<VerificationAwareInvocation> invocations) {
-        ScenarioPrinter scenarioPrinter = new ScenarioPrinter();
-        String scenario = scenarioPrinter.print(invocations);
+    public void noMoreInteractionsWanted(final Invocation undesired, final List<VerificationAwareInvocation> invocations) {
+        final ScenarioPrinter scenarioPrinter = new ScenarioPrinter();
+        final String scenario = scenarioPrinter.print(invocations);
 
         throw new NoInteractionsWanted(join(
                 "No interactions wanted here:",
@@ -433,7 +443,7 @@ public class Reporter {
         ));
     }
 
-    public void noMoreInteractionsWantedInOrder(Invocation undesired) {
+    public void noMoreInteractionsWantedInOrder(final Invocation undesired) {
         throw new VerificationInOrderFailure(join(
                 "No interactions wanted here:",
                 new LocationImpl(),
@@ -442,7 +452,7 @@ public class Reporter {
         ));
     }
 
-    public void cannotMockFinalClass(Class<?> clazz) {
+    public void cannotMockFinalClass(final Class<?> clazz) {
         throw new MockitoException(join(
                 "Cannot mock/spy " + clazz.toString(),
                 "Mockito cannot mock/spy following:",
@@ -452,7 +462,7 @@ public class Reporter {
         ));
     }
 
-    public void cannotStubVoidMethodWithAReturnValue(String methodName) {
+    public void cannotStubVoidMethodWithAReturnValue(final String methodName) {
         throw new CannotStubVoidMethodWithReturnValue(join(
                 "'" + methodName + "' is a *void method* and it *cannot* be stubbed with a *return value*!",
                 "Voids are usually stubbed with Throwables:",
@@ -481,7 +491,7 @@ public class Reporter {
         ));
     }
 
-    public void wrongTypeOfReturnValue(String expectedType, String actualType, String methodName) {
+    public void wrongTypeOfReturnValue(final String expectedType, final String actualType, final String methodName) {
         throw new WrongTypeOfReturnValue(join(
                 actualType + " cannot be returned by " + methodName + "()",
                 methodName + "() should return " + expectedType,
@@ -496,7 +506,7 @@ public class Reporter {
         ));
     }
 
-    public void wrongTypeReturnedByDefaultAnswer(Object mock, String expectedType, String actualType, String methodName) {
+    public void wrongTypeReturnedByDefaultAnswer(final Object mock, final String expectedType, final String actualType, final String methodName) {
         throw new WrongTypeOfReturnValue(join(
                 "Default answer returned a result with the wrong type:",
                 actualType + " cannot be returned by " + methodName + "()",
@@ -508,11 +518,11 @@ public class Reporter {
     }
 
 
-    public void wantedAtMostX(int maxNumberOfInvocations, int foundSize) {
+    public void wantedAtMostX(final int maxNumberOfInvocations, final int foundSize) {
         throw new MockitoAssertionError(join("Wanted at most " + pluralize(maxNumberOfInvocations) + " but was " + foundSize));
     }
 
-    public void misplacedArgumentMatcher(List<LocalizedMatcher> lastMatchers) {
+    public void misplacedArgumentMatcher(final List<LocalizedMatcher> lastMatchers) {
         throw new InvalidUseOfMatchersException(join(
                 "Misplaced argument matcher detected here:",
                 locationsOf(lastMatchers),
@@ -530,7 +540,7 @@ public class Reporter {
         ));
     }
 
-    public void smartNullPointerException(String invocation, Location location) {
+    public void smartNullPointerException(final String invocation, final Location location) {
         throw new SmartNullPointerException(join(
                 "You have a NullPointerException here:",
                 new LocationImpl(),
@@ -562,14 +572,14 @@ public class Reporter {
         ));
     }
 
-    public void extraInterfacesAcceptsOnlyInterfaces(Class<?> wrongType) {
+    public void extraInterfacesAcceptsOnlyInterfaces(final Class<?> wrongType) {
         throw new MockitoException(join(
                 "extraInterfaces() accepts only interfaces.",
                 "You passed following type: " + wrongType.getSimpleName() + " which is not an interface."
         ));
     }
 
-    public void extraInterfacesCannotContainMockedType(Class<?> wrongType) {
+    public void extraInterfacesCannotContainMockedType(final Class<?> wrongType) {
         throw new MockitoException(join(
                 "extraInterfaces() does not accept the same type as the mocked type.",
                 "You mocked following type: " + wrongType.getSimpleName(),
@@ -583,7 +593,7 @@ public class Reporter {
         ));
     }
 
-    public void mockedTypeIsInconsistentWithSpiedInstanceType(Class<?> mockedType, Object spiedInstance) {
+    public void mockedTypeIsInconsistentWithSpiedInstanceType(final Class<?> mockedType, final Object spiedInstance) {
         throw new MockitoException(join(
                 "Mocked type must be the same as the type of your spied instance.",
                 "Mocked type must be: " + spiedInstance.getClass().getSimpleName() + ", but is: " + mockedType.getSimpleName(),
@@ -613,18 +623,18 @@ public class Reporter {
         ));
     }
 
-    public void moreThanOneAnnotationNotAllowed(String fieldName) {
+    public void moreThanOneAnnotationNotAllowed(final String fieldName) {
         throw new MockitoException("You cannot have more than one Mockito annotation on a field!\n" +
                 "The field '" + fieldName + "' has multiple Mockito annotations.\n" +
                 "For info how to use annotations see examples in javadoc for MockitoAnnotations class.");
     }
 
-    public void unsupportedCombinationOfAnnotations(String undesiredAnnotationOne, String undesiredAnnotationTwo) {
+    public void unsupportedCombinationOfAnnotations(final String undesiredAnnotationOne, final String undesiredAnnotationTwo) {
         throw new MockitoException("This combination of annotations is not permitted on a single field:\n" +
                 "@" + undesiredAnnotationOne + " and @" + undesiredAnnotationTwo);
     }
 
-    public void cannotInitializeForSpyAnnotation(String fieldName, Exception details) {
+    public void cannotInitializeForSpyAnnotation(final String fieldName, final Exception details) {
         throw new MockitoException(join("Cannot instantiate a @Spy for '" + fieldName + "' field.",
                 "You haven't provided the instance for spying at field declaration so I tried to construct the instance.",
                 "However, I failed because: " + details.getMessage(),
@@ -635,7 +645,7 @@ public class Reporter {
                 ""), details);
     }
 
-    public void cannotInitializeForInjectMocksAnnotation(String fieldName, Exception details) {
+    public void cannotInitializeForInjectMocksAnnotation(final String fieldName, final Exception details) {
         throw new MockitoException(join("Cannot instantiate @InjectMocks field named '" + fieldName + "'.",
                 "You haven't provided the instance at field declaration so I tried to construct the instance.",
                 "However, I failed because: " + details.getMessage(),
@@ -658,7 +668,7 @@ public class Reporter {
                 ""));
     }
 
-    public void fieldInitialisationThrewException(Field field, Throwable details) {
+    public void fieldInitialisationThrewException(final Field field, final Throwable details) {
         throw new MockitoException(join(
                 "Cannot instantiate @InjectMocks field named '" + field.getName() + "' of type '" + field.getType() + "'.",
                 "You haven't provided the instance at field declaration so I tried to construct the instance.",
@@ -675,13 +685,13 @@ public class Reporter {
         throw new MockitoException("invocationListeners() requires at least one listener");
     }
 
-    public void invocationListenerThrewException(InvocationListener listener, Throwable listenerThrowable) {
+    public void invocationListenerThrewException(final InvocationListener listener, final Throwable listenerThrowable) {
         throw new MockitoException(StringJoiner.join(
                 "The invocation listener with type " + listener.getClass().getName(),
                 "threw an exception : " + listenerThrowable.getClass().getName() + listenerThrowable.getMessage()), listenerThrowable);
     }
 
-    public void cannotInjectDependency(Field field, Object matchingMock, Exception details) {
+    public void cannotInjectDependency(final Field field, final Object matchingMock, final Exception details) {
         throw new MockitoException(join(
                 "Mockito couldn't inject mock dependency '" + safelyGetMockName(matchingMock) + "' on field ",
                 "'" + field + "'",
@@ -691,14 +701,14 @@ public class Reporter {
         ), details);
     }
 
-    private String exceptionCauseMessageIfAvailable(Exception details) {
+    private String exceptionCauseMessageIfAvailable(final Exception details) {
         if (details.getCause() == null) {
             return details.getMessage();
         }
         return details.getCause().getMessage();
     }
 
-    public void mockedTypeIsInconsistentWithDelegatedInstanceType(Class mockedType, Object delegatedInstance) {
+    public void mockedTypeIsInconsistentWithDelegatedInstanceType(final Class mockedType, final Object delegatedInstance) {
         throw new MockitoException(join(
                 "Mocked type must be the same as the type of your delegated instance.",
                 "Mocked type must be: " + delegatedInstance.getClass().getSimpleName() + ", but is: " + mockedType.getSimpleName(),
@@ -722,26 +732,26 @@ public class Reporter {
                 "returned."));
     }
 
-    public int invalidArgumentPositionRangeAtInvocationTime(InvocationOnMock invocation, boolean willReturnLastParameter, int argumentIndex) {
+    public int invalidArgumentPositionRangeAtInvocationTime(final InvocationOnMock invocation, final boolean willReturnLastParameter, final int argumentIndex) {
         throw new MockitoException(
                 join("Invalid argument index for the current invocation of method : ",
                         " -> " + safelyGetMockName(invocation.getMock()) + "." + invocation.getMethod().getName() + "()",
                         "",
-                        (willReturnLastParameter ?
-                                "Last parameter wanted" :
-                                "Wanted parameter at position " + argumentIndex) + " but " + possibleArgumentTypesOf(invocation),
+                        (willReturnLastParameter
+                             ? "Last parameter wanted"
+                             : "Wanted parameter at position " + argumentIndex) + " but " + possibleArgumentTypesOf(invocation),
                         "The index need to be a positive number that indicates a valid position of the argument in the invocation.",
                         "However it is possible to use the -1 value to indicates that the last argument should be returned.",
                         ""));
     }
 
-    private StringBuilder possibleArgumentTypesOf(InvocationOnMock invocation) {
-        Class<?>[] parameterTypes = invocation.getMethod().getParameterTypes();
+    private StringBuilder possibleArgumentTypesOf(final InvocationOnMock invocation) {
+        final Class<?>[] parameterTypes = invocation.getMethod().getParameterTypes();
         if (parameterTypes.length == 0) {
             return new StringBuilder("the method has no arguments.\n");
         }
 
-        StringBuilder stringBuilder = new StringBuilder("the possible argument indexes for this method are :\n");
+        final StringBuilder stringBuilder = new StringBuilder("the possible argument indexes for this method are :\n");
         for (int i = 0, parameterTypesLength = parameterTypes.length; i < parameterTypesLength; i++) {
             stringBuilder.append("    [").append(i);
 
@@ -754,7 +764,7 @@ public class Reporter {
         return stringBuilder;
     }
 
-    public void wrongTypeOfArgumentToReturn(InvocationOnMock invocation, String expectedType, Class actualType, int argumentIndex) {
+    public void wrongTypeOfArgumentToReturn(final InvocationOnMock invocation, final String expectedType, final Class actualType, final int argumentIndex) {
         throw new WrongTypeOfReturnValue(join(
                 "The argument of type '" + actualType.getSimpleName() + "' cannot be returned because the following ",
                 "method should return the type '" + expectedType + "'",
@@ -780,7 +790,7 @@ public class Reporter {
         throw new MockitoException("defaultAnswer() does not accept null parameter");
     }
 
-    public void serializableWontWorkForObjectsThatDontImplementSerializable(Class classToMock) {
+    public void serializableWontWorkForObjectsThatDontImplementSerializable(final Class classToMock) {
         throw new MockitoException(join(
                 "You are using the setting 'withSettings().serializable()' however the type you are trying to mock '" + classToMock.getSimpleName() + "'",
                 "do not implement Serializable AND do not have a no-arg constructor.",
@@ -792,7 +802,7 @@ public class Reporter {
         ));
     }
 
-    public void delegatedMethodHasWrongReturnType(Method mockMethod, Method delegateMethod, Object mock, Object delegate) {
+    public void delegatedMethodHasWrongReturnType(final Method mockMethod, final Method delegateMethod, final Object mock, final Object delegate) {
         throw new MockitoException(join(
                 "Methods called on delegated instance must have compatible return types with the mock.",
                 "When calling: " + mockMethod + " on mock: " + safelyGetMockName(mock),
@@ -802,7 +812,7 @@ public class Reporter {
         ));
     }
 
-    public void delegatedMethodDoesNotExistOnDelegate(Method mockMethod, Object mock, Object delegate) {
+    public void delegatedMethodDoesNotExistOnDelegate(final Method mockMethod, final Object mock, final Object delegate) {
         throw new MockitoException(join(
                 "Methods called on mock must exist in delegated instance.",
                 "When calling: " + mockMethod + " on mock: " + safelyGetMockName(mock),
@@ -812,11 +822,11 @@ public class Reporter {
         ));
     }
 
-    public void usingConstructorWithFancySerializable(SerializableMode mode) {
+    public void usingConstructorWithFancySerializable(final SerializableMode mode) {
         throw new MockitoException("Mocks instantiated with constructor cannot be combined with " + mode + " serialization mode.");
     }
 
-    public void cannotCreateTimerWithNegativeDurationTime(long durationMillis) {
+    public void cannotCreateTimerWithNegativeDurationTime(final long durationMillis) {
         throw new FriendlyReminderException(join("",
                 "Don't panic! I'm just a friendly reminder!",
                 "It is impossible for time to go backward, therefore...",
@@ -825,7 +835,7 @@ public class Reporter {
                 ""));
     }
 
-    private MockName safelyGetMockName(Object mock) {
+    private MockName safelyGetMockName(final Object mock) {
         return new MockUtil().getMockName(mock);
     }
 }

--- a/src/org/mockito/exceptions/base/MockitoSerializationIssue.java
+++ b/src/org/mockito/exceptions/base/MockitoSerializationIssue.java
@@ -5,9 +5,9 @@
 
 package org.mockito.exceptions.base;
 
-import org.mockito.internal.exceptions.stacktrace.ConditionalStackTraceFilter;
-
 import java.io.ObjectStreamException;
+
+import org.mockito.internal.exceptions.stacktrace.ConditionalStackTraceFilter;
 
 /**
  * Raised by mockito to emit an error either due to Mockito, or due to the User.
@@ -22,9 +22,10 @@ import java.io.ObjectStreamException;
  */
 public class MockitoSerializationIssue extends ObjectStreamException {
 
+    private static final long serialVersionUID = 5195617906606661289L;
     private StackTraceElement[] unfilteredStackTrace;
 
-    public MockitoSerializationIssue(String message, Exception cause) {
+    public MockitoSerializationIssue(final String message, final Exception cause) {
         super(message);
         initCause(cause);
         filterStackTrace();
@@ -39,7 +40,7 @@ public class MockitoSerializationIssue extends ObjectStreamException {
     private void filterStackTrace() {
         unfilteredStackTrace = super.getStackTrace();
 
-        ConditionalStackTraceFilter filter = new ConditionalStackTraceFilter();
+        final ConditionalStackTraceFilter filter = new ConditionalStackTraceFilter();
         filter.filter(this);
     }
 

--- a/src/org/mockito/exceptions/misusing/CannotStubVoidMethodWithReturnValue.java
+++ b/src/org/mockito/exceptions/misusing/CannotStubVoidMethodWithReturnValue.java
@@ -3,7 +3,10 @@ package org.mockito.exceptions.misusing;
 import org.mockito.exceptions.base.MockitoException;
 
 public class CannotStubVoidMethodWithReturnValue extends MockitoException {
-    public CannotStubVoidMethodWithReturnValue(String message) {
+
+    private static final long serialVersionUID = -2422014409790413960L;
+
+    public CannotStubVoidMethodWithReturnValue(final String message) {
         super(message);
     }
 }

--- a/src/org/mockito/exceptions/misusing/CannotVerifyStubOnlyMock.java
+++ b/src/org/mockito/exceptions/misusing/CannotVerifyStubOnlyMock.java
@@ -9,7 +9,9 @@ import org.mockito.exceptions.base.MockitoException;
 
 public class CannotVerifyStubOnlyMock extends MockitoException {
 
-    public CannotVerifyStubOnlyMock(String message) {
+    private static final long serialVersionUID = 1432030325988142053L;
+
+    public CannotVerifyStubOnlyMock(final String message) {
         super(message);
     }
 }

--- a/src/org/mockito/internal/InternalMockHandler.java
+++ b/src/org/mockito/internal/InternalMockHandler.java
@@ -12,6 +12,7 @@ import org.mockito.mock.MockCreationSettings;
 import org.mockito.stubbing.Answer;
 import org.mockito.stubbing.VoidMethodStubbable;
 
+@SuppressWarnings("rawtypes")
 public interface InternalMockHandler<T> extends MockHandler {
 
     MockCreationSettings getMockSettings();

--- a/src/org/mockito/internal/InternalMockHandler.java
+++ b/src/org/mockito/internal/InternalMockHandler.java
@@ -12,14 +12,13 @@ import org.mockito.mock.MockCreationSettings;
 import org.mockito.stubbing.Answer;
 import org.mockito.stubbing.VoidMethodStubbable;
 
-@SuppressWarnings("unchecked")
 public interface InternalMockHandler<T> extends MockHandler {
 
     MockCreationSettings getMockSettings();
 
-    VoidMethodStubbable<T> voidMethodStubbable(T mock);
+    VoidMethodStubbable<T> voidMethodStubbable(final T mock);
     
-    void setAnswersForStubbing(List<Answer> answers);
+    void setAnswersForStubbing(final List<Answer> answers);
 
     InvocationContainer getInvocationContainer();
 

--- a/src/org/mockito/internal/MockitoCore.java
+++ b/src/org/mockito/internal/MockitoCore.java
@@ -37,32 +37,32 @@ import org.mockito.stubbing.Stubber;
 import org.mockito.stubbing.VoidMethodStubbable;
 import org.mockito.verification.VerificationMode;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class MockitoCore {
 
     private final Reporter reporter = new Reporter();
     private final MockUtil mockUtil = new MockUtil();
     private final MockingProgress mockingProgress = new ThreadSafeMockingProgress();
 
-    public boolean isTypeMockable(Class<?> typeToMock) {
+    public boolean isTypeMockable(final Class<?> typeToMock) {
         return mockUtil.isTypeMockable(typeToMock);
     }
 
-    public <T> T mock(Class<T> typeToMock, MockSettings settings) {
+    public <T> T mock(final Class<T> typeToMock, final MockSettings settings) {
         if (!MockSettingsImpl.class.isInstance(settings)) {
             throw new IllegalArgumentException(
                     "Unexpected implementation of '" + settings.getClass().getCanonicalName() + "'\n"
                     + "At the moment, you cannot provide your own implementations that class.");
         }
-        MockSettingsImpl impl = MockSettingsImpl.class.cast(settings);
-        MockCreationSettings<T> creationSettings = impl.confirm(typeToMock);
-        T mock = mockUtil.createMock(creationSettings);
+        final MockSettingsImpl impl = MockSettingsImpl.class.cast(settings);
+        final MockCreationSettings<T> creationSettings = impl.confirm(typeToMock);
+        final T mock = mockUtil.createMock(creationSettings);
         mockingProgress.mockingStarted(mock, typeToMock);
         return mock;
     }
     
     public IOngoingStubbing stub() {
-        IOngoingStubbing stubbing = mockingProgress.pullOngoingStubbing();
+        final IOngoingStubbing stubbing = mockingProgress.pullOngoingStubbing();
         if (stubbing == null) {
             mockingProgress.reset();
             reporter.missingMethodInvocation();
@@ -70,17 +70,17 @@ public class MockitoCore {
         return stubbing;
     }
 
-    public <T> DeprecatedOngoingStubbing<T> stub(T methodCall) {
+    public <T> DeprecatedOngoingStubbing<T> stub(final T methodCall) {
         mockingProgress.stubbingStarted();
         return (DeprecatedOngoingStubbing) stub();
     }
 
-    public <T> OngoingStubbing<T> when(T methodCall) {
+    public <T> OngoingStubbing<T> when(final T methodCall) {
         mockingProgress.stubbingStarted();
         return (OngoingStubbing) stub();
     }
     
-    public <T> T verify(T mock, VerificationMode mode) {
+    public <T> T verify(final T mock, final VerificationMode mode) {
         if (mock == null) {
             reporter.nullPassedToVerify();
         } else if (!mockUtil.isMock(mock)) {
@@ -90,51 +90,51 @@ public class MockitoCore {
         return mock;
     }
     
-    public <T> void reset(T ... mocks) {
+    public <T> void reset(final T ... mocks) {
         mockingProgress.validateState();
         mockingProgress.reset();
         mockingProgress.resetOngoingStubbing();
         
-        for (T m : mocks) {
+        for (final T m : mocks) {
             mockUtil.resetMock(m);
         }
     }
     
-    public void verifyNoMoreInteractions(Object... mocks) {
+    public void verifyNoMoreInteractions(final Object... mocks) {
         assertMocksNotEmpty(mocks);
         mockingProgress.validateState();
-        for (Object mock : mocks) {
+        for (final Object mock : mocks) {
             try {
                 if (mock == null) {
                     reporter.nullPassedToVerifyNoMoreInteractions();
                 }
-                InvocationContainer invocations = mockUtil.getMockHandler(mock).getInvocationContainer();
-                VerificationDataImpl data = new VerificationDataImpl(invocations, null);
+                final InvocationContainer invocations = mockUtil.getMockHandler(mock).getInvocationContainer();
+                final VerificationDataImpl data = new VerificationDataImpl(invocations, null);
                 VerificationModeFactory.noMoreInteractions().verify(data);
-            } catch (NotAMockException e) {
+            } catch (final NotAMockException e) {
                 reporter.notAMockPassedToVerifyNoMoreInteractions();
             }
         }
     }
 
-    public void verifyNoMoreInteractionsInOrder(List<Object> mocks, InOrderContext inOrderContext) {
+    public void verifyNoMoreInteractionsInOrder(final List<Object> mocks, final InOrderContext inOrderContext) {
         mockingProgress.validateState();
-        VerifiableInvocationsFinder finder = new VerifiableInvocationsFinder();
-        VerificationDataInOrder data = new VerificationDataInOrderImpl(inOrderContext, finder.find(mocks), null);
+        final VerifiableInvocationsFinder finder = new VerifiableInvocationsFinder();
+        final VerificationDataInOrder data = new VerificationDataInOrderImpl(inOrderContext, finder.find(mocks), null);
         VerificationModeFactory.noMoreInteractions().verifyInOrder(data);
     }    
     
-    private void assertMocksNotEmpty(Object[] mocks) {
+    private void assertMocksNotEmpty(final Object[] mocks) {
         if (mocks == null || mocks.length == 0) {
             reporter.mocksHaveToBePassedToVerifyNoMoreInteractions();
         }
     }
     
-    public InOrder inOrder(Object... mocks) {
+    public InOrder inOrder(final Object... mocks) {
         if (mocks == null || mocks.length == 0) {
             reporter.mocksHaveToBePassedWhenCreatingInOrder();
         }
-        for (Object mock : mocks) {
+        for (final Object mock : mocks) {
             if (mock == null) {
                 reporter.nullPassedWhenCreatingInOrder();
             } else if (!mockUtil.isMock(mock)) {
@@ -144,14 +144,14 @@ public class MockitoCore {
         return new InOrderImpl(Arrays.asList(mocks));
     }
     
-    public Stubber doAnswer(Answer answer) {
+    public Stubber doAnswer(final Answer answer) {
         mockingProgress.stubbingStarted();
         mockingProgress.resetOngoingStubbing();
         return new StubberImpl().doAnswer(answer);
     }
     
-    public <T> VoidMethodStubbable<T> stubVoid(T mock) {
-        InternalMockHandler<T> handler = mockUtil.getMockHandler(mock);
+    public <T> VoidMethodStubbable<T> stubVoid(final T mock) {
+        final InternalMockHandler<T> handler = mockUtil.getMockHandler(mock);
         mockingProgress.stubbingStarted();
         return handler.voidMethodStubbable(mock);
     }
@@ -165,16 +165,16 @@ public class MockitoCore {
      * @return last invocation
      */
     public Invocation getLastInvocation() {
-        OngoingStubbingImpl ongoingStubbing = ((OngoingStubbingImpl) mockingProgress.pullOngoingStubbing());
-        List<Invocation> allInvocations = ongoingStubbing.getRegisteredInvocations();
+        final OngoingStubbingImpl ongoingStubbing = ((OngoingStubbingImpl) mockingProgress.pullOngoingStubbing());
+        final List<Invocation> allInvocations = ongoingStubbing.getRegisteredInvocations();
         return allInvocations.get(allInvocations.size()-1);
     }
 
-    public Object[] ignoreStubs(Object... mocks) {
-        for (Object m : mocks) {
-            InvocationContainer invocationContainer = new MockUtil().getMockHandler(m).getInvocationContainer();
-            List<Invocation> ins = invocationContainer.getInvocations();
-            for (Invocation in : ins) {
+    public Object[] ignoreStubs(final Object... mocks) {
+        for (final Object m : mocks) {
+            final InvocationContainer invocationContainer = new MockUtil().getMockHandler(m).getInvocationContainer();
+            final List<Invocation> ins = invocationContainer.getInvocations();
+            for (final Invocation in : ins) {
                 if (in.stubInfo() != null) {
                     in.ignoreForVerification();
                 }
@@ -183,7 +183,7 @@ public class MockitoCore {
         return mocks;
     }
 
-    public MockingDetails mockingDetails(Object toInspect) {
+    public MockingDetails mockingDetails(final Object toInspect) {
         return new DefaultMockingDetails(toInspect, new MockUtil());
     }
 }

--- a/src/org/mockito/internal/configuration/CaptorAnnotationProcessor.java
+++ b/src/org/mockito/internal/configuration/CaptorAnnotationProcessor.java
@@ -4,25 +4,26 @@
  */
 package org.mockito.internal.configuration;
 
+import java.lang.reflect.Field;
+
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.util.reflection.GenericMaster;
 
-import java.lang.reflect.Field;
-
 /**
  * Instantiate {@link ArgumentCaptor} a field annotated by &#64;Captor.
  */
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class CaptorAnnotationProcessor implements FieldAnnotationProcessor<Captor> {
-    public Object process(Captor annotation, Field field) {
-        Class<?> type = field.getType();
+    public Object process(final Captor annotation, final Field field) {
+        final Class<?> type = field.getType();
         if (!ArgumentCaptor.class.isAssignableFrom(type)) {
             throw new MockitoException("@Captor field must be of the type ArgumentCaptor.\n" + "Field: '"
                + field.getName() + "' has wrong type\n"
                + "For info how to use @Captor annotations see examples in javadoc for MockitoAnnotations class.");
         }
-        Class cls = new GenericMaster().getGenericType(field);
+        final Class cls = new GenericMaster().getGenericType(field);
         return ArgumentCaptor.forClass(cls);
     }
 }

--- a/src/org/mockito/internal/configuration/ClassPathLoader.java
+++ b/src/org/mockito/internal/configuration/ClassPathLoader.java
@@ -44,6 +44,7 @@ import org.mockito.plugins.MockMaker;
  * </ul>
  * </p>
  */
+@SuppressWarnings("rawtypes")
 public class ClassPathLoader {
 
     public static final String MOCKITO_CONFIGURATION_CLASS_NAME = "org.mockito.configuration.MockitoConfiguration";

--- a/src/org/mockito/internal/configuration/ClassPathLoader.java
+++ b/src/org/mockito/internal/configuration/ClassPathLoader.java
@@ -5,17 +5,8 @@
 package org.mockito.internal.configuration;
 
 import org.mockito.configuration.IMockitoConfiguration;
-import org.mockito.exceptions.base.MockitoException;
 import org.mockito.exceptions.misusing.MockitoConfigurationException;
 import org.mockito.plugins.MockMaker;
-import org.mockito.plugins.StackTraceCleanerProvider;
-
-import java.io.*;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.List;
 
 /**
  * Loads configuration or extension points available in the classpath.
@@ -60,22 +51,21 @@ public class ClassPathLoader {
     /**
      * @return configuration loaded from classpath or null
      */
-    @SuppressWarnings({"unchecked"})
     public IMockitoConfiguration loadConfiguration() {
         //Trying to get config from classpath
         Class configClass;
         try {
-            configClass = (Class) Class.forName(MOCKITO_CONFIGURATION_CLASS_NAME);
-        } catch (ClassNotFoundException e) {
+            configClass = Class.forName(MOCKITO_CONFIGURATION_CLASS_NAME);
+        } catch (final ClassNotFoundException e) {
             //that's ok, it means there is no global config, using default one.
             return null;
         }
 
         try {
             return (IMockitoConfiguration) configClass.newInstance();
-        } catch (ClassCastException e) {
+        } catch (final ClassCastException e) {
             throw new MockitoConfigurationException("MockitoConfiguration class must implement " + IMockitoConfiguration.class.getName() + " interface.", e);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             throw new MockitoConfigurationException("Unable to instantiate " + MOCKITO_CONFIGURATION_CLASS_NAME +" class. Does it have a safe, no-arg constructor?", e);
         }
     }

--- a/src/org/mockito/internal/configuration/DefaultAnnotationEngine.java
+++ b/src/org/mockito/internal/configuration/DefaultAnnotationEngine.java
@@ -4,6 +4,11 @@
  */
 package org.mockito.internal.configuration;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -11,11 +16,6 @@ import org.mockito.configuration.AnnotationEngine;
 import org.mockito.exceptions.Reporter;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.util.reflection.FieldSetter;
-
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Field;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Initializes fields annotated with &#64;{@link org.mockito.Mock} or &#64;{@link org.mockito.Captor}.
@@ -38,38 +38,37 @@ public class DefaultAnnotationEngine implements AnnotationEngine {
     /* (non-Javadoc)
     * @see org.mockito.AnnotationEngine#createMockFor(java.lang.annotation.Annotation, java.lang.reflect.Field)
     */
-    @SuppressWarnings("deprecation")
-    public Object createMockFor(Annotation annotation, Field field) {
+    public Object createMockFor(final Annotation annotation, final Field field) {
         return forAnnotation(annotation).process(annotation, field);
     }
 
-    private <A extends Annotation> FieldAnnotationProcessor<A> forAnnotation(A annotation) {
+    private <A extends Annotation> FieldAnnotationProcessor<A> forAnnotation(final A annotation) {
         if (annotationProcessorMap.containsKey(annotation.annotationType())) {
             return (FieldAnnotationProcessor<A>) annotationProcessorMap.get(annotation.annotationType());
         }
         return new FieldAnnotationProcessor<A>() {
-            public Object process(A annotation, Field field) {
+            public Object process(final A annotation, final Field field) {
                 return null;
             }
         };
     }
 
-    private <A extends Annotation> void registerAnnotationProcessor(Class<A> annotationClass, FieldAnnotationProcessor<A> fieldAnnotationProcessor) {
+    private <A extends Annotation> void registerAnnotationProcessor(final Class<A> annotationClass, final FieldAnnotationProcessor<A> fieldAnnotationProcessor) {
         annotationProcessorMap.put(annotationClass, fieldAnnotationProcessor);
     }
 
-    public void process(Class<?> clazz, Object testInstance) {
-        Field[] fields = clazz.getDeclaredFields();
-        for (Field field : fields) {
+    public void process(final Class<?> clazz, final Object testInstance) {
+        final Field[] fields = clazz.getDeclaredFields();
+        for (final Field field : fields) {
             boolean alreadyAssigned = false;
-            for(Annotation annotation : field.getAnnotations()) {           
-                Object mock = createMockFor(annotation, field);
+            for(final Annotation annotation : field.getAnnotations()) {           
+                final Object mock = createMockFor(annotation, field);
                 if (mock != null) {
                     throwIfAlreadyAssigned(field, alreadyAssigned);                    
                     alreadyAssigned = true;                    
                     try {
                         new FieldSetter(testInstance, field).set(mock);
-                    } catch (Exception e) {
+                    } catch (final Exception e) {
                         throw new MockitoException("Problems setting field " + field.getName() + " annotated with "
                                 + annotation, e);
                     }
@@ -78,7 +77,7 @@ public class DefaultAnnotationEngine implements AnnotationEngine {
         }
     }
     
-    void throwIfAlreadyAssigned(Field field, boolean alreadyAssigned) {
+    void throwIfAlreadyAssigned(final Field field, final boolean alreadyAssigned) {
         if (alreadyAssigned) {
             new Reporter().moreThanOneAnnotationNotAllowed(field.getName());
         }

--- a/src/org/mockito/internal/configuration/InjectingAnnotationEngine.java
+++ b/src/org/mockito/internal/configuration/InjectingAnnotationEngine.java
@@ -4,22 +4,21 @@
  */
 package org.mockito.internal.configuration;
 
-import org.mockito.*;
-import org.mockito.configuration.AnnotationEngine;
-import org.mockito.internal.configuration.injection.scanner.InjectMocksScanner;
-import org.mockito.internal.configuration.injection.scanner.MockScanner;
+import static org.mockito.internal.util.collections.Sets.newMockSafeHashSet;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.mockito.internal.util.collections.Sets.newMockSafeHashSet;
+import org.mockito.MockitoAnnotations;
+import org.mockito.configuration.AnnotationEngine;
+import org.mockito.internal.configuration.injection.scanner.InjectMocksScanner;
+import org.mockito.internal.configuration.injection.scanner.MockScanner;
 
 /**
  * See {@link MockitoAnnotations}
  */
-@SuppressWarnings({"deprecation", "unchecked"})
 public class InjectingAnnotationEngine implements AnnotationEngine {
     private final AnnotationEngine delegate = new DefaultAnnotationEngine();
     private final AnnotationEngine spyAnnotationEngine = new SpyAnnotationEngine();
@@ -31,7 +30,7 @@ public class InjectingAnnotationEngine implements AnnotationEngine {
      * @see org.mockito.configuration.AnnotationEngine#createMockFor(java.lang.annotation.Annotation, java.lang.reflect.Field)
      */
     @Deprecated
-    public Object createMockFor(Annotation annotation, Field field) {
+    public Object createMockFor(final Annotation annotation, final Field field) {
         return delegate.createMockFor(annotation, field);
     }
 
@@ -51,7 +50,7 @@ public class InjectingAnnotationEngine implements AnnotationEngine {
      *
      * @see org.mockito.configuration.AnnotationEngine#process(Class, Object)
      */
-    public void process(Class<?> clazz, Object testInstance) {
+    public void process(final Class<?> clazz, final Object testInstance) {
         processIndependentAnnotations(testInstance.getClass(), testInstance);
         processInjectMocks(testInstance.getClass(), testInstance);
     }
@@ -88,8 +87,8 @@ public class InjectingAnnotationEngine implements AnnotationEngine {
      */
     public void injectMocks(final Object testClassInstance) {
         Class<?> clazz = testClassInstance.getClass();
-        Set<Field> mockDependentFields = new HashSet<Field>();
-        Set<Object> mocks = newMockSafeHashSet();
+        final Set<Field> mockDependentFields = new HashSet<Field>();
+        final Set<Object> mocks = newMockSafeHashSet();
         
         while (clazz != Object.class) {
             new InjectMocksScanner(clazz).addTo(mockDependentFields);

--- a/src/org/mockito/internal/configuration/SpyAnnotationEngine.java
+++ b/src/org/mockito/internal/configuration/SpyAnnotationEngine.java
@@ -4,11 +4,7 @@
  */
 package org.mockito.internal.configuration;
 
-import org.mockito.*;
-import org.mockito.configuration.AnnotationEngine;
-import org.mockito.exceptions.Reporter;
-import org.mockito.exceptions.base.MockitoException;
-import org.mockito.internal.util.MockUtil;
+import static org.mockito.Mockito.withSettings;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
@@ -16,7 +12,16 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 
-import static org.mockito.Mockito.withSettings;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockSettings;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.configuration.AnnotationEngine;
+import org.mockito.exceptions.Reporter;
+import org.mockito.exceptions.base.MockitoException;
+import org.mockito.internal.util.MockUtil;
 
 /**
  * Process fields annotated with &#64;Spy.
@@ -66,31 +71,31 @@ public class SpyAnnotationEngine implements AnnotationEngine {
                     } else {
                         field.set(testInstance, newSpyInstance(testInstance, field));
                     }
-                } catch (Exception e) {
+                } catch (final Exception e) {
                     throw new MockitoException("Unable to initialize @Spy annotated field '" + field.getName() + "'.\n" + e.getMessage(), e);
                 }
             }
         }
     }
 
-    private static void assertNotInterface(Object testInstance, Class<?> type) {
+    private static void assertNotInterface(final Object testInstance, Class<?> type) {
         type = testInstance != null? testInstance.getClass() : type;
         if (type.isInterface()) {
             throw new MockitoException("Type '" + type.getSimpleName() + "' is an interface and it cannot be spied on.");
         }
     }
 
-    private static Object newSpyInstance(Object testInstance, Field field)
+    private static Object newSpyInstance(final Object testInstance, final Field field)
             throws InstantiationException, IllegalAccessException, InvocationTargetException {
-        MockSettings settings = withSettings()
+        final MockSettings settings = withSettings()
                 .defaultAnswer(Mockito.CALLS_REAL_METHODS)
                 .name(field.getName());
-        Class<?> type = field.getType();
+        final Class<?> type = field.getType();
         if (type.isInterface()) {
             return Mockito.mock(type, settings.useConstructor());
         }
         if (!Modifier.isStatic(type.getModifiers())) {
-            Class<?> enclosing = type.getEnclosingClass();
+            final Class<?> enclosing = type.getEnclosingClass();
             if (enclosing != null) {
                 if (!enclosing.isInstance(testInstance)) {
                     throw new MockitoException("@Spy annotation can only initialize inner classes declared in the test. "
@@ -105,7 +110,7 @@ public class SpyAnnotationEngine implements AnnotationEngine {
         Constructor<?> constructor;
         try {
             constructor = type.getDeclaredConstructor();
-        } catch (NoSuchMethodException e) {
+        } catch (final NoSuchMethodException e) {
             throw new MockitoException("Please ensure that the type '" + type.getSimpleName() + "' has 0-arg constructor.");
         }
 
@@ -119,8 +124,8 @@ public class SpyAnnotationEngine implements AnnotationEngine {
     }
 
     //TODO duplicated elsewhere
-    void assertNoIncompatibleAnnotations(Class annotation, Field field, Class... undesiredAnnotations) {
-        for (Class u : undesiredAnnotations) {
+    void assertNoIncompatibleAnnotations(final Class annotation, final Field field, final Class... undesiredAnnotations) {
+        for (final Class u : undesiredAnnotations) {
             if (field.isAnnotationPresent(u)) {
                 new Reporter().unsupportedCombinationOfAnnotations(annotation.getSimpleName(), annotation.getClass().getSimpleName());
             }

--- a/src/org/mockito/internal/configuration/SpyAnnotationEngine.java
+++ b/src/org/mockito/internal/configuration/SpyAnnotationEngine.java
@@ -41,17 +41,17 @@ import org.mockito.internal.util.MockUtil;
  * <p/>
  * <p>This engine will fail, if the field is also annotated with incompatible Mockito annotations.
  */
-@SuppressWarnings({"unchecked"})
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class SpyAnnotationEngine implements AnnotationEngine {
 
-    public Object createMockFor(Annotation annotation, Field field) {
+    public Object createMockFor(final Annotation annotation, final Field field) {
         return null;
     }
 
     @SuppressWarnings("deprecation") // for MockitoAnnotations.Mock
-    public void process(Class<?> context, Object testInstance) {
-        Field[] fields = context.getDeclaredFields();
-        for (Field field : fields) {
+    public void process(final Class<?> context, final Object testInstance) {
+        final Field[] fields = context.getDeclaredFields();
+        for (final Field field : fields) {
             if (field.isAnnotationPresent(Spy.class) && !field.isAnnotationPresent(InjectMocks.class)) {
                 assertNoIncompatibleAnnotations(Spy.class, field, Mock.class, org.mockito.MockitoAnnotations.Mock.class, Captor.class);
                 field.setAccessible(true);

--- a/src/org/mockito/internal/configuration/injection/ConstructorInjection.java
+++ b/src/org/mockito/internal/configuration/injection/ConstructorInjection.java
@@ -5,17 +5,17 @@
 
 package org.mockito.internal.configuration.injection;
 
-import org.mockito.exceptions.Reporter;
-import org.mockito.exceptions.base.MockitoException;
-import org.mockito.internal.util.reflection.FieldInitializationReport;
-import org.mockito.internal.util.reflection.FieldInitializer;
-import org.mockito.internal.util.reflection.FieldInitializer.ConstructorArgumentResolver;
-
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+
+import org.mockito.exceptions.Reporter;
+import org.mockito.exceptions.base.MockitoException;
+import org.mockito.internal.util.reflection.FieldInitializationReport;
+import org.mockito.internal.util.reflection.FieldInitializer;
+import org.mockito.internal.util.reflection.FieldInitializer.ConstructorArgumentResolver;
 
 /**
  * Injection strategy based on constructor.
@@ -42,19 +42,19 @@ public class ConstructorInjection extends MockInjectionStrategy {
     public ConstructorInjection() { }
 
     // visible for testing
-    ConstructorInjection(ConstructorArgumentResolver argResolver) {
+    ConstructorInjection(final ConstructorArgumentResolver argResolver) {
         this.argResolver = argResolver;
     }
 
-    public boolean processInjection(Field field, Object fieldOwner, Set<Object> mockCandidates) {
+    public boolean processInjection(final Field field, final Object fieldOwner, final Set<Object> mockCandidates) {
         try {
-            SimpleArgumentResolver simpleArgumentResolver = new SimpleArgumentResolver(mockCandidates);
-            FieldInitializationReport report = new FieldInitializer(fieldOwner, field, simpleArgumentResolver).initialize();
+            final SimpleArgumentResolver simpleArgumentResolver = new SimpleArgumentResolver(mockCandidates);
+            final FieldInitializationReport report = new FieldInitializer(fieldOwner, field, simpleArgumentResolver).initialize();
 
             return report.fieldWasInitializedUsingContructorArgs();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             if(e.getCause() instanceof InvocationTargetException) {
-                Throwable realCause = e.getCause().getCause();
+                final Throwable realCause = e.getCause().getCause();
                 new Reporter().fieldInitialisationThrewException(field, realCause);
             }
             // other causes should be fine
@@ -69,21 +69,23 @@ public class ConstructorInjection extends MockInjectionStrategy {
     static class SimpleArgumentResolver implements ConstructorArgumentResolver {
         final Set<Object> objects;
 
-        public SimpleArgumentResolver(Set<Object> objects) {
+        public SimpleArgumentResolver(final Set<Object> objects) {
             this.objects = objects;
         }
 
-        public Object[] resolveTypeInstances(Class<?>... argTypes) {
-            List<Object> argumentInstances = new ArrayList<Object>(argTypes.length);
-            for (Class<?> argType : argTypes) {
+        public Object[] resolveTypeInstances(final Class<?>... argTypes) {
+            final List<Object> argumentInstances = new ArrayList<Object>(argTypes.length);
+            for (final Class<?> argType : argTypes) {
                 argumentInstances.add(objectThatIsAssignableFrom(argType));
             }
             return argumentInstances.toArray();
         }
 
-        private Object objectThatIsAssignableFrom(Class<?> argType) {
-            for (Object object : objects) {
-                if(argType.isAssignableFrom(object.getClass())) return object;
+        private Object objectThatIsAssignableFrom(final Class<?> argType) {
+            for (final Object object : objects) {
+                if(argType.isAssignableFrom(object.getClass())) {
+                    return object;
+				}
             }
             return null;
         }

--- a/src/org/mockito/internal/configuration/injection/ConstructorInjection.java
+++ b/src/org/mockito/internal/configuration/injection/ConstructorInjection.java
@@ -37,6 +37,7 @@ import org.mockito.internal.util.reflection.FieldInitializer.ConstructorArgument
  */
 public class ConstructorInjection extends MockInjectionStrategy {
 
+    @SuppressWarnings("unused")
     private ConstructorArgumentResolver argResolver;
 
     public ConstructorInjection() { }
@@ -85,7 +86,7 @@ public class ConstructorInjection extends MockInjectionStrategy {
             for (final Object object : objects) {
                 if(argType.isAssignableFrom(object.getClass())) {
                     return object;
-				}
+                }
             }
             return null;
         }

--- a/src/org/mockito/internal/configuration/injection/filter/NameBasedCandidateFilter.java
+++ b/src/org/mockito/internal/configuration/injection/filter/NameBasedCandidateFilter.java
@@ -25,7 +25,7 @@ public class NameBasedCandidateFilter implements MockCandidateFilter {
                                            final Object injectee) {
         if (mocks.size() == 1
                 && anotherCandidateMatchesMockName(mocks, candidateFieldToBeInjected, allRemainingCandidateFields)) {
-            return OngoingInjector.nop;
+            return OngoingInjector.NOOP;
         }
 
         return next.filterCandidate(tooMany(mocks) ? selectMatchingName(mocks, candidateFieldToBeInjected) : mocks,

--- a/src/org/mockito/internal/configuration/injection/filter/OngoingInjector.java
+++ b/src/org/mockito/internal/configuration/injection/filter/OngoingInjector.java
@@ -23,7 +23,7 @@ public interface OngoingInjector {
     /**
      * Injector that will do nothing, and will return <code>null</code> as no mocks will be injected
      */
-    OngoingInjector nop = new OngoingInjector() {
+    OngoingInjector NOOP = new OngoingInjector() {
         public Object thenInject() {
             return null;
         }

--- a/src/org/mockito/internal/configuration/injection/filter/TerminalMockCandidateFilter.java
+++ b/src/org/mockito/internal/configuration/injection/filter/TerminalMockCandidateFilter.java
@@ -42,7 +42,7 @@ public class TerminalMockCandidateFilter implements MockCandidateFilter {
             };
         }
 
-        return OngoingInjector.nop;
+        return OngoingInjector.NOOP;
 
     }
 }

--- a/src/org/mockito/internal/configuration/injection/scanner/InjectMocksScanner.java
+++ b/src/org/mockito/internal/configuration/injection/scanner/InjectMocksScanner.java
@@ -4,20 +4,20 @@
  */
 package org.mockito.internal.configuration.injection.scanner;
 
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.exceptions.Reporter;
 
-import java.lang.reflect.Field;
-import java.util.HashSet;
-import java.util.Set;
-
 /**
  * Scan field for injection.
  */
-@SuppressWarnings("deprecation")
+@SuppressWarnings({"deprecation", "unchecked", "rawtypes"})
 public class InjectMocksScanner {
     private final Class<?> clazz;
 
@@ -26,7 +26,7 @@ public class InjectMocksScanner {
      *
      * @param clazz    Current class in the hierarchy of the test
      */
-    public InjectMocksScanner(Class<?> clazz) {
+    public InjectMocksScanner(final Class<?> clazz) {
         this.clazz = clazz;
     }
 
@@ -36,7 +36,7 @@ public class InjectMocksScanner {
      *
      * @param mockDependentFields Set of fields annotated by  @{@link InjectMocks}
      */
-    public void addTo(Set<Field> mockDependentFields) {
+    public void addTo(final Set<Field> mockDependentFields) {
         mockDependentFields.addAll(scan());
     }
 
@@ -46,9 +46,9 @@ public class InjectMocksScanner {
      * @return Fields that depends on Mock
      */
     private Set<Field> scan() {
-        Set<Field> mockDependentFields = new HashSet<Field>();
-        Field[] fields = clazz.getDeclaredFields();
-        for (Field field : fields) {
+        final Set<Field> mockDependentFields = new HashSet<Field>();
+        final Field[] fields = clazz.getDeclaredFields();
+        for (final Field field : fields) {
             if (null != field.getAnnotation(InjectMocks.class)) {
                 assertNoAnnotations(field, Mock.class, MockitoAnnotations.Mock.class, Captor.class);
                 mockDependentFields.add(field);
@@ -59,7 +59,7 @@ public class InjectMocksScanner {
     }
 
     void assertNoAnnotations(final Field field, final Class... annotations) {
-        for (Class annotation : annotations) {
+        for (final Class annotation : annotations) {
             if (field.isAnnotationPresent(annotation)) {
                 new Reporter().unsupportedCombinationOfAnnotations(annotation.getSimpleName(), InjectMocks.class.getSimpleName());
             }

--- a/src/org/mockito/internal/configuration/plugins/PluginFileReader.java
+++ b/src/org/mockito/internal/configuration/plugins/PluginFileReader.java
@@ -1,16 +1,15 @@
 package org.mockito.internal.configuration.plugins;
 
-import org.mockito.internal.util.io.IOUtil;
-
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Reader;
+
+import org.mockito.internal.util.io.IOUtil;
 
 class PluginFileReader {
 
-    String readPluginClass(InputStream input) throws IOException {
-        for(String line: IOUtil.readLines(input)) {
-            String stripped = stripCommentAndWhitespace(line);
+    String readPluginClass(final InputStream input) throws IOException {
+        for(final String line: IOUtil.readLines(input)) {
+            final String stripped = stripCommentAndWhitespace(line);
             if (stripped.length() > 0) {
                 return stripped;
             }
@@ -19,7 +18,7 @@ class PluginFileReader {
     }
 
     private static String stripCommentAndWhitespace(String line) {
-        int hash = line.indexOf('#');
+        final int hash = line.indexOf('#');
         if (hash != -1) {
             line = line.substring(0, hash);
         }

--- a/src/org/mockito/internal/creation/MockSettingsImpl.java
+++ b/src/org/mockito/internal/creation/MockSettingsImpl.java
@@ -4,6 +4,13 @@
  */
 package org.mockito.internal.creation;
 
+import static org.mockito.internal.util.collections.Sets.newSet;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.mockito.MockSettings;
 import org.mockito.exceptions.Reporter;
 import org.mockito.internal.creation.settings.CreationSettings;
@@ -16,14 +23,7 @@ import org.mockito.mock.MockName;
 import org.mockito.mock.SerializableMode;
 import org.mockito.stubbing.Answer;
 
-import java.io.Serializable;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import static org.mockito.internal.util.collections.Sets.newSet;
-
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSettings, MockCreationSettings<T> {
 
     private static final long serialVersionUID = 4475297236197939569L;
@@ -34,17 +34,17 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
         return serializable(SerializableMode.BASIC);
     }
 
-    public MockSettings serializable(SerializableMode mode) {
+    public MockSettings serializable(final SerializableMode mode) {
         this.serializableMode = mode;
         return this;
     }
 
-    public MockSettings extraInterfaces(Class... extraInterfaces) {
+    public MockSettings extraInterfaces(final Class... extraInterfaces) {
         if (extraInterfaces == null || extraInterfaces.length == 0) {
             new Reporter().extraInterfacesRequiresAtLeastOneInterface();
         }
 
-        for (Class i : extraInterfaces) {
+        for (final Class i : extraInterfaces) {
             if (i == null) {
                 new Reporter().extraInterfacesDoesNotAcceptNullParameters();
             } else if (!i.isInterface()) {
@@ -67,17 +67,17 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
         return spiedInstance;
     }
 
-    public MockSettings name(String name) {
+    public MockSettings name(final String name) {
         this.name = name;
         return this;
     }
 
-    public MockSettings spiedInstance(Object spiedInstance) {
+    public MockSettings spiedInstance(final Object spiedInstance) {
         this.spiedInstance = spiedInstance;
         return this;
     }
 
-    public MockSettings defaultAnswer(Answer defaultAnswer) {
+    public MockSettings defaultAnswer(final Answer defaultAnswer) {
         this.defaultAnswer = defaultAnswer;
         if (defaultAnswer == null) {
             new Reporter().defaultAnswerDoesNotAcceptNullParameter();
@@ -99,7 +99,7 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
         return this;
     }
 
-    public MockSettings outerInstance(Object outerClassInstance) {
+    public MockSettings outerInstance(final Object outerClassInstance) {
         this.outerClassInstance = outerClassInstance;
         return this;
     }
@@ -123,11 +123,11 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
         return this;
     }
 
-    public MockSettings invocationListeners(InvocationListener... listeners) {
+    public MockSettings invocationListeners(final InvocationListener... listeners) {
         if (listeners == null || listeners.length == 0) {
             new Reporter().invocationListenersRequiresAtLeastOneListener();
         }
-        for (InvocationListener listener : listeners) {
+        for (final InvocationListener listener : listeners) {
             if (listener == null) {
                 new Reporter().invocationListenerDoesNotAcceptNullParameters();
             }
@@ -136,8 +136,8 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
         return this;
     }
 
-    private boolean invocationListenersContainsType(Class<?> clazz) {
-        for (InvocationListener listener : invocationListeners) {
+    private boolean invocationListenersContainsType(final Class<?> clazz) {
+        for (final InvocationListener listener : invocationListeners) {
             if (listener.getClass().equals(clazz)) {
                 return true;
             }
@@ -157,12 +157,12 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
         return typeToMock;
     }
 
-    public MockCreationSettings<T> confirm(Class<T> typeToMock) {
+    public MockCreationSettings<T> confirm(final Class<T> typeToMock) {
         return validatedSettings(typeToMock, this);
     }
 
-    private static <T> CreationSettings<T> validatedSettings(Class<T> typeToMock, CreationSettings<T> source) {
-        MockCreationValidator validator = new MockCreationValidator();
+    private static <T> CreationSettings<T> validatedSettings(final Class<T> typeToMock, final CreationSettings<T> source) {
+        final MockCreationValidator validator = new MockCreationValidator();
 
         validator.validateType(typeToMock);
         validator.validateExtraInterfaces(typeToMock, source.getExtraInterfaces());
@@ -175,15 +175,15 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
         validator.validateConstructorUse(source.isUsingConstructor(), source.getSerializableMode());
 
         //TODO SF - I don't think we really need CreationSettings type
-        CreationSettings<T> settings = new CreationSettings<T>(source);
+        final CreationSettings<T> settings = new CreationSettings<T>(source);
         settings.setMockName(new MockNameImpl(source.getName(), typeToMock));
         settings.setTypeToMock(typeToMock);
         settings.setExtraInterfaces(prepareExtraInterfaces(source));
         return settings;
     }
 
-    private static Set<Class> prepareExtraInterfaces(CreationSettings settings) {
-        Set<Class> interfaces = new HashSet<Class>(settings.getExtraInterfaces());
+    private static Set<Class> prepareExtraInterfaces(final CreationSettings settings) {
+        final Set<Class> interfaces = new HashSet<Class>(settings.getExtraInterfaces());
         if(settings.isSerializable()) {
             interfaces.add(Serializable.class);
         }

--- a/src/org/mockito/internal/creation/instance/InstantiationException.java
+++ b/src/org/mockito/internal/creation/instance/InstantiationException.java
@@ -4,7 +4,9 @@ import org.mockito.exceptions.base.MockitoException;
 
 public class InstantiationException extends MockitoException {
 
-    public InstantiationException(String message, Throwable cause) {
+    private static final long serialVersionUID = 8161061096631959435L;
+
+    public InstantiationException(final String message, final Throwable cause) {
         super(message, cause);
     }
 }

--- a/src/org/mockito/internal/creation/instance/InstantiatorProvider.java
+++ b/src/org/mockito/internal/creation/instance/InstantiatorProvider.java
@@ -4,9 +4,9 @@ import org.mockito.mock.MockCreationSettings;
 
 public class InstantiatorProvider {
 
-    private final static Instantiator INSTANCE = new ObjenesisInstantiator();
+    private static final Instantiator INSTANCE = new ObjenesisInstantiator();
 
-    public Instantiator getInstantiator(MockCreationSettings settings) {
+    public Instantiator getInstantiator(final MockCreationSettings settings) {
         if (settings.isUsingConstructor()) {
             return new ConstructorInstantiator(settings.getOuterClassInstance());
         } else {

--- a/src/org/mockito/internal/creation/instance/InstantiatorProvider.java
+++ b/src/org/mockito/internal/creation/instance/InstantiatorProvider.java
@@ -2,6 +2,7 @@ package org.mockito.internal.creation.instance;
 
 import org.mockito.mock.MockCreationSettings;
 
+@SuppressWarnings("rawtypes")
 public class InstantiatorProvider {
 
     private static final Instantiator INSTANCE = new ObjenesisInstantiator();

--- a/src/org/mockito/internal/creation/settings/CreationSettings.java
+++ b/src/org/mockito/internal/creation/settings/CreationSettings.java
@@ -4,21 +4,22 @@
  */
 package org.mockito.internal.creation.settings;
 
-import org.mockito.listeners.InvocationListener;
-import org.mockito.mock.MockCreationSettings;
-import org.mockito.mock.MockName;
-import org.mockito.mock.SerializableMode;
-import org.mockito.stubbing.Answer;
-
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.mockito.listeners.InvocationListener;
+import org.mockito.mock.MockCreationSettings;
+import org.mockito.mock.MockName;
+import org.mockito.mock.SerializableMode;
+import org.mockito.stubbing.Answer;
+
 /**
  * by Szczepan Faber, created at: 4/9/12
  */
+@SuppressWarnings("rawtypes")
 public class CreationSettings<T> implements MockCreationSettings<T>, Serializable {
     private static final long serialVersionUID = -6789800638070123629L;
 
@@ -37,7 +38,7 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
     public CreationSettings() {}
 
     @SuppressWarnings("unchecked")
-    public CreationSettings(CreationSettings copy) {
+    public CreationSettings(final CreationSettings copy) {
         this.typeToMock = copy.typeToMock;
         this.extraInterfaces = copy.extraInterfaces;
         this.name = copy.name;
@@ -55,7 +56,7 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
         return typeToMock;
     }
 
-    public CreationSettings<T> setTypeToMock(Class<T> typeToMock) {
+    public CreationSettings<T> setTypeToMock(final Class<T> typeToMock) {
         this.typeToMock = typeToMock;
         return this;
     }
@@ -64,7 +65,7 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
         return extraInterfaces;
     }
 
-    public CreationSettings<T> setExtraInterfaces(Set<Class> extraInterfaces) {
+    public CreationSettings<T> setExtraInterfaces(final Set<Class> extraInterfaces) {
         this.extraInterfaces = extraInterfaces;
         return this;
     }
@@ -85,7 +86,7 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
         return mockName;
     }
 
-    public CreationSettings<T> setMockName(MockName mockName) {
+    public CreationSettings<T> setMockName(final MockName mockName) {
         this.mockName = mockName;
         return this;
     }

--- a/src/org/mockito/internal/creation/util/SearchingClassLoader.java
+++ b/src/org/mockito/internal/creation/util/SearchingClassLoader.java
@@ -4,7 +4,7 @@
  */
 package org.mockito.internal.creation.util;
 
-import static java.lang.Thread.*;
+import static java.lang.Thread.currentThread;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,20 +15,20 @@ import java.util.List;
 public class SearchingClassLoader extends ClassLoader {
     private final ClassLoader nextToSearch;
     
-    public SearchingClassLoader(ClassLoader parent, ClassLoader nextToSearch) {
+    public SearchingClassLoader(final ClassLoader parent, final ClassLoader nextToSearch) {
         super(parent);
         this.nextToSearch = nextToSearch;
     }
     
-    public static ClassLoader combineLoadersOf(Class<?>... classes) {
+    public static ClassLoader combineLoadersOf(final Class<?>... classes) {
         return combineLoadersOf(classes[0], classes);
     }
     
-    private static ClassLoader combineLoadersOf(Class<?> first, Class<?>... others) {
-        List<ClassLoader> loaders = new ArrayList<ClassLoader>();
+    private static ClassLoader combineLoadersOf(final Class<?> first, final Class<?>... others) {
+        final List<ClassLoader> loaders = new ArrayList<ClassLoader>();
         
         addIfNewElement(loaders, first.getClassLoader());
-        for (Class<?> c : others) {
+        for (final Class<?> c : others) {
             addIfNewElement(loaders, c.getClassLoader());
         }
         
@@ -49,7 +49,7 @@ public class SearchingClassLoader extends ClassLoader {
         return combine(loaders);
     }
     
-    private static ClassLoader combine(List<ClassLoader> parentLoaders) {
+    private static ClassLoader combine(final List<ClassLoader> parentLoaders) {
         ClassLoader loader = parentLoaders.get(parentLoaders.size()-1);
         
         for (int i = parentLoaders.size()-2; i >= 0; i--) {
@@ -59,14 +59,14 @@ public class SearchingClassLoader extends ClassLoader {
         return loader;
     }
     
-    private static void addIfNewElement(List<ClassLoader> loaders, ClassLoader c) {
+    private static void addIfNewElement(final List<ClassLoader> loaders, final ClassLoader c) {
         if (c != null && !loaders.contains(c)) {
             loaders.add(c);
         }
     }
     
     @Override
-    protected Class<?> findClass(String name) throws ClassNotFoundException {
+    protected Class<?> findClass(final String name) throws ClassNotFoundException {
         if (nextToSearch != null) {
             return nextToSearch.loadClass(name);
         } else {

--- a/src/org/mockito/internal/debugging/WarningsCollector.java
+++ b/src/org/mockito/internal/debugging/WarningsCollector.java
@@ -4,6 +4,9 @@
  */
 package org.mockito.internal.debugging;
 
+import java.util.LinkedList;
+import java.util.List;
+
 import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockito.internal.invocation.UnusedStubsFinder;
 import org.mockito.internal.invocation.finder.AllInvocationsFinder;
@@ -12,26 +15,22 @@ import org.mockito.internal.progress.MockingProgress;
 import org.mockito.internal.progress.ThreadSafeMockingProgress;
 import org.mockito.invocation.Invocation;
 
-import java.util.LinkedList;
-import java.util.List;
-
-@SuppressWarnings("unchecked")
 public class WarningsCollector {
    
     List createdMocks;
 
     public WarningsCollector() {
         createdMocks = new LinkedList();
-        MockingProgress progress = new ThreadSafeMockingProgress();
+        final MockingProgress progress = new ThreadSafeMockingProgress();
         progress.setListener(new CollectCreatedMocks(createdMocks));
     }
 
     public String getWarnings() {
-        List<Invocation> unused = new UnusedStubsFinder().find(createdMocks);
-        List<Invocation> all = new AllInvocationsFinder().find(createdMocks);
-        List<InvocationMatcher> allInvocationMatchers = InvocationMatcher.createFrom(all);
+        final List<Invocation> unused = new UnusedStubsFinder().find(createdMocks);
+        final List<Invocation> all = new AllInvocationsFinder().find(createdMocks);
+        final List<InvocationMatcher> allInvocationMatchers = InvocationMatcher.createFrom(all);
 
-        String warnings = new WarningsPrinterImpl(unused, allInvocationMatchers, false).print();
+        final String warnings = new WarningsPrinterImpl(unused, allInvocationMatchers, false).print();
 
         return warnings;
     }

--- a/src/org/mockito/internal/debugging/WarningsCollector.java
+++ b/src/org/mockito/internal/debugging/WarningsCollector.java
@@ -15,6 +15,7 @@ import org.mockito.internal.progress.MockingProgress;
 import org.mockito.internal.progress.ThreadSafeMockingProgress;
 import org.mockito.invocation.Invocation;
 
+@SuppressWarnings("rawtypes")
 public class WarningsCollector {
    
     List createdMocks;

--- a/src/org/mockito/internal/debugging/WarningsFinder.java
+++ b/src/org/mockito/internal/debugging/WarningsFinder.java
@@ -4,33 +4,33 @@
  */
 package org.mockito.internal.debugging;
 
-import org.mockito.internal.invocation.InvocationMatcher;
-import org.mockito.invocation.Invocation;
-
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+
+import org.mockito.internal.invocation.InvocationMatcher;
+import org.mockito.invocation.Invocation;
 
 @SuppressWarnings("unchecked")
 public class WarningsFinder {
     private final List<Invocation> baseUnusedStubs;
     private final List<InvocationMatcher> baseAllInvocations;
 
-    public WarningsFinder(List<Invocation> unusedStubs, List<InvocationMatcher> allInvocations) {
+    public WarningsFinder(final List<Invocation> unusedStubs, final List<InvocationMatcher> allInvocations) {
         this.baseUnusedStubs = unusedStubs;
         this.baseAllInvocations = allInvocations;
     }
     
-    public void find(FindingsListener findingsListener) {
-        List<Invocation> unusedStubs = new LinkedList(this.baseUnusedStubs);
-        List<InvocationMatcher> allInvocations = new LinkedList(this.baseAllInvocations);
+    public void find(final FindingsListener findingsListener) {
+        final List<Invocation> unusedStubs = new LinkedList(this.baseUnusedStubs);
+        final List<InvocationMatcher> allInvocations = new LinkedList(this.baseAllInvocations);
 
-        Iterator<Invocation> unusedIterator = unusedStubs.iterator();
+        final Iterator<Invocation> unusedIterator = unusedStubs.iterator();
         while(unusedIterator.hasNext()) {
-            Invocation unused = unusedIterator.next();
-            Iterator<InvocationMatcher> unstubbedIterator = allInvocations.iterator();
+            final Invocation unused = unusedIterator.next();
+            final Iterator<InvocationMatcher> unstubbedIterator = allInvocations.iterator();
             while(unstubbedIterator.hasNext()) {
-                InvocationMatcher unstubbed = unstubbedIterator.next();
+                final InvocationMatcher unstubbed = unstubbedIterator.next();
                 if(unstubbed.hasSimilarMethod(unused)) {
                     findingsListener.foundStubCalledWithDifferentArgs(unused, unstubbed);
                     unusedIterator.remove();
@@ -39,11 +39,11 @@ public class WarningsFinder {
             }
         }
 
-        for (Invocation i : unusedStubs) {
+        for (final Invocation i : unusedStubs) {
             findingsListener.foundUnusedStub(i);
         }
 
-        for (InvocationMatcher i : allInvocations) {
+        for (final InvocationMatcher i : allInvocations) {
             findingsListener.foundUnstubbed(i);
         }
     }

--- a/src/org/mockito/internal/debugging/WarningsFinder.java
+++ b/src/org/mockito/internal/debugging/WarningsFinder.java
@@ -11,7 +11,7 @@ import java.util.List;
 import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockito.invocation.Invocation;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class WarningsFinder {
     private final List<Invocation> baseUnusedStubs;
     private final List<InvocationMatcher> baseAllInvocations;

--- a/src/org/mockito/internal/exceptions/MockitoLimitations.java
+++ b/src/org/mockito/internal/exceptions/MockitoLimitations.java
@@ -2,6 +2,6 @@ package org.mockito.internal.exceptions;
 
 public class MockitoLimitations {
 
-    public final static String NON_PUBLIC_PARENT = "Mocking methods declared on non-public parent classes is not supported.";
+    public static final String NON_PUBLIC_PARENT = "Mocking methods declared on non-public parent classes is not supported.";
 
 }

--- a/src/org/mockito/internal/handler/InvocationNotifierHandler.java
+++ b/src/org/mockito/internal/handler/InvocationNotifierHandler.java
@@ -5,6 +5,7 @@
 package org.mockito.internal.handler;
 
 import java.util.List;
+
 import org.mockito.exceptions.Reporter;
 import org.mockito.internal.InternalMockHandler;
 import org.mockito.internal.listeners.NotifiedMethodInvocationReport;
@@ -24,41 +25,42 @@ import org.mockito.stubbing.VoidMethodStubbable;
  */
 class InvocationNotifierHandler<T> implements MockHandler, InternalMockHandler<T> {
 
+    private static final long serialVersionUID = -4146835657113951837L;
     private final List<InvocationListener> invocationListeners;
     private final InternalMockHandler<T> mockHandler;
 
-    public InvocationNotifierHandler(InternalMockHandler<T> mockHandler, MockCreationSettings settings) {
+    public InvocationNotifierHandler(final InternalMockHandler<T> mockHandler, final MockCreationSettings settings) {
         this.mockHandler = mockHandler;
         this.invocationListeners = settings.getInvocationListeners();
     }
 
-    public Object handle(Invocation invocation) throws Throwable {
+    public Object handle(final Invocation invocation) throws Throwable {
         try {
-            Object returnedValue = mockHandler.handle(invocation);
+            final Object returnedValue = mockHandler.handle(invocation);
             notifyMethodCall(invocation, returnedValue);
             return returnedValue;
-        } catch (Throwable t){
+        } catch (final Throwable t){
             notifyMethodCallException(invocation, t);
             throw t;
         }
     }
 
 
-    private void notifyMethodCall(Invocation invocation, Object returnValue) {
-        for (InvocationListener listener : invocationListeners) {
+    private void notifyMethodCall(final Invocation invocation, final Object returnValue) {
+        for (final InvocationListener listener : invocationListeners) {
             try {
                 listener.reportInvocation(new NotifiedMethodInvocationReport(invocation, returnValue));
-            } catch(Throwable listenerThrowable) {
+            } catch(final Throwable listenerThrowable) {
                 new Reporter().invocationListenerThrewException(listener, listenerThrowable);
             }
         }
     }
 
-    private void notifyMethodCallException(Invocation invocation, Throwable exception) {
-        for (InvocationListener listener : invocationListeners) {
+    private void notifyMethodCallException(final Invocation invocation, final Throwable exception) {
+        for (final InvocationListener listener : invocationListeners) {
             try {
                 listener.reportInvocation(new NotifiedMethodInvocationReport(invocation, exception));
-            } catch(Throwable listenerThrowable) {
+            } catch(final Throwable listenerThrowable) {
                 new Reporter().invocationListenerThrewException(listener, listenerThrowable);
             }
         }

--- a/src/org/mockito/internal/handler/InvocationNotifierHandler.java
+++ b/src/org/mockito/internal/handler/InvocationNotifierHandler.java
@@ -23,6 +23,7 @@ import org.mockito.stubbing.VoidMethodStubbable;
  *
  * Also imposterize MockHandlerImpl, delegate all call of InternalMockHandler to the real mockHandler
  */
+@SuppressWarnings({"unchecked", "rawtypes"})
 class InvocationNotifierHandler<T> implements MockHandler, InternalMockHandler<T> {
 
     private static final long serialVersionUID = -4146835657113951837L;
@@ -70,11 +71,11 @@ class InvocationNotifierHandler<T> implements MockHandler, InternalMockHandler<T
         return mockHandler.getMockSettings();
     }
 
-    public VoidMethodStubbable<T> voidMethodStubbable(T mock) {
+    public VoidMethodStubbable<T> voidMethodStubbable(final T mock) {
         return mockHandler.voidMethodStubbable(mock);
     }
 
-    public void setAnswersForStubbing(List<Answer> answers) {
+    public void setAnswersForStubbing(final List<Answer> answers) {
         mockHandler.setAnswersForStubbing(answers);
     }
 

--- a/src/org/mockito/internal/handler/MockHandlerFactory.java
+++ b/src/org/mockito/internal/handler/MockHandlerFactory.java
@@ -10,12 +10,13 @@ import org.mockito.mock.MockCreationSettings;
 /**
  * by Szczepan Faber, created at: 5/21/12
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class MockHandlerFactory {
 
-    public InternalMockHandler create(MockCreationSettings settings) {
-        InternalMockHandler handler = new MockHandlerImpl(settings);
-        InternalMockHandler nullResultGuardian = new NullResultGuardian(handler);
-        InternalMockHandler notifier = new InvocationNotifierHandler(nullResultGuardian, settings);
+    public InternalMockHandler create(final MockCreationSettings settings) {
+        final InternalMockHandler handler = new MockHandlerImpl(settings);
+        final InternalMockHandler nullResultGuardian = new NullResultGuardian(handler);
+        final InternalMockHandler notifier = new InvocationNotifierHandler(nullResultGuardian, settings);
 
         return notifier;
     }

--- a/src/org/mockito/internal/handler/NullResultGuardian.java
+++ b/src/org/mockito/internal/handler/NullResultGuardian.java
@@ -4,6 +4,8 @@
  */
 package org.mockito.internal.handler;
 
+import java.util.List;
+
 import org.mockito.internal.InternalMockHandler;
 import org.mockito.internal.progress.HandyReturnValues;
 import org.mockito.internal.stubbing.InvocationContainer;
@@ -11,23 +13,24 @@ import org.mockito.invocation.Invocation;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.stubbing.VoidMethodStubbable;
 
-import java.util.List;
-
 /**
  * Protects the results from delegate MockHandler. Makes sure the results are valid.
  *
  * by Szczepan Faber, created at: 5/22/12
  */
+@SuppressWarnings({"unchecked", "rawtypes"})
 class NullResultGuardian implements InternalMockHandler {
+
+    private static final long serialVersionUID = 3415582812871378410L;
     private final InternalMockHandler delegate;
 
-    public NullResultGuardian(InternalMockHandler delegate) {
+    public NullResultGuardian(final InternalMockHandler delegate) {
         this.delegate = delegate;
     }
 
-    public Object handle(Invocation invocation) throws Throwable {
-        Object result = delegate.handle(invocation);
-        Class<?> returnType = invocation.getMethod().getReturnType();
+    public Object handle(final Invocation invocation) throws Throwable {
+        final Object result = delegate.handle(invocation);
+        final Class<?> returnType = invocation.getMethod().getReturnType();
         if(result == null && returnType.isPrimitive()) {
             //primitive values cannot be null
             return new HandyReturnValues().returnFor(returnType);
@@ -42,11 +45,11 @@ class NullResultGuardian implements InternalMockHandler {
         return delegate.getMockSettings();
     }
 
-    public VoidMethodStubbable voidMethodStubbable(Object mock) {
+    public VoidMethodStubbable voidMethodStubbable(final Object mock) {
         return delegate.voidMethodStubbable(mock);
     }
 
-    public void setAnswersForStubbing(List answers) {
+    public void setAnswersForStubbing(final List answers) {
         delegate.setAnswersForStubbing(answers);
     }
 

--- a/src/org/mockito/internal/invocation/ArgumentsComparator.java
+++ b/src/org/mockito/internal/invocation/ArgumentsComparator.java
@@ -11,6 +11,7 @@ import org.mockito.internal.matchers.MatcherDecorator;
 import org.mockito.internal.matchers.VarargMatcher;
 import org.mockito.invocation.Invocation;
 
+@SuppressWarnings("rawtypes")
 public class ArgumentsComparator {
     public boolean argumentsMatch(final InvocationMatcher invocationMatcher, final Invocation actual) {
         final Object[] actualArgs = actual.getArguments();

--- a/src/org/mockito/internal/invocation/ArgumentsComparator.java
+++ b/src/org/mockito/internal/invocation/ArgumentsComparator.java
@@ -4,21 +4,20 @@
  */
 package org.mockito.internal.invocation;
 
+import java.util.List;
+
 import org.hamcrest.Matcher;
 import org.mockito.internal.matchers.MatcherDecorator;
 import org.mockito.internal.matchers.VarargMatcher;
 import org.mockito.invocation.Invocation;
 
-import java.util.List;
-
-@SuppressWarnings("unchecked")
 public class ArgumentsComparator {
-    public boolean argumentsMatch(InvocationMatcher invocationMatcher, Invocation actual) {
-        Object[] actualArgs = actual.getArguments();
+    public boolean argumentsMatch(final InvocationMatcher invocationMatcher, final Invocation actual) {
+        final Object[] actualArgs = actual.getArguments();
         return argumentsMatch(invocationMatcher, actualArgs) || varArgsMatch(invocationMatcher, actual);
     }
 
-    public boolean argumentsMatch(InvocationMatcher invocationMatcher, Object[] actualArgs) {
+    public boolean argumentsMatch(final InvocationMatcher invocationMatcher, final Object[] actualArgs) {
         if (actualArgs.length != invocationMatcher.getMatchers().size()) {
             return false;
         }
@@ -31,28 +30,28 @@ public class ArgumentsComparator {
     }
 
     //ok, this method is a little bit messy but the vararg business unfortunately is messy...      
-    private boolean varArgsMatch(InvocationMatcher invocationMatcher, Invocation actual) {
+    private boolean varArgsMatch(final InvocationMatcher invocationMatcher, final Invocation actual) {
         if (!actual.getMethod().isVarArgs()) {
             //if the method is not vararg forget about it
             return false;
         }
 
         //we must use raw arguments, not arguments...
-        Object[] rawArgs = actual.getRawArguments();
-        List<Matcher> matchers = invocationMatcher.getMatchers();
+        final Object[] rawArgs = actual.getRawArguments();
+        final List<Matcher> matchers = invocationMatcher.getMatchers();
 
         if (rawArgs.length != matchers.size()) {
             return false;
         }
 
         for (int i = 0; i < rawArgs.length; i++) {
-            Matcher m = matchers.get(i);
+            final Matcher m = matchers.get(i);
             //it's a vararg because it's the last array in the arg list
             if (rawArgs[i] != null && rawArgs[i].getClass().isArray() && i == rawArgs.length-1) {
                 Matcher actualMatcher;
                 //this is necessary as the framework often decorates matchers
                 if (m instanceof MatcherDecorator) {
-                    actualMatcher = ((MatcherDecorator)m).getActualMatcher();
+                    actualMatcher = ((MatcherDecorator) m).getActualMatcher();
                 } else {
                     actualMatcher = m;
                 }

--- a/src/org/mockito/internal/invocation/ArgumentsProcessor.java
+++ b/src/org/mockito/internal/invocation/ArgumentsProcessor.java
@@ -4,17 +4,18 @@
  */
 package org.mockito.internal.invocation;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.hamcrest.Matcher;
 import org.mockito.internal.matchers.ArrayEquals;
 import org.mockito.internal.matchers.Equals;
 import org.mockito.internal.util.collections.ArrayUtils;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * by Szczepan Faber, created at: 3/31/12
  */
+@SuppressWarnings("rawtypes")
 public class ArgumentsProcessor {
     // expands array varArgs that are given by runtime (1, [a, b]) into true
     // varArgs (1, a, b);
@@ -32,15 +33,15 @@ public class ArgumentsProcessor {
             varArgs = ArrayEquals.createObjectArray(args[nonVarArgsCount]);
         }
         final int varArgsCount = varArgs.length;
-        Object[] newArgs = new Object[nonVarArgsCount + varArgsCount];
+        final Object[] newArgs = new Object[nonVarArgsCount + varArgsCount];
         System.arraycopy(args, 0, newArgs, 0, nonVarArgsCount);
         System.arraycopy(varArgs, 0, newArgs, nonVarArgsCount, varArgsCount);
         return newArgs;
     }
 
-    public static List<Matcher> argumentsToMatchers(Object[] arguments) {
-        List<Matcher> matchers = new ArrayList<Matcher>(arguments.length);
-        for (Object arg : arguments) {
+    public static List<Matcher> argumentsToMatchers(final Object[] arguments) {
+        final List<Matcher> matchers = new ArrayList<Matcher>(arguments.length);
+        for (final Object arg : arguments) {
             if (arg != null && arg.getClass().isArray()) {
                 matchers.add(new ArrayEquals(arg));
             } else {

--- a/src/org/mockito/internal/invocation/InvocationImpl.java
+++ b/src/org/mockito/internal/invocation/InvocationImpl.java
@@ -5,15 +5,17 @@
 
 package org.mockito.internal.invocation;
 
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
 import org.mockito.exceptions.Reporter;
 import org.mockito.internal.debugging.LocationImpl;
 import org.mockito.internal.exceptions.VerificationAwareInvocation;
 import org.mockito.internal.invocation.realmethod.RealMethod;
 import org.mockito.internal.reporting.PrintSettings;
-import org.mockito.invocation.*;
-
-import java.lang.reflect.Method;
-import java.util.Arrays;
+import org.mockito.invocation.Invocation;
+import org.mockito.invocation.Location;
+import org.mockito.invocation.StubInfo;
 
 /**
  * Method call on a mock object.
@@ -40,7 +42,7 @@ public class InvocationImpl implements Invocation, VerificationAwareInvocation {
     final RealMethod realMethod;
     private StubInfo stubInfo;
 
-    public InvocationImpl(Object mock, MockitoMethod mockitoMethod, Object[] args, int sequenceNumber, RealMethod realMethod) {
+    public InvocationImpl(final Object mock, final MockitoMethod mockitoMethod, final Object[] args, final int sequenceNumber, final RealMethod realMethod) {
         this.method = mockitoMethod;
         this.mock = mock;
         this.realMethod = realMethod;
@@ -62,7 +64,7 @@ public class InvocationImpl implements Invocation, VerificationAwareInvocation {
         return arguments;
     }
 
-    public <T> T getArgumentAt(int index, Class<T> clazz) {
+    public <T> T getArgumentAt(final int index, final Class<T> clazz) {
         return (T) arguments[index];
     }
 
@@ -74,17 +76,17 @@ public class InvocationImpl implements Invocation, VerificationAwareInvocation {
         return sequenceNumber;
     }
 
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (o == null || !o.getClass().equals(this.getClass())) {
             return false;
         }
 
-        InvocationImpl other = (InvocationImpl) o;
+        final InvocationImpl other = (InvocationImpl) o;
 
         return this.mock.equals(other.mock) && this.method.equals(other.method) && this.equalArguments(other.arguments);
     }
 
-    private boolean equalArguments(Object[] arguments) {
+    private boolean equalArguments(final Object[] arguments) {
         return Arrays.equals(arguments, this.arguments);
     }
 
@@ -124,7 +126,7 @@ public class InvocationImpl implements Invocation, VerificationAwareInvocation {
         return stubInfo;
     }
 
-    public void markStubbed(StubInfo stubInfo) {
+    public void markStubbed(final StubInfo stubInfo) {
         this.stubInfo = stubInfo;
     }
 

--- a/src/org/mockito/internal/invocation/InvocationMatcher.java
+++ b/src/org/mockito/internal/invocation/InvocationMatcher.java
@@ -5,6 +5,15 @@
 
 package org.mockito.internal.invocation;
 
+import java.io.Serializable;
+import java.lang.reflect.Array;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
 import org.hamcrest.Matcher;
 import org.mockito.internal.matchers.CapturesArguments;
 import org.mockito.internal.matchers.MatcherDecorator;
@@ -13,19 +22,13 @@ import org.mockito.invocation.DescribedInvocation;
 import org.mockito.invocation.Invocation;
 import org.mockito.invocation.Location;
 
-import java.io.Serializable;
-import java.lang.reflect.Array;
-import java.lang.reflect.Method;
-import java.util.*;
-
-@SuppressWarnings("unchecked")
 public class InvocationMatcher implements DescribedInvocation, CapturesArgumentsFromInvocation, Serializable {
 
     private static final long serialVersionUID = -3047126096857467610L;
     private final Invocation invocation;
     private final List<Matcher> matchers;
 
-    public InvocationMatcher(Invocation invocation, List<Matcher> matchers) {
+    public InvocationMatcher(final Invocation invocation, final List<Matcher> matchers) {
         this.invocation = invocation;
         if (matchers.isEmpty()) {
             this.matchers = ArgumentsProcessor.argumentsToMatchers(invocation.getArguments());
@@ -34,7 +37,7 @@ public class InvocationMatcher implements DescribedInvocation, CapturesArguments
         }
     }
 
-    public InvocationMatcher(Invocation invocation) {
+    public InvocationMatcher(final Invocation invocation) {
         this(invocation, Collections.<Matcher>emptyList());
     }
 
@@ -50,20 +53,21 @@ public class InvocationMatcher implements DescribedInvocation, CapturesArguments
         return this.matchers;
     }
 
+    @Override
     public String toString() {
         return new PrintSettings().print(matchers, invocation);
     }
 
-    public boolean matches(Invocation actual) {
+    public boolean matches(final Invocation actual) {
         return invocation.getMock().equals(actual.getMock())
                 && hasSameMethod(actual)
                 && new ArgumentsComparator().argumentsMatch(this, actual);
     }
 
-    private boolean safelyArgumentsMatch(Object[] actualArgs) {
+    private boolean safelyArgumentsMatch(final Object[] actualArgs) {
         try {
             return new ArgumentsComparator().argumentsMatch(this, actualArgs);
-        } catch (Throwable t) {
+        } catch (final Throwable t) {
             return false;
         }
     }
@@ -72,9 +76,9 @@ public class InvocationMatcher implements DescribedInvocation, CapturesArguments
      * similar means the same method name, same mock, unverified
      * and: if arguments are the same cannot be overloaded
      */
-    public boolean hasSimilarMethod(Invocation candidate) {
-        String wantedMethodName = getMethod().getName();
-        String currentMethodName = candidate.getMethod().getName();
+    public boolean hasSimilarMethod(final Invocation candidate) {
+        final String wantedMethodName = getMethod().getName();
+        final String currentMethodName = candidate.getMethod().getName();
 
         final boolean methodNameEquals = wantedMethodName.equals(currentMethodName);
         final boolean isUnverified = !candidate.isVerified();
@@ -90,20 +94,21 @@ public class InvocationMatcher implements DescribedInvocation, CapturesArguments
         return !overloadedButSameArgs;
     }
 
-    public boolean hasSameMethod(Invocation candidate) {
+    public boolean hasSameMethod(final Invocation candidate) {
         //not using method.equals() for 1 good reason:
         //sometimes java generates forwarding methods when generics are in play see JavaGenericsForwardingMethodsTest
-        Method m1 = invocation.getMethod();
-        Method m2 = candidate.getMethod();
+        final Method m1 = invocation.getMethod();
+        final Method m2 = candidate.getMethod();
 
         if (m1.getName() != null && m1.getName().equals(m2.getName())) {
             /* Avoid unnecessary cloning */
-            Class[] params1 = m1.getParameterTypes();
-            Class[] params2 = m2.getParameterTypes();
+            final Class[] params1 = m1.getParameterTypes();
+            final Class[] params2 = m2.getParameterTypes();
             if (params1.length == params2.length) {
                 for (int i = 0; i < params1.length; i++) {
-                    if (params1[i] != params2[i])
+                    if (params1[i] != params2[i]) {
                         return false;
+                    }
                 }
                 return true;
             }
@@ -115,28 +120,28 @@ public class InvocationMatcher implements DescribedInvocation, CapturesArguments
         return invocation.getLocation();
     }
 
-    public void captureArgumentsFrom(Invocation invocation) {
+    public void captureArgumentsFrom(final Invocation invocation) {
         captureRegularArguments(invocation);
         captureVarargsPart(invocation);
     }
 
-    private void captureRegularArguments(Invocation invocation) {
+    private void captureRegularArguments(final Invocation invocation) {
         for (int position = 0; position < regularArgumentsSize(invocation); position++) {
-            Matcher m = matchers.get(position);
+            final Matcher m = matchers.get(position);
             if (m instanceof CapturesArguments) {
                 ((CapturesArguments) m).captureFrom(invocation.getArgumentAt(position, Object.class));
             }
         }
     }
 
-    private void captureVarargsPart(Invocation invocation) {
+    private void captureVarargsPart(final Invocation invocation) {
         if (!invocation.getMethod().isVarArgs()) {
             return;
         }
-        int indexOfVararg = invocation.getRawArguments().length - 1;
-        for (Matcher m : uniqueMatcherSet(indexOfVararg)) {
+        final int indexOfVararg = invocation.getRawArguments().length - 1;
+        for (final Matcher m : uniqueMatcherSet(indexOfVararg)) {
             if (m instanceof CapturesArguments) {
-                Object rawArgument = invocation.getRawArguments()[indexOfVararg];
+                final Object rawArgument = invocation.getRawArguments()[indexOfVararg];
                 for (int i = 0; i < Array.getLength(rawArgument); i++) {
                     ((CapturesArguments) m).captureFrom(Array.get(rawArgument, i));
                 }
@@ -144,16 +149,16 @@ public class InvocationMatcher implements DescribedInvocation, CapturesArguments
         }
     }
 
-    private int regularArgumentsSize(Invocation invocation) {
-        return invocation.getMethod().isVarArgs() ?
-                invocation.getRawArguments().length - 1 // ignores vararg holder array
+    private int regularArgumentsSize(final Invocation invocation) {
+        return invocation.getMethod().isVarArgs()
+                ? invocation.getRawArguments().length - 1 // ignores vararg holder array
                 : matchers.size();
     }
 
-    private Set<Matcher> uniqueMatcherSet(int indexOfVararg) {
-        HashSet<Matcher> set = new HashSet<Matcher>();
+    private Set<Matcher> uniqueMatcherSet(final int indexOfVararg) {
+        final HashSet<Matcher> set = new HashSet<Matcher>();
         for (int position = indexOfVararg; position < matchers.size(); position++) {
-            Matcher matcher = matchers.get(position);
+            final Matcher matcher = matchers.get(position);
             if (matcher instanceof MatcherDecorator) {
                 set.add(((MatcherDecorator) matcher).getActualMatcher());
             } else {
@@ -163,9 +168,9 @@ public class InvocationMatcher implements DescribedInvocation, CapturesArguments
         return set;
     }
 
-    public static List<InvocationMatcher> createFrom(List<Invocation> invocations) {
-        LinkedList<InvocationMatcher> out = new LinkedList<InvocationMatcher>();
-        for (Invocation i : invocations) {
+    public static List<InvocationMatcher> createFrom(final List<Invocation> invocations) {
+        final LinkedList<InvocationMatcher> out = new LinkedList<InvocationMatcher>();
+        for (final Invocation i : invocations) {
             out.add(new InvocationMatcher(i));
         }
         return out;

--- a/src/org/mockito/internal/invocation/InvocationMatcher.java
+++ b/src/org/mockito/internal/invocation/InvocationMatcher.java
@@ -22,6 +22,7 @@ import org.mockito.invocation.DescribedInvocation;
 import org.mockito.invocation.Invocation;
 import org.mockito.invocation.Location;
 
+@SuppressWarnings("rawtypes")
 public class InvocationMatcher implements DescribedInvocation, CapturesArgumentsFromInvocation, Serializable {
 
     private static final long serialVersionUID = -3047126096857467610L;

--- a/src/org/mockito/internal/invocation/MatchersBinder.java
+++ b/src/org/mockito/internal/invocation/MatchersBinder.java
@@ -5,32 +5,31 @@
 
 package org.mockito.internal.invocation;
 
-import org.hamcrest.Matcher;
+import java.io.Serializable;
+import java.util.List;
+
 import org.mockito.exceptions.Reporter;
 import org.mockito.internal.matchers.LocalizedMatcher;
 import org.mockito.internal.progress.ArgumentMatcherStorage;
 import org.mockito.invocation.Invocation;
-
-import java.io.Serializable;
-import java.util.List;
 
 @SuppressWarnings("unchecked")
 public class MatchersBinder implements Serializable {
 
     private static final long serialVersionUID = -311433939339443463L;
 
-    public InvocationMatcher bindMatchers(ArgumentMatcherStorage argumentMatcherStorage, Invocation invocation) {
-        List<LocalizedMatcher> lastMatchers = argumentMatcherStorage.pullLocalizedMatchers();
+    public InvocationMatcher bindMatchers(final ArgumentMatcherStorage argumentMatcherStorage, final Invocation invocation) {
+        final List<LocalizedMatcher> lastMatchers = argumentMatcherStorage.pullLocalizedMatchers();
         validateMatchers(invocation, lastMatchers);
 
-        InvocationMatcher invocationWithMatchers = new InvocationMatcher(invocation, (List<Matcher>)(List) lastMatchers);
+        final InvocationMatcher invocationWithMatchers = new InvocationMatcher(invocation, (List) lastMatchers);
         return invocationWithMatchers;
     }
 
-    private void validateMatchers(Invocation invocation, List<LocalizedMatcher> lastMatchers) {
+    private void validateMatchers(final Invocation invocation, final List<LocalizedMatcher> lastMatchers) {
         if (!lastMatchers.isEmpty()) {
-            int recordedMatchersSize = lastMatchers.size();
-            int expectedMatchersSize = invocation.getArguments().length;
+            final int recordedMatchersSize = lastMatchers.size();
+            final int expectedMatchersSize = invocation.getArguments().length;
             if (expectedMatchersSize != recordedMatchersSize) {
                 new Reporter().invalidUseOfMatchers(expectedMatchersSize, lastMatchers);
             }

--- a/src/org/mockito/internal/invocation/MatchersBinder.java
+++ b/src/org/mockito/internal/invocation/MatchersBinder.java
@@ -13,7 +13,7 @@ import org.mockito.internal.matchers.LocalizedMatcher;
 import org.mockito.internal.progress.ArgumentMatcherStorage;
 import org.mockito.invocation.Invocation;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class MatchersBinder implements Serializable {
 
     private static final long serialVersionUID = -311433939339443463L;

--- a/src/org/mockito/internal/invocation/MockitoMethod.java
+++ b/src/org/mockito/internal/invocation/MockitoMethod.java
@@ -8,15 +8,15 @@ import java.lang.reflect.Method;
 
 public interface MockitoMethod extends AbstractAwareMethod {
 
-    public String getName();
+    String getName();
 
-    public Class<?> getReturnType();
+    Class<?> getReturnType();
 
-    public Class<?>[] getParameterTypes();
+    Class<?>[] getParameterTypes();
 
-    public Class<?>[] getExceptionTypes();
+    Class<?>[] getExceptionTypes();
 
-    public boolean isVarArgs();
+    boolean isVarArgs();
 
-    public Method getJavaMethod();
+    Method getJavaMethod();
 }

--- a/src/org/mockito/internal/invocation/SerializableMethod.java
+++ b/src/org/mockito/internal/invocation/SerializableMethod.java
@@ -4,12 +4,12 @@
  */
 package org.mockito.internal.invocation;
 
-import org.mockito.exceptions.base.MockitoException;
-
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
+
+import org.mockito.exceptions.base.MockitoException;
 
 public class SerializableMethod implements Serializable, MockitoMethod {
 
@@ -23,7 +23,7 @@ public class SerializableMethod implements Serializable, MockitoMethod {
     private final boolean isVarArgs;
     private final boolean isAbstract;
 
-    public SerializableMethod(Method method) {
+    public SerializableMethod(final Method method) {
         declaringClass = method.getDeclaringClass();
         methodName = method.getName();
         parameterTypes = method.getParameterTypes();
@@ -60,13 +60,13 @@ public class SerializableMethod implements Serializable, MockitoMethod {
     public Method getJavaMethod() {
         try {
             return declaringClass.getDeclaredMethod(methodName, parameterTypes);
-        } catch (SecurityException e) {
-            String message = String.format(
+        } catch (final SecurityException e) {
+            final String message = String.format(
                     "The method %1$s.%2$s is probably private or protected and cannot be mocked.\n" +
                             "Please report this as a defect with an example of how to reproduce it.", declaringClass, methodName);
             throw new MockitoException(message, e);
-        } catch (NoSuchMethodException e) {
-            String message = String.format(
+        } catch (final NoSuchMethodException e) {
+            final String message = String.format(
                     "The method %1$s.%2$s does not exists and you should not get to this point.\n" +
                             "Please report this as a defect with an example of how to reproduce it.", declaringClass, methodName);
             throw new MockitoException(message, e);
@@ -79,31 +79,41 @@ public class SerializableMethod implements Serializable, MockitoMethod {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
+    public boolean equals(final Object obj) {
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null) {
             return false;
-        if (getClass() != obj.getClass())
+        }
+        if (getClass() != obj.getClass()) {
             return false;
-        SerializableMethod other = (SerializableMethod) obj;
+        }
+        final SerializableMethod other = (SerializableMethod) obj;
         if (declaringClass == null) {
-            if (other.declaringClass != null)
+            if (other.declaringClass != null) {
                 return false;
-        } else if (!declaringClass.equals(other.declaringClass))
+            }
+        } else if (!declaringClass.equals(other.declaringClass)) {
             return false;
+        }
         if (methodName == null) {
-            if (other.methodName != null)
+            if (other.methodName != null) {
                 return false;
-        } else if (!methodName.equals(other.methodName))
+            }
+        } else if (!methodName.equals(other.methodName)) {
             return false;
-        if (!Arrays.equals(parameterTypes, other.parameterTypes))
+        }
+        if (!Arrays.equals(parameterTypes, other.parameterTypes)) {
             return false;
+        }
         if (returnType == null) {
-            if (other.returnType != null)
+            if (other.returnType != null) {
                 return false;
-        } else if (!returnType.equals(other.returnType))
+            }
+        } else if (!returnType.equals(other.returnType)) {
             return false;
+        }
         return true;
     }
 }

--- a/src/org/mockito/internal/invocation/UnusedStubsFinder.java
+++ b/src/org/mockito/internal/invocation/UnusedStubsFinder.java
@@ -5,12 +5,13 @@
 
 package org.mockito.internal.invocation;
 
+import java.util.LinkedList;
+import java.util.List;
+
 import org.mockito.internal.InternalMockHandler;
 import org.mockito.internal.stubbing.StubbedInvocationMatcher;
 import org.mockito.internal.util.MockUtil;
 import org.mockito.invocation.Invocation;
-
-import java.util.*;
 
 public class UnusedStubsFinder {
 
@@ -19,12 +20,12 @@ public class UnusedStubsFinder {
      * 
      * @param mocks
      */
-    public List<Invocation> find(List<?> mocks) {
-        List<Invocation> unused = new LinkedList<Invocation>();
-        for (Object mock : mocks) {
-            InternalMockHandler<Object> handler = new MockUtil().getMockHandler(mock);
-            List<StubbedInvocationMatcher> fromSingleMock = handler.getInvocationContainer().getStubbedInvocations();
-            for(StubbedInvocationMatcher s : fromSingleMock) {
+    public List<Invocation> find(final List<?> mocks) {
+        final List<Invocation> unused = new LinkedList<Invocation>();
+        for (final Object mock : mocks) {
+            final InternalMockHandler<Object> handler = new MockUtil().getMockHandler(mock);
+            final List<StubbedInvocationMatcher> fromSingleMock = handler.getInvocationContainer().getStubbedInvocations();
+            for(final StubbedInvocationMatcher s : fromSingleMock) {
                 if (!s.wasUsed()) {
                      unused.add(s.getInvocation());
                 }

--- a/src/org/mockito/internal/invocation/finder/AllInvocationsFinder.java
+++ b/src/org/mockito/internal/invocation/finder/AllInvocationsFinder.java
@@ -5,11 +5,15 @@
 
 package org.mockito.internal.invocation.finder;
 
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
 import org.mockito.internal.InternalMockHandler;
 import org.mockito.internal.util.MockUtil;
 import org.mockito.invocation.Invocation;
-
-import java.util.*;
 
 public class AllInvocationsFinder {
     
@@ -19,11 +23,11 @@ public class AllInvocationsFinder {
      * @param mocks mocks
      * @return invocations
      */
-    public List<Invocation> find(List<?> mocks) {
-        Set<Invocation> invocationsInOrder = new TreeSet<Invocation>(new SequenceNumberComparator());
-        for (Object mock : mocks) {
-            InternalMockHandler<Object> handler = new MockUtil().getMockHandler(mock);
-            List<Invocation> fromSingleMock = handler.getInvocationContainer().getInvocations();
+    public List<Invocation> find(final List<?> mocks) {
+        final Set<Invocation> invocationsInOrder = new TreeSet<Invocation>(new SequenceNumberComparator());
+        for (final Object mock : mocks) {
+            final InternalMockHandler<Object> handler = new MockUtil().getMockHandler(mock);
+            final List<Invocation> fromSingleMock = handler.getInvocationContainer().getInvocations();
             invocationsInOrder.addAll(fromSingleMock);
         }
         
@@ -31,7 +35,7 @@ public class AllInvocationsFinder {
     }
 
     private static final class SequenceNumberComparator implements Comparator<Invocation> {
-        public int compare(Invocation o1, Invocation o2) {
+        public int compare(final Invocation o1, final Invocation o2) {
             return Integer.valueOf(o1.getSequenceNumber()).compareTo(o2.getSequenceNumber());
         }
     }

--- a/src/org/mockito/internal/listeners/CollectCreatedMocks.java
+++ b/src/org/mockito/internal/listeners/CollectCreatedMocks.java
@@ -6,16 +6,16 @@ package org.mockito.internal.listeners;
 
 import java.util.List;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class CollectCreatedMocks implements MockingStartedListener {
     
     private final List toBeFilled;
 
-    public CollectCreatedMocks(List toBeFilled) {
+    public CollectCreatedMocks(final List toBeFilled) {
         this.toBeFilled = toBeFilled;
     }
 
-    public void mockingStarted(Object mock, Class classToMock) {
+    public void mockingStarted(final Object mock, final Class classToMock) {
         toBeFilled.add(mock);
     }
 }

--- a/src/org/mockito/internal/listeners/MockingStartedListener.java
+++ b/src/org/mockito/internal/listeners/MockingStartedListener.java
@@ -4,10 +4,8 @@
  */
 package org.mockito.internal.listeners;
 
-import org.mockito.MockSettings;
 
-@SuppressWarnings("unchecked")
 public interface MockingStartedListener extends MockingProgressListener {
     
-    void mockingStarted(Object mock, Class classToMock);
+    void mockingStarted(final Object mock, final Class classToMock);
 }

--- a/src/org/mockito/internal/listeners/MockingStartedListener.java
+++ b/src/org/mockito/internal/listeners/MockingStartedListener.java
@@ -4,7 +4,7 @@
  */
 package org.mockito.internal.listeners;
 
-
+@SuppressWarnings("rawtypes")
 public interface MockingStartedListener extends MockingProgressListener {
     
     void mockingStarted(final Object mock, final Class classToMock);

--- a/src/org/mockito/internal/listeners/NotifiedMethodInvocationReport.java
+++ b/src/org/mockito/internal/listeners/NotifiedMethodInvocationReport.java
@@ -4,11 +4,11 @@
  */
 package org.mockito.internal.listeners;
 
+import static org.mockito.internal.matchers.Equality.areEqual;
+
 import org.mockito.invocation.DescribedInvocation;
 import org.mockito.invocation.Invocation;
 import org.mockito.listeners.MethodInvocationReport;
-
-import static org.mockito.internal.matchers.Equality.areEqual;
 
 /**
  * Report on a method call
@@ -26,7 +26,7 @@ public class NotifiedMethodInvocationReport implements MethodInvocationReport {
      * @param invocation Information on the method call
      * @param returnedValue The value returned by the method invocation
      */
-    public NotifiedMethodInvocationReport(Invocation invocation, Object returnedValue) {
+    public NotifiedMethodInvocationReport(final Invocation invocation, final Object returnedValue) {
         this.invocation = invocation;
         this.returnedValue = returnedValue;
         this.throwable = null;

--- a/src/org/mockito/internal/listeners/NotifiedMethodInvocationReport.java
+++ b/src/org/mockito/internal/listeners/NotifiedMethodInvocationReport.java
@@ -18,13 +18,15 @@ public class NotifiedMethodInvocationReport implements MethodInvocationReport {
     private final Object returnedValue;
     private final Throwable throwable;
 
-
     /**
-     * Build a new {@link org.mockito.listeners.MethodInvocationReport} with a return value.
+     * Build a new {@link org.mockito.listeners.MethodInvocationReport} with a
+     * return value.
      *
      *
-     * @param invocation Information on the method call
-     * @param returnedValue The value returned by the method invocation
+     * @param invocation
+     *            Information on the method call
+     * @param returnedValue
+     *            The value returned by the method invocation
      */
     public NotifiedMethodInvocationReport(final Invocation invocation, final Object returnedValue) {
         this.invocation = invocation;
@@ -33,13 +35,16 @@ public class NotifiedMethodInvocationReport implements MethodInvocationReport {
     }
 
     /**
-     * Build a new {@link org.mockito.listeners.MethodInvocationReport} with a return value.
+     * Build a new {@link org.mockito.listeners.MethodInvocationReport} with a
+     * return value.
      *
      *
-     * @param invocation Information on the method call
-     * @param throwable Tha throwable raised by the method invocation
+     * @param invocation
+     *            Information on the method call
+     * @param throwable
+     *            Tha throwable raised by the method invocation
      */
-    public NotifiedMethodInvocationReport(Invocation invocation, Throwable throwable) {
+    public NotifiedMethodInvocationReport(final Invocation invocation, final Throwable throwable) {
         this.invocation = invocation;
         this.returnedValue = null;
         this.throwable = throwable;
@@ -65,16 +70,19 @@ public class NotifiedMethodInvocationReport implements MethodInvocationReport {
         return (invocation.stubInfo() == null) ? null : invocation.stubInfo().stubbedAt().toString();
     }
 
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        final NotifiedMethodInvocationReport that = (NotifiedMethodInvocationReport) o;
 
-        NotifiedMethodInvocationReport that = (NotifiedMethodInvocationReport) o;
-
-        return areEqual(invocation, that.invocation) &&
-               areEqual(returnedValue, that.returnedValue) &&
-               areEqual(throwable, that.throwable);
+        return areEqual(invocation, that.invocation)
+                && areEqual(returnedValue, that.returnedValue)
+                && areEqual(throwable, that.throwable);
     }
 
     public int hashCode() {

--- a/src/org/mockito/internal/matchers/And.java
+++ b/src/org/mockito/internal/matchers/And.java
@@ -13,18 +13,18 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.mockito.ArgumentMatcher;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class And extends ArgumentMatcher implements Serializable {
 
     private static final long serialVersionUID = -4624719625691177501L;
     private final List<Matcher> matchers;
 
-    public And(List<Matcher> matchers) {
+    public And(final List<Matcher> matchers) {
         this.matchers = matchers;
     }
 
-    public boolean matches(Object actual) {
-        for (Matcher matcher : matchers) {
+    public boolean matches(final Object actual) {
+        for (final Matcher matcher : matchers) {
             if (!matcher.matches(actual)) {
                 return false;
             }
@@ -32,9 +32,9 @@ public class And extends ArgumentMatcher implements Serializable {
         return true;
     }
 
-    public void describeTo(Description description) {
+    public void describeTo(final Description description) {
         description.appendText("and(");
-        for (Iterator<Matcher> it = matchers.iterator(); it.hasNext();) {
+        for (final Iterator<Matcher> it = matchers.iterator(); it.hasNext();) {
             it.next().describeTo(description);
             if (it.hasNext()) {
                 description.appendText(", ");

--- a/src/org/mockito/internal/matchers/Any.java
+++ b/src/org/mockito/internal/matchers/Any.java
@@ -10,7 +10,7 @@ import java.io.Serializable;
 import org.hamcrest.Description;
 import org.mockito.ArgumentMatcher;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class Any extends ArgumentMatcher implements Serializable {
 
     private static final long serialVersionUID = -4062420125651019029L;
@@ -18,11 +18,11 @@ public class Any extends ArgumentMatcher implements Serializable {
     
     private Any() {}
     
-    public boolean matches(Object actual) {
+    public boolean matches(final Object actual) {
         return true;
     }
 
-    public void describeTo(Description description) {
+    public void describeTo(final Description description) {
         description.appendText("<any>");
     }
 }

--- a/src/org/mockito/internal/matchers/AnyVararg.java
+++ b/src/org/mockito/internal/matchers/AnyVararg.java
@@ -9,13 +9,13 @@ import java.io.Serializable;
 import org.hamcrest.Matcher;
 import org.mockito.ArgumentMatcher;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class AnyVararg extends ArgumentMatcher implements VarargMatcher, Serializable {
 
     private static final long serialVersionUID = 1700721373094731555L;
     public static final Matcher ANY_VARARG = new AnyVararg();
 
-    public boolean matches(Object arg) {
+    public boolean matches(final Object arg) {
         return true;
     }
 }

--- a/src/org/mockito/internal/matchers/CapturingMatcher.java
+++ b/src/org/mockito/internal/matchers/CapturingMatcher.java
@@ -4,15 +4,15 @@
  */
 package org.mockito.internal.matchers;
 
-import org.hamcrest.Description;
-import org.mockito.ArgumentMatcher;
-import org.mockito.exceptions.Reporter;
-
 import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.List;
 
-@SuppressWarnings("unchecked")
+import org.hamcrest.Description;
+import org.mockito.ArgumentMatcher;
+import org.mockito.exceptions.Reporter;
+
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class CapturingMatcher<T> extends ArgumentMatcher<T> implements CapturesArguments, VarargMatcher, Serializable {
     
     private static final long serialVersionUID = 4274067078639307295L;
@@ -21,14 +21,14 @@ public class CapturingMatcher<T> extends ArgumentMatcher<T> implements CapturesA
     /* (non-Javadoc)
      * @see org.mockito.ArgumentMatcher#matches(java.lang.Object)
      */
-    public boolean matches(Object argument) {
+    public boolean matches(final Object argument) {
         return true;
     }    
 
     /* (non-Javadoc)
      * @see org.mockito.ArgumentMatcher#describeTo(org.hamcrest.Description)
      */
-    public void describeTo(Description description) {
+    public void describeTo(final Description description) {
         description.appendText("<Capturing argument>");
     }
 
@@ -45,7 +45,7 @@ public class CapturingMatcher<T> extends ArgumentMatcher<T> implements CapturesA
         return (List) arguments;
     }
 
-    public void captureFrom(Object argument) {
+    public void captureFrom(final Object argument) {
         this.arguments.add(argument);
     }
 }

--- a/src/org/mockito/internal/matchers/CompareTo.java
+++ b/src/org/mockito/internal/matchers/CompareTo.java
@@ -8,16 +8,16 @@ package org.mockito.internal.matchers;
 import org.hamcrest.Description;
 import org.mockito.ArgumentMatcher;
 
-
+@SuppressWarnings("rawtypes")
 public abstract class CompareTo<T extends Comparable<T>> extends ArgumentMatcher<T> {
     private final Comparable<T> wanted;
 
-    public CompareTo(Comparable<T> value) {
+    public CompareTo(final Comparable<T> value) {
         this.wanted = value;
     }
 
     @SuppressWarnings("unchecked")
-    public boolean matches(Object actual) {
+    public boolean matches(final Object actual) {
         
         if(!(actual instanceof Comparable)) {
             return false;
@@ -26,11 +26,11 @@ public abstract class CompareTo<T extends Comparable<T>> extends ArgumentMatcher
         return matchResult(((Comparable) actual).compareTo(wanted));
     }
 
-    public void describeTo(Description description) {
+    public void describeTo(final Description description) {
         description.appendText(getName() + "(" + wanted + ")");
     }
     
     protected abstract String getName();
     
-    protected abstract boolean matchResult(int result);
+    protected abstract boolean matchResult(final int result);
 }

--- a/src/org/mockito/internal/matchers/Equality.java
+++ b/src/org/mockito/internal/matchers/Equality.java
@@ -9,7 +9,7 @@ import java.lang.reflect.Array;
 //stolen from hamcrest because I didn't want to have more dependency than Matcher class 
 public class Equality {
 
-    public static boolean areEqual(Object o1, Object o2) {
+    public static boolean areEqual(final Object o1, final Object o2) {
         if (o1 == o2 ) {
             return true;
     } else if (o1 == null || o2 == null) {
@@ -21,23 +21,25 @@ public class Equality {
         }
     }
 
-    static boolean areArraysEqual(Object o1, Object o2) {
+    static boolean areArraysEqual(final Object o1, final Object o2) {
         return areArrayLengthsEqual(o1, o2)
                 && areArrayElementsEqual(o1, o2);
     }
 
-    static boolean areArrayLengthsEqual(Object o1, Object o2) {
+    static boolean areArrayLengthsEqual(final Object o1, final Object o2) {
         return Array.getLength(o1) == Array.getLength(o2);
     }
 
-    static boolean areArrayElementsEqual(Object o1, Object o2) {
+    static boolean areArrayElementsEqual(final Object o1, final Object o2) {
         for (int i = 0; i < Array.getLength(o1); i++) {
-            if (!areEqual(Array.get(o1, i), Array.get(o2, i))) return false;
+            if (!areEqual(Array.get(o1, i), Array.get(o2, i))) {
+                return false;
+            }
         }
         return true;
     }
 
-    static boolean isArray(Object o) {
+    static boolean isArray(final Object o) {
         return o.getClass().isArray();
     }
 }

--- a/src/org/mockito/internal/matchers/LocalizedMatcher.java
+++ b/src/org/mockito/internal/matchers/LocalizedMatcher.java
@@ -4,22 +4,22 @@
  */
 package org.mockito.internal.matchers;
 
+import java.io.Serializable;
+
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.SelfDescribing;
 import org.mockito.internal.debugging.LocationImpl;
 import org.mockito.invocation.Location;
 
-import java.io.Serializable;
-
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class LocalizedMatcher implements Matcher, ContainsExtraTypeInformation, CapturesArguments, MatcherDecorator, Serializable {
 
     private static final long serialVersionUID = 6748641229659825725L;
     private final Matcher actualMatcher;
     private final Location location;
 
-    public LocalizedMatcher(Matcher actualMatcher) {
+    public LocalizedMatcher(final Matcher actualMatcher) {
         this.actualMatcher = actualMatcher;
         this.location = new LocationImpl();
     }
@@ -28,11 +28,11 @@ public class LocalizedMatcher implements Matcher, ContainsExtraTypeInformation, 
         // yeah right
     }
 
-    public boolean matches(Object item) {
+    public boolean matches(final Object item) {
         return actualMatcher.matches(item);
     }
 
-    public void describeTo(Description description) {
+    public void describeTo(final Description description) {
         actualMatcher.describeTo(description);
     }
 
@@ -53,12 +53,12 @@ public class LocalizedMatcher implements Matcher, ContainsExtraTypeInformation, 
         }
     }
 
-    public boolean typeMatches(Object object) {
+    public boolean typeMatches(final Object object) {
         return actualMatcher instanceof ContainsExtraTypeInformation
                 && ((ContainsExtraTypeInformation) actualMatcher).typeMatches(object);
     }
 
-    public void captureFrom(Object argument) {
+    public void captureFrom(final Object argument) {
         if (actualMatcher instanceof CapturesArguments) {
             ((CapturesArguments) actualMatcher).captureFrom(argument);
         }

--- a/src/org/mockito/internal/matchers/MatcherDecorator.java
+++ b/src/org/mockito/internal/matchers/MatcherDecorator.java
@@ -8,7 +8,7 @@ import java.io.Serializable;
 
 import org.hamcrest.Matcher;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public interface MatcherDecorator extends Serializable {
     Matcher getActualMatcher();
 }

--- a/src/org/mockito/internal/matchers/MatchersPrinter.java
+++ b/src/org/mockito/internal/matchers/MatchersPrinter.java
@@ -13,23 +13,23 @@ import org.hamcrest.SelfDescribing;
 import org.hamcrest.StringDescription;
 import org.mockito.internal.reporting.PrintSettings;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class MatchersPrinter {
     
-    public String getArgumentsLine(List<Matcher> matchers, PrintSettings printSettings) {
-        Description result = new StringDescription();
+    public String getArgumentsLine(final List<Matcher> matchers, final PrintSettings printSettings) {
+        final Description result = new StringDescription();
         result.appendList("(", ", ", ");", applyPrintSettings(matchers, printSettings));
         return result.toString();
     }
 
-    public String getArgumentsBlock(List<Matcher> matchers, PrintSettings printSettings) {
-        Description result = new StringDescription();
+    public String getArgumentsBlock(final List<Matcher> matchers, final PrintSettings printSettings) {
+        final Description result = new StringDescription();
         result.appendList("(\n    ", ",\n    ", "\n);", applyPrintSettings(matchers, printSettings));
         return result.toString();
     }
 
-    private List<SelfDescribing> applyPrintSettings(List<Matcher> matchers, PrintSettings printSettings) {
-        List<SelfDescribing> withPrintSettings = new LinkedList<SelfDescribing>();
+    private List<SelfDescribing> applyPrintSettings(final List<Matcher> matchers, final PrintSettings printSettings) {
+        final List<SelfDescribing> withPrintSettings = new LinkedList<SelfDescribing>();
         int i = 0;
         for (final Matcher matcher : matchers) {
             if (matcher instanceof ContainsExtraTypeInformation && printSettings.extraTypeInfoFor(i)) {

--- a/src/org/mockito/internal/matchers/Not.java
+++ b/src/org/mockito/internal/matchers/Not.java
@@ -11,21 +11,21 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.mockito.ArgumentMatcher;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class Not extends ArgumentMatcher implements Serializable {
 
     private static final long serialVersionUID = 4627373642333593264L;
     private final Matcher first;
 
-    public Not(Matcher first) {
+    public Not(final Matcher first) {
         this.first = first;
     }
 
-    public boolean matches(Object actual) {
+    public boolean matches(final Object actual) {
         return !first.matches(actual);
     }
 
-    public void describeTo(Description description) {
+    public void describeTo(final Description description) {
         description.appendText("not(");
         first.describeTo(description);
         description.appendText(")");

--- a/src/org/mockito/internal/matchers/Or.java
+++ b/src/org/mockito/internal/matchers/Or.java
@@ -13,18 +13,18 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.mockito.ArgumentMatcher;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class Or extends ArgumentMatcher implements Serializable {
 
     private static final long serialVersionUID = 5888739035212283087L;
     private final List<Matcher> matchers;
 
-    public Or(List<Matcher> matchers) {
+    public Or(final List<Matcher> matchers) {
         this.matchers = matchers;
     }
 
-    public boolean matches(Object actual) {
-        for (Matcher matcher : matchers) {
+    public boolean matches(final Object actual) {
+        for (final Matcher matcher : matchers) {
             if (matcher.matches(actual)) {
                 return true;
             }
@@ -32,9 +32,9 @@ public class Or extends ArgumentMatcher implements Serializable {
         return false;
     }
 
-    public void describeTo(Description description) {
+    public void describeTo(final Description description) {
         description.appendText("or(");
-        for (Iterator<Matcher> it = matchers.iterator(); it.hasNext();) {
+        for (final Iterator<Matcher> it = matchers.iterator(); it.hasNext();) {
             it.next().describeTo(description);
             if (it.hasNext()) {
                 description.appendText(", ");

--- a/src/org/mockito/internal/matchers/apachecommons/EqualsBuilder.java
+++ b/src/org/mockito/internal/matchers/apachecommons/EqualsBuilder.java
@@ -73,7 +73,7 @@ import java.util.List;
  * @since 1.0
  * @version $Id: EqualsBuilder.java 611543 2008-01-13 07:00:22Z bayard $
  */
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 class EqualsBuilder {
     
     /**
@@ -112,7 +112,7 @@ class EqualsBuilder {
      * @param rhs  the other object
      * @return <code>true</code> if the two Objects have tested equals.
      */
-    public static boolean reflectionEquals(Object lhs, Object rhs) {
+    public static boolean reflectionEquals(final Object lhs, final Object rhs) {
         return reflectionEquals(lhs, rhs, false, null, null);
     }
 
@@ -135,7 +135,7 @@ class EqualsBuilder {
      * @param excludeFields  array of field names to exclude from testing
      * @return <code>true</code> if the two Objects have tested equals.
      */
-    public static boolean reflectionEquals(Object lhs, Object rhs, String[] excludeFields) {
+    public static boolean reflectionEquals(final Object lhs, final Object rhs, final String[] excludeFields) {
         return reflectionEquals(lhs, rhs, false, null, excludeFields);
     }
 
@@ -159,7 +159,7 @@ class EqualsBuilder {
      * @param testTransients  whether to include transient fields
      * @return <code>true</code> if the two Objects have tested equals.
      */
-    public static boolean reflectionEquals(Object lhs, Object rhs, boolean testTransients) {
+    public static boolean reflectionEquals(final Object lhs, final Object rhs, final boolean testTransients) {
         return reflectionEquals(lhs, rhs, testTransients, null, null);
     }
 
@@ -188,7 +188,7 @@ class EqualsBuilder {
      * @return <code>true</code> if the two Objects have tested equals.
      * @since 2.0
      */
-    public static boolean reflectionEquals(Object lhs, Object rhs, boolean testTransients, Class reflectUpToClass) {
+    public static boolean reflectionEquals(final Object lhs, final Object rhs, final boolean testTransients, final Class reflectUpToClass) {
         return reflectionEquals(lhs, rhs, testTransients, reflectUpToClass, null);
     }
 
@@ -218,8 +218,8 @@ class EqualsBuilder {
      * @return <code>true</code> if the two Objects have tested equals.
      * @since 2.0
      */
-    public static boolean reflectionEquals(Object lhs, Object rhs, boolean testTransients, Class reflectUpToClass,
-            String[] excludeFields) {
+    public static boolean reflectionEquals(final Object lhs, final Object rhs, final boolean testTransients, final Class reflectUpToClass,
+            final String[] excludeFields) {
         if (lhs == rhs) {
             return true;
         }
@@ -230,8 +230,8 @@ class EqualsBuilder {
         // class or in classes between the leaf and root.
         // If we are not testing transients or a subclass has no ivars, 
         // then a subclass can test equals to a superclass.
-        Class lhsClass = lhs.getClass();
-        Class rhsClass = rhs.getClass();
+        final Class lhsClass = lhs.getClass();
+        final Class rhsClass = rhs.getClass();
         Class testClass;
         if (lhsClass.isInstance(rhs)) {
             testClass = lhsClass;
@@ -249,14 +249,14 @@ class EqualsBuilder {
             // The two classes are not related.
             return false;
         }
-        EqualsBuilder equalsBuilder = new EqualsBuilder();
+        final EqualsBuilder equalsBuilder = new EqualsBuilder();
         try {
             reflectionAppend(lhs, rhs, testClass, equalsBuilder, testTransients, excludeFields);
             while (testClass.getSuperclass() != null && testClass != reflectUpToClass) {
                 testClass = testClass.getSuperclass();
                 reflectionAppend(lhs, rhs, testClass, equalsBuilder, testTransients, excludeFields);
             }
-        } catch (IllegalArgumentException e) {
+        } catch (final IllegalArgumentException e) {
             // In this case, we tried to test a subclass vs. a superclass and
             // the subclass has ivars or the ivars are transient and 
             // we are testing transients.
@@ -279,24 +279,24 @@ class EqualsBuilder {
      * @param excludeFields  array of field names to exclude from testing
      */
     private static void reflectionAppend(
-        Object lhs,
-        Object rhs,
-        Class clazz,
-        EqualsBuilder builder,
-        boolean useTransients,
-        String[] excludeFields) {
-        Field[] fields = clazz.getDeclaredFields();
-        List excludedFieldList = excludeFields != null ? Arrays.asList(excludeFields) : Collections.EMPTY_LIST;
+        final Object lhs,
+        final Object rhs,
+        final Class clazz,
+        final EqualsBuilder builder,
+        final boolean useTransients,
+        final String[] excludeFields) {
+        final Field[] fields = clazz.getDeclaredFields();
+        final List excludedFieldList = excludeFields != null ? Arrays.asList(excludeFields) : Collections.EMPTY_LIST;
         AccessibleObject.setAccessible(fields, true);
         for (int i = 0; i < fields.length && builder.isEquals; i++) {
-            Field f = fields[i];
+            final Field f = fields[i];
             if (!excludedFieldList.contains(f.getName())
                 && (f.getName().indexOf('$') == -1)
                 && (useTransients || !Modifier.isTransient(f.getModifiers()))
                 && (!Modifier.isStatic(f.getModifiers()))) {
                 try {
                     builder.append(f.get(lhs), f.get(rhs));
-                } catch (IllegalAccessException e) {
+                } catch (final IllegalAccessException e) {
                     //this can't happen. Would get a Security exception instead
                     //throw a runtime exception in case the impossible happens.
                     throw new InternalError("Unexpected IllegalAccessException");
@@ -314,7 +314,7 @@ class EqualsBuilder {
      * @return EqualsBuilder - used to chain calls.
      * @since 2.0
      */
-    public EqualsBuilder appendSuper(boolean superEquals) {
+    public EqualsBuilder appendSuper(final boolean superEquals) {
         isEquals &= superEquals;
         return this;
     }
@@ -329,7 +329,7 @@ class EqualsBuilder {
      * @param rhs  the right hand object
      * @return EqualsBuilder - used to chain calls.
      */
-    public EqualsBuilder append(Object lhs, Object rhs) {
+    public EqualsBuilder append(final Object lhs, final Object rhs) {
         if (!isEquals) {
             return this;
         }
@@ -340,7 +340,7 @@ class EqualsBuilder {
             this.setEquals(false);
             return this;
         }
-        Class lhsClass = lhs.getClass();
+        final Class lhsClass = lhs.getClass();
         if (!lhsClass.isArray()) {
             if (lhs instanceof java.math.BigDecimal && rhs instanceof java.math.BigDecimal) {
                 isEquals = (((java.math.BigDecimal) lhs).compareTo((java.math.BigDecimal) rhs) == 0);
@@ -388,7 +388,7 @@ class EqualsBuilder {
      *                  the right hand <code>long</code>
      * @return EqualsBuilder - used to chain calls.
      */
-    public EqualsBuilder append(long lhs, long rhs) {
+    public EqualsBuilder append(final long lhs, final long rhs) {
         isEquals &= (lhs == rhs);
         return this;
     }
@@ -400,7 +400,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>int</code>
      * @return EqualsBuilder - used to chain calls.
      */
-    public EqualsBuilder append(int lhs, int rhs) {
+    public EqualsBuilder append(final int lhs, final int rhs) {
         isEquals &= (lhs == rhs);
         return this;
     }
@@ -412,7 +412,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>short</code>
      * @return EqualsBuilder - used to chain calls.
      */
-    public EqualsBuilder append(short lhs, short rhs) {
+    public EqualsBuilder append(final short lhs, final short rhs) {
         isEquals &= (lhs == rhs);
         return this;
     }
@@ -424,7 +424,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>char</code>
      * @return EqualsBuilder - used to chain calls.
      */
-    public EqualsBuilder append(char lhs, char rhs) {
+    public EqualsBuilder append(final char lhs, final char rhs) {
         isEquals &= (lhs == rhs);
         return this;
     }
@@ -436,7 +436,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>byte</code>
      * @return EqualsBuilder - used to chain calls.
      */
-    public EqualsBuilder append(byte lhs, byte rhs) {
+    public EqualsBuilder append(final byte lhs, final byte rhs) {
         isEquals &= (lhs == rhs);
         return this;
     }
@@ -454,7 +454,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>double</code>
      * @return EqualsBuilder - used to chain calls.
      */
-    public EqualsBuilder append(double lhs, double rhs) {
+    public EqualsBuilder append(final double lhs, final double rhs) {
         if (!isEquals) {
             return this;
         }
@@ -474,7 +474,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>float</code>
      * @return EqualsBuilder - used to chain calls.
      */
-    public EqualsBuilder append(float lhs, float rhs) {
+    public EqualsBuilder append(final float lhs, final float rhs) {
         if (!isEquals) {
             return this;
         }
@@ -488,7 +488,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>boolean</code>
      * @return EqualsBuilder - used to chain calls.
       */
-    public EqualsBuilder append(boolean lhs, boolean rhs) {
+    public EqualsBuilder append(final boolean lhs, final boolean rhs) {
         isEquals &= (lhs == rhs);
         return this;
     }
@@ -503,7 +503,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>Object[]</code>
      * @return EqualsBuilder - used to chain calls.
      */
-    public EqualsBuilder append(Object[] lhs, Object[] rhs) {
+    public EqualsBuilder append(final Object[] lhs, final Object[] rhs) {
         if (!isEquals) {
             return this;
         }
@@ -534,7 +534,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>long[]</code>
      * @return EqualsBuilder - used to chain calls.
      */
-    public EqualsBuilder append(long[] lhs, long[] rhs) {
+    public EqualsBuilder append(final long[] lhs, final long[] rhs) {
         if (!isEquals) {
             return this;
         }
@@ -565,7 +565,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>int[]</code>
      * @return EqualsBuilder - used to chain calls.
      */
-    public EqualsBuilder append(int[] lhs, int[] rhs) {
+    public EqualsBuilder append(final int[] lhs, final int[] rhs) {
         if (!isEquals) {
             return this;
         }
@@ -596,7 +596,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>short[]</code>
      * @return EqualsBuilder - used to chain calls.
      */
-    public EqualsBuilder append(short[] lhs, short[] rhs) {
+    public EqualsBuilder append(final short[] lhs, final short[] rhs) {
         if (!isEquals) {
             return this;
         }
@@ -627,7 +627,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>char[]</code>
      * @return EqualsBuilder - used to chain calls.
      */
-    public EqualsBuilder append(char[] lhs, char[] rhs) {
+    public EqualsBuilder append(final char[] lhs, final char[] rhs) {
         if (!isEquals) {
             return this;
         }
@@ -658,7 +658,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>byte[]</code>
      * @return EqualsBuilder - used to chain calls.
      */
-    public EqualsBuilder append(byte[] lhs, byte[] rhs) {
+    public EqualsBuilder append(final byte[] lhs, final byte[] rhs) {
         if (!isEquals) {
             return this;
         }
@@ -689,7 +689,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>double[]</code>
      * @return EqualsBuilder - used to chain calls.
      */
-    public EqualsBuilder append(double[] lhs, double[] rhs) {
+    public EqualsBuilder append(final double[] lhs, final double[] rhs) {
         if (!isEquals) {
             return this;
         }
@@ -720,7 +720,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>float[]</code>
      * @return EqualsBuilder - used to chain calls.
      */
-    public EqualsBuilder append(float[] lhs, float[] rhs) {
+    public EqualsBuilder append(final float[] lhs, final float[] rhs) {
         if (!isEquals) {
             return this;
         }
@@ -751,7 +751,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>boolean[]</code>
      * @return EqualsBuilder - used to chain calls.
      */
-    public EqualsBuilder append(boolean[] lhs, boolean[] rhs) {
+    public EqualsBuilder append(final boolean[] lhs, final boolean[] rhs) {
         if (!isEquals) {
             return this;
         }
@@ -788,7 +788,7 @@ class EqualsBuilder {
      * @param isEquals The value to set.
      * @since 2.1
      */
-    protected void setEquals(boolean isEquals) {
+    protected void setEquals(final boolean isEquals) {
         this.isEquals = isEquals;
     }
 }

--- a/src/org/mockito/internal/progress/ArgumentMatcherStorage.java
+++ b/src/org/mockito/internal/progress/ArgumentMatcherStorage.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.hamcrest.Matcher;
 import org.mockito.internal.matchers.LocalizedMatcher;
 
+@SuppressWarnings("rawtypes")
 public interface ArgumentMatcherStorage {
 
     HandyReturnValues reportMatcher(final Matcher matcher);

--- a/src/org/mockito/internal/progress/ArgumentMatcherStorage.java
+++ b/src/org/mockito/internal/progress/ArgumentMatcherStorage.java
@@ -4,15 +4,14 @@
  */
 package org.mockito.internal.progress;
 
+import java.util.List;
+
 import org.hamcrest.Matcher;
 import org.mockito.internal.matchers.LocalizedMatcher;
 
-import java.util.List;
-
-@SuppressWarnings("unchecked")
 public interface ArgumentMatcherStorage {
 
-    HandyReturnValues reportMatcher(Matcher matcher);
+    HandyReturnValues reportMatcher(final Matcher matcher);
 
     List<LocalizedMatcher> pullLocalizedMatchers();
 

--- a/src/org/mockito/internal/progress/ArgumentMatcherStorageImpl.java
+++ b/src/org/mockito/internal/progress/ArgumentMatcherStorageImpl.java
@@ -5,6 +5,12 @@
 
 package org.mockito.internal.progress;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Stack;
+
 import org.hamcrest.Matcher;
 import org.mockito.exceptions.Reporter;
 import org.mockito.internal.matchers.And;
@@ -12,13 +18,7 @@ import org.mockito.internal.matchers.LocalizedMatcher;
 import org.mockito.internal.matchers.Not;
 import org.mockito.internal.matchers.Or;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Stack;
-
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class ArgumentMatcherStorageImpl implements ArgumentMatcherStorage {
 
     public static final int TWO_SUB_MATCHERS = 2;
@@ -28,7 +28,7 @@ public class ArgumentMatcherStorageImpl implements ArgumentMatcherStorage {
     /* (non-Javadoc)
      * @see org.mockito.internal.progress.ArgumentMatcherStorage#reportMatcher(org.hamcrest.Matcher)
      */
-    public HandyReturnValues reportMatcher(Matcher matcher) {
+    public HandyReturnValues reportMatcher(final Matcher matcher) {
         matcherStack.push(new LocalizedMatcher(matcher));
         return new HandyReturnValues();
     }
@@ -41,9 +41,9 @@ public class ArgumentMatcherStorageImpl implements ArgumentMatcherStorage {
             return Collections.emptyList();
         }
         
-        List<LocalizedMatcher> matchers = new ArrayList<LocalizedMatcher>(matcherStack);
+        final List<LocalizedMatcher> matchers = new ArrayList<LocalizedMatcher>(matcherStack);
         matcherStack.clear();
-        return (List) matchers;
+        return matchers;
     }
 
     /* (non-Javadoc)
@@ -51,7 +51,7 @@ public class ArgumentMatcherStorageImpl implements ArgumentMatcherStorage {
     */
     public HandyReturnValues reportAnd() {
         assertStateFor("And(?)", TWO_SUB_MATCHERS);
-        And and = new And(popLastArgumentMatchers(TWO_SUB_MATCHERS));
+        final And and = new And(popLastArgumentMatchers(TWO_SUB_MATCHERS));
         matcherStack.push(new LocalizedMatcher(and));
         return new HandyReturnValues();
     }
@@ -61,7 +61,7 @@ public class ArgumentMatcherStorageImpl implements ArgumentMatcherStorage {
      */
     public HandyReturnValues reportOr() {
         assertStateFor("Or(?)", TWO_SUB_MATCHERS);
-        Or or = new Or(popLastArgumentMatchers(TWO_SUB_MATCHERS));
+        final Or or = new Or(popLastArgumentMatchers(TWO_SUB_MATCHERS));
         matcherStack.push(new LocalizedMatcher(or));
         return new HandyReturnValues();
     }
@@ -71,18 +71,18 @@ public class ArgumentMatcherStorageImpl implements ArgumentMatcherStorage {
      */
     public HandyReturnValues reportNot() {
         assertStateFor("Not(?)", ONE_SUB_MATCHER);
-        Not not = new Not(popLastArgumentMatchers(ONE_SUB_MATCHER).get(0));
+        final Not not = new Not(popLastArgumentMatchers(ONE_SUB_MATCHER).get(0));
         matcherStack.push(new LocalizedMatcher(not));
         return new HandyReturnValues();
     }
 
-    private void assertStateFor(String additionalMatcherName, int subMatchersCount) {
+    private void assertStateFor(final String additionalMatcherName, final int subMatchersCount) {
         assertMatchersFoundFor(additionalMatcherName);
         assertIncorrectUseOfAdditionalMatchers(additionalMatcherName, subMatchersCount);
     }
 
-    private List<Matcher> popLastArgumentMatchers(int count) {
-        List<Matcher> result = new LinkedList<Matcher>();
+    private List<Matcher> popLastArgumentMatchers(final int count) {
+        final List<Matcher> result = new LinkedList<Matcher>();
         result.addAll(matcherStack.subList(matcherStack.size() - count, matcherStack.size()));
         for (int i = 0; i < count; i++) {
             matcherStack.pop();
@@ -90,16 +90,16 @@ public class ArgumentMatcherStorageImpl implements ArgumentMatcherStorage {
         return result;
     }
 
-    private void assertMatchersFoundFor(String additionalMatcherName) {
+    private void assertMatchersFoundFor(final String additionalMatcherName) {
         if (matcherStack.isEmpty()) {
             matcherStack.clear();
             new Reporter().reportNoSubMatchersFound(additionalMatcherName);
         }
     }
 
-    private void assertIncorrectUseOfAdditionalMatchers(String additionalMatcherName, int count) {
+    private void assertIncorrectUseOfAdditionalMatchers(final String additionalMatcherName, final int count) {
         if(matcherStack.size() < count) {
-            ArrayList<LocalizedMatcher> lastMatchers = new ArrayList<LocalizedMatcher>(matcherStack);
+            final ArrayList<LocalizedMatcher> lastMatchers = new ArrayList<LocalizedMatcher>(matcherStack);
             matcherStack.clear();
             new Reporter().incorrectUseOfAdditionalMatchers(additionalMatcherName, count, lastMatchers);
         }
@@ -110,7 +110,7 @@ public class ArgumentMatcherStorageImpl implements ArgumentMatcherStorage {
      */
     public void validateState() {
         if (!matcherStack.isEmpty()) {
-            ArrayList lastMatchers = new ArrayList<LocalizedMatcher>(matcherStack);
+            final ArrayList lastMatchers = new ArrayList<LocalizedMatcher>(matcherStack);
             matcherStack.clear();
             new Reporter().misplacedArgumentMatcher(lastMatchers);
         }

--- a/src/org/mockito/internal/progress/HandyReturnValues.java
+++ b/src/org/mockito/internal/progress/HandyReturnValues.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class HandyReturnValues {
 
     public byte returnZero() {

--- a/src/org/mockito/internal/progress/HandyReturnValues.java
+++ b/src/org/mockito/internal/progress/HandyReturnValues.java
@@ -4,10 +4,15 @@
  */
 package org.mockito.internal.progress;
 
-import java.util.*;
-
 import static org.mockito.internal.util.Primitives.defaultValueForPrimitiveOrWrapper;
 import static org.mockito.internal.util.Primitives.isPrimitiveOrWrapper;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @SuppressWarnings("unchecked")
 public class HandyReturnValues {
@@ -32,7 +37,7 @@ public class HandyReturnValues {
         return "";
     }
 
-    public <T> T returnFor(Class<T> clazz) {
+    public <T> T returnFor(final Class<T> clazz) {
         // explicitly return null if type is not a primitive or a wrapper
         if (isPrimitiveOrWrapper(clazz)) {
             return defaultValueForPrimitiveOrWrapper(clazz);
@@ -52,7 +57,7 @@ public class HandyReturnValues {
         return new HashSet();
     }
 
-    public <T> T returnFor(T instance) {
+    public <T> T returnFor(final T instance) {
         return instance == null ? null : (T) returnFor(instance.getClass());
     }
 }

--- a/src/org/mockito/internal/progress/MockingProgress.java
+++ b/src/org/mockito/internal/progress/MockingProgress.java
@@ -9,6 +9,7 @@ import org.mockito.internal.listeners.MockingProgressListener;
 import org.mockito.invocation.Invocation;
 import org.mockito.verification.VerificationMode;
 
+@SuppressWarnings("rawtypes")
 public interface MockingProgress {
     
     void reportOngoingStubbing(final IOngoingStubbing iOngoingStubbing);

--- a/src/org/mockito/internal/progress/MockingProgress.java
+++ b/src/org/mockito/internal/progress/MockingProgress.java
@@ -5,25 +5,23 @@
 
 package org.mockito.internal.progress;
 
-import org.mockito.MockSettings;
 import org.mockito.internal.listeners.MockingProgressListener;
 import org.mockito.invocation.Invocation;
 import org.mockito.verification.VerificationMode;
 
-@SuppressWarnings("unchecked")
 public interface MockingProgress {
     
-    void reportOngoingStubbing(IOngoingStubbing iOngoingStubbing);
+    void reportOngoingStubbing(final IOngoingStubbing iOngoingStubbing);
 
     IOngoingStubbing pullOngoingStubbing();
 
-    void verificationStarted(VerificationMode verificationMode);
+    void verificationStarted(final VerificationMode verificationMode);
 
     VerificationMode pullVerificationMode();
 
     void stubbingStarted();
 
-    void stubbingCompleted(Invocation invocation);
+    void stubbingCompleted(final Invocation invocation);
     
     void validateState();
 
@@ -37,7 +35,7 @@ public interface MockingProgress {
 
     ArgumentMatcherStorage getArgumentMatcherStorage();
     
-    void mockingStarted(Object mock, Class classToMock);
+    void mockingStarted(final Object mock, final Class classToMock);
 
-    void setListener(MockingProgressListener listener);
+    void setListener(final MockingProgressListener listener);
 }

--- a/src/org/mockito/internal/progress/MockingProgressImpl.java
+++ b/src/org/mockito/internal/progress/MockingProgressImpl.java
@@ -15,7 +15,7 @@ import org.mockito.invocation.Invocation;
 import org.mockito.invocation.Location;
 import org.mockito.verification.VerificationMode;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class MockingProgressImpl implements MockingProgress {
     
     private final Reporter reporter = new Reporter();
@@ -26,17 +26,17 @@ public class MockingProgressImpl implements MockingProgress {
     private Location stubbingInProgress = null;
     private MockingProgressListener listener;
 
-    public void reportOngoingStubbing(IOngoingStubbing iOngoingStubbing) {
+    public void reportOngoingStubbing(final IOngoingStubbing iOngoingStubbing) {
         this.iOngoingStubbing = iOngoingStubbing;
     }
 
     public IOngoingStubbing pullOngoingStubbing() {
-        IOngoingStubbing temp = iOngoingStubbing;
+        final IOngoingStubbing temp = iOngoingStubbing;
         iOngoingStubbing = null;
         return temp;
     }
     
-    public void verificationStarted(VerificationMode verify) {
+    public void verificationStarted(final VerificationMode verify) {
         validateState();
         resetOngoingStubbing();
         verificationMode = new Localized(verify);
@@ -54,7 +54,7 @@ public class MockingProgressImpl implements MockingProgress {
             return null;
         }
         
-        VerificationMode temp = verificationMode.getObject();
+        final VerificationMode temp = verificationMode.getObject();
         verificationMode = null;
         return temp;
     }
@@ -69,7 +69,7 @@ public class MockingProgressImpl implements MockingProgress {
         
         //validate stubbing:
         if (stubbingInProgress != null) {
-            Location temp = stubbingInProgress;
+            final Location temp = stubbingInProgress;
             stubbingInProgress = null;
             reporter.unfinishedStubbing(temp);
         }
@@ -81,7 +81,7 @@ public class MockingProgressImpl implements MockingProgress {
         GlobalConfiguration.validate();
 
         if (verificationMode != null) {
-            Location location = verificationMode.getLocation();
+            final Location location = verificationMode.getLocation();
             verificationMode = null;
             reporter.unfinishedVerificationException(location);
         }
@@ -89,7 +89,7 @@ public class MockingProgressImpl implements MockingProgress {
         getArgumentMatcherStorage().validateState();
     }
 
-    public void stubbingCompleted(Invocation invocation) {
+    public void stubbingCompleted(final Invocation invocation) {
         stubbingInProgress = null;
     }
     
@@ -109,14 +109,14 @@ public class MockingProgressImpl implements MockingProgress {
         return argumentMatcherStorage;
     }
 
-    public void mockingStarted(Object mock, Class classToMock) {
+    public void mockingStarted(final Object mock, final Class classToMock) {
         if (listener instanceof MockingStartedListener) {
             ((MockingStartedListener) listener).mockingStarted(mock, classToMock);
         }
         validateMostStuff();
     }
 
-    public void setListener(MockingProgressListener listener) {
+    public void setListener(final MockingProgressListener listener) {
         this.listener = listener;
     }
 }

--- a/src/org/mockito/internal/progress/ThreadSafeMockingProgress.java
+++ b/src/org/mockito/internal/progress/ThreadSafeMockingProgress.java
@@ -11,16 +11,17 @@ import org.mockito.internal.listeners.MockingProgressListener;
 import org.mockito.invocation.Invocation;
 import org.mockito.verification.VerificationMode;
 
+@SuppressWarnings("rawtypes")
 public class ThreadSafeMockingProgress implements MockingProgress, Serializable {
     
     private static final long serialVersionUID = 6839454041642082618L;
-    private static final ThreadLocal<MockingProgress> mockingProgress = new ThreadLocal<MockingProgress>();
+    private static final ThreadLocal<MockingProgress> MOCKING_PROGRESS = new ThreadLocal<MockingProgress>();
 
     static MockingProgress threadSafely() {
-        if (mockingProgress.get() == null) {
-            mockingProgress.set(new MockingProgressImpl());
+        if (MOCKING_PROGRESS.get() == null) {
+            MOCKING_PROGRESS.set(new MockingProgressImpl());
         }
-        return mockingProgress.get();
+        return MOCKING_PROGRESS.get();
     }
     
     public void reportOngoingStubbing(final IOngoingStubbing iOngoingStubbing) {

--- a/src/org/mockito/internal/progress/ThreadSafeMockingProgress.java
+++ b/src/org/mockito/internal/progress/ThreadSafeMockingProgress.java
@@ -5,13 +5,12 @@
 
 package org.mockito.internal.progress;
 
+import java.io.Serializable;
+
 import org.mockito.internal.listeners.MockingProgressListener;
 import org.mockito.invocation.Invocation;
 import org.mockito.verification.VerificationMode;
 
-import java.io.Serializable;
-
-@SuppressWarnings("unchecked")
 public class ThreadSafeMockingProgress implements MockingProgress, Serializable {
     
     private static final long serialVersionUID = 6839454041642082618L;
@@ -24,7 +23,7 @@ public class ThreadSafeMockingProgress implements MockingProgress, Serializable 
         return mockingProgress.get();
     }
     
-    public void reportOngoingStubbing(IOngoingStubbing iOngoingStubbing) {
+    public void reportOngoingStubbing(final IOngoingStubbing iOngoingStubbing) {
         threadSafely().reportOngoingStubbing(iOngoingStubbing);
     }
 
@@ -32,7 +31,7 @@ public class ThreadSafeMockingProgress implements MockingProgress, Serializable 
         return threadSafely().pullOngoingStubbing();
     }
     
-    public void verificationStarted(VerificationMode verify) {
+    public void verificationStarted(final VerificationMode verify) {
         threadSafely().verificationStarted(verify);
     }
 
@@ -48,7 +47,7 @@ public class ThreadSafeMockingProgress implements MockingProgress, Serializable 
         threadSafely().validateState();
     }
 
-    public void stubbingCompleted(Invocation invocation) {
+    public void stubbingCompleted(final Invocation invocation) {
         threadSafely().stubbingCompleted(invocation);
     }
     
@@ -68,11 +67,11 @@ public class ThreadSafeMockingProgress implements MockingProgress, Serializable 
         return threadSafely().getArgumentMatcherStorage();
     }
     
-    public void mockingStarted(Object mock, Class classToMock) {
+    public void mockingStarted(final Object mock, final Class classToMock) {
         threadSafely().mockingStarted(mock, classToMock);
     }
 
-    public void setListener(MockingProgressListener listener) {
+    public void setListener(final MockingProgressListener listener) {
         threadSafely().setListener(listener);
     }
 }

--- a/src/org/mockito/internal/reporting/PrintSettings.java
+++ b/src/org/mockito/internal/reporting/PrintSettings.java
@@ -4,6 +4,10 @@
  */
 package org.mockito.internal.reporting;
 
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
 import org.hamcrest.Matcher;
 import org.mockito.internal.invocation.ArgumentsProcessor;
 import org.mockito.internal.invocation.InvocationMatcher;
@@ -11,17 +15,14 @@ import org.mockito.internal.matchers.MatchersPrinter;
 import org.mockito.internal.util.MockUtil;
 import org.mockito.invocation.Invocation;
 
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
-
+@SuppressWarnings("rawtypes")
 public class PrintSettings {
 
     public static final int MAX_LINE_LENGTH = 45;
     private boolean multiline;
     private List<Integer> withTypeInfo = new LinkedList<Integer>();
 
-    public void setMultiline(boolean multiline) {
+    public void setMultiline(final boolean multiline) {
         this.multiline = multiline;
     }
 
@@ -29,24 +30,24 @@ public class PrintSettings {
         return multiline;
     }
 
-    public static PrintSettings verboseMatchers(Integer ... indexesOfMatchers) {
-        PrintSettings settings = new PrintSettings();
+    public static PrintSettings verboseMatchers(final Integer ... indexesOfMatchers) {
+        final PrintSettings settings = new PrintSettings();
         settings.setMatchersToBeDescribedWithExtraTypeInfo(indexesOfMatchers);
         return settings;
     }
 
-    public boolean extraTypeInfoFor(int argumentIndex) {
+    public boolean extraTypeInfoFor(final int argumentIndex) {
         return withTypeInfo.contains(argumentIndex);
     }
 
-    public void setMatchersToBeDescribedWithExtraTypeInfo(Integer[] indexesOfMatchers) {
+    public void setMatchersToBeDescribedWithExtraTypeInfo(final Integer[] indexesOfMatchers) {
         this.withTypeInfo = Arrays.asList(indexesOfMatchers);
     }
 
-    public String print(List<Matcher> matchers, Invocation invocation) {
-        MatchersPrinter matchersPrinter = new MatchersPrinter();
-        String qualifiedName = new MockUtil().getMockName(invocation.getMock()) + "." + invocation.getMethod().getName();
-        String invocationString = qualifiedName + matchersPrinter.getArgumentsLine(matchers, this);
+    public String print(final List<Matcher> matchers, final Invocation invocation) {
+        final MatchersPrinter matchersPrinter = new MatchersPrinter();
+        final String qualifiedName = new MockUtil().getMockName(invocation.getMock()) + "." + invocation.getMethod().getName();
+        final String invocationString = qualifiedName + matchersPrinter.getArgumentsLine(matchers, this);
         if (isMultiline() || (!matchers.isEmpty() && invocationString.length() > MAX_LINE_LENGTH)) {
             return qualifiedName + matchersPrinter.getArgumentsBlock(matchers, this);
         } else {
@@ -54,11 +55,11 @@ public class PrintSettings {
         }
     }
 
-    public String print(Invocation invocation) {
+    public String print(final Invocation invocation) {
         return print(ArgumentsProcessor.argumentsToMatchers(invocation.getArguments()), invocation);
     }
 
-    public String print(InvocationMatcher invocationMatcher) {
+    public String print(final InvocationMatcher invocationMatcher) {
         return print(invocationMatcher.getMatchers(), invocationMatcher.getInvocation());
     }
 }

--- a/src/org/mockito/internal/stubbing/BaseStubbing.java
+++ b/src/org/mockito/internal/stubbing/BaseStubbing.java
@@ -14,32 +14,32 @@ import org.mockito.stubbing.OngoingStubbing;
 public abstract class BaseStubbing<T> implements OngoingStubbing<T>, DeprecatedOngoingStubbing<T> {
 
     //TODO why we need this method? The other thenReturn covers it.
-    public OngoingStubbing<T> thenReturn(T value) {
+    public OngoingStubbing<T> thenReturn(final T value) {
         return thenAnswer(new Returns(value));
     }
 
-    public OngoingStubbing<T> thenReturn(T value, T... values) {
+    public OngoingStubbing<T> thenReturn(final T value, final T... values) {
         OngoingStubbing<T> stubbing = thenReturn(value);            
         if (values == null) {
             //TODO below does not seem right
             return stubbing.thenReturn(null);
         }
-        for (T v: values) {
+        for (final T v: values) {
             stubbing = stubbing.thenReturn(v);
         }
         return stubbing;
     }
 
-    private OngoingStubbing<T> thenThrow(Throwable throwable) {
+    private OngoingStubbing<T> thenThrow(final Throwable throwable) {
         return thenAnswer(new ThrowsException(throwable));
     }
 
-    public OngoingStubbing<T> thenThrow(Throwable... throwables) {
+    public OngoingStubbing<T> thenThrow(final Throwable... throwables) {
         if (throwables == null) {
             thenThrow((Throwable) null);
         }
         OngoingStubbing<T> stubbing = null;
-        for (Throwable t: throwables) {
+        for (final Throwable t: throwables) {
             if (stubbing == null) {
                 stubbing = thenThrow(t);                    
             } else {
@@ -49,16 +49,17 @@ public abstract class BaseStubbing<T> implements OngoingStubbing<T>, DeprecatedO
         return stubbing;
     }        
 
-    private OngoingStubbing<T> thenThrow(Class<? extends Throwable> throwableClass) {
+    private OngoingStubbing<T> thenThrow(final Class<? extends Throwable> throwableClass) {
         return thenAnswer(new ThrowsExceptionClass(throwableClass));
     }
 
-    public OngoingStubbing<T> thenThrow(Class<? extends Throwable>... throwableClasses) {
+    @SuppressWarnings("unchecked")
+    public OngoingStubbing<T> thenThrow(final Class<? extends Throwable>... throwableClasses) {
         if (throwableClasses == null) {
             thenThrow((Throwable) null);
         }
         OngoingStubbing<T> stubbing = null;
-        for (Class<? extends Throwable> t: throwableClasses) {
+        for (final Class<? extends Throwable> t: throwableClasses) {
             if (stubbing == null) {
                 stubbing = thenThrow(t);
             } else {
@@ -72,11 +73,11 @@ public abstract class BaseStubbing<T> implements OngoingStubbing<T>, DeprecatedO
         return thenAnswer(new CallsRealMethods());
     }
 
-    public DeprecatedOngoingStubbing<T> toReturn(T value) {
+    public DeprecatedOngoingStubbing<T> toReturn(final T value) {
         return toAnswer(new Returns(value));
     }
 
-    public DeprecatedOngoingStubbing<T> toThrow(Throwable throwable) {
+    public DeprecatedOngoingStubbing<T> toThrow(final Throwable throwable) {
         return toAnswer(new ThrowsException(throwable));
     }
 }

--- a/src/org/mockito/internal/stubbing/ConsecutiveStubbing.java
+++ b/src/org/mockito/internal/stubbing/ConsecutiveStubbing.java
@@ -11,24 +11,25 @@ import org.mockito.stubbing.OngoingStubbing;
 public class ConsecutiveStubbing<T> extends BaseStubbing<T> {
     private final InvocationContainerImpl invocationContainerImpl;
 
-    public ConsecutiveStubbing(InvocationContainerImpl invocationContainerImpl) {
+    public ConsecutiveStubbing(final InvocationContainerImpl invocationContainerImpl) {
         this.invocationContainerImpl = invocationContainerImpl;
     }
 
-    public OngoingStubbing<T> thenAnswer(Answer<?> answer) {
+    public OngoingStubbing<T> thenAnswer(final Answer<?> answer) {
         invocationContainerImpl.addConsecutiveAnswer(answer);
         return this;
     }
 
-    public OngoingStubbing<T> then(Answer<?> answer) {
+    public OngoingStubbing<T> then(final Answer<?> answer) {
         return thenAnswer(answer);
     }
     
-    public DeprecatedOngoingStubbing<T> toAnswer(Answer<?> answer) {
+    public DeprecatedOngoingStubbing<T> toAnswer(final Answer<?> answer) {
         invocationContainerImpl.addConsecutiveAnswer(answer);
         return this;
     }
 
+    @SuppressWarnings("unchecked")
     public <M> M getMock() {
         return (M) invocationContainerImpl.invokedMock();
     }

--- a/src/org/mockito/internal/stubbing/InvocationContainerImpl.java
+++ b/src/org/mockito/internal/stubbing/InvocationContainerImpl.java
@@ -20,6 +20,7 @@ import org.mockito.invocation.Invocation;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.stubbing.Answer;
 
+@SuppressWarnings("rawtypes")
 public class InvocationContainerImpl implements InvocationContainer, Serializable {
 
     private static final long serialVersionUID = -5334301962749537177L;
@@ -30,7 +31,7 @@ public class InvocationContainerImpl implements InvocationContainer, Serializabl
 
     private InvocationMatcher invocationForStubbing;
 
-    public InvocationContainerImpl(final MockingProgress mockingProgress, final MockCreationSettings mockSettings) {
+    public InvocationContainerImpl(final MockingProgress mockingProgress, final MockCreationSettings<?> mockSettings) {
         this.mockingProgress = mockingProgress;
         this.registeredInvocations = createRegisteredInvocations(mockSettings);
     }
@@ -44,16 +45,16 @@ public class InvocationContainerImpl implements InvocationContainer, Serializabl
         this.invocationForStubbing = invocationMatcher;
     }
 
-    public void addAnswer(final Answer answer) {
+    public void addAnswer(final Answer<?> answer) {
         registeredInvocations.removeLast();
         addAnswer(answer, false);
     }
 
-    public void addConsecutiveAnswer(final Answer answer) {
+    public void addConsecutiveAnswer(final Answer<?> answer) {
         addAnswer(answer, true);
     }
 
-    public void addAnswer(final Answer answer, final boolean isConsecutive) {
+    public void addAnswer(final Answer<?> answer, final boolean isConsecutive) {
         final Invocation invocation = invocationForStubbing.getInvocation();
         mockingProgress.stubbingCompleted(invocation);
         final AnswersValidator answersValidator = new AnswersValidator();
@@ -86,7 +87,7 @@ public class InvocationContainerImpl implements InvocationContainer, Serializabl
         return null;
     }
 
-    public void addAnswerForVoidMethod(final Answer answer) {
+    public void addAnswerForVoidMethod(final Answer<?> answer) {
         answersForStubbing.add(answer);
     }
 
@@ -132,7 +133,7 @@ public class InvocationContainerImpl implements InvocationContainer, Serializabl
         return invocationForStubbing;
     }
 
-    private RegisteredInvocations createRegisteredInvocations(final MockCreationSettings mockSettings) {
+    private RegisteredInvocations createRegisteredInvocations(final MockCreationSettings<?> mockSettings) {
         return mockSettings.isStubOnly()
           ? new SingleRegisteredInvocation()
           : new DefaultRegisteredInvocations();

--- a/src/org/mockito/internal/stubbing/InvocationContainerImpl.java
+++ b/src/org/mockito/internal/stubbing/InvocationContainerImpl.java
@@ -4,6 +4,11 @@
  */
 package org.mockito.internal.stubbing;
 
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
 import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockito.internal.invocation.StubInfoImpl;
 import org.mockito.internal.progress.MockingProgress;
@@ -15,12 +20,6 @@ import org.mockito.invocation.Invocation;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.stubbing.Answer;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-
-@SuppressWarnings("unchecked")
 public class InvocationContainerImpl implements InvocationContainer, Serializable {
 
     private static final long serialVersionUID = -5334301962749537177L;
@@ -31,33 +30,33 @@ public class InvocationContainerImpl implements InvocationContainer, Serializabl
 
     private InvocationMatcher invocationForStubbing;
 
-    public InvocationContainerImpl(MockingProgress mockingProgress, MockCreationSettings mockSettings) {
+    public InvocationContainerImpl(final MockingProgress mockingProgress, final MockCreationSettings mockSettings) {
         this.mockingProgress = mockingProgress;
         this.registeredInvocations = createRegisteredInvocations(mockSettings);
     }
 
-    public void setInvocationForPotentialStubbing(InvocationMatcher invocation) {
+    public void setInvocationForPotentialStubbing(final InvocationMatcher invocation) {
         registeredInvocations.add(invocation.getInvocation());
         this.invocationForStubbing = invocation;
     }
 
-    public void resetInvocationForPotentialStubbing(InvocationMatcher invocationMatcher) {
+    public void resetInvocationForPotentialStubbing(final InvocationMatcher invocationMatcher) {
         this.invocationForStubbing = invocationMatcher;
     }
 
-    public void addAnswer(Answer answer) {
+    public void addAnswer(final Answer answer) {
         registeredInvocations.removeLast();
         addAnswer(answer, false);
     }
 
-    public void addConsecutiveAnswer(Answer answer) {
+    public void addConsecutiveAnswer(final Answer answer) {
         addAnswer(answer, true);
     }
 
-    public void addAnswer(Answer answer, boolean isConsecutive) {
-        Invocation invocation = invocationForStubbing.getInvocation();
+    public void addAnswer(final Answer answer, final boolean isConsecutive) {
+        final Invocation invocation = invocationForStubbing.getInvocation();
         mockingProgress.stubbingCompleted(invocation);
-        AnswersValidator answersValidator = new AnswersValidator();
+        final AnswersValidator answersValidator = new AnswersValidator();
         answersValidator.validate(answer, invocation);
 
         synchronized (stubbed) {
@@ -69,13 +68,13 @@ public class InvocationContainerImpl implements InvocationContainer, Serializabl
         }
     }
 
-    Object answerTo(Invocation invocation) throws Throwable {
+    Object answerTo(final Invocation invocation) throws Throwable {
         return findAnswerFor(invocation).answer(invocation);
     }
 
-    public StubbedInvocationMatcher findAnswerFor(Invocation invocation) {
+    public StubbedInvocationMatcher findAnswerFor(final Invocation invocation) {
         synchronized (stubbed) {
-            for (StubbedInvocationMatcher s : stubbed) {
+            for (final StubbedInvocationMatcher s : stubbed) {
                 if (s.matches(invocation)) {
                     s.markStubUsed(invocation);
                     invocation.markStubbed(new StubInfoImpl(s));
@@ -87,11 +86,11 @@ public class InvocationContainerImpl implements InvocationContainer, Serializabl
         return null;
     }
 
-    public void addAnswerForVoidMethod(Answer answer) {
+    public void addAnswerForVoidMethod(final Answer answer) {
         answersForStubbing.add(answer);
     }
 
-    public void setAnswersForStubbing(List<Answer> answers) {
+    public void setAnswersForStubbing(final List<Answer> answers) {
         answersForStubbing.addAll(answers);
     }
 
@@ -103,7 +102,7 @@ public class InvocationContainerImpl implements InvocationContainer, Serializabl
         return !registeredInvocations.isEmpty();
     }
 
-    public void setMethodForStubbing(InvocationMatcher invocation) {
+    public void setMethodForStubbing(final InvocationMatcher invocation) {
         invocationForStubbing = invocation;
         assert hasAnswersForStubbing();
         for (int i = 0; i < answersForStubbing.size(); i++) {
@@ -133,7 +132,7 @@ public class InvocationContainerImpl implements InvocationContainer, Serializabl
         return invocationForStubbing;
     }
 
-    private RegisteredInvocations createRegisteredInvocations(MockCreationSettings mockSettings) {
+    private RegisteredInvocations createRegisteredInvocations(final MockCreationSettings mockSettings) {
         return mockSettings.isStubOnly()
           ? new SingleRegisteredInvocation()
           : new DefaultRegisteredInvocations();

--- a/src/org/mockito/internal/stubbing/OngoingStubbingImpl.java
+++ b/src/org/mockito/internal/stubbing/OngoingStubbingImpl.java
@@ -4,23 +4,23 @@
  */
 package org.mockito.internal.stubbing;
 
+import java.util.List;
+
 import org.mockito.exceptions.Reporter;
 import org.mockito.invocation.Invocation;
 import org.mockito.stubbing.Answer;
 import org.mockito.stubbing.DeprecatedOngoingStubbing;
 import org.mockito.stubbing.OngoingStubbing;
 
-import java.util.List;
-
 public class OngoingStubbingImpl<T> extends BaseStubbing<T> {
     
     private final InvocationContainerImpl invocationContainerImpl;
 
-    public OngoingStubbingImpl(InvocationContainerImpl invocationContainerImpl) {
+    public OngoingStubbingImpl(final InvocationContainerImpl invocationContainerImpl) {
         this.invocationContainerImpl = invocationContainerImpl;
     }
 
-    public OngoingStubbing<T> thenAnswer(Answer<?> answer) {
+    public OngoingStubbing<T> thenAnswer(final Answer<?> answer) {
         if(!invocationContainerImpl.hasInvocationForPotentialStubbing()) {
             new Reporter().incorrectUseOfApi();
         }
@@ -29,11 +29,11 @@ public class OngoingStubbingImpl<T> extends BaseStubbing<T> {
         return new ConsecutiveStubbing<T>(invocationContainerImpl);
     }
 
-    public OngoingStubbing<T> then(Answer<?> answer) {
+    public OngoingStubbing<T> then(final Answer<?> answer) {
         return thenAnswer(answer);
     }
 
-    public DeprecatedOngoingStubbing<T> toAnswer(Answer<?> answer) {
+    public DeprecatedOngoingStubbing<T> toAnswer(final Answer<?> answer) {
         invocationContainerImpl.addAnswer(answer);
         return new ConsecutiveStubbing<T>(invocationContainerImpl);
     }
@@ -43,6 +43,7 @@ public class OngoingStubbingImpl<T> extends BaseStubbing<T> {
         return invocationContainerImpl.getInvocations();
     }
 
+    @SuppressWarnings("unchecked")
     public <M> M getMock() {
         return (M) invocationContainerImpl.invokedMock();
     }

--- a/src/org/mockito/internal/stubbing/StubbedInvocationMatcher.java
+++ b/src/org/mockito/internal/stubbing/StubbedInvocationMatcher.java
@@ -13,19 +13,18 @@ import org.mockito.invocation.DescribedInvocation;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-@SuppressWarnings("unchecked")
 public class StubbedInvocationMatcher extends InvocationMatcher implements Answer, Serializable {
 
     private static final long serialVersionUID = 4919105134123672727L;
     private final Queue<Answer> answers = new ConcurrentLinkedQueue<Answer>();
     private DescribedInvocation usedAt;
 
-    public StubbedInvocationMatcher(InvocationMatcher invocation, Answer answer) {
+    public StubbedInvocationMatcher(final InvocationMatcher invocation, final Answer answer) {
         super(invocation.getInvocation(), invocation.getMatchers());
         this.answers.add(answer);
     }
 
-    public Object answer(InvocationOnMock invocation) throws Throwable {
+    public Object answer(final InvocationOnMock invocation) throws Throwable {
         //see ThreadsShareGenerouslyStubbedMockTest
         Answer a;
         synchronized(answers) {
@@ -34,11 +33,11 @@ public class StubbedInvocationMatcher extends InvocationMatcher implements Answe
         return a.answer(invocation);
     }
 
-    public void addAnswer(Answer answer) {
+    public void addAnswer(final Answer answer) {
         answers.add(answer);
     }
 
-    public void markStubUsed(DescribedInvocation usedAt) {
+    public void markStubUsed(final DescribedInvocation usedAt) {
         this.usedAt = usedAt;
     }
 

--- a/src/org/mockito/internal/stubbing/StubbedInvocationMatcher.java
+++ b/src/org/mockito/internal/stubbing/StubbedInvocationMatcher.java
@@ -13,6 +13,7 @@ import org.mockito.invocation.DescribedInvocation;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+@SuppressWarnings("rawtypes")
 public class StubbedInvocationMatcher extends InvocationMatcher implements Answer, Serializable {
 
     private static final long serialVersionUID = 4919105134123672727L;

--- a/src/org/mockito/internal/stubbing/StubberImpl.java
+++ b/src/org/mockito/internal/stubbing/StubberImpl.java
@@ -4,23 +4,28 @@
  */
 package org.mockito.internal.stubbing;
 
+import java.util.LinkedList;
+import java.util.List;
+
 import org.mockito.exceptions.Reporter;
-import org.mockito.internal.stubbing.answers.*;
+import org.mockito.internal.stubbing.answers.CallsRealMethods;
+import org.mockito.internal.stubbing.answers.DoesNothing;
+import org.mockito.internal.stubbing.answers.Returns;
+import org.mockito.internal.stubbing.answers.ThrowsException;
+import org.mockito.internal.stubbing.answers.ThrowsExceptionClass;
 import org.mockito.internal.util.MockUtil;
 import org.mockito.stubbing.Answer;
 import org.mockito.stubbing.Stubber;
 
-import java.util.LinkedList;
-import java.util.List;
-
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class StubberImpl implements Stubber {
 
     final List<Answer> answers = new LinkedList<Answer>();
+    
     private final Reporter reporter = new Reporter();
 
-    public <T> T when(T mock) {
-        MockUtil mockUtil = new MockUtil();
+    public <T> T when(final T mock) {
+        final MockUtil mockUtil = new MockUtil();
         
         if (mock == null) {
             reporter.nullPassedToWhenMethod();
@@ -34,17 +39,17 @@ public class StubberImpl implements Stubber {
         return mock;
     }
 
-    public Stubber doReturn(Object toBeReturned) {
+    public Stubber doReturn(final Object toBeReturned) {
         answers.add(new Returns(toBeReturned));
         return this;
     }
 
-    public Stubber doThrow(Throwable toBeThrown) {
+    public Stubber doThrow(final Throwable toBeThrown) {
         answers.add(new ThrowsException(toBeThrown));
         return this;
     }
 
-    public Stubber doThrow(Class<? extends Throwable> toBeThrown) {
+    public Stubber doThrow(final Class<? extends Throwable> toBeThrown) {
         answers.add(new ThrowsExceptionClass(toBeThrown));
         return this;
     }
@@ -54,7 +59,7 @@ public class StubberImpl implements Stubber {
         return this;
     }
 
-    public Stubber doAnswer(Answer answer) {
+    public Stubber doAnswer(final Answer answer) {
         answers.add(answer);
         return this;
     }

--- a/src/org/mockito/internal/stubbing/answers/MethodInfo.java
+++ b/src/org/mockito/internal/stubbing/answers/MethodInfo.java
@@ -4,28 +4,29 @@
  */
 package org.mockito.internal.stubbing.answers;
 
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
 import org.mockito.internal.invocation.AbstractAwareMethod;
 import org.mockito.internal.util.Primitives;
 import org.mockito.invocation.Invocation;
 
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-
 /**
  * by Szczepan Faber, created at: 3/31/12
  */
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class MethodInfo implements AbstractAwareMethod {
 
     private final Method method;
 
-    public MethodInfo(Invocation theInvocation) {
+    public MethodInfo(final Invocation theInvocation) {
         this.method = theInvocation.getMethod();
     }
 
-    public boolean isValidException(Throwable throwable) {
-        Class<?>[] exceptions = method.getExceptionTypes();
-        Class<?> throwableClass = throwable.getClass();
-        for (Class<?> exception : exceptions) {
+    public boolean isValidException(final Throwable throwable) {
+        final Class<?>[] exceptions = method.getExceptionTypes();
+        final Class<?> throwableClass = throwable.getClass();
+        for (final Class<?> exception : exceptions) {
             if (exception.isAssignableFrom(throwableClass)) {
                 return true;
             }
@@ -34,7 +35,7 @@ public class MethodInfo implements AbstractAwareMethod {
         return false;
     }
 
-    public boolean isValidReturnType(Class clazz) {
+    public boolean isValidReturnType(final Class clazz) {
         if (method.getReturnType().isPrimitive() || clazz.isPrimitive()) {
             return Primitives.primitiveTypeOf(clazz) == Primitives.primitiveTypeOf(method.getReturnType());
         } else {

--- a/src/org/mockito/internal/stubbing/answers/ReturnsArgumentAt.java
+++ b/src/org/mockito/internal/stubbing/answers/ReturnsArgumentAt.java
@@ -4,11 +4,11 @@
  */
 package org.mockito.internal.stubbing.answers;
 
+import java.io.Serializable;
+
 import org.mockito.exceptions.Reporter;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-
-import java.io.Serializable;
 
 /**
  * Returns the passed parameter identity at specified index.
@@ -33,35 +33,34 @@ public class ReturnsArgumentAt implements Answer<Object>, Serializable {
      * @param wantedArgumentPosition The position of the argument identity to return in the invocation.
      *                      Using <code>-1</code> indicates the last argument.
      */
-    public ReturnsArgumentAt(int wantedArgumentPosition) {
+    public ReturnsArgumentAt(final int wantedArgumentPosition) {
         this.wantedArgumentPosition = checkWithinAllowedRange(wantedArgumentPosition);
     }
 
-    public Object answer(InvocationOnMock invocation) throws Throwable {
+    public Object answer(final InvocationOnMock invocation) throws Throwable {
         validateIndexWithinInvocationRange(invocation);
         return invocation.getArguments()[actualArgumentPosition(invocation)];
     }
 
 
-    private int actualArgumentPosition(InvocationOnMock invocation) {
-        return returningLastArg() ?
-                lastArgumentIndexOf(invocation) :
-                argumentIndexOf(invocation);
+    private int actualArgumentPosition(final InvocationOnMock invocation) {
+        return returningLastArg() ? lastArgumentIndexOf(invocation)
+                        : argumentIndexOf(invocation);
     }
 
     private boolean returningLastArg() {
         return wantedArgumentPosition == LAST_ARGUMENT;
     }
 
-    private int argumentIndexOf(InvocationOnMock invocation) {
+    private int argumentIndexOf(final InvocationOnMock invocation) {
         return wantedArgumentPosition;
     }
 
-    private int lastArgumentIndexOf(InvocationOnMock invocation) {
+    private int lastArgumentIndexOf(final InvocationOnMock invocation) {
         return invocation.getArguments().length - 1;
     }
 
-    private int checkWithinAllowedRange(int argumentPosition) {
+    private int checkWithinAllowedRange(final int argumentPosition) {
         if (argumentPosition != LAST_ARGUMENT && argumentPosition < 0) {
             new Reporter().invalidArgumentRangeAtIdentityAnswerCreationTime();
         }
@@ -72,7 +71,7 @@ public class ReturnsArgumentAt implements Answer<Object>, Serializable {
         return wantedArgumentPosition;
     }
 
-    public void validateIndexWithinInvocationRange(InvocationOnMock invocation) {
+    public void validateIndexWithinInvocationRange(final InvocationOnMock invocation) {
         if (!argumentPositionInRange(invocation)) {
             new Reporter().invalidArgumentPositionRangeAtInvocationTime(invocation,
                                                                         returningLastArg(),
@@ -80,8 +79,8 @@ public class ReturnsArgumentAt implements Answer<Object>, Serializable {
         }
     }
 
-    private boolean argumentPositionInRange(InvocationOnMock invocation) {
-        int actualArgumentPosition = actualArgumentPosition(invocation);
+    private boolean argumentPositionInRange(final InvocationOnMock invocation) {
+        final int actualArgumentPosition = actualArgumentPosition(invocation);
         if (actualArgumentPosition < 0) {
             return false;
         }
@@ -92,15 +91,15 @@ public class ReturnsArgumentAt implements Answer<Object>, Serializable {
         return true;
     }
 
-    public Class returnedTypeOnSignature(InvocationOnMock invocation) {
-        int actualArgumentPosition = actualArgumentPosition(invocation);
+    public Class returnedTypeOnSignature(final InvocationOnMock invocation) {
+        final int actualArgumentPosition = actualArgumentPosition(invocation);
 
         if(!invocation.getMethod().isVarArgs()) {
             return invocation.getMethod().getParameterTypes()[actualArgumentPosition];
         }
 
-        Class<?>[] parameterTypes = invocation.getMethod().getParameterTypes();
-        int varargPosition = parameterTypes.length - 1;
+        final Class<?>[] parameterTypes = invocation.getMethod().getParameterTypes();
+        final int varargPosition = parameterTypes.length - 1;
 
         if(actualArgumentPosition < varargPosition) {
             return parameterTypes[actualArgumentPosition];

--- a/src/org/mockito/internal/stubbing/answers/ReturnsArgumentAt.java
+++ b/src/org/mockito/internal/stubbing/answers/ReturnsArgumentAt.java
@@ -19,6 +19,7 @@ import org.mockito.stubbing.Answer;
  * @see org.mockito.AdditionalAnswers
  * @since 1.9.5
  */
+@SuppressWarnings("rawtypes")
 public class ReturnsArgumentAt implements Answer<Object>, Serializable {
 
     private static final long serialVersionUID = -589315085166295101L;

--- a/src/org/mockito/internal/stubbing/answers/ReturnsElementsOf.java
+++ b/src/org/mockito/internal/stubbing/answers/ReturnsElementsOf.java
@@ -6,6 +6,7 @@ package org.mockito.internal.stubbing.answers;
 
 import java.util.Collection;
 import java.util.LinkedList;
+
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -33,7 +34,7 @@ public class ReturnsElementsOf implements Answer<Object> {
 
     private final LinkedList<Object> elements;
 
-    public ReturnsElementsOf(Collection<?> elements) {
+    public ReturnsElementsOf(final Collection<?> elements) {
         if (elements == null) {
             throw new MockitoException("ReturnsElementsOf does not accept null as constructor argument.\n" +
                     "Please pass a collection instance");
@@ -41,10 +42,11 @@ public class ReturnsElementsOf implements Answer<Object> {
         this.elements = new LinkedList<Object>(elements);
     }
 
-    public Object answer(InvocationOnMock invocation) throws Throwable {
-        if (elements.size() == 1)
+    public Object answer(final InvocationOnMock invocation) throws Throwable {
+        if (elements.size() == 1) {
             return elements.get(0);
-        else 
+        } else {
             return elements.poll();
+        }
     }
 }

--- a/src/org/mockito/internal/stubbing/answers/ThrowsExceptionClass.java
+++ b/src/org/mockito/internal/stubbing/answers/ThrowsExceptionClass.java
@@ -5,25 +5,26 @@
 
 package org.mockito.internal.stubbing.answers;
 
+import java.io.Serializable;
+
 import org.mockito.internal.exceptions.stacktrace.ConditionalStackTraceFilter;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.objenesis.ObjenesisHelper;
 
-import java.io.Serializable;
-
 public class ThrowsExceptionClass implements Answer<Object>, Serializable {
 
+    private static final long serialVersionUID = 4118083979304825900L;
     private final Class<? extends Throwable> throwableClass;
     private final ConditionalStackTraceFilter filter = new ConditionalStackTraceFilter();
 
-    public ThrowsExceptionClass(Class<? extends Throwable> throwableClass) {
+    public ThrowsExceptionClass(final Class<? extends Throwable> throwableClass) {
         this.throwableClass = throwableClass;
     }
 
-    public Object answer(InvocationOnMock invocation) throws Throwable {
+    public Object answer(final InvocationOnMock invocation) throws Throwable {
         //TODO centralize the use of Objenesis. Why do we use ObjenesisHelper?
-        Throwable throwable = (Throwable) ObjenesisHelper.newInstance(throwableClass);
+        final Throwable throwable = ObjenesisHelper.newInstance(throwableClass);
         throwable.fillInStackTrace();
         filter.filter(throwable);
         throw throwable;

--- a/src/org/mockito/internal/stubbing/defaultanswers/Answers.java
+++ b/src/org/mockito/internal/stubbing/defaultanswers/Answers.java
@@ -24,8 +24,7 @@ public enum Answers {
     RETURNS_SMART_NULLS(new ReturnsSmartNulls()),
     RETURNS_MOCKS(new ReturnsMocks()),
     RETURNS_DEEP_STUBS(new ReturnsDeepStubs()),
-    CALLS_REAL_METHODS(new CallsRealMethods())
-    ;
+    CALLS_REAL_METHODS(new CallsRealMethods());
 
     private final Answer<Object> implementation;
 

--- a/src/org/mockito/internal/stubbing/defaultanswers/ForwardsInvocations.java
+++ b/src/org/mockito/internal/stubbing/defaultanswers/ForwardsInvocations.java
@@ -9,9 +9,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 import org.mockito.exceptions.Reporter;
-import org.mockito.exceptions.base.MockitoException;
-import org.mockito.internal.stubbing.answers.MethodInfo;
-import org.mockito.internal.util.Primitives;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -25,26 +22,26 @@ public class ForwardsInvocations implements Answer<Object>, Serializable {
 
     private Object delegatedObject = null;
 
-    public ForwardsInvocations(Object delegatedObject) {
+    public ForwardsInvocations(final Object delegatedObject) {
         this.delegatedObject = delegatedObject;
     }
 
-    public Object answer(InvocationOnMock invocation) throws Throwable {
-        Method mockMethod = invocation.getMethod();
+    public Object answer(final InvocationOnMock invocation) throws Throwable {
+        final Method mockMethod = invocation.getMethod();
         
         Object result = null;
         
         try {
-            Method delegateMethod = getDelegateMethod(mockMethod);
+            final Method delegateMethod = getDelegateMethod(mockMethod);
             
             if (!compatibleReturnTypes(mockMethod.getReturnType(), delegateMethod.getReturnType())) {
                 new Reporter().delegatedMethodHasWrongReturnType(mockMethod, delegateMethod, invocation.getMock(), delegatedObject);
             }
             
             result = delegateMethod.invoke(delegatedObject, invocation.getArguments());
-        } catch (NoSuchMethodException e) {
+        } catch (final NoSuchMethodException e) {
             new Reporter().delegatedMethodDoesNotExistOnDelegate(mockMethod, invocation.getMock(), delegatedObject);
-        } catch (InvocationTargetException e) {
+        } catch (final InvocationTargetException e) {
             // propagate the original exception from the delegate
             throw e.getCause();
         }
@@ -52,7 +49,7 @@ public class ForwardsInvocations implements Answer<Object>, Serializable {
         return result;
     }
 
-    private Method getDelegateMethod(Method mockMethod) throws NoSuchMethodException {
+    private Method getDelegateMethod(final Method mockMethod) throws NoSuchMethodException {
         if (mockMethod.getDeclaringClass().isAssignableFrom(delegatedObject.getClass())) {
             // Compatible class. Return original method.
             return mockMethod;
@@ -62,7 +59,7 @@ public class ForwardsInvocations implements Answer<Object>, Serializable {
         }
     }
 
-    private static boolean compatibleReturnTypes(Class<?> superType, Class<?> subType) {
+    private static boolean compatibleReturnTypes(final Class<?> superType, final Class<?> subType) {
         return superType.equals(subType) || superType.isAssignableFrom(subType);
     }
 }

--- a/src/org/mockito/internal/stubbing/defaultanswers/ForwardsInvocations.java
+++ b/src/org/mockito/internal/stubbing/defaultanswers/ForwardsInvocations.java
@@ -23,10 +23,10 @@ import org.mockito.stubbing.Answer;
 public class ForwardsInvocations implements Answer<Object>, Serializable {
     private static final long serialVersionUID = -8343690268123254910L;
 
-    private Object delegatedObject = null ;
+    private Object delegatedObject = null;
 
     public ForwardsInvocations(Object delegatedObject) {
-        this.delegatedObject = delegatedObject ;
+        this.delegatedObject = delegatedObject;
     }
 
     public Object answer(InvocationOnMock invocation) throws Throwable {

--- a/src/org/mockito/internal/stubbing/defaultanswers/ReturnsDeepStubs.java
+++ b/src/org/mockito/internal/stubbing/defaultanswers/ReturnsDeepStubs.java
@@ -40,6 +40,7 @@ import org.mockito.stubbing.Answer;
  * @see org.mockito.Mockito#RETURNS_DEEP_STUBS
  * @see org.mockito.Answers#RETURNS_DEEP_STUBS
  */
+@SuppressWarnings("rawtypes")
 public class ReturnsDeepStubs implements Answer<Object>, Serializable {
 
     private static final long serialVersionUID = -7105341425736035847L;

--- a/src/org/mockito/internal/stubbing/defaultanswers/ReturnsDeepStubs.java
+++ b/src/org/mockito/internal/stubbing/defaultanswers/ReturnsDeepStubs.java
@@ -4,6 +4,11 @@
  */
 package org.mockito.internal.stubbing.defaultanswers;
 
+import static org.mockito.Mockito.withSettings;
+
+import java.io.IOException;
+import java.io.Serializable;
+
 import org.mockito.MockSettings;
 import org.mockito.Mockito;
 import org.mockito.internal.InternalMockHandler;
@@ -16,11 +21,6 @@ import org.mockito.internal.util.reflection.GenericMetadataSupport;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.stubbing.Answer;
-
-import java.io.IOException;
-import java.io.Serializable;
-
-import static org.mockito.Mockito.withSettings;
 
 /**
  * Returning deep stub implementation.
@@ -44,11 +44,11 @@ public class ReturnsDeepStubs implements Answer<Object>, Serializable {
 
     private static final long serialVersionUID = -7105341425736035847L;
 
-    public Object answer(InvocationOnMock invocation) throws Throwable {
-        GenericMetadataSupport returnTypeGenericMetadata =
+    public Object answer(final InvocationOnMock invocation) throws Throwable {
+        final GenericMetadataSupport returnTypeGenericMetadata =
                 actualParameterizedType(invocation.getMock()).resolveGenericReturnType(invocation.getMethod());
 
-        Class<?> rawType = returnTypeGenericMetadata.rawType();
+        final Class<?> rawType = returnTypeGenericMetadata.rawType();
         if (!mockitoCore().isTypeMockable(rawType)) {
             return delegate().returnValueFor(rawType);
         }
@@ -56,12 +56,12 @@ public class ReturnsDeepStubs implements Answer<Object>, Serializable {
         return deepStub(invocation, returnTypeGenericMetadata);
     }
 
-    private Object deepStub(InvocationOnMock invocation, GenericMetadataSupport returnTypeGenericMetadata) throws Throwable {
-        InternalMockHandler<Object> handler = new MockUtil().getMockHandler(invocation.getMock());
-        InvocationContainerImpl container = (InvocationContainerImpl) handler.getInvocationContainer();
+    private Object deepStub(final InvocationOnMock invocation, final GenericMetadataSupport returnTypeGenericMetadata) throws Throwable {
+        final InternalMockHandler<Object> handler = new MockUtil().getMockHandler(invocation.getMock());
+        final InvocationContainerImpl container = (InvocationContainerImpl) handler.getInvocationContainer();
 
         // matches invocation for verification
-        for (StubbedInvocationMatcher stubbedInvocationMatcher : container.getStubbedInvocations()) {
+        for (final StubbedInvocationMatcher stubbedInvocationMatcher : container.getStubbedInvocations()) {
             if (container.getInvocationForStubbing().matches(stubbedInvocationMatcher.getInvocation())) {
                 return stubbedInvocationMatcher.answer(invocation);
             }
@@ -85,24 +85,24 @@ public class ReturnsDeepStubs implements Answer<Object>, Serializable {
      * @param parentMock The parent of the current deep stub mock.
      * @return The mock
      */
-    private Object newDeepStubMock(GenericMetadataSupport returnTypeGenericMetadata, Object parentMock) {
-        MockCreationSettings parentMockSettings = new MockUtil().getMockSettings(parentMock);
+    private Object newDeepStubMock(final GenericMetadataSupport returnTypeGenericMetadata, final Object parentMock) {
+        final MockCreationSettings parentMockSettings = new MockUtil().getMockSettings(parentMock);
         return mockitoCore().mock(
                 returnTypeGenericMetadata.rawType(),
                 withSettingsUsing(returnTypeGenericMetadata, parentMockSettings)
         );
     }
 
-    private MockSettings withSettingsUsing(GenericMetadataSupport returnTypeGenericMetadata, MockCreationSettings parentMockSettings) {
-        MockSettings mockSettings = returnTypeGenericMetadata.hasRawExtraInterfaces() ?
-                withSettings().extraInterfaces(returnTypeGenericMetadata.rawExtraInterfaces())
+    private MockSettings withSettingsUsing(final GenericMetadataSupport returnTypeGenericMetadata, final MockCreationSettings parentMockSettings) {
+        final MockSettings mockSettings = returnTypeGenericMetadata.hasRawExtraInterfaces()
+                ? withSettings().extraInterfaces(returnTypeGenericMetadata.rawExtraInterfaces())
                 : withSettings();
 
         return propagateSerializationSettings(mockSettings, parentMockSettings)
                 .defaultAnswer(returnsDeepStubsAnswerUsing(returnTypeGenericMetadata));
     }
 
-    private MockSettings propagateSerializationSettings(MockSettings mockSettings, MockCreationSettings parentMockSettings) {
+    private MockSettings propagateSerializationSettings(final MockSettings mockSettings, final MockCreationSettings parentMockSettings) {
         return mockSettings.serializable(parentMockSettings.getSerializableMode());
     }
 
@@ -110,27 +110,29 @@ public class ReturnsDeepStubs implements Answer<Object>, Serializable {
         return new ReturnsDeepStubsSerializationFallback(returnTypeGenericMetadata);
     }
 
-    private Object recordDeepStubAnswer(final Object mock, InvocationContainerImpl container) throws Throwable {
+    private Object recordDeepStubAnswer(final Object mock, final InvocationContainerImpl container) throws Throwable {
         container.addAnswer(new DeeplyStubbedAnswer(mock), false);
         return mock;
     }
 
-    protected GenericMetadataSupport actualParameterizedType(Object mock) {
-        CreationSettings mockSettings = (CreationSettings) new MockUtil().getMockHandler(mock).getMockSettings();
+    protected GenericMetadataSupport actualParameterizedType(final Object mock) {
+        final CreationSettings mockSettings = (CreationSettings) new MockUtil().getMockHandler(mock).getMockSettings();
         return GenericMetadataSupport.inferFrom(mockSettings.getTypeToMock());
     }
 
 
     private static class ReturnsDeepStubsSerializationFallback extends ReturnsDeepStubs implements Serializable {
-        @SuppressWarnings("serial") // not gonna be serialized
+
+        private static final long serialVersionUID = 1L;
+        
         private final GenericMetadataSupport returnTypeGenericMetadata;
 
-        public ReturnsDeepStubsSerializationFallback(GenericMetadataSupport returnTypeGenericMetadata) {
+        public ReturnsDeepStubsSerializationFallback(final GenericMetadataSupport returnTypeGenericMetadata) {
             this.returnTypeGenericMetadata = returnTypeGenericMetadata;
         }
 
         @Override
-        protected GenericMetadataSupport actualParameterizedType(Object mock) {
+        protected GenericMetadataSupport actualParameterizedType(final Object mock) {
             return returnTypeGenericMetadata;
         }
         private Object writeReplace() throws IOException {
@@ -140,13 +142,15 @@ public class ReturnsDeepStubs implements Answer<Object>, Serializable {
 
 
     private static class DeeplyStubbedAnswer implements Answer<Object>, Serializable {
-        @SuppressWarnings("serial") // serialization will fail with a nice message if mock not serializable
+   
+        private static final long serialVersionUID = 1L;
+
         private final Object mock;
 
-        DeeplyStubbedAnswer(Object mock) {
+        DeeplyStubbedAnswer(final Object mock) {
             this.mock = mock;
         }
-        public Object answer(InvocationOnMock invocation) throws Throwable {
+        public Object answer(final InvocationOnMock invocation) throws Throwable {
             return mock;
         }
     }

--- a/src/org/mockito/internal/stubbing/defaultanswers/ReturnsMocks.java
+++ b/src/org/mockito/internal/stubbing/defaultanswers/ReturnsMocks.java
@@ -4,21 +4,22 @@
  */
 package org.mockito.internal.stubbing.defaultanswers;
 
+import java.io.Serializable;
+
 import org.mockito.internal.MockitoCore;
 import org.mockito.internal.creation.MockSettingsImpl;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import java.io.Serializable;
-
+@SuppressWarnings("rawtypes")
 public class ReturnsMocks implements Answer<Object>, Serializable {
     
     private static final long serialVersionUID = -6755257986994634579L;
     private final MockitoCore mockitoCore = new MockitoCore();
     private final Answer<Object> delegate = new ReturnsMoreEmptyValues();
     
-    public Object answer(InvocationOnMock invocation) throws Throwable {
-        Object ret = delegate.answer(invocation);
+    public Object answer(final InvocationOnMock invocation) throws Throwable {
+        final Object ret = delegate.answer(invocation);
         if (ret != null) {
             return ret;
         }
@@ -26,7 +27,7 @@ public class ReturnsMocks implements Answer<Object>, Serializable {
         return returnValueFor(invocation.getMethod().getReturnType());
     }
 
-    Object returnValueFor(Class<?> clazz) {
+    Object returnValueFor(final Class<?> clazz) {
         if (!mockitoCore.isTypeMockable(clazz)) {
             return null;
         }

--- a/src/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNulls.java
+++ b/src/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNulls.java
@@ -10,9 +10,9 @@ import java.lang.reflect.Modifier;
 import org.mockito.Mockito;
 import org.mockito.exceptions.Reporter;
 import org.mockito.internal.debugging.LocationImpl;
-import org.mockito.invocation.Location;
 import org.mockito.internal.util.ObjectMethodsGuru;
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.invocation.Location;
 import org.mockito.stubbing.Answer;
 
 /**
@@ -33,6 +33,7 @@ import org.mockito.stubbing.Answer;
  * ReturnsSmartNulls will be probably the default return values strategy in
  * Mockito 2.0
  */
+@SuppressWarnings("rawtypes")
 public class ReturnsSmartNulls implements Answer<Object>, Serializable {
 
     private static final long serialVersionUID = 7618312406617949441L;
@@ -40,11 +41,11 @@ public class ReturnsSmartNulls implements Answer<Object>, Serializable {
     private final Answer<Object> delegate = new ReturnsMoreEmptyValues();
 
     public Object answer(final InvocationOnMock invocation) throws Throwable {
-        Object defaultReturnValue = delegate.answer(invocation);
+        final Object defaultReturnValue = delegate.answer(invocation);
         if (defaultReturnValue != null) {
             return defaultReturnValue;
         }
-        Class<?> type = invocation.getMethod().getReturnType();
+        final Class<?> type = invocation.getMethod().getReturnType();
         if (!type.isPrimitive() && !Modifier.isFinal(type.getModifiers())) {
             final Location location = new LocationImpl();
             return Mockito.mock(type, new ThrowsSmartNullPointer(invocation, location));
@@ -56,12 +57,12 @@ public class ReturnsSmartNulls implements Answer<Object>, Serializable {
         private final InvocationOnMock unstubbedInvocation;
         private final Location location;
 
-        public ThrowsSmartNullPointer(InvocationOnMock unstubbedInvocation, Location location) {
+        public ThrowsSmartNullPointer(final InvocationOnMock unstubbedInvocation, final Location location) {
             this.unstubbedInvocation = unstubbedInvocation;
             this.location = location;
         }
 
-        public Object answer(InvocationOnMock currentInvocation) throws Throwable {
+        public Object answer(final InvocationOnMock currentInvocation) throws Throwable {
             if (new ObjectMethodsGuru().isToString(currentInvocation.getMethod())) {
                 return "SmartNull returned by this unstubbed method call on a mock:\n" +
                         unstubbedInvocation.toString();

--- a/src/org/mockito/internal/util/Checks.java
+++ b/src/org/mockito/internal/util/Checks.java
@@ -8,18 +8,19 @@ package org.mockito.internal.util;
 /**
  * Pre-made preconditions
  */
+@SuppressWarnings("rawtypes")
 public class Checks {
 
-    public static <T> T checkNotNull(T value, String checkedValue) {
+    public static <T> T checkNotNull(final T value, final String checkedValue) {
         if(value == null) {
             throw new NullPointerException(checkedValue + " should not be null");
         }
         return value;
     }
 
-    public static <T extends Iterable> T checkItemsNotNull(T iterable, String checkedIterable) {
+    public static <T extends Iterable> T checkItemsNotNull(final T iterable, final String checkedIterable) {
         checkNotNull(iterable, checkedIterable);
-        for (Object item : iterable) {
+        for (final Object item : iterable) {
             checkNotNull(item, "item in " + checkedIterable);
         }
         return iterable;

--- a/src/org/mockito/internal/util/DefaultMockingDetails.java
+++ b/src/org/mockito/internal/util/DefaultMockingDetails.java
@@ -14,6 +14,7 @@ import org.mockito.invocation.Invocation;
  * Class to inspect any object, and identify whether a particular object is either a mock or a spy.  This is
  * a wrapper for {@link org.mockito.internal.util.MockUtil}.
  */
+@SuppressWarnings("rawtypes")
 public class DefaultMockingDetails implements MockingDetails {
 
     private final Object toInspect;

--- a/src/org/mockito/internal/util/DefaultMockingDetails.java
+++ b/src/org/mockito/internal/util/DefaultMockingDetails.java
@@ -4,11 +4,11 @@
  */
 package org.mockito.internal.util;
 
-import org.mockito.MockingDetails;
-import org.mockito.invocation.Invocation;
-
 import java.util.Collection;
 import java.util.Set;
+
+import org.mockito.MockingDetails;
+import org.mockito.invocation.Invocation;
 
 /**
  * Class to inspect any object, and identify whether a particular object is either a mock or a spy.  This is
@@ -19,32 +19,27 @@ public class DefaultMockingDetails implements MockingDetails {
     private final Object toInspect;
     private final MockUtil delegate;
 
-    public DefaultMockingDetails(Object toInspect, MockUtil delegate){
+    public DefaultMockingDetails(final Object toInspect, final MockUtil delegate){
         this.toInspect = toInspect;
         this.delegate = delegate;
     }
-
-    @Override
+    
     public boolean isMock(){
         return delegate.isMock(toInspect);
     }
-
-    @Override
+    
     public boolean isSpy(){
         return delegate.isSpy(toInspect);
     }
-
-    @Override
+    
     public Collection<Invocation> getInvocations() {
         return delegate.getMockHandler(toInspect).getInvocationContainer().getInvocations();
     }
 
-    @Override
     public Class<?> getMockedType() {
         return delegate.getMockHandler(toInspect).getMockSettings().getTypeToMock();
     }
-
-    @Override
+    
     @SuppressWarnings("unchecked")
     public Set<Class> getExtraInterfaces() {
         return delegate.getMockHandler(toInspect).getMockSettings().getExtraInterfaces();

--- a/src/org/mockito/internal/util/MockCreationValidator.java
+++ b/src/org/mockito/internal/util/MockCreationValidator.java
@@ -11,6 +11,7 @@ import org.mockito.exceptions.Reporter;
 import org.mockito.internal.util.reflection.Constructors;
 import org.mockito.mock.SerializableMode;
 
+@SuppressWarnings("rawtypes")
 public class MockCreationValidator {
 
     private final MockUtil mockUtil = new MockUtil();

--- a/src/org/mockito/internal/util/MockCreationValidator.java
+++ b/src/org/mockito/internal/util/MockCreationValidator.java
@@ -4,37 +4,36 @@
  */
 package org.mockito.internal.util;
 
+import java.io.Serializable;
+import java.util.Collection;
+
 import org.mockito.exceptions.Reporter;
 import org.mockito.internal.util.reflection.Constructors;
 import org.mockito.mock.SerializableMode;
 
-import java.io.Serializable;
-import java.util.Collection;
-
-@SuppressWarnings("unchecked")
 public class MockCreationValidator {
 
     private final MockUtil mockUtil = new MockUtil();
 
-    public void validateType(Class classToMock) {
+    public void validateType(final Class classToMock) {
         if (!mockUtil.isTypeMockable(classToMock)) {
             new Reporter().cannotMockFinalClass(classToMock);
         }
     }
 
-    public void validateExtraInterfaces(Class classToMock, Collection<Class> extraInterfaces) {
+    public void validateExtraInterfaces(final Class classToMock, final Collection<Class> extraInterfaces) {
         if (extraInterfaces == null) {
             return;
         }
 
-        for (Class i : extraInterfaces) {
+        for (final Class i : extraInterfaces) {
             if (classToMock == i) {
                 new Reporter().extraInterfacesCannotContainMockedType(classToMock);
             }
         }
     }
 
-    public void validateMockedType(Class classToMock, Object spiedInstance) {
+    public void validateMockedType(final Class classToMock, final Object spiedInstance) {
         if (classToMock == null || spiedInstance == null) {
             return;
         }
@@ -43,7 +42,7 @@ public class MockCreationValidator {
         }
     }
 
-    public void validateDelegatedInstance(Class classToMock, Object delegatedInstance) {
+    public void validateDelegatedInstance(final Class classToMock, final Object delegatedInstance) {
         if (classToMock == null || delegatedInstance == null) {
             return;
         }
@@ -52,7 +51,7 @@ public class MockCreationValidator {
         }
     }
 
-    public void validateSerializable(Class classToMock, boolean serializable) {
+    public void validateSerializable(final Class classToMock, final boolean serializable) {
         // We can't catch all the errors with this piece of code
         // Having a **superclass that do not implements Serializable** might fail as well when serialized
         // Though it might prevent issues when mockito is mocking a class without superclass.
@@ -65,7 +64,7 @@ public class MockCreationValidator {
         }
     }
 
-    public void validateConstructorUse(boolean usingConstructor, SerializableMode mode) {
+    public void validateConstructorUse(final boolean usingConstructor, final SerializableMode mode) {
         if (usingConstructor && mode == SerializableMode.ACROSS_CLASSLOADERS) {
             new Reporter().usingConstructorWithFancySerializable(mode);
         }

--- a/src/org/mockito/internal/util/MockNameImpl.java
+++ b/src/org/mockito/internal/util/MockNameImpl.java
@@ -4,9 +4,9 @@
  */
 package org.mockito.internal.util;
 
-import org.mockito.mock.MockName;
-
 import java.io.Serializable;
+
+import org.mockito.mock.MockName;
 
 public class MockNameImpl implements MockName, Serializable {
     
@@ -14,8 +14,7 @@ public class MockNameImpl implements MockName, Serializable {
     private final String mockName;
     private boolean defaultName;
 
-    @SuppressWarnings("unchecked")
-    public MockNameImpl(String mockName, Class classToMock) {
+    public MockNameImpl(final String mockName, final Class classToMock) {
         if (mockName == null) {
             this.mockName = toInstanceName(classToMock);
             this.defaultName = true;
@@ -24,11 +23,11 @@ public class MockNameImpl implements MockName, Serializable {
         }
     }
 
-    public MockNameImpl(String mockName) {
+    public MockNameImpl(final String mockName) {
         this.mockName = mockName;
     }
 
-    private static String toInstanceName(Class<?> clazz) {
+    private static String toInstanceName(final Class<?> clazz) {
         String className = clazz.getSimpleName();
         if (className.length() == 0) {
             //it's an anonymous class, let's get name from the parent

--- a/src/org/mockito/internal/util/MockNameImpl.java
+++ b/src/org/mockito/internal/util/MockNameImpl.java
@@ -8,6 +8,7 @@ import java.io.Serializable;
 
 import org.mockito.mock.MockName;
 
+@SuppressWarnings("rawtypes")
 public class MockNameImpl implements MockName, Serializable {
     
     private static final long serialVersionUID = 8014974700844306925L;

--- a/src/org/mockito/internal/util/MockUtil.java
+++ b/src/org/mockito/internal/util/MockUtil.java
@@ -4,6 +4,8 @@
  */
 package org.mockito.internal.util;
 
+import java.lang.reflect.Modifier;
+
 import org.mockito.Mockito;
 import org.mockito.exceptions.misusing.NotAMockException;
 import org.mockito.internal.InternalMockHandler;
@@ -16,23 +18,21 @@ import org.mockito.mock.MockCreationSettings;
 import org.mockito.mock.MockName;
 import org.mockito.plugins.MockMaker;
 
-import java.lang.reflect.Modifier;
-
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class MockUtil {
 
-    private static final MockMaker mockMaker = Plugins.getMockMaker();
+    private static final MockMaker MOCK_MAKER = Plugins.getMockMaker();
 
-    public boolean isTypeMockable(Class<?> type) {
+    public boolean isTypeMockable(final Class<?> type) {
       return !type.isPrimitive() && !Modifier.isFinal(type.getModifiers());
     }
 
-    public <T> T createMock(MockCreationSettings<T> settings) {
-        MockHandler mockHandler = new MockHandlerFactory().create(settings);
+    public <T> T createMock(final MockCreationSettings<T> settings) {
+        final MockHandler mockHandler = new MockHandlerFactory().create(settings);
 
-        T mock = mockMaker.createMock(settings, mockHandler);
+        final T mock = MOCK_MAKER.createMock(settings, mockHandler);
 
-        Object spiedInstance = settings.getSpiedInstance();
+        final Object spiedInstance = settings.getSpiedInstance();
         if (spiedInstance != null) {
             new LenientCopyTool().copyToMock(spiedInstance, mock);
         }
@@ -40,53 +40,53 @@ public class MockUtil {
         return mock;
     }
 
-    public <T> void resetMock(T mock) {
-        InternalMockHandler oldHandler = (InternalMockHandler) getMockHandler(mock);
-        MockCreationSettings settings = oldHandler.getMockSettings();
-        MockHandler newHandler = new MockHandlerFactory().create(settings);
+    public <T> void resetMock(final T mock) {
+        final InternalMockHandler oldHandler = getMockHandler(mock);
+        final MockCreationSettings settings = oldHandler.getMockSettings();
+        final MockHandler newHandler = new MockHandlerFactory().create(settings);
 
-        mockMaker.resetMock(mock, newHandler, settings);
+        MOCK_MAKER.resetMock(mock, newHandler, settings);
     }
 
-    public <T> InternalMockHandler<T> getMockHandler(T mock) {
+    public <T> InternalMockHandler<T> getMockHandler(final T mock) {
         if (mock == null) {
             throw new NotAMockException("Argument should be a mock, but is null!");
         }
 
         if (isMockitoMock(mock)) {
-            MockHandler handler = mockMaker.getHandler(mock);
+            final MockHandler handler = MOCK_MAKER.getHandler(mock);
             return (InternalMockHandler) handler;
         } else {
             throw new NotAMockException("Argument should be a mock, but is: " + mock.getClass());
         }
     }
 
-    public boolean isMock(Object mock) {
+    public boolean isMock(final Object mock) {
         // double check to avoid classes that have the same interfaces, could be great to have a custom mockito field in the proxy instead of relying on instance fields
         return isMockitoMock(mock);
     }
 
-    public boolean isSpy(Object mock) {
+    public boolean isSpy(final Object mock) {
         return isMockitoMock(mock) && getMockSettings(mock).getDefaultAnswer() == Mockito.CALLS_REAL_METHODS;
     }
 
-    private <T> boolean isMockitoMock(T mock) {
-        return mockMaker.getHandler(mock) != null;
+    private <T> boolean isMockitoMock(final T mock) {
+        return MOCK_MAKER.getHandler(mock) != null;
     }
 
-    public MockName getMockName(Object mock) {
+    public MockName getMockName(final Object mock) {
         return getMockHandler(mock).getMockSettings().getMockName();
     }
 
-    public void maybeRedefineMockName(Object mock, String newName) {
-        MockName mockName = getMockName(mock);
+    public void maybeRedefineMockName(final Object mock, final String newName) {
+        final MockName mockName = getMockName(mock);
         //TODO SF hacky...
         if (mockName.isDefault() && getMockHandler(mock).getMockSettings() instanceof CreationSettings) {
             ((CreationSettings) getMockHandler(mock).getMockSettings()).setMockName(new MockNameImpl(newName));
         }
     }
 
-    public MockCreationSettings getMockSettings(Object mock) {
+    public MockCreationSettings getMockSettings(final Object mock) {
         return getMockHandler(mock).getMockSettings();
     }
 }

--- a/src/org/mockito/internal/util/collections/ArrayUtils.java
+++ b/src/org/mockito/internal/util/collections/ArrayUtils.java
@@ -4,10 +4,9 @@
  */
 package org.mockito.internal.util.collections;
 
-@SuppressWarnings("unchecked")
 public class ArrayUtils {
 
-    public <T> boolean isEmpty(T[] array) {
+    public <T> boolean isEmpty(final T[] array) {
         return array == null || array.length == 0;
     }
 

--- a/src/org/mockito/internal/util/collections/HashCodeAndEqualsMockWrapper.java
+++ b/src/org/mockito/internal/util/collections/HashCodeAndEqualsMockWrapper.java
@@ -28,7 +28,7 @@ public class HashCodeAndEqualsMockWrapper {
 
     private final Object mockInstance;
 
-    public HashCodeAndEqualsMockWrapper(Object mockInstance) {
+    public HashCodeAndEqualsMockWrapper(final Object mockInstance) {
         this.mockInstance = mockInstance;
     }
 
@@ -37,11 +37,15 @@ public class HashCodeAndEqualsMockWrapper {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof HashCodeAndEqualsMockWrapper)) return false;
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof HashCodeAndEqualsMockWrapper)) {
+            return false;
+        }
 
-        HashCodeAndEqualsMockWrapper that = (HashCodeAndEqualsMockWrapper) o;
+        final HashCodeAndEqualsMockWrapper that = (HashCodeAndEqualsMockWrapper) o;
 
         return mockInstance == that.mockInstance;
     }
@@ -51,12 +55,12 @@ public class HashCodeAndEqualsMockWrapper {
         return System.identityHashCode(mockInstance);
     }
 
-    public static HashCodeAndEqualsMockWrapper of(Object mock) {
+    public static HashCodeAndEqualsMockWrapper of(final Object mock) {
         return new HashCodeAndEqualsMockWrapper(mock);
     }
 
     @Override public String toString() {
-        MockUtil mockUtil = new MockUtil();
+        final MockUtil mockUtil = new MockUtil();
         return "HashCodeAndEqualsMockWrapper{" +
                 "mockInstance=" + (mockUtil.isMock(mockInstance) ? mockUtil.getMockName(mockInstance) : typeInstanceString()) +
                 '}';

--- a/src/org/mockito/internal/util/collections/HashCodeAndEqualsSafeSet.java
+++ b/src/org/mockito/internal/util/collections/HashCodeAndEqualsSafeSet.java
@@ -29,6 +29,7 @@ import org.mockito.internal.util.Checks;
  *
  * @see HashCodeAndEqualsMockWrapper
  */
+@SuppressWarnings("unchecked")
 public class HashCodeAndEqualsSafeSet implements Set<Object> {
 
     private final HashSet<HashCodeAndEqualsMockWrapper> backingHashSet = new HashSet<HashCodeAndEqualsMockWrapper>();

--- a/src/org/mockito/internal/util/collections/HashCodeAndEqualsSafeSet.java
+++ b/src/org/mockito/internal/util/collections/HashCodeAndEqualsSafeSet.java
@@ -4,7 +4,7 @@
  */
 package org.mockito.internal.util.collections;
 
-import org.mockito.internal.util.Checks;
+import static java.lang.reflect.Array.newInstance;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -12,7 +12,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
-import static java.lang.reflect.Array.*;
+import org.mockito.internal.util.Checks;
 
 /**
  * hashCode and equals safe hash based set.
@@ -59,15 +59,15 @@ public class HashCodeAndEqualsSafeSet implements Set<Object> {
         return backingHashSet.isEmpty();
     }
 
-    public boolean contains(Object mock) {
+    public boolean contains(final Object mock) {
         return backingHashSet.contains(HashCodeAndEqualsMockWrapper.of(mock));
     }
 
-    public boolean add(Object mock) {
+    public boolean add(final Object mock) {
         return backingHashSet.add(HashCodeAndEqualsMockWrapper.of(mock));
     }
 
-    public boolean remove(Object mock) {
+    public boolean remove(final Object mock) {
         return backingHashSet.remove(HashCodeAndEqualsMockWrapper.of(mock));
     }
 
@@ -79,11 +79,11 @@ public class HashCodeAndEqualsSafeSet implements Set<Object> {
         throw new CloneNotSupportedException();
     }
 
-    @Override public boolean equals(Object o) {
+    @Override public boolean equals(final Object o) {
         if (!(o instanceof HashCodeAndEqualsSafeSet)) {
             return false;
         }
-        HashCodeAndEqualsSafeSet that = (HashCodeAndEqualsSafeSet) o;
+        final HashCodeAndEqualsSafeSet that = (HashCodeAndEqualsSafeSet) o;
         return backingHashSet.equals(that.backingHashSet);
     }
 
@@ -95,8 +95,8 @@ public class HashCodeAndEqualsSafeSet implements Set<Object> {
         return unwrapTo(new Object[size()]);
     }
 
-    private <T> T[] unwrapTo(T[] array) {
-        Iterator<Object> iterator = iterator();
+    private <T> T[] unwrapTo(final T[] array) {
+        final Iterator<Object> iterator = iterator();
         for (int i = 0, objectsLength = array.length; i < objectsLength; i++) {
             if (iterator.hasNext()) {
                 array[i] = (T) iterator.next();
@@ -106,33 +106,33 @@ public class HashCodeAndEqualsSafeSet implements Set<Object> {
     }
 
 
-    public <T> T[] toArray(T[] typedArray) {
-        T[] array = typedArray.length >= size() ? typedArray :
-                (T[]) newInstance(typedArray.getClass().getComponentType(), size());
+    public <T> T[] toArray(final T[] typedArray) {
+        final T[] array = typedArray.length >= size() ? typedArray
+                : (T[]) newInstance(typedArray.getClass().getComponentType(), size());
         return unwrapTo(array);
     }
 
-    public boolean removeAll(Collection<?> mocks) {
+    public boolean removeAll(final Collection<?> mocks) {
         return backingHashSet.removeAll(asWrappedMocks(mocks));
     }
 
-    public boolean containsAll(Collection<?> mocks) {
+    public boolean containsAll(final Collection<?> mocks) {
         return backingHashSet.containsAll(asWrappedMocks(mocks));
     }
 
-    public boolean addAll(Collection<?> mocks) {
+    public boolean addAll(final Collection<?> mocks) {
         return backingHashSet.addAll(asWrappedMocks(mocks));
     }
 
-    public boolean retainAll(Collection<?> mocks) {
+    public boolean retainAll(final Collection<?> mocks) {
         return backingHashSet.retainAll(asWrappedMocks(mocks));
     }
 
-    private HashSet<HashCodeAndEqualsMockWrapper> asWrappedMocks(Collection<?> mocks) {
+    private HashSet<HashCodeAndEqualsMockWrapper> asWrappedMocks(final Collection<?> mocks) {
         Checks.checkNotNull(mocks, "Passed collection should notify() be null");
-        HashSet<HashCodeAndEqualsMockWrapper> hashSet = new HashSet<HashCodeAndEqualsMockWrapper>();
-        for (Object mock : mocks) {
-            assert ! (mock instanceof HashCodeAndEqualsMockWrapper) : "WRONG";
+        final HashSet<HashCodeAndEqualsMockWrapper> hashSet = new HashSet<HashCodeAndEqualsMockWrapper>();
+        for (final Object mock : mocks) {
+            assert !(mock instanceof HashCodeAndEqualsMockWrapper) : "WRONG";
             hashSet.add(HashCodeAndEqualsMockWrapper.of(mock));
         }
         return hashSet;
@@ -142,14 +142,14 @@ public class HashCodeAndEqualsSafeSet implements Set<Object> {
         return backingHashSet.toString();
     }
 
-    public static HashCodeAndEqualsSafeSet of(Object... mocks) {
+    public static HashCodeAndEqualsSafeSet of(final Object... mocks) {
         return of(Arrays.asList(mocks));
     }
 
-    public static HashCodeAndEqualsSafeSet of(Iterable<Object> objects) {
-        HashCodeAndEqualsSafeSet hashCodeAndEqualsSafeSet = new HashCodeAndEqualsSafeSet();
+    public static HashCodeAndEqualsSafeSet of(final Iterable<Object> objects) {
+        final HashCodeAndEqualsSafeSet hashCodeAndEqualsSafeSet = new HashCodeAndEqualsSafeSet();
         if (objects != null) {
-            for (Object mock : objects) {
+            for (final Object mock : objects) {
                 hashCodeAndEqualsSafeSet.add(mock);
             }
         }

--- a/src/org/mockito/internal/util/collections/IdentitySet.java
+++ b/src/org/mockito/internal/util/collections/IdentitySet.java
@@ -6,13 +6,13 @@ package org.mockito.internal.util.collections;
 
 import java.util.LinkedList;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class IdentitySet {
 
     LinkedList list = new LinkedList();
     
-    public boolean contains(Object o) {
-        for(Object existing:list) {
+    public boolean contains(final Object o) {
+        for(final Object existing:list) {
             if (existing == o) {
                 return true;
             }
@@ -20,7 +20,7 @@ public class IdentitySet {
         return false;
     }
 
-    public void add(Object o) {
+    public void add(final Object o) {
         list.add(o);        
     }
 }

--- a/src/org/mockito/internal/util/collections/Sets.java
+++ b/src/org/mockito/internal/util/collections/Sets.java
@@ -5,18 +5,17 @@
 package org.mockito.internal.util.collections;
 
 
-import java.util.HashSet;
+import static java.util.Arrays.asList;
+
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import static java.util.Arrays.asList;
-
 public abstract class Sets {
-    public static Set<Object> newMockSafeHashSet(Iterable<Object> mocks) {
+    public static Set<Object> newMockSafeHashSet(final Iterable<Object> mocks) {
         return HashCodeAndEqualsSafeSet.of(mocks);
     }
 
-    public static Set<Object> newMockSafeHashSet(Object... mocks) {
+    public static Set<Object> newMockSafeHashSet(final Object... mocks) {
         return HashCodeAndEqualsSafeSet.of(mocks);
     }
 
@@ -24,7 +23,7 @@ public abstract class Sets {
         return new IdentitySet();
     }
 
-    public static <T> Set<T> newSet(T ... elements) {
+    public static <T> Set<T> newSet(final T ... elements) {
         if (elements == null) {
             throw new IllegalArgumentException("Expected an array of elements (or empty array) but received a null.");
         }

--- a/src/org/mockito/internal/util/io/IOUtil.java
+++ b/src/org/mockito/internal/util/io/IOUtil.java
@@ -1,11 +1,18 @@
 package org.mockito.internal.util.io;
 
-import org.mockito.exceptions.base.MockitoException;
-
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+
+import org.mockito.exceptions.base.MockitoException;
 
 /**
  * IO utils. A bit of reinventing the wheel but we don't want extra dependencies at this stage and we want to be java.
@@ -15,27 +22,27 @@ public class IOUtil {
     /**
      * Writes text to file
      */
-    public static void writeText(String text, File output) {
+    public static void writeText(final String text, final File output) {
         PrintWriter pw = null;
         try {
             pw = new PrintWriter(new FileWriter(output));
             pw.write(text);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             throw new MockitoException("Problems writing text to file: " + output, e);
         } finally {
             close(pw);
         }
     }
 
-    public static Collection<String> readLines(InputStream is) {
-        List<String> out = new LinkedList<String>();
-        BufferedReader r = new BufferedReader(new InputStreamReader(is));
+    public static Collection<String> readLines(final InputStream is) {
+        final List<String> out = new LinkedList<String>();
+        final BufferedReader r = new BufferedReader(new InputStreamReader(is));
         String line;
         try {
             while((line = r.readLine()) != null) {
                 out.add(line);
             }
-        } catch (IOException e) {
+        } catch (final IOException e) {
             throw new MockitoException("Problems reading from: " + is, e);
         }
         return out;
@@ -46,10 +53,10 @@ public class IOUtil {
      *
      * @param closeable the target, may be null
      */
-    public static void closeQuietly(Closeable closeable) {
+    public static void closeQuietly(final Closeable closeable) {
         try {
             close(closeable);
-        } catch (MockitoException ignored) {
+        } catch (final MockitoException ignored) {
             //ignore, for backwards compatibility
         }
     }
@@ -59,11 +66,11 @@ public class IOUtil {
      *
      * @param closeable the target, may be null
      */
-    public static void close(Closeable closeable) {
+    public static void close(final Closeable closeable) {
         if (closeable != null) {
             try {
                 closeable.close();
-            } catch (IOException e) {
+            } catch (final IOException e) {
                 throw new MockitoException("Problems closing stream: " + closeable, e);
             }
         }

--- a/src/org/mockito/internal/util/reflection/GenericMaster.java
+++ b/src/org/mockito/internal/util/reflection/GenericMaster.java
@@ -8,7 +8,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 
-@SuppressWarnings("unchecked")
 public class GenericMaster {
 
     /**
@@ -16,10 +15,10 @@ public class GenericMaster {
      * 
      * @param field
      */
-    public Class getGenericType(Field field) {        
-        Type generic = field.getGenericType();
+    public Class getGenericType(final Field field) {        
+        final Type generic = field.getGenericType();
         if (generic instanceof ParameterizedType) {
-            Type actual = ((ParameterizedType) generic).getActualTypeArguments()[0];
+            final Type actual = ((ParameterizedType) generic).getActualTypeArguments()[0];
             if (actual instanceof Class) {
                 return (Class) actual;
             } else if (actual instanceof ParameterizedType) {

--- a/src/org/mockito/internal/util/reflection/GenericMaster.java
+++ b/src/org/mockito/internal/util/reflection/GenericMaster.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 
+@SuppressWarnings("rawtypes")
 public class GenericMaster {
 
     /**

--- a/src/org/mockito/internal/util/reflection/GenericMetadataSupport.java
+++ b/src/org/mockito/internal/util/reflection/GenericMetadataSupport.java
@@ -4,7 +4,6 @@
  */
 package org.mockito.internal.util.reflection;
 
-
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -32,14 +31,14 @@ import org.mockito.internal.util.Checks;
  * </p>
  *
  * <p>
- *     Hence :
- *     <ul>
+ * Hence :
+ * <ul>
  *         <li>A new instance representing the metadata is created using the {@link #inferFrom(Type)} method from a real
  *         <code>Class</code> or from a <code>ParameterizedType</code>, other types are not yet supported.</li>
  *
  *         <li>Then from this metadata, we can extract meta-data for a generic return type of a method, using
  *         {@link #resolveGenericReturnType(Method)}.</li>
- *     </ul>
+ * </ul>
  * </p>
  *
  * <p>
@@ -62,6 +61,7 @@ import org.mockito.internal.util.Checks;
  * @see #resolveGenericReturnType(Method)
  * @see org.mockito.internal.stubbing.defaultanswers.ReturnsDeepStubs
  */
+@SuppressWarnings("rawtypes")
 public abstract class GenericMetadataSupport {
 
     // public static MockitoLogger logger = new ConsoleMockitoLogger();
@@ -70,7 +70,6 @@ public abstract class GenericMetadataSupport {
      * Represents actual type variables resolved for current class.
      */
     protected Map<TypeVariable, Type> contextualActualTypeParameters = new HashMap<TypeVariable, Type>();
-
 
     protected void registerTypeVariablesOn(final Type classType) {
         if (!(classType instanceof ParameterizedType)) {
@@ -88,7 +87,6 @@ public abstract class GenericMetadataSupport {
             } else if (typeParameter != actualTypeArgument) {
                 contextualActualTypeParameters.put(typeParameter, actualTypeArgument);
             }
-            // logger.log("For '" + parameterizedType + "' found type variable : { '" + typeParameter + "(" + System.identityHashCode(typeParameter) + ")" + "' : '" + actualTypeArgument + "(" + System.identityHashCode(typeParameter) + ")" + "' }");
         }
     }
 
@@ -101,14 +99,14 @@ public abstract class GenericMetadataSupport {
     private void registerTypeVariableIfNotPresent(final TypeVariable typeVariable) {
         if (!contextualActualTypeParameters.containsKey(typeVariable)) {
             contextualActualTypeParameters.put(typeVariable, boundsOf(typeVariable));
-            // logger.log("For '" + typeVariable.getGenericDeclaration() + "' found type variable : { '" + typeVariable + "(" + System.identityHashCode(typeVariable) + ")" + "' : '" + boundsOf(typeVariable) + "' }");
         }
     }
 
     /**
-     * @param typeParameter The TypeVariable parameter
-     * @return A {@link BoundedType} for easy bound information, if first bound is a TypeVariable
-     *         then retrieve BoundedType of this TypeVariable
+     * @param typeParameter
+     *            The TypeVariable parameter
+     * @return A {@link BoundedType} for easy bound information, if first bound
+     *         is a TypeVariable then retrieve BoundedType of this TypeVariable
      */
     private BoundedType boundsOf(final TypeVariable typeParameter) {
         if (typeParameter.getBounds()[0] instanceof TypeVariable) {
@@ -118,15 +116,19 @@ public abstract class GenericMetadataSupport {
     }
 
     /**
-     * @param wildCard The WildCard type
-     * @return A {@link BoundedType} for easy bound information, if first bound is a TypeVariable
-     *         then retrieve BoundedType of this TypeVariable
+     * @param wildCard
+     *            The WildCard type
+     * @return A {@link BoundedType} for easy bound information, if first bound
+     *         is a TypeVariable then retrieve BoundedType of this TypeVariable
      */
     private BoundedType boundsOf(final WildcardType wildCard) {
         /*
-         *  According to JLS(http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues.html#4.5.1):
-         *  - Lower and upper can't coexist: (for instance, this is not allowed: <? extends List<String> & super MyInterface>)
-         *  - Multiple bounds are not supported (for instance, this is not allowed: <? extends List<String> & MyInterface>)
+         * According to
+         * JLS(http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues
+         * .html#4.5.1): - Lower and upper can't coexist: (for instance, this is
+         * not allowed: <? extends List<String> & super MyInterface>) - Multiple
+         * bounds are not supported (for instance, this is not allowed: <?
+         * extends List<String> & MyInterface>)
          */
 
         final WildCardBoundedType wildCardBoundedType = new WildCardBoundedType(wildCard);
@@ -137,40 +139,38 @@ public abstract class GenericMetadataSupport {
         return wildCardBoundedType;
     }
 
-
-
     /**
      * @return Raw type of the current instance.
      */
     public abstract Class<?> rawType();
 
-
-
     /**
-     * @return Returns extra interfaces <strong>if relevant</strong>, otherwise empty List.
+     * @return Returns extra interfaces <strong>if relevant</strong>, otherwise
+     *         empty List.
      */
     public List<Type> extraInterfaces() {
         return Collections.emptyList();
     }
 
     /**
-     * @return Returns an array with the raw types of {@link #extraInterfaces()} <strong>if relevant</strong>.
+     * @return Returns an array with the raw types of {@link #extraInterfaces()}
+     *         <strong>if relevant</strong>.
      */
     public Class<?>[] rawExtraInterfaces() {
         return new Class[0];
     }
 
     /**
-     * @return Returns true if metadata knows about extra-interfaces {@link #extraInterfaces()} <strong>if relevant</strong>.
+     * @return Returns true if metadata knows about extra-interfaces
+     *         {@link #extraInterfaces()} <strong>if relevant</strong>.
      */
     public boolean hasRawExtraInterfaces() {
         return rawExtraInterfaces().length > 0;
     }
 
-
-
     /**
-     * @return Actual type arguments matching the type variables of the raw type represented by this {@link GenericMetadataSupport} instance.
+     * @return Actual type arguments matching the type variables of the raw type
+     *         represented by this {@link GenericMetadataSupport} instance.
      */
     public Map<TypeVariable, Type> actualTypeArguments() {
         final TypeVariable[] typeParameters = rawType().getTypeParameters();
@@ -181,7 +181,6 @@ public abstract class GenericMetadataSupport {
             final Type actualType = getActualTypeArgumentFor(typeParameter);
 
             actualTypeArguments.put(typeParameter, actualType);
-            // logger.log("For '" + rawType().getCanonicalName() + "' returning explicit TypeVariable : { '" + typeParameter + "(" + System.identityHashCode(typeParameter) + ")" + "' : '" + actualType +"' }");
         }
 
         return actualTypeArguments;
@@ -197,17 +196,17 @@ public abstract class GenericMetadataSupport {
         return type;
     }
 
-
-
     /**
-     * Resolve current method generic return type to a {@link GenericMetadataSupport}.
+     * Resolve current method generic return type to a
+     * {@link GenericMetadataSupport}.
      *
-     * @param method Method to resolve the return type.
-     * @return {@link GenericMetadataSupport} representing this generic return type.
+     * @param method
+     *            Method to resolve the return type.
+     * @return {@link GenericMetadataSupport} representing this generic return
+     *         type.
      */
     public GenericMetadataSupport resolveGenericReturnType(final Method method) {
         final Type genericReturnType = method.getGenericReturnType();
-        // logger.log("Method '" + method.toGenericString() + "' has return type : " + genericReturnType.getClass().getInterfaces()[0].getSimpleName() + " : " + genericReturnType);
 
         if (genericReturnType instanceof Class) {
             return new NotGenericReturnTypeSupport(genericReturnType);
@@ -223,16 +222,22 @@ public abstract class GenericMetadataSupport {
     }
 
     /**
-     * Create an new instance of {@link GenericMetadataSupport} inferred from a {@link Type}.
+     * Create an new instance of {@link GenericMetadataSupport} inferred from a
+     * {@link Type}.
      *
      * <p>
-     *     At the moment <code>type</code> can only be a {@link Class} or a {@link ParameterizedType}, otherwise
-     *     it'll throw a {@link MockitoException}.
+     * At the moment <code>type</code> can only be a {@link Class} or a
+     * {@link ParameterizedType}, otherwise it'll throw a
+     * {@link MockitoException}.
      * </p>
      *
-     * @param type The class from which the {@link GenericMetadataSupport} should be built.
+     * @param type
+     *            The class from which the {@link GenericMetadataSupport} should
+     *            be built.
      * @return The new {@link GenericMetadataSupport}.
-     * @throws MockitoException Raised if type is not a {@link Class} or a {@link ParameterizedType}.
+     * @throws MockitoException
+     *             Raised if type is not a {@link Class} or a
+     *             {@link ParameterizedType}.
      */
     public static GenericMetadataSupport inferFrom(final Type type) {
         Checks.checkNotNull(type, "type");
@@ -246,16 +251,17 @@ public abstract class GenericMetadataSupport {
         throw new MockitoException("Type meta-data for this Type (" + type.getClass().getCanonicalName() + ") is not supported : " + type);
     }
 
-
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    //// Below are specializations of GenericMetadataSupport that could handle retrieval of possible Types
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // // Below are specializations of GenericMetadataSupport that could handle
+    // retrieval of possible Types
+    // //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     /**
      * Generic metadata implementation for {@link Class}.
      *
-     * Offer support to retrieve generic metadata on a {@link Class} by reading type parameters and type variables on
-     * the class and its ancestors and interfaces.
+     * Offer support to retrieve generic metadata on a {@link Class} by reading
+     * type parameters and type variables on the class and its ancestors and
+     * interfaces.
      */
     private static class FromClassGenericMetadataSupport extends GenericMetadataSupport {
         private final Class<?> clazz;
@@ -263,10 +269,7 @@ public abstract class GenericMetadataSupport {
         public FromClassGenericMetadataSupport(final Class<?> clazz) {
             this.clazz = clazz;
 
-            for (Class currentExploredClass = clazz;
-                 currentExploredClass != null && currentExploredClass != Object.class;
-                 currentExploredClass = superClassOf(currentExploredClass)
-                ) {
+            for (Class currentExploredClass = clazz; currentExploredClass != null && currentExploredClass != Object.class; currentExploredClass = superClassOf(currentExploredClass)) {
                 readActualTypeParametersOnDeclaringClass(currentExploredClass);
             }
         }
@@ -294,17 +297,19 @@ public abstract class GenericMetadataSupport {
         }
     }
 
-
     /**
-     * Generic metadata implementation for "standalone" {@link ParameterizedType}.
+     * Generic metadata implementation for "standalone"
+     * {@link ParameterizedType}.
      *
-     * Offer support to retrieve generic metadata on a {@link ParameterizedType} by reading type variables of
-     * the related raw type and declared type variable of this parameterized type.
+     * Offer support to retrieve generic metadata on a {@link ParameterizedType}
+     * by reading type variables of the related raw type and declared type
+     * variable of this parameterized type.
      *
-     * This class is not designed to work on ParameterizedType returned by {@link Method#getGenericReturnType()}, as
-     * the ParameterizedType instance return in these cases could have Type Variables that refer to type declaration(s).
-     * That's what meant the "standalone" word at the beginning of the Javadoc.
-     * Instead use {@link ParameterizedReturnType}.
+     * This class is not designed to work on ParameterizedType returned by
+     * {@link Method#getGenericReturnType()}, as the ParameterizedType instance
+     * return in these cases could have Type Variables that refer to type
+     * declaration(s). That's what meant the "standalone" word at the beginning
+     * of the Javadoc. Instead use {@link ParameterizedReturnType}.
      */
     private static class FromParameterizedTypeGenericMetadataSupport extends GenericMetadataSupport {
         private final ParameterizedType parameterizedType;
@@ -325,9 +330,9 @@ public abstract class GenericMetadataSupport {
         }
     }
 
-
     /**
-     * Generic metadata specific to {@link ParameterizedType} returned via {@link Method#getGenericReturnType()}.
+     * Generic metadata specific to {@link ParameterizedType} returned via
+     * {@link Method#getGenericReturnType()}.
      */
     private static class ParameterizedReturnType extends GenericMetadataSupport {
         private final ParameterizedType parameterizedType;
@@ -357,16 +362,14 @@ public abstract class GenericMetadataSupport {
 
     }
 
-
     /**
-     * Generic metadata for {@link TypeVariable} returned via {@link Method#getGenericReturnType()}.
+     * Generic metadata for {@link TypeVariable} returned via
+     * {@link Method#getGenericReturnType()}.
      */
     private static class TypeVariableReturnType extends GenericMetadataSupport {
         private final TypeVariable typeVariable;
         private final TypeVariable[] typeParameters;
         private Class<?> rawType;
-
-
 
         public TypeVariableReturnType(final GenericMetadataSupport source, final TypeVariable[] typeParameters, final TypeVariable typeVariable) {
             this.typeParameters = typeParameters;
@@ -409,8 +412,9 @@ public abstract class GenericMetadataSupport {
             }
             if (type instanceof TypeVariable) {
                 /*
-                 * If type is a TypeVariable, then it is needed to gather data elsewhere. Usually TypeVariables are declared
-                 * on the class definition, such as such as List<E>.
+                 * If type is a TypeVariable, then it is needed to gather data
+                 * elsewhere. Usually TypeVariables are declared on the class
+                 * definition, such as such as List<E>.
                  */
                 return extractRawTypeOf(contextualActualTypeParameters.get(type));
             }
@@ -433,7 +437,8 @@ public abstract class GenericMetadataSupport {
         }
 
         /**
-         * @return Returns an array with the extracted raw types of {@link #extraInterfaces()}.
+         * @return Returns an array with the extracted raw types of
+         *         {@link #extraInterfaces()}.
          * @see #extractRawTypeOf(java.lang.reflect.Type)
          */
         public Class<?>[] rawExtraInterfaces() {
@@ -441,8 +446,9 @@ public abstract class GenericMetadataSupport {
             final List<Class<?>> rawExtraInterfaces = new ArrayList<Class<?>>();
             for (final Type extraInterface : extraInterfaces) {
                 final Class<?> rawInterface = extractRawTypeOf(extraInterface);
-                // avoid interface collision with actual raw type (with typevariables, resolution ca be quite aggressive)
-                if(!rawType().equals(rawInterface)) {
+                // avoid interface collision with actual raw type (with
+                // typevariables, resolution ca be quite aggressive)
+                if (!rawType().equals(rawInterface)) {
                     rawExtraInterfaces.add(rawInterface);
                 }
             }
@@ -452,26 +458,28 @@ public abstract class GenericMetadataSupport {
         private Type extractActualBoundedTypeOf(final Type type) {
             if (type instanceof TypeVariable) {
                 /*
-                If type is a TypeVariable, then it is needed to gather data elsewhere. Usually TypeVariables are declared
-                on the class definition, such as such as List<E>.
-                */
+                 * If type is a TypeVariable, then it is needed to gather data
+                 * elsewhere. Usually TypeVariables are declared on the class
+                 * definition, such as such as List<E>.
+                 */
                 return extractActualBoundedTypeOf(contextualActualTypeParameters.get(type));
             }
             if (type instanceof BoundedType) {
                 final Type actualFirstBound = extractActualBoundedTypeOf(((BoundedType) type).firstBound());
                 if (!(actualFirstBound instanceof BoundedType)) {
-                    return type; // avoid going one step further, ie avoid : O(TypeVar) -> K(TypeVar) -> Some ParamType
+                    return type; // avoid going one step further, ie avoid :
+                                 // O(TypeVar) -> K(TypeVar) -> Some ParamType
                 }
                 return actualFirstBound;
             }
-            return type; // irrelevant, we don't manage other types as they are not bounded.
+            return type; // irrelevant, we don't manage other types as they are
+                         // not bounded.
         }
     }
 
-
-
     /**
-     * Non-Generic metadata for {@link Class} returned via {@link Method#getGenericReturnType()}.
+     * Non-Generic metadata for {@link Class} returned via
+     * {@link Method#getGenericReturnType()}.
      */
     private static class NotGenericReturnTypeSupport extends GenericMetadataSupport {
         private final Class<?> returnType;
@@ -486,15 +494,15 @@ public abstract class GenericMetadataSupport {
         }
     }
 
-
-
     /**
      * Type representing bounds of a type
      *
      * @see TypeVarBoundedType
-     * @see <a href="http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues.html#4.4">http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues.html#4.4</a>
+     * @see <a
+     *      href="http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues.html#4.4">http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues.html#4.4</a>
      * @see WildCardBoundedType
-     * @see <a href="http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues.html#4.5.1">http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues.html#4.5.1</a>
+     * @see <a
+     *      href="http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues.html#4.5.1">http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues.html#4.5.1</a>
      */
     public interface BoundedType extends Type {
         Type firstBound();
@@ -503,46 +511,58 @@ public abstract class GenericMetadataSupport {
     }
 
     /**
-     * Type representing bounds of a type variable, allows to keep all bounds information.
+     * Type representing bounds of a type variable, allows to keep all bounds
+     * information.
      *
-     * <p>It uses the first bound in the array, as this array is never null and always contains at least
-     * one element (Object is always here if no bounds are declared).</p>
+     * <p>
+     * It uses the first bound in the array, as this array is never null and
+     * always contains at least one element (Object is always here if no bounds
+     * are declared).
+     * </p>
      *
-     * <p>If upper bounds are declared with SomeClass and additional interfaces, then firstBound will be SomeClass and
-     * interfacesBound will be an array of the additional interfaces.
+     * <p>
+     * If upper bounds are declared with SomeClass and additional interfaces,
+     * then firstBound will be SomeClass and interfacesBound will be an array of
+     * the additional interfaces.
      *
      * i.e. <code>SomeClass</code>.
-     * <pre class="code"><code class="java">
+     * 
+     * <pre class="code">
+     * <code class="java">
      *     interface UpperBoundedTypeWithClass<E extends Comparable<E> & Cloneable> {
      *         E get();
      *     }
      *     // will return Comparable type
-     * </code></pre>
+     * </code>
+     * </pre>
+     * 
      * </p>
      *
-     * @see <a href="http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues.html#4.4">http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues.html#4.4</a>
+     * @see <a
+     *      href="http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues.html#4.4">http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues.html#4.4</a>
      */
     public static class TypeVarBoundedType implements BoundedType {
         private final TypeVariable typeVariable;
-
 
         public TypeVarBoundedType(final TypeVariable typeVariable) {
             this.typeVariable = typeVariable;
         }
 
         /**
-         * @return either a class or an interface (parameterized or not), if no bounds declared Object is returned.
+         * @return either a class or an interface (parameterized or not), if no
+         *         bounds declared Object is returned.
          */
         public Type firstBound() {
             return typeVariable.getBounds()[0]; //
         }
 
         /**
-         * On a Type Variable (typeVar extends C_0 & I_1 & I_2 & etc), will return an array
-         * containing I_1 and I_2.
+         * On a Type Variable (typeVar extends C_0 & I_1 & I_2 & etc), will
+         * return an array containing I_1 and I_2.
          *
-         * @return other bounds for this type, these bounds can only be only interfaces as the JLS says,
-         * empty array if no other bound declared.
+         * @return other bounds for this type, these bounds can only be only
+         *         interfaces as the JLS says, empty array if no other bound
+         *         declared.
          */
         public Type[] interfaceBounds() {
             final Type[] interfaceBounds = new Type[typeVariable.getBounds().length - 1];
@@ -552,8 +572,12 @@ public abstract class GenericMetadataSupport {
 
         @Override
         public boolean equals(final Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             return typeVariable.equals(((TypeVarBoundedType) o).typeVariable);
 
@@ -575,23 +599,26 @@ public abstract class GenericMetadataSupport {
     }
 
     /**
-     * Type representing bounds of a wildcard, allows to keep all bounds information.
+     * Type representing bounds of a wildcard, allows to keep all bounds
+     * information.
      *
-     * <p>The JLS says that lower bound and upper bound are mutually exclusive, and that multiple bounds
-     * are not allowed.
+     * <p>
+     * The JLS says that lower bound and upper bound are mutually exclusive, and
+     * that multiple bounds are not allowed.
      *
-     * @see <a href="http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues.html#4.4">http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues.html#4.4</a>
+     * @see <a
+     *      href="http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues.html#4.4">http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues.html#4.4</a>
      */
     public static class WildCardBoundedType implements BoundedType {
         private final WildcardType wildcard;
-
 
         public WildCardBoundedType(final WildcardType wildcard) {
             this.wildcard = wildcard;
         }
 
         /**
-         * @return The first bound, either a type or a reference to a TypeVariable
+         * @return The first bound, either a type or a reference to a
+         *         TypeVariable
          */
         public Type firstBound() {
             final Type[] lowerBounds = wildcard.getLowerBounds();
@@ -609,8 +636,12 @@ public abstract class GenericMetadataSupport {
 
         @Override
         public boolean equals(final Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             return wildcard.equals(((TypeVarBoundedType) o).typeVariable);
 
@@ -632,5 +663,3 @@ public abstract class GenericMetadataSupport {
     }
 
 }
-
-

--- a/src/org/mockito/internal/util/reflection/InstanceField.java
+++ b/src/org/mockito/internal/util/reflection/InstanceField.java
@@ -4,10 +4,10 @@
  */
 package org.mockito.internal.util.reflection;
 
-import org.mockito.internal.util.Checks;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+
+import org.mockito.internal.util.Checks;
 
 /**
  * Represents an accessible instance field.
@@ -22,11 +22,13 @@ public class InstanceField {
     /**
      * Create a new InstanceField.
      *
-     * @param field The field that should be accessed, note that no checks are performed to ensure
-     *              the field belong to this instance class.
-     * @param instance The instance from which the field shall be accessed.
+     * @param field
+     *            The field that should be accessed, note that no checks are
+     *            performed to ensure the field belong to this instance class.
+     * @param instance
+     *            The instance from which the field shall be accessed.
      */
-    public InstanceField(Field field, Object instance) {
+    public InstanceField(final Field field, final Object instance) {
         this.field = Checks.checkNotNull(field, "field");
         this.instance = Checks.checkNotNull(instance, "instance");
     }
@@ -44,10 +46,11 @@ public class InstanceField {
     /**
      * Set the given value to the field of this instance.
      *
-     * @param value The value that should be written to the field.
+     * @param value
+     *            The value that should be written to the field.
      * @see FieldSetter
      */
-    public void set(Object value) {
+    public void set(final Object value) {
         new FieldSetter(instance, field).set(value);
     }
 
@@ -63,21 +66,25 @@ public class InstanceField {
     /**
      * Check if the field is annotated by the given annotation.
      *
-     * @param annotationClass The annotation type to check.
-     * @return <code>true</code> if the field is annotated by this annotation, else <code>false</code>.
+     * @param annotationClass
+     *            The annotation type to check.
+     * @return <code>true</code> if the field is annotated by this annotation,
+     *         else <code>false</code>.
      */
-    public boolean isAnnotatedBy(Class<? extends Annotation> annotationClass) {
+    public boolean isAnnotatedBy(final Class<? extends Annotation> annotationClass) {
         return field.isAnnotationPresent(annotationClass);
     }
 
     /**
      * Returns the annotation instance for the given annotation type.
      *
-     * @param annotationClass Tha annotation type to retrieve.
-     * @param <A> Type of the annotation.
+     * @param annotationClass
+     *            Tha annotation type to retrieve.
+     * @param <A>
+     *            Type of the annotation.
      * @return The annotation instance.
      */
-    public <A extends Annotation> A annotation(Class<A> annotationClass) {
+    public <A extends Annotation> A annotation(final Class<A> annotationClass) {
         return field.getAnnotation(annotationClass);
     }
 
@@ -107,11 +114,15 @@ public class InstanceField {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
-        InstanceField that = (InstanceField) o;
+        final InstanceField that = (InstanceField) o;
         return field.equals(that.field) && instance.equals(that.instance);
     }
 

--- a/src/org/mockito/internal/util/reflection/LenientCopyTool.java
+++ b/src/org/mockito/internal/util/reflection/LenientCopyTool.java
@@ -7,6 +7,7 @@ package org.mockito.internal.util.reflection;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
+@SuppressWarnings("rawtypes")
 public class LenientCopyTool {
 
     FieldCopier fieldCopier = new FieldCopier();

--- a/src/org/mockito/internal/util/reflection/LenientCopyTool.java
+++ b/src/org/mockito/internal/util/reflection/LenientCopyTool.java
@@ -7,40 +7,39 @@ package org.mockito.internal.util.reflection;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
-@SuppressWarnings("unchecked")
 public class LenientCopyTool {
 
     FieldCopier fieldCopier = new FieldCopier();
 
-    public <T> void copyToMock(T from, T mock) {
+    public <T> void copyToMock(final T from, final T mock) {
         copy(from, mock, from.getClass(), mock.getClass().getSuperclass());
     }
 
-    public <T> void copyToRealObject(T from, T to) {
+    public <T> void copyToRealObject(final T from, final T to) {
         copy(from, to, from.getClass(), to.getClass());
     }
 
-    private <T> void copy(T from, T to, Class fromClazz, Class toClass) {
+    private <T> void copy(final T from, final T to, Class fromClazz, final Class toClass) {
         while (fromClazz != Object.class) {
             copyValues(from, to, fromClazz);
             fromClazz = fromClazz.getSuperclass();
         }
     }
 
-    private <T> void copyValues(T from, T mock, Class classFrom) {
-        Field[] fields = classFrom.getDeclaredFields();
+    private <T> void copyValues(final T from, final T mock, final Class classFrom) {
+        final Field[] fields = classFrom.getDeclaredFields();
 
         for (int i = 0; i < fields.length; i++) {
             // ignore static fields
-            Field field = fields[i];
+            final Field field = fields[i];
             if (Modifier.isStatic(field.getModifiers())) {
                 continue;
             }
-            AccessibilityChanger accessibilityChanger = new AccessibilityChanger();
+            final AccessibilityChanger accessibilityChanger = new AccessibilityChanger();
             try {
                 accessibilityChanger.enableAccess(field);
                 fieldCopier.copyValue(from, mock, field);
-            } catch (Throwable t) {
+            } catch (final Throwable t) {
                 //Ignore - be lenient - if some field cannot be copied then let's be it
             } finally {
                 accessibilityChanger.safelyDisableAccess(field);

--- a/src/org/mockito/internal/verification/Calls.java
+++ b/src/org/mockito/internal/verification/Calls.java
@@ -5,39 +5,40 @@
 
 package org.mockito.internal.verification;
 
+import java.util.List;
+
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockito.internal.verification.api.VerificationData;
 import org.mockito.internal.verification.api.VerificationDataInOrder;
 import org.mockito.internal.verification.api.VerificationInOrderMode;
-import org.mockito.internal.verification.checkers.*;
+import org.mockito.internal.verification.checkers.MissingInvocationInOrderChecker;
+import org.mockito.internal.verification.checkers.NonGreedyNumberOfInvocationsInOrderChecker;
 import org.mockito.invocation.Invocation;
 import org.mockito.verification.VerificationMode;
-
-import java.util.List;
 
 public class Calls implements VerificationMode, VerificationInOrderMode {
 
     final int wantedCount;
 
-    public Calls(int wantedNumberOfInvocations) {
+    public Calls(final int wantedNumberOfInvocations) {
         if( wantedNumberOfInvocations <= 0 ) {
             throw new MockitoException( "Negative and zero values are not allowed here" );
         }
         this.wantedCount = wantedNumberOfInvocations;
     }
 
-    public void verify(VerificationData data) {
+    public void verify(final VerificationData data) {
         throw new MockitoException( "calls is only intended to work with InOrder" );
     }
 
-    public void verifyInOrder(VerificationDataInOrder data) {
-        List<Invocation> allInvocations = data.getAllInvocations();
-        InvocationMatcher wanted = data.getWanted();
+    public void verifyInOrder(final VerificationDataInOrder data) {
+        final List<Invocation> allInvocations = data.getAllInvocations();
+        final InvocationMatcher wanted = data.getWanted();
         
-        MissingInvocationInOrderChecker missingInvocation = new MissingInvocationInOrderChecker();
+        final MissingInvocationInOrderChecker missingInvocation = new MissingInvocationInOrderChecker();
         missingInvocation.check( allInvocations, wanted, this, data.getOrderingContext());
-        NonGreedyNumberOfInvocationsInOrderChecker numberOfCalls = new NonGreedyNumberOfInvocationsInOrderChecker();
+        final NonGreedyNumberOfInvocationsInOrderChecker numberOfCalls = new NonGreedyNumberOfInvocationsInOrderChecker();
         numberOfCalls.check( allInvocations, wanted, wantedCount, data.getOrderingContext());
     }    
     

--- a/src/org/mockito/internal/verification/DefaultRegisteredInvocations.java
+++ b/src/org/mockito/internal/verification/DefaultRegisteredInvocations.java
@@ -5,14 +5,14 @@
 
 package org.mockito.internal.verification;
 
+import java.io.Serializable;
+import java.util.LinkedList;
+import java.util.List;
+
 import org.mockito.internal.util.ObjectMethodsGuru;
 import org.mockito.internal.util.collections.ListUtil;
 import org.mockito.internal.util.collections.ListUtil.Filter;
 import org.mockito.invocation.Invocation;
-
-import java.io.Serializable;
-import java.util.LinkedList;
-import java.util.List;
 
 
 public class DefaultRegisteredInvocations implements RegisteredInvocations, Serializable {
@@ -20,7 +20,7 @@ public class DefaultRegisteredInvocations implements RegisteredInvocations, Seri
     private static final long serialVersionUID = -2674402327380736290L;
     private final LinkedList<Invocation> invocations = new LinkedList<Invocation>();
 
-    public void add(Invocation invocation) {
+    public void add(final Invocation invocation) {
         synchronized (invocations) {
             invocations.add(invocation);
         }
@@ -29,7 +29,7 @@ public class DefaultRegisteredInvocations implements RegisteredInvocations, Seri
     public void removeLast() {
         //TODO: add specific test for synchronization of this block (it is tested by InvocationContainerImplTest at the moment)
         synchronized (invocations) {
-            if (! invocations.isEmpty()) {
+            if (!invocations.isEmpty()) {
                 invocations.removeLast();
             }
         }
@@ -38,7 +38,7 @@ public class DefaultRegisteredInvocations implements RegisteredInvocations, Seri
     public List<Invocation> getAll() {
         List<Invocation> copiedList;
         synchronized (invocations) {
-            copiedList = new LinkedList<Invocation>(invocations) ;
+            copiedList = new LinkedList<Invocation>(invocations);
         }
 
         return ListUtil.filter(copiedList, new RemoveToString());
@@ -51,7 +51,7 @@ public class DefaultRegisteredInvocations implements RegisteredInvocations, Seri
     }
 
     private static class RemoveToString implements Filter<Invocation> {
-        public boolean isOut(Invocation invocation) {
+        public boolean isOut(final Invocation invocation) {
             return new ObjectMethodsGuru().isToString(invocation.getMethod());
         }
     }

--- a/src/org/mockito/internal/verification/NoMoreInteractions.java
+++ b/src/org/mockito/internal/verification/NoMoreInteractions.java
@@ -15,19 +15,20 @@ import org.mockito.internal.verification.api.VerificationInOrderMode;
 import org.mockito.invocation.Invocation;
 import org.mockito.verification.VerificationMode;
 
+@SuppressWarnings("rawtypes")
 public class NoMoreInteractions implements VerificationMode, VerificationInOrderMode {
 
     @SuppressWarnings("unchecked")
-    public void verify(VerificationData data) {
-        Invocation unverified = new InvocationsFinder().findFirstUnverified(data.getAllInvocations());
+    public void verify(final VerificationData data) {
+        final Invocation unverified = new InvocationsFinder().findFirstUnverified(data.getAllInvocations());
         if (unverified != null) {
             new Reporter().noMoreInteractionsWanted(unverified, (List) data.getAllInvocations());
         }
     }
 
-    public void verifyInOrder(VerificationDataInOrder data) {
-        List<Invocation> invocations = data.getAllInvocations();
-        Invocation unverified = new InvocationsFinder().findFirstUnverifiedInOrder(data.getOrderingContext(), invocations);
+    public void verifyInOrder(final VerificationDataInOrder data) {
+        final List<Invocation> invocations = data.getAllInvocations();
+        final Invocation unverified = new InvocationsFinder().findFirstUnverifiedInOrder(data.getOrderingContext(), invocations);
         
         if (unverified != null) {
             new Reporter().noMoreInteractionsWantedInOrder(unverified);

--- a/src/org/mockito/internal/verification/Only.java
+++ b/src/org/mockito/internal/verification/Only.java
@@ -14,6 +14,7 @@ import org.mockito.internal.verification.api.VerificationData;
 import org.mockito.invocation.Invocation;
 import org.mockito.verification.VerificationMode;
 
+@SuppressWarnings("rawtypes")
 public class Only implements VerificationMode {
 
     private final InvocationsFinder finder = new InvocationsFinder();
@@ -21,12 +22,12 @@ public class Only implements VerificationMode {
     private final Reporter reporter = new Reporter();
 
     @SuppressWarnings("unchecked")
-    public void verify(VerificationData data) {
-        InvocationMatcher wantedMatcher = data.getWanted();
-        List<Invocation> invocations = data.getAllInvocations();
-        List<Invocation> chunk = finder.findInvocations(invocations, wantedMatcher);
+    public void verify(final VerificationData data) {
+        final InvocationMatcher wantedMatcher = data.getWanted();
+        final List<Invocation> invocations = data.getAllInvocations();
+        final List<Invocation> chunk = finder.findInvocations(invocations, wantedMatcher);
         if (invocations.size() != 1 && chunk.size() > 0) {            
-            Invocation unverified = finder.findFirstUnverified(invocations);
+            final Invocation unverified = finder.findFirstUnverified(invocations);
             reporter.noMoreInteractionsWanted(unverified, (List) invocations);
         } else if (invocations.size() != 1 || chunk.size() == 0) {
             reporter.wantedButNotInvoked(wantedMatcher);

--- a/src/org/mockito/internal/verification/Only.java
+++ b/src/org/mockito/internal/verification/Only.java
@@ -24,7 +24,7 @@ public class Only implements VerificationMode {
     public void verify(VerificationData data) {
         InvocationMatcher wantedMatcher = data.getWanted();
         List<Invocation> invocations = data.getAllInvocations();
-        List<Invocation> chunk = finder.findInvocations(invocations,wantedMatcher);
+        List<Invocation> chunk = finder.findInvocations(invocations, wantedMatcher);
         if (invocations.size() != 1 && chunk.size() > 0) {            
             Invocation unverified = finder.findFirstUnverified(invocations);
             reporter.noMoreInteractionsWanted(unverified, (List) invocations);

--- a/src/org/mockito/internal/verification/RegisteredInvocations.java
+++ b/src/org/mockito/internal/verification/RegisteredInvocations.java
@@ -5,17 +5,14 @@
 
 package org.mockito.internal.verification;
 
-import org.mockito.internal.util.ObjectMethodsGuru;
-import org.mockito.internal.util.collections.ListUtil;
-import org.mockito.internal.util.collections.ListUtil.Filter;
-import org.mockito.invocation.Invocation;
-
 import java.util.List;
+
+import org.mockito.invocation.Invocation;
 
 
 public interface RegisteredInvocations {
 
-    void add(Invocation invocation);
+    void add(final Invocation invocation);
 
     void removeLast();
 

--- a/src/org/mockito/internal/verification/SingleRegisteredInvocation.java
+++ b/src/org/mockito/internal/verification/SingleRegisteredInvocation.java
@@ -5,17 +5,18 @@
 
 package org.mockito.internal.verification;
 
-import org.mockito.invocation.Invocation;
-
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
 
+import org.mockito.invocation.Invocation;
+
 public class SingleRegisteredInvocation implements RegisteredInvocations, Serializable {
 
+    private static final long serialVersionUID = 1252072993982392338L;
     private Invocation invocation;
 
-    public void add(Invocation invocation) {
+    public void add(final Invocation invocation) {
         this.invocation = invocation;
     }
 

--- a/src/org/mockito/internal/verification/VerificationOverTimeImpl.java
+++ b/src/org/mockito/internal/verification/VerificationOverTimeImpl.java
@@ -32,7 +32,7 @@ public class VerificationOverTimeImpl implements VerificationMode {
      *                        the delegate is satisfied and the full duration has passed (as in
      *                        {@link org.mockito.verification.VerificationAfterDelay}).
      */
-    public VerificationOverTimeImpl(long pollingPeriodMillis, long durationMillis, VerificationMode delegate, boolean returnOnSuccess) {
+    public VerificationOverTimeImpl(final long pollingPeriodMillis, final long durationMillis, final VerificationMode delegate, final boolean returnOnSuccess) {
         this(pollingPeriodMillis, delegate, returnOnSuccess, new Timer(durationMillis));
     }
 
@@ -47,7 +47,7 @@ public class VerificationOverTimeImpl implements VerificationMode {
      *                        {@link org.mockito.verification.VerificationAfterDelay}).
      * @param timer Checker of whether the duration of the verification is still acceptable
      */
-    public VerificationOverTimeImpl(long pollingPeriodMillis, VerificationMode delegate, boolean returnOnSuccess, Timer timer) {
+    public VerificationOverTimeImpl(final long pollingPeriodMillis, final VerificationMode delegate, final boolean returnOnSuccess, final Timer timer) {
         this.pollingPeriodMillis = pollingPeriodMillis;
         this.delegate = delegate;
         this.returnOnSuccess = returnOnSuccess;
@@ -69,7 +69,7 @@ public class VerificationOverTimeImpl implements VerificationMode {
      *
      * @throws MockitoAssertionError if the delegate verification mode does not succeed before the timeout
      */
-    public void verify(VerificationData data) {
+    public void verify(final VerificationData data) {
         AssertionError error = null;
 
         timer.start();
@@ -82,10 +82,9 @@ public class VerificationOverTimeImpl implements VerificationMode {
                 } else {
                     error = null;
                 }
-            } catch (MockitoAssertionError e) {
+            } catch (final MockitoAssertionError e) {
                 error = handleVerifyException(e);
-            }
-            catch (AssertionError e) {
+            } catch (final AssertionError e) {
                 error = handleVerifyException(e);
             }
         }
@@ -95,7 +94,7 @@ public class VerificationOverTimeImpl implements VerificationMode {
         }
     }
 
-    private AssertionError handleVerifyException(AssertionError e) {
+    private AssertionError handleVerifyException(final AssertionError e) {
         if (canRecoverFromFailure(delegate)) {
             sleep(pollingPeriodMillis);
             return e;
@@ -104,18 +103,18 @@ public class VerificationOverTimeImpl implements VerificationMode {
         }
     }
 
-    protected boolean canRecoverFromFailure(VerificationMode verificationMode) {
+    protected boolean canRecoverFromFailure(final VerificationMode verificationMode) {
         return !(verificationMode instanceof AtMost || verificationMode instanceof NoMoreInteractions);
     }
 
-    public VerificationOverTimeImpl copyWithVerificationMode(VerificationMode verificationMode) {
+    public VerificationOverTimeImpl copyWithVerificationMode(final VerificationMode verificationMode) {
         return new VerificationOverTimeImpl(pollingPeriodMillis, timer.duration(), verificationMode, returnOnSuccess);
     }
 
-    private void sleep(long sleep) {
+    private void sleep(final long sleep) {
         try {
             Thread.sleep(sleep);
-        } catch (InterruptedException ie) {
+        } catch (final InterruptedException ie) {
             throw new RuntimeException("Thread sleep has been interrupted", ie);
         }
     }

--- a/src/org/mockito/internal/verification/argumentmatching/ArgumentMatchingTool.java
+++ b/src/org/mockito/internal/verification/argumentmatching/ArgumentMatchingTool.java
@@ -11,20 +11,19 @@ import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
 import org.mockito.internal.matchers.ContainsExtraTypeInformation;
 
-@SuppressWarnings("unchecked")
 public class ArgumentMatchingTool {
 
     /**
      * Suspiciously not matching arguments are those that don't match, the toString() representation is the same but types are different.
      */
-    public Integer[] getSuspiciouslyNotMatchingArgsIndexes(List<Matcher> matchers, Object[] arguments) {
+    public Integer[] getSuspiciouslyNotMatchingArgsIndexes(final List<Matcher> matchers, final Object[] arguments) {
         if (matchers.size() != arguments.length) {
             return new Integer[0];
         }
         
-        List<Integer> suspicious = new LinkedList<Integer>();
+        final List<Integer> suspicious = new LinkedList<Integer>();
         int i = 0;
-        for (Matcher m : matchers) {
+        for (final Matcher m : matchers) {
             if (m instanceof ContainsExtraTypeInformation 
                     && !safelyMatches(m, arguments[i]) 
                     && toStringEquals(m, arguments[i])
@@ -36,15 +35,15 @@ public class ArgumentMatchingTool {
         return suspicious.toArray(new Integer[0]);
     }
 
-    private boolean safelyMatches(Matcher m, Object arg) {
+    private boolean safelyMatches(final Matcher m, final Object arg) {
         try {
             return m.matches(arg);
-        } catch (Throwable t) {
+        } catch (final Throwable t) {
             return false;
         }
     }
 
-    private boolean toStringEquals(Matcher m, Object arg) {
+    private boolean toStringEquals(final Matcher m, final Object arg) {
         return StringDescription.toString(m).equals(arg == null? "null" : arg.toString());
     }
 }

--- a/src/org/mockito/internal/verification/argumentmatching/ArgumentMatchingTool.java
+++ b/src/org/mockito/internal/verification/argumentmatching/ArgumentMatchingTool.java
@@ -11,6 +11,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
 import org.mockito.internal.matchers.ContainsExtraTypeInformation;
 
+@SuppressWarnings("rawtypes")
 public class ArgumentMatchingTool {
 
     /**

--- a/src/org/mockito/invocation/Invocation.java
+++ b/src/org/mockito/invocation/Invocation.java
@@ -14,6 +14,7 @@ package org.mockito.invocation;
  *
  * @since 1.9.5
  */
+@SuppressWarnings("rawtypes")
 public interface Invocation extends InvocationOnMock, DescribedInvocation {
 
     /**
@@ -66,7 +67,7 @@ public interface Invocation extends InvocationOnMock, DescribedInvocation {
      *
      * @param stubInfo the information about stubbing.
      */
-    void markStubbed(StubInfo stubInfo);
+    void markStubbed(final StubInfo stubInfo);
 
     /**
      * Informs if the invocation participates in verify-no-more-invocations or verification in order.

--- a/src/org/mockito/mock/MockCreationSettings.java
+++ b/src/org/mockito/mock/MockCreationSettings.java
@@ -5,16 +5,17 @@
 
 package org.mockito.mock;
 
+import java.util.List;
+import java.util.Set;
+
 import org.mockito.Incubating;
 import org.mockito.listeners.InvocationListener;
 import org.mockito.stubbing.Answer;
 
-import java.util.List;
-import java.util.Set;
-
 /**
  * Informs about the mock settings. An immutable view of {@link org.mockito.MockSettings}.
  */
+@SuppressWarnings("rawtypes")
 public interface MockCreationSettings<T> {
 
     /**

--- a/src/org/mockito/plugins/MockMaker.java
+++ b/src/org/mockito/plugins/MockMaker.java
@@ -41,6 +41,7 @@ import org.mockito.mock.MockCreationSettings;
  * @see org.mockito.invocation.MockHandler
  * @since 1.9.5
  */
+@SuppressWarnings("rawtypes")
 public interface MockMaker {
 
     /**
@@ -64,8 +65,8 @@ public interface MockMaker {
      * @since 1.9.5
      */
     <T> T createMock(
-            MockCreationSettings<T> settings,
-            MockHandler handler
+            final MockCreationSettings<T> settings,
+            final MockHandler handler
     );
 
     /**
@@ -78,7 +79,7 @@ public interface MockMaker {
      *   This means the passed object is not really a Mockito mock.
      * @since 1.9.5
      */
-    MockHandler getHandler(Object mock);
+    MockHandler getHandler(final Object mock);
 
     /**
      * Replaces the existing handler on {@code mock} with {@code newHandler}.
@@ -95,8 +96,8 @@ public interface MockMaker {
      * @since 1.9.5
      */
     void resetMock(
-            Object mock,
-            MockHandler newHandler,
-            MockCreationSettings settings
+            final Object mock,
+            final MockHandler newHandler,
+            final MockCreationSettings settings
     );
 }

--- a/src/org/mockito/plugins/PluginSwitch.java
+++ b/src/org/mockito/plugins/PluginSwitch.java
@@ -27,7 +27,7 @@ import org.mockito.Incubating;
  *     <li>The implementation itself, for example <code>org.awesome.mockito.AwesomeMockMaker</code> that extends the <code>MockMaker</code>.</li>
  *     <li>A file "<code>mockito-extensions/org.mockito.plugins.MockMaker</code>". The content of this file is
  *     exactly a <strong>one</strong> line with the qualified name: <code>org.awesome.mockito.AwesomeMockMaker</code>.</li>
- * </ol></p>
+ * </ol>
  *
  * <p>Note that if several <code>mockito-extensions/org.mockito.plugins.MockMaker</code> files exists in the classpath
  * Mockito will only use the first returned by the standard {@link ClassLoader#getResource} mechanism.
@@ -48,5 +48,5 @@ public interface PluginSwitch {
      *
      * @since 1.10.15
      */
-    boolean isEnabled(String pluginClassName);
+    boolean isEnabled(final String pluginClassName);
 }

--- a/src/org/mockito/stubbing/Stubber.java
+++ b/src/org/mockito/stubbing/Stubber.java
@@ -38,6 +38,7 @@ import org.mockito.Mockito;
  * 
  * See examples in javadoc for {@link Mockito}
  */
+@SuppressWarnings("rawtypes")
 public interface Stubber {
 
     /**

--- a/src/org/mockito/stubbing/Stubber.java
+++ b/src/org/mockito/stubbing/Stubber.java
@@ -38,7 +38,6 @@ import org.mockito.Mockito;
  * 
  * See examples in javadoc for {@link Mockito}
  */
-@SuppressWarnings("unchecked")
 public interface Stubber {
 
     /**
@@ -69,7 +68,7 @@ public interface Stubber {
      * @param mock The mock
      * @return select method for stubbing
      */
-    <T> T when(T mock);
+    <T> T when(final T mock);
 
     /**
      * Use it for stubbing consecutive calls in {@link Mockito#doThrow(Throwable)} style:
@@ -83,7 +82,7 @@ public interface Stubber {
      * @param toBeThrown to be thrown when the stubbed method is called
      * @return stubber - to select a method for stubbing
      */
-    Stubber doThrow(Throwable toBeThrown);
+    Stubber doThrow(final Throwable toBeThrown);
 
     /**
      * Use it for stubbing consecutive calls in {@link Mockito#doThrow(Class)} style:
@@ -97,7 +96,7 @@ public interface Stubber {
      * @param toBeThrown exception class to be thrown when the stubbed method is called
      * @return stubber - to select a method for stubbing
      */
-    Stubber doThrow(Class<? extends Throwable> toBeThrown);
+    Stubber doThrow(final Class<? extends Throwable> toBeThrown);
 
     /**
      * Use it for stubbing consecutive calls in {@link Mockito#doAnswer(Answer)} style:
@@ -111,7 +110,7 @@ public interface Stubber {
      * @param answer to answer when the stubbed method is called
      * @return stubber - to select a method for stubbing
      */
-    Stubber doAnswer(Answer answer);    
+    Stubber doAnswer(final Answer answer);    
     
     /**
      * Use it for stubbing consecutive calls in {@link Mockito#doNothing()} style:
@@ -134,7 +133,7 @@ public interface Stubber {
      * @param toBeReturned to be returned when the stubbed method is called
      * @return stubber - to select a method for stubbing
      */
-    Stubber doReturn(Object toBeReturned);
+    Stubber doReturn(final Object toBeReturned);
 
     /**
      * Use it for stubbing consecutive calls in {@link Mockito#doCallRealMethod()} style.

--- a/src/org/mockito/verification/VerificationAfterDelay.java
+++ b/src/org/mockito/verification/VerificationAfterDelay.java
@@ -31,34 +31,34 @@ public interface VerificationAfterDelay extends VerificationMode {
     /**
      * Verifies that there are exactly N invocations during the given period. This will wait the full period given.
      */
-    public VerificationMode times(int wantedNumberOfInvocations);
+    VerificationMode times(final int wantedNumberOfInvocations);
 
     /**
      * Allows verification that there are no invocations at any point during the given period. This will wait the 
      * full period given, unless an invocation occurs (in which case there will be immediate failure)
      */
-    public VerificationMode never();
+    VerificationMode never();
     
     /**
      * Verifies that there is at least 1 invocation during the given period. This will wait the full period given.
      */
-    public VerificationMode atLeastOnce();
+    VerificationMode atLeastOnce();
     
     /**
      * Verifies that there is are least N invocations during the given period. This will wait the full period given.
      */
-    public VerificationMode atLeast(int minNumberOfInvocations);
+    VerificationMode atLeast(final int minNumberOfInvocations);
     
     /**
      * Verifies that there is are most N invocations during the given period. This will wait the full period given,
      * unless too many invocations occur (in which case there will be an immediate failure)
      */
-    public VerificationMode atMost(int maxNumberOfInvocations);
+    VerificationMode atMost(final int maxNumberOfInvocations);
     
     /**
      * Verifies that there the given method is invoked and is the only method invoked. This will wait the full 
      * period given, unless another method is invoked (in which case there will be an immediate failure)
      */
-    public VerificationMode only();
+    VerificationMode only();
     
 }

--- a/src/org/mockito/verification/VerificationWithTimeout.java
+++ b/src/org/mockito/verification/VerificationWithTimeout.java
@@ -39,7 +39,7 @@ public interface VerificationWithTimeout extends VerificationMode {
      * 
      * @return verification mode
      */
-    public VerificationMode times(int wantedNumberOfInvocations);
+    VerificationMode times(final int wantedNumberOfInvocations);
     
     /**
      * @deprecated
@@ -55,7 +55,7 @@ public interface VerificationWithTimeout extends VerificationMode {
      * @return verification mode
      */
     @Deprecated    
-    public VerificationMode never();
+    VerificationMode never();
     
     /**
      * Allows at-least-once verification within given timeout. E.g:
@@ -68,7 +68,7 @@ public interface VerificationWithTimeout extends VerificationMode {
      * 
      * @return verification mode
      */
-    public VerificationMode atLeastOnce();
+    VerificationMode atLeastOnce();
 
     /**
      * Allows at-least-x verification within given timeout. E.g:
@@ -82,7 +82,7 @@ public interface VerificationWithTimeout extends VerificationMode {
      * 
      * @return verification mode
      */
-    public VerificationMode atLeast(int minNumberOfInvocations);
+    VerificationMode atLeast(final int minNumberOfInvocations);
 
     /**
      * @deprecated
@@ -100,7 +100,7 @@ public interface VerificationWithTimeout extends VerificationMode {
      * @return verification mode
      */
     @Deprecated
-    public VerificationMode atMost(int maxNumberOfInvocations);
+    VerificationMode atMost(final int maxNumberOfInvocations);
 
     /**
      * Allows checking if given method was the only one invoked. E.g:
@@ -118,5 +118,5 @@ public interface VerificationWithTimeout extends VerificationMode {
      * 
      * @return verification mode
      */
-    public VerificationMode only();       
+    VerificationMode only();       
 }

--- a/test/org/concurrentmockito/ThreadVerifiesContinuoslyInteractingMockTest.java
+++ b/test/org/concurrentmockito/ThreadVerifiesContinuoslyInteractingMockTest.java
@@ -5,7 +5,8 @@
 
 package org.concurrentmockito;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
 
 import org.junit.Test;
 import org.mockito.Mock;
@@ -34,7 +35,7 @@ public class ThreadVerifiesContinuoslyInteractingMockTest extends TestBase {
                 public void run() {
                     try {
                         Thread.sleep(x * 10);
-                    } catch (InterruptedException e) {
+                    } catch (final InterruptedException e) {
                         throw new RuntimeException(e);
                     }
                     mock.simpleMethod();

--- a/test/org/concurrentmockito/ThreadsShareAMockTest.java
+++ b/test/org/concurrentmockito/ThreadsShareAMockTest.java
@@ -5,7 +5,9 @@
 
 package org.concurrentmockito;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import org.junit.Test;
 import org.mockitousage.IMethods;

--- a/test/org/concurrentmockito/ThreadsShareGenerouslyStubbedMockTest.java
+++ b/test/org/concurrentmockito/ThreadsShareGenerouslyStubbedMockTest.java
@@ -5,7 +5,8 @@
 
 package org.concurrentmockito;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 import org.mockitousage.IMethods;
@@ -47,7 +48,7 @@ public class ThreadsShareGenerouslyStubbedMockTest extends TestBase {
                         mock.simpleMethod("foo");
                         mock.simpleMethod("foo");
                         mock.simpleMethod("foo");
-                    } catch (Exception e) {
+                    } catch (final Exception e) {
                         throw new RuntimeException(e);
                     }
                 }

--- a/test/org/concurrentmockito/ThreadsStubSharedMockTest.java
+++ b/test/org/concurrentmockito/ThreadsStubSharedMockTest.java
@@ -5,7 +5,9 @@
 
 package org.concurrentmockito;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.stubVoid;
+import static org.mockito.Mockito.when;
 
 import org.junit.Ignore;
 import org.junit.Test;

--- a/test/org/concurrentmockito/VerificationInOrderFromMultipleThreadsTest.java
+++ b/test/org/concurrentmockito/VerificationInOrderFromMultipleThreadsTest.java
@@ -4,7 +4,8 @@
  */
 
 package org.concurrentmockito;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
 
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -16,7 +17,7 @@ public class VerificationInOrderFromMultipleThreadsTest extends TestBase {
     public void shouldVerifyInOrderWhenMultipleThreadsInteractWithMock() throws Exception {
         final Foo testInf = mock(Foo.class);
         
-        Thread threadOne = new Thread(new Runnable(){
+        final Thread threadOne = new Thread(new Runnable(){
             public void run() {
                 testInf.methodOne();
             }
@@ -24,7 +25,7 @@ public class VerificationInOrderFromMultipleThreadsTest extends TestBase {
         threadOne.start();
         threadOne.join();
         
-        Thread threadTwo = new Thread(new Runnable(){
+        final Thread threadTwo = new Thread(new Runnable(){
             public void run() {
                 testInf.methodTwo();
             }
@@ -32,7 +33,7 @@ public class VerificationInOrderFromMultipleThreadsTest extends TestBase {
         threadTwo.start();
         threadTwo.join();
         
-        InOrder inOrder = inOrder(testInf);
+        final InOrder inOrder = inOrder(testInf);
         inOrder.verify(testInf).methodOne();
         inOrder.verify(testInf).methodTwo();
     }

--- a/test/org/mockito/AnnotationsAreCopiedFromMockedTypeTest.java
+++ b/test/org/mockito/AnnotationsAreCopiedFromMockedTypeTest.java
@@ -1,8 +1,10 @@
 package org.mockito;
 
-import org.fest.assertions.Assertions;
-import org.junit.Ignore;
-import org.junit.Test;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static org.mockito.Mockito.mock;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
@@ -12,15 +14,16 @@ import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
-import static java.lang.annotation.ElementType.*;
-import static org.mockito.Mockito.mock;
+import org.fest.assertions.Assertions;
+import org.junit.Ignore;
+import org.junit.Test;
 
 public class AnnotationsAreCopiedFromMockedTypeTest {
 
     @Test
     public void mock_should_have_annotations_copied_from_mocked_type_at_class_level() {
-        AnnotationWithDefaultValue onClassDefaultValue = mock(OnClass.class).getClass().getAnnotation(AnnotationWithDefaultValue.class);
-        AnnotationWithCustomValue onClassCustomValue = mock(OnClass.class).getClass().getAnnotation(AnnotationWithCustomValue.class);
+        final AnnotationWithDefaultValue onClassDefaultValue = mock(OnClass.class).getClass().getAnnotation(AnnotationWithDefaultValue.class);
+        final AnnotationWithCustomValue onClassCustomValue = mock(OnClass.class).getClass().getAnnotation(AnnotationWithCustomValue.class);
 
         Assertions.assertThat(mock(OnClass.class).getClass()).isNotSameAs(OnClass.class);
         Assertions.assertThat(onClassDefaultValue.value()).isEqualTo("yup");
@@ -30,8 +33,8 @@ public class AnnotationsAreCopiedFromMockedTypeTest {
     @Test
     @Ignore("fields are not copied in the byte buddy mock, this is currently expected")
     public void mock_should_have_annotations_copied_from_mocked_type_on_fields() {
-        AnnotationWithDefaultValue onClassDefaultValue = field("field", mock(OnField.class)).getAnnotation(AnnotationWithDefaultValue.class);
-        AnnotationWithCustomValue onClassCustomValue = field("field", mock(OnField.class)).getAnnotation(AnnotationWithCustomValue.class);
+        final AnnotationWithDefaultValue onClassDefaultValue = field("field", mock(OnField.class)).getAnnotation(AnnotationWithDefaultValue.class);
+        final AnnotationWithCustomValue onClassCustomValue = field("field", mock(OnField.class)).getAnnotation(AnnotationWithCustomValue.class);
 
         Assertions.assertThat(onClassDefaultValue.value()).isEqualTo("yup");
         Assertions.assertThat(onClassCustomValue.value()).isEqualTo("yay");
@@ -39,8 +42,8 @@ public class AnnotationsAreCopiedFromMockedTypeTest {
 
     @Test
     public void mock_should_have_annotations_copied_from_mocked_type_on_methods() {
-        AnnotationWithDefaultValue onClassDefaultValue = method("method", mock(OnMethod.class)).getAnnotation(AnnotationWithDefaultValue.class);
-        AnnotationWithCustomValue onClassCustomValue = method("method", mock(OnMethod.class)).getAnnotation(AnnotationWithCustomValue.class);
+        final AnnotationWithDefaultValue onClassDefaultValue = method("method", mock(OnMethod.class)).getAnnotation(AnnotationWithDefaultValue.class);
+        final AnnotationWithCustomValue onClassCustomValue = method("method", mock(OnMethod.class)).getAnnotation(AnnotationWithCustomValue.class);
 
         Assertions.assertThat(onClassDefaultValue.value()).isEqualTo("yup");
         Assertions.assertThat(onClassCustomValue.value()).isEqualTo("yay");
@@ -48,26 +51,24 @@ public class AnnotationsAreCopiedFromMockedTypeTest {
 
     @Test
     public void mock_should_have_annotations_copied_from_mocked_type_on_method_parameters() {
-        AnnotationWithDefaultValue onClassDefaultValue = firstParamOf(method("method", mock(OnMethod.class))).getAnnotation(AnnotationWithDefaultValue.class);
-        AnnotationWithCustomValue onClassCustomValue = firstParamOf(method("method", mock(OnMethod.class))).getAnnotation(AnnotationWithCustomValue.class);
+        final AnnotationWithDefaultValue onClassDefaultValue = firstParamOf(method("method", mock(OnMethod.class))).getAnnotation(AnnotationWithDefaultValue.class);
+        final AnnotationWithCustomValue onClassCustomValue = firstParamOf(method("method", mock(OnMethod.class))).getAnnotation(AnnotationWithCustomValue.class);
 
         Assertions.assertThat(onClassDefaultValue.value()).isEqualTo("yup");
         Assertions.assertThat(onClassCustomValue.value()).isEqualTo("yay");
     }
 
-    private AnnotatedElement firstParamOf(Method method) {
+    private AnnotatedElement firstParamOf(final Method method) {
         final Annotation[] firstParamAnnotations = method.getParameterAnnotations()[0];
 
         return new AnnotatedElement() {
-            @Override
-            public boolean isAnnotationPresent(Class<? extends Annotation> annotationClass) {
+            public boolean isAnnotationPresent(final Class<? extends Annotation> annotationClass) {
                 return getAnnotation(annotationClass) != null;
             }
 
-            @Override
             @SuppressWarnings("unchecked")
-            public <T extends Annotation> T getAnnotation(Class<T> annotationClass) {
-                for (Annotation firstParamAnnotation : firstParamAnnotations) {
+            public <T extends Annotation> T getAnnotation(final Class<T> annotationClass) {
+                for (final Annotation firstParamAnnotation : firstParamAnnotations) {
                     if (annotationClass.isAssignableFrom(firstParamAnnotation.getClass())) {
                         return (T) firstParamAnnotation;
                     }
@@ -75,20 +76,18 @@ public class AnnotationsAreCopiedFromMockedTypeTest {
                 return null;
             }
 
-            @Override
             public Annotation[] getAnnotations() {
                 return firstParamAnnotations;
             }
 
-            @Override
             public Annotation[] getDeclaredAnnotations() {
                 return firstParamAnnotations;
             }
         };
     }
 
-    private Method method(String methodName, Object mock) {
-        for (Method method : mock.getClass().getDeclaredMethods()) {
+    private Method method(final String methodName, final Object mock) {
+        for (final Method method : mock.getClass().getDeclaredMethods()) {
             if(methodName.equals(method.getName())) {
                 return method;
             }
@@ -96,8 +95,8 @@ public class AnnotationsAreCopiedFromMockedTypeTest {
         throw new IllegalArgumentException("method name not found : " + methodName);
     }
 
-    private Field field(String fieldName, Object mock) {
-        for (Field field : mock.getClass().getDeclaredFields()) {
+    private Field field(final String fieldName, final Object mock) {
+        for (final Field field : mock.getClass().getDeclaredFields()) {
             if(fieldName.equals(field.getName())) {
                 return field;
             }
@@ -115,9 +114,11 @@ public class AnnotationsAreCopiedFromMockedTypeTest {
         @AnnotationWithCustomValue("yay")
         public String method(
                 @AnnotationWithDefaultValue
-                @AnnotationWithCustomValue("yay")
+                @AnnotationWithCustomValue("yay") final
                 String ignored
-        ) { return ""; }
+        ) {
+            return "";
+        }
     }
 
     public class OnField {

--- a/test/org/mockito/MockingDetailsTest.java
+++ b/test/org/mockito/MockingDetailsTest.java
@@ -1,38 +1,36 @@
 package org.mockito;
 
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
 import org.junit.Test;
 import org.mockito.internal.MockitoCore;
 import org.mockito.invocation.Invocation;
 import org.mockitoutil.TestBase;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
-import static org.mockito.Mockito.mock;
-
 public class MockingDetailsTest extends TestBase {
     
     @Test
+    @SuppressWarnings("unchecked")
     public void should_provide_invocations() {
-        List<String> methodsInvoked = new ArrayList<String>() {{
-            add("add");
-            add("remove");
-            add("clear");
-        }};
+        final List<String> methodsInvoked = new ArrayList<String>(Arrays.asList("add", "remove", "clear"));
         
-        List<String> mockedList = (List<String>) mock(List.class);
+        final List<String> mockedList = mock(List.class);
         
         mockedList.add("one");
         mockedList.remove(0);
         mockedList.clear();
         
-        MockingDetails mockingDetails = new MockitoCore().mockingDetails(mockedList);
-        Collection<Invocation> invocations = mockingDetails.getInvocations();
+        final MockingDetails mockingDetails = new MockitoCore().mockingDetails(mockedList);
+        final Collection<Invocation> invocations = mockingDetails.getInvocations();
         
         assertNotNull(invocations);
         assertEquals(invocations.size(), 3);
-        for (Invocation method : invocations) {
+        for (final Invocation method : invocations) {
             assertTrue(methodsInvoked.contains(method.getMethod().getName()));
             if (method.getMethod().getName().equals("add")) {
                 assertEquals(method.getArguments().length, 1);

--- a/test/org/mockito/MockingDetailsTest.java
+++ b/test/org/mockito/MockingDetailsTest.java
@@ -31,12 +31,12 @@ public class MockingDetailsTest extends TestBase {
         Collection<Invocation> invocations = mockingDetails.getInvocations();
         
         assertNotNull(invocations);
-        assertEquals(invocations.size(),3);
+        assertEquals(invocations.size(), 3);
         for (Invocation method : invocations) {
             assertTrue(methodsInvoked.contains(method.getMethod().getName()));
             if (method.getMethod().getName().equals("add")) {
-                assertEquals(method.getArguments().length,1);
-                assertEquals(method.getArguments()[0],"one");
+                assertEquals(method.getArguments().length, 1);
+                assertEquals(method.getArguments()[0], "one");
             }
         }    
     }

--- a/test/org/mockito/MockitoTest.java
+++ b/test/org/mockito/MockitoTest.java
@@ -5,22 +5,22 @@
 
 package org.mockito;
 
+import static org.mockito.Mockito.times;
+
+import java.util.List;
+
 import org.junit.Test;
 import org.mockito.exceptions.misusing.NotAMockException;
 import org.mockito.internal.creation.MockSettingsImpl;
 import org.mockito.internal.progress.ThreadSafeMockingProgress;
 import org.mockitoutil.TestBase;
 
-import java.util.List;
-
-import static org.mockito.Mockito.times;
-
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class MockitoTest extends TestBase {
 
     @Test
     public void shouldRemoveStubbableFromProgressAfterStubbing() {
-        List mock = Mockito.mock(List.class);
+        final List mock = Mockito.mock(List.class);
         Mockito.when(mock.add("test")).thenReturn(true);
         //TODO Consider to move to separate test
         assertNull(new ThreadSafeMockingProgress().pullOngoingStubbing());
@@ -60,7 +60,7 @@ public class MockitoTest extends TestBase {
     @Test
     public void shouldStartingMockSettingsContainDefaultBehavior() {
         //when
-        MockSettingsImpl settings = (MockSettingsImpl) Mockito.withSettings();
+        final MockSettingsImpl settings = (MockSettingsImpl) Mockito.withSettings();
         
         //then
         assertEquals(Mockito.RETURNS_DEFAULTS, settings.getDefaultAnswer());

--- a/test/org/mockito/internal/InOrderImplTest.java
+++ b/test/org/mockito/internal/InOrderImplTest.java
@@ -4,7 +4,7 @@
  */
 package org.mockito.internal;
 
-import static java.util.Arrays.*;
+import static java.util.Arrays.asList;
 
 import java.util.List;
 
@@ -15,7 +15,7 @@ import org.mockito.invocation.Invocation;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class InOrderImplTest extends TestBase {
     
     @Mock IMethods mock;
@@ -23,8 +23,8 @@ public class InOrderImplTest extends TestBase {
     @Test
     public void shouldMarkVerifiedInOrder() throws Exception {
         //given
-        InOrderImpl impl = new InOrderImpl((List) asList(mock));
-        Invocation i = new InvocationBuilder().toInvocation();
+        final InOrderImpl impl = new InOrderImpl((List) asList(mock));
+        final Invocation i = new InvocationBuilder().toInvocation();
         assertFalse(impl.isVerified(i));
         
         //when

--- a/test/org/mockito/internal/InvalidStateDetectionTest.java
+++ b/test/org/mockito/internal/InvalidStateDetectionTest.java
@@ -5,8 +5,16 @@
 
 package org.mockito.internal;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.stubVoid;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
 import org.junit.After;
 import org.junit.Test;
@@ -37,7 +45,7 @@ import org.mockitoutil.TestBase;
  *    -on stub
  *    -on stubVoid
  */
-@SuppressWarnings({"unchecked", "deprecation"})
+@SuppressWarnings({"rawtypes", "deprecation"})
 public class InvalidStateDetectionTest extends TestBase {
 
     @Mock private IMethods mock;
@@ -180,13 +188,13 @@ public class InvalidStateDetectionTest extends TestBase {
         try {
             stubVoid(mock).toThrow(new RuntimeException()).on().oneArg(true);
             fail();
-        } catch (UnfinishedStubbingException e) {}
+        } catch (final UnfinishedStubbingException e) {}
         
         stubVoid(mock).toThrow(new RuntimeException()).on().oneArg(true);
         try {
             mock.oneArg(true);
             fail();
-        } catch (RuntimeException e) {}
+        } catch (final RuntimeException e) {}
     }
     
     @Test
@@ -197,80 +205,80 @@ public class InvalidStateDetectionTest extends TestBase {
         try {
             verify(mock).simpleMethod();
             fail();
-        } catch (UnfinishedVerificationException e) {}
+        } catch (final UnfinishedVerificationException e) {}
         
         verify(mock).simpleMethod();
     }
     
     private interface DetectsInvalidState {
-        void detect(IMethods mock);
+        void detect(final IMethods mock);
     }
     
     private static class OnVerify implements DetectsInvalidState {
-        public void detect(IMethods mock) {
+        public void detect(final IMethods mock) {
             verify(mock);
         }
     }
     
     private static class OnVerifyInOrder implements DetectsInvalidState {
-        public void detect(IMethods mock) {
+        public void detect(final IMethods mock) {
             inOrder(mock).verify(mock);
         }
     }
     
     private static class OnVerifyZeroInteractions implements DetectsInvalidState {
-        public void detect(IMethods mock) {
+        public void detect(final IMethods mock) {
             verifyZeroInteractions(mock);
         }
     }
     
     private static class OnVerifyNoMoreInteractions implements DetectsInvalidState {
-        public void detect(IMethods mock) {
+        public void detect(final IMethods mock) {
             verifyNoMoreInteractions(mock);
         }
     }   
     
     private static class OnDoAnswer implements DetectsInvalidState {
-        public void detect(IMethods mock) {
+        public void detect(final IMethods mock) {
             doAnswer(null);
         }
     }  
     
     private static class OnStub implements DetectsInvalidState {
-        public void detect(IMethods mock) {
+        public void detect(final IMethods mock) {
             when(mock);
         }
     }
     
     private static class OnStubVoid implements DetectsInvalidState {
-        public void detect(IMethods mock) {
+        public void detect(final IMethods mock) {
             stubVoid(mock);
         }
     }
     
     private static class OnMethodCallOnMock implements DetectsInvalidState {
-        public void detect(IMethods mock) {
+        public void detect(final IMethods mock) {
             mock.simpleMethod();
         }
     }
     
     private static class OnMockCreation implements DetectsInvalidState {
-        public void detect(IMethods mock) {
+        public void detect(final IMethods mock) {
             mock(IMethods.class);
         }
     }
     
     private static class OnSpyCreation implements DetectsInvalidState {
-        public void detect(IMethods mock) {
+        public void detect(final IMethods mock) {
             spy(new Object());
         }
     }
     
-    private void detectsAndCleansUp(DetectsInvalidState detector, Class expected) {
+    private void detectsAndCleansUp(final DetectsInvalidState detector, final Class expected) {
         try {
             detector.detect(mock);
             fail("Should throw an exception");
-        } catch (Exception e) {
+        } catch (final Exception e) {
             assertEquals(expected, e.getClass());
         }
         //Make sure state is cleaned up

--- a/test/org/mockito/internal/configuration/ClassPathLoaderTest.java
+++ b/test/org/mockito/internal/configuration/ClassPathLoaderTest.java
@@ -1,24 +1,23 @@
 package org.mockito.internal.configuration;
 
+import static org.mockito.Mockito.mock;
+
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-
 public class ClassPathLoaderTest extends TestBase {
 
     @Test
     public void shouldReadConfigurationClassFromClassPath() {
         ConfigurationAccess.getConfig().overrideDefaultAnswer(new Answer<Object>() {
-            public Object answer(InvocationOnMock invocation) {
+            public Object answer(final InvocationOnMock invocation) {
                 return "foo";
             }});
 
-        IMethods mock = mock(IMethods.class);
+        final IMethods mock = mock(IMethods.class);
         assertEquals("foo", mock.simpleMethod());
     }
 }

--- a/test/org/mockito/internal/configuration/MockInjectionTest.java
+++ b/test/org/mockito/internal/configuration/MockInjectionTest.java
@@ -5,19 +5,19 @@
 
 package org.mockito.internal.configuration;
 
-import org.junit.After;
-import org.junit.Test;
-import org.mockito.internal.configuration.injection.MockInjection;
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.Observer;
 import java.util.Set;
 
-import static org.fest.assertions.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
+import org.junit.After;
+import org.junit.Test;
+import org.mockito.internal.configuration.injection.MockInjection;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class MockInjectionTest {
 
     private AnObjectWithConstructor withConstructor;
@@ -86,14 +86,14 @@ public class MockInjectionTest {
         return Collections.singleton(mock(Observer.class));
     }
 
-    private Field field(String field) throws NoSuchFieldException {
+    private Field field(final String field) throws NoSuchFieldException {
         return getClass().getDeclaredField(field);
     }
 
 
     public static class AnObjectWithConstructor {
         public boolean initializedWithConstructor = false;
-        public AnObjectWithConstructor(Set<String> strings) {
+        public AnObjectWithConstructor(final Set<String> strings) {
             initializedWithConstructor = true;
         }
     }

--- a/test/org/mockito/internal/configuration/injection/ConstructorInjectionTest.java
+++ b/test/org/mockito/internal/configuration/injection/ConstructorInjectionTest.java
@@ -5,6 +5,15 @@
 
 package org.mockito.internal.configuration.injection;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.BDDMockito.given;
+
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.Observer;
+import java.util.Set;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -13,15 +22,7 @@ import org.mockito.Mock;
 import org.mockito.internal.util.reflection.FieldInitializer.ConstructorArgumentResolver;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import java.lang.reflect.Field;
-import java.util.HashSet;
-import java.util.Observer;
-import java.util.Set;
-
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.BDDMockito.given;
-
+@SuppressWarnings("unused")
 @RunWith(MockitoJUnitRunner.class)
 public class ConstructorInjectionTest {
 
@@ -40,23 +41,23 @@ public class ConstructorInjectionTest {
     public void should_do_the_trick_of_instantiating() throws Exception {
         given(resolver.resolveTypeInstances(Matchers.<Class<?>[]>anyVararg())).willReturn(new Object[] { observer });
 
-        boolean result = underTest.process(field("whatever"), this, newSetOf(observer));
+        final boolean result = underTest.process(field("whatever"), this, newSetOf(observer));
 
         assertTrue(result);
         assertNotNull(whatever);
     }
 
-    private Set<Object> newSetOf(Object item) {
-        HashSet<Object> mocks = new HashSet<Object>();
+    private Set<Object> newSetOf(final Object item) {
+        final HashSet<Object> mocks = new HashSet<Object>();
         mocks.add(item);
         return mocks;
     }
 
-    private Field field(String fieldName) throws NoSuchFieldException {
+    private Field field(final String fieldName) throws NoSuchFieldException {
         return this.getClass().getDeclaredField(fieldName);
     }
 
     private static class ArgConstructor {
-        ArgConstructor(Observer observer) {}
+        ArgConstructor(final Observer observer) {}
     }
 }

--- a/test/org/mockito/internal/configuration/injection/SimpleArgumentResolverTest.java
+++ b/test/org/mockito/internal/configuration/injection/SimpleArgumentResolverTest.java
@@ -5,24 +5,30 @@
 
 package org.mockito.internal.configuration.injection;
 
-import org.junit.Test;
-
-import java.io.ByteArrayOutputStream;
-import java.io.OutputStream;
-import java.util.*;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.junit.Test;
+
+@SuppressWarnings("rawtypes")
 public class SimpleArgumentResolverTest {
 
     @Test
     public void should_return_object_matching_given_types() throws Exception {
-        ConstructorInjection.SimpleArgumentResolver resolver =
+        final ConstructorInjection.SimpleArgumentResolver resolver =
                 new ConstructorInjection.SimpleArgumentResolver(newSetOf(new HashSet(), new ByteArrayOutputStream(), new HashMap()));
 
-        Object[] resolvedInstance = resolver.resolveTypeInstances(Set.class, Map.class, OutputStream.class);
+        final Object[] resolvedInstance = resolver.resolveTypeInstances(Set.class, Map.class, OutputStream.class);
 
         assertEquals(3, resolvedInstance.length);
         assertTrue(resolvedInstance[0] instanceof Set);
@@ -32,10 +38,10 @@ public class SimpleArgumentResolverTest {
 
     @Test
     public void should_return_null_when_match_is_not_possible_on_given_types() throws Exception {
-        ConstructorInjection.SimpleArgumentResolver resolver =
+        final ConstructorInjection.SimpleArgumentResolver resolver =
                 new ConstructorInjection.SimpleArgumentResolver(newSetOf(new HashSet(), new ByteArrayOutputStream()));
 
-        Object[] resolvedInstance = resolver.resolveTypeInstances(Set.class, Map.class, OutputStream.class);
+        final Object[] resolvedInstance = resolver.resolveTypeInstances(Set.class, Map.class, OutputStream.class);
 
         assertEquals(3, resolvedInstance.length);
         assertTrue(resolvedInstance[0] instanceof Set);
@@ -45,10 +51,10 @@ public class SimpleArgumentResolverTest {
 
     @Test
     public void should_return_null_when_types_are_primitives() throws Exception {
-        ConstructorInjection.SimpleArgumentResolver resolver =
+        final ConstructorInjection.SimpleArgumentResolver resolver =
                 new ConstructorInjection.SimpleArgumentResolver(newSetOf(new HashMap(), new TreeSet()));
 
-        Object[] resolvedInstance = resolver.resolveTypeInstances(Set.class, Map.class, Boolean.class);
+        final Object[] resolvedInstance = resolver.resolveTypeInstances(Set.class, Map.class, Boolean.class);
 
         assertEquals(3, resolvedInstance.length);
         assertTrue(resolvedInstance[0] instanceof Set);
@@ -56,7 +62,7 @@ public class SimpleArgumentResolverTest {
         assertNull(resolvedInstance[2]);
     }
 
-    private Set<Object> newSetOf(Object... objects) {
+    private Set<Object> newSetOf(final Object... objects) {
         return new HashSet<Object>(Arrays.asList(objects));
     }
 

--- a/test/org/mockito/internal/configuration/plugins/PluginFileReaderTest.java
+++ b/test/org/mockito/internal/configuration/plugins/PluginFileReaderTest.java
@@ -7,17 +7,8 @@ package org.mockito.internal.configuration.plugins;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.StringReader;
-import java.util.Arrays;
-import java.util.Collections;
-import static org.mockito.Mockito.*;
 
-import junit.framework.Assert;
 import org.junit.Test;
-import org.mockito.internal.configuration.ClassPathLoader;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
-import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
 public class PluginFileReaderTest extends TestBase {
@@ -38,7 +29,7 @@ public class PluginFileReaderTest extends TestBase {
         assertNull(reader.readPluginClass(impl("  \n # foo \n # foo \n ")));
     }
 
-    private InputStream impl(String s) {
+    private InputStream impl(final String s) {
         return new ByteArrayInputStream(s.getBytes());
     }
 

--- a/test/org/mockito/internal/configuration/plugins/PluginFinderTest.java
+++ b/test/org/mockito/internal/configuration/plugins/PluginFinderTest.java
@@ -15,94 +15,111 @@ import org.mockito.internal.util.io.IOUtil;
 import org.mockito.plugins.PluginSwitch;
 import org.mockitoutil.TestBase;
 
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class PluginFinderTest extends TestBase {
 
     @Mock
     PluginSwitch switcher;
-    @InjectMocks PluginFinder finder;
-    @Rule public TemporaryFolder tmp = new TemporaryFolder();
+    @InjectMocks
+    PluginFinder finder;
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
 
-    @Test public void empty_resources() {
+    @Test
+    public void empty_resources() {
         assertNull(finder.findPluginClass((Iterable) asList()));
     }
 
-    @Test public void no_valid_impl() throws Exception {
+    @Test
+    public void no_valid_impl() throws Exception {
         final File f = tmp.newFile();
 
-        //when
+        // when
         IOUtil.writeText("  \n  ", f);
 
-        //then
+        // then
         assertNull(finder.findPluginClass(asList(f.toURI().toURL())));
     }
 
-    @Test public void single_implementation() throws Exception {
+    @Test
+    public void single_implementation() throws Exception {
         final File f = tmp.newFile();
         when(switcher.isEnabled("foo.Foo")).thenReturn(true);
 
-        //when
+        // when
         IOUtil.writeText("  foo.Foo  ", f);
 
-        //then
+        // then
         assertEquals("foo.Foo", finder.findPluginClass(asList(f.toURI().toURL())));
     }
 
-    @Test public void single_implementation_disabled() throws Exception {
+    @Test
+    public void single_implementation_disabled() throws Exception {
         final File f = tmp.newFile();
         when(switcher.isEnabled("foo.Foo")).thenReturn(false);
 
-        //when
+        // when
         IOUtil.writeText("  foo.Foo  ", f);
 
-        //then
+        // then
         assertEquals(null, finder.findPluginClass(asList(f.toURI().toURL())));
     }
 
-    @Test public void multiple_implementations_only_one_enabled() throws Exception {
-        final File f1 = tmp.newFile(); final File f2 = tmp.newFile();
+    @Test
+    public void multiple_implementations_only_one_enabled() throws Exception {
+        final File f1 = tmp.newFile();
+        final File f2 = tmp.newFile();
 
         when(switcher.isEnabled("Bar")).thenReturn(true);
 
-        //when
-        IOUtil.writeText("Foo", f1); IOUtil.writeText("Bar", f2);
+        // when
+        IOUtil.writeText("Foo", f1);
+        IOUtil.writeText("Bar", f2);
 
-        //then
+        // then
         assertEquals("Bar", finder.findPluginClass(asList(f1.toURI().toURL(), f2.toURI().toURL())));
     }
 
-    @Test public void multiple_implementations_only_one_useful() throws Exception {
-        final File f1 = tmp.newFile(); final File f2 = tmp.newFile();
+    @Test
+    public void multiple_implementations_only_one_useful() throws Exception {
+        final File f1 = tmp.newFile();
+        final File f2 = tmp.newFile();
 
         when(switcher.isEnabled(anyString())).thenReturn(true);
 
-        //when
-        IOUtil.writeText("   ", f1); IOUtil.writeText("X", f2);
+        // when
+        IOUtil.writeText("   ", f1);
+        IOUtil.writeText("X", f2);
 
-        //then
+        // then
         assertEquals("X", finder.findPluginClass(asList(f1.toURI().toURL(), f2.toURI().toURL())));
     }
 
-    @Test public void multiple_empty_implementations() throws Exception {
-        final File f1 = tmp.newFile(); final File f2 = tmp.newFile();
+    @Test
+    public void multiple_empty_implementations() throws Exception {
+        final File f1 = tmp.newFile();
+        final File f2 = tmp.newFile();
 
         when(switcher.isEnabled(anyString())).thenReturn(true);
 
-        //when
-        IOUtil.writeText("   ", f1); IOUtil.writeText("\n", f2);
+        // when
+        IOUtil.writeText("   ", f1);
+        IOUtil.writeText("\n", f2);
 
-        //then
+        // then
         assertEquals(null, finder.findPluginClass(asList(f1.toURI().toURL(), f2.toURI().toURL())));
     }
 
-    @Test public void problems_loading_impl() throws Exception {
+    @Test
+    public void problems_loading_impl() throws Exception {
         when(switcher.isEnabled(anyString())).thenThrow(new RuntimeException("Boo!"));
 
         try {
-            //when
+            // when
             finder.findPluginClass(asList(new File("xxx").toURI().toURL()));
-            //then
+            // then
             fail();
-        } catch(final Exception e) {
+        } catch (final Exception e) {
             assertContains("xxx", e.getMessage());
             e.getCause().getMessage().equals("Boo!");
         }

--- a/test/org/mockito/internal/configuration/plugins/PluginFinderTest.java
+++ b/test/org/mockito/internal/configuration/plugins/PluginFinderTest.java
@@ -1,5 +1,11 @@
 package org.mockito.internal.configuration.plugins;
 
+import static java.util.Arrays.asList;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -9,57 +15,51 @@ import org.mockito.internal.util.io.IOUtil;
 import org.mockito.plugins.PluginSwitch;
 import org.mockitoutil.TestBase;
 
-import java.io.File;
-
-import static java.util.Arrays.asList;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.when;
-
 public class PluginFinderTest extends TestBase {
 
     @Mock
     PluginSwitch switcher;
     @InjectMocks PluginFinder finder;
-    public @Rule TemporaryFolder tmp = new TemporaryFolder();
+    @Rule public TemporaryFolder tmp = new TemporaryFolder();
 
     @Test public void empty_resources() {
         assertNull(finder.findPluginClass((Iterable) asList()));
     }
 
     @Test public void no_valid_impl() throws Exception {
-        File f = tmp.newFile();
+        final File f = tmp.newFile();
 
         //when
         IOUtil.writeText("  \n  ", f);
 
         //then
-        assertNull(finder.findPluginClass((Iterable) asList(f.toURI().toURL())));
+        assertNull(finder.findPluginClass(asList(f.toURI().toURL())));
     }
 
     @Test public void single_implementation() throws Exception {
-        File f = tmp.newFile();
+        final File f = tmp.newFile();
         when(switcher.isEnabled("foo.Foo")).thenReturn(true);
 
         //when
         IOUtil.writeText("  foo.Foo  ", f);
 
         //then
-        assertEquals("foo.Foo", finder.findPluginClass((Iterable) asList(f.toURI().toURL())));
+        assertEquals("foo.Foo", finder.findPluginClass(asList(f.toURI().toURL())));
     }
 
     @Test public void single_implementation_disabled() throws Exception {
-        File f = tmp.newFile();
+        final File f = tmp.newFile();
         when(switcher.isEnabled("foo.Foo")).thenReturn(false);
 
         //when
         IOUtil.writeText("  foo.Foo  ", f);
 
         //then
-        assertEquals(null, finder.findPluginClass((Iterable) asList(f.toURI().toURL())));
+        assertEquals(null, finder.findPluginClass(asList(f.toURI().toURL())));
     }
 
     @Test public void multiple_implementations_only_one_enabled() throws Exception {
-        File f1 = tmp.newFile(); File f2 = tmp.newFile();
+        final File f1 = tmp.newFile(); final File f2 = tmp.newFile();
 
         when(switcher.isEnabled("Bar")).thenReturn(true);
 
@@ -67,11 +67,11 @@ public class PluginFinderTest extends TestBase {
         IOUtil.writeText("Foo", f1); IOUtil.writeText("Bar", f2);
 
         //then
-        assertEquals("Bar", finder.findPluginClass((Iterable) asList(f1.toURI().toURL(), f2.toURI().toURL())));
+        assertEquals("Bar", finder.findPluginClass(asList(f1.toURI().toURL(), f2.toURI().toURL())));
     }
 
     @Test public void multiple_implementations_only_one_useful() throws Exception {
-        File f1 = tmp.newFile(); File f2 = tmp.newFile();
+        final File f1 = tmp.newFile(); final File f2 = tmp.newFile();
 
         when(switcher.isEnabled(anyString())).thenReturn(true);
 
@@ -79,11 +79,11 @@ public class PluginFinderTest extends TestBase {
         IOUtil.writeText("   ", f1); IOUtil.writeText("X", f2);
 
         //then
-        assertEquals("X", finder.findPluginClass((Iterable) asList(f1.toURI().toURL(), f2.toURI().toURL())));
+        assertEquals("X", finder.findPluginClass(asList(f1.toURI().toURL(), f2.toURI().toURL())));
     }
 
     @Test public void multiple_empty_implementations() throws Exception {
-        File f1 = tmp.newFile(); File f2 = tmp.newFile();
+        final File f1 = tmp.newFile(); final File f2 = tmp.newFile();
 
         when(switcher.isEnabled(anyString())).thenReturn(true);
 
@@ -91,7 +91,7 @@ public class PluginFinderTest extends TestBase {
         IOUtil.writeText("   ", f1); IOUtil.writeText("\n", f2);
 
         //then
-        assertEquals(null, finder.findPluginClass((Iterable) asList(f1.toURI().toURL(), f2.toURI().toURL())));
+        assertEquals(null, finder.findPluginClass(asList(f1.toURI().toURL(), f2.toURI().toURL())));
     }
 
     @Test public void problems_loading_impl() throws Exception {
@@ -99,10 +99,10 @@ public class PluginFinderTest extends TestBase {
 
         try {
             //when
-            finder.findPluginClass((Iterable) asList(new File("xxx").toURI().toURL()));
+            finder.findPluginClass(asList(new File("xxx").toURI().toURL()));
             //then
             fail();
-        } catch(Exception e) {
+        } catch(final Exception e) {
             assertContains("xxx", e.getMessage());
             e.getCause().getMessage().equals("Boo!");
         }

--- a/test/org/mockito/internal/creation/DelegatingMethodTest.java
+++ b/test/org/mockito/internal/creation/DelegatingMethodTest.java
@@ -1,10 +1,10 @@
 package org.mockito.internal.creation;
 
+import java.lang.reflect.Method;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockitoutil.TestBase;
-
-import java.lang.reflect.Method;
 
 public class DelegatingMethodTest extends TestBase {
 
@@ -20,13 +20,13 @@ public class DelegatingMethodTest extends TestBase {
 
     @Test
     public void equals_should_return_false_when_not_equal() throws Exception {
-        DelegatingMethod notEqual = new DelegatingMethod(otherMethod);
+        final DelegatingMethod notEqual = new DelegatingMethod(otherMethod);
         assertFalse(delegatingMethod.equals(notEqual));
     }
 
     @Test
     public void equals_should_return_true_when_equal() throws Exception {
-        DelegatingMethod equal = new DelegatingMethod(someMethod);
+        final DelegatingMethod equal = new DelegatingMethod(someMethod);
         assertTrue(delegatingMethod.equals(equal));
     }
 
@@ -47,8 +47,8 @@ public class DelegatingMethodTest extends TestBase {
 
     private interface Something {
 
-        public Object someMethod(Object param);
+        Object someMethod(final Object param);
 
-        public Object otherMethod(Object param);
+        Object otherMethod(final Object param);
     }
 }

--- a/test/org/mockito/internal/creation/MockSettingsImplTest.java
+++ b/test/org/mockito/internal/creation/MockSettingsImplTest.java
@@ -4,6 +4,10 @@
  */
 package org.mockito.internal.creation;
 
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
 import org.fest.assertions.Assertions;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -12,13 +16,9 @@ import org.mockito.internal.debugging.VerboseMockInvocationLogger;
 import org.mockito.listeners.InvocationListener;
 import org.mockitoutil.TestBase;
 
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
-
 public class MockSettingsImplTest extends TestBase {
 
-    private MockSettingsImpl mockSettingsImpl = new MockSettingsImpl();
+    private final MockSettingsImpl mockSettingsImpl = new MockSettingsImpl();
     
     @Mock private InvocationListener invocationListener;
 
@@ -106,7 +106,7 @@ public class MockSettingsImplTest extends TestBase {
     @SuppressWarnings("all")
     @Test(expected=MockitoException.class)
     public void shouldNotAllowNullListener() {
-        mockSettingsImpl.invocationListeners((InvocationListener[])null);
+        mockSettingsImpl.invocationListeners((InvocationListener[]) null);
     }
 
     @Test
@@ -138,7 +138,7 @@ public class MockSettingsImplTest extends TestBase {
         try {
             mockSettingsImpl.invocationListeners();
             fail();
-        } catch (Exception e) {
+        } catch (final Exception e) {
             Assertions.assertThat(e.getMessage()).contains("at least one listener");
         }
     }
@@ -148,7 +148,7 @@ public class MockSettingsImplTest extends TestBase {
         try {
             mockSettingsImpl.invocationListeners(invocationListener, null);
             fail();
-        } catch (Exception e) {
+        } catch (final Exception e) {
             Assertions.assertThat(e.getMessage()).contains("does not accept null");
         }
     }

--- a/test/org/mockito/internal/creation/MockSettingsImplTest.java
+++ b/test/org/mockito/internal/creation/MockSettingsImplTest.java
@@ -16,6 +16,7 @@ import org.mockito.internal.debugging.VerboseMockInvocationLogger;
 import org.mockito.listeners.InvocationListener;
 import org.mockitoutil.TestBase;
 
+@SuppressWarnings("rawtypes")
 public class MockSettingsImplTest extends TestBase {
 
     private final MockSettingsImpl mockSettingsImpl = new MockSettingsImpl();

--- a/test/org/mockito/internal/debugging/LoggingListenerTest.java
+++ b/test/org/mockito/internal/debugging/LoggingListenerTest.java
@@ -4,8 +4,9 @@
  */
 package org.mockito.internal.debugging;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import org.junit.Test;
 import org.mockito.Mock;
@@ -20,7 +21,7 @@ public class LoggingListenerTest extends TestBase {
     @Test
     public void shouldLogUnusedStub() {
         //given
-        LoggingListener listener = new LoggingListener(false, logger);
+        final LoggingListener listener = new LoggingListener(false, logger);
 
         //when
         listener.foundUnusedStub(new InvocationBuilder().toInvocation());
@@ -32,7 +33,7 @@ public class LoggingListenerTest extends TestBase {
     @Test
     public void shouldLogUnstubbed() {
         //given
-        LoggingListener listener = new LoggingListener(true, logger);
+        final LoggingListener listener = new LoggingListener(true, logger);
 
         //when
         listener.foundUnstubbed(new InvocationBuilder().toInvocationMatcher());
@@ -44,7 +45,7 @@ public class LoggingListenerTest extends TestBase {
     @Test
     public void shouldNotLogUnstubbed() {
         //given
-        LoggingListener listener = new LoggingListener(false, logger);
+        final LoggingListener listener = new LoggingListener(false, logger);
 
         //when
         listener.foundUnstubbed(new InvocationBuilder().toInvocationMatcher());
@@ -56,7 +57,7 @@ public class LoggingListenerTest extends TestBase {
     @Test
     public void shouldLogDifferentArgs() {
         //given
-        LoggingListener listener = new LoggingListener(true, logger);
+        final LoggingListener listener = new LoggingListener(true, logger);
 
         //when
         listener.foundStubCalledWithDifferentArgs(new InvocationBuilder().toInvocation(), new InvocationBuilder().toInvocationMatcher());

--- a/test/org/mockito/internal/debugging/WarningsFinderTest.java
+++ b/test/org/mockito/internal/debugging/WarningsFinderTest.java
@@ -4,14 +4,14 @@
  */
 package org.mockito.internal.debugging;
 
-import static java.util.Arrays.*;
-import static org.mockito.Mockito.*;
+import static java.util.Arrays.asList;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.verify;
 
 import java.util.Arrays;
 
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.internal.invocation.InvocationImpl;
 import org.mockito.internal.invocation.InvocationBuilder;
 import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockito.invocation.Invocation;
@@ -26,10 +26,10 @@ public class WarningsFinderTest extends TestBase {
     @Test
     public void shouldPrintUnusedStub() {
         // given
-        Invocation unusedStub = new InvocationBuilder().simpleMethod().toInvocation();
+        final Invocation unusedStub = new InvocationBuilder().simpleMethod().toInvocation();
 
         // when
-        WarningsFinder finder = new WarningsFinder(asList(unusedStub), Arrays.<InvocationMatcher>asList());
+        final WarningsFinder finder = new WarningsFinder(asList(unusedStub), Arrays.<InvocationMatcher>asList());
         finder.find(listener);
 
         // then
@@ -39,10 +39,10 @@ public class WarningsFinderTest extends TestBase {
     @Test
     public void shouldPrintUnstubbedInvocation() {
         // given
-        InvocationMatcher unstubbedInvocation = new InvocationBuilder().differentMethod().toInvocationMatcher();
+        final InvocationMatcher unstubbedInvocation = new InvocationBuilder().differentMethod().toInvocationMatcher();
 
         // when
-        WarningsFinder finder = new WarningsFinder(Arrays.<Invocation>asList(), Arrays.<InvocationMatcher>asList(unstubbedInvocation));
+        final WarningsFinder finder = new WarningsFinder(Arrays.<Invocation>asList(), Arrays.<InvocationMatcher>asList(unstubbedInvocation));
         finder.find(listener);
 
         // then
@@ -52,11 +52,11 @@ public class WarningsFinderTest extends TestBase {
     @Test
     public void shouldPrintStubWasUsedWithDifferentArgs() {
         // given
-        Invocation stub = new InvocationBuilder().arg("foo").mock(mock).toInvocation();
-        InvocationMatcher wrongArg = new InvocationBuilder().arg("bar").mock(mock).toInvocationMatcher();
+        final Invocation stub = new InvocationBuilder().arg("foo").mock(mock).toInvocation();
+        final InvocationMatcher wrongArg = new InvocationBuilder().arg("bar").mock(mock).toInvocationMatcher();
 
         // when
-        WarningsFinder finder = new WarningsFinder(Arrays.<Invocation> asList(stub), Arrays.<InvocationMatcher> asList(wrongArg));
+        final WarningsFinder finder = new WarningsFinder(Arrays.<Invocation> asList(stub), Arrays.<InvocationMatcher> asList(wrongArg));
         finder.find(listener);
 
         // then

--- a/test/org/mockito/internal/debugging/WarningsPrinterImplTest.java
+++ b/test/org/mockito/internal/debugging/WarningsPrinterImplTest.java
@@ -4,8 +4,9 @@
  */
 package org.mockito.internal.debugging;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -21,13 +22,13 @@ public class WarningsPrinterImplTest extends TestBase {
     @Test
     public void shouldUseFinderCorrectly() {
         // given
-        WarningsPrinterImpl printer = new WarningsPrinterImpl(false, finder);
+        final WarningsPrinterImpl printer = new WarningsPrinterImpl(false, finder);
 
         // when
         printer.print(logger);
 
         // then
-        ArgumentCaptor<LoggingListener> arg = ArgumentCaptor.forClass(LoggingListener.class);
+        final ArgumentCaptor<LoggingListener> arg = ArgumentCaptor.forClass(LoggingListener.class);
         verify(finder).find(arg.capture());
         assertEquals(logger, arg.getValue().getLogger());
         assertEquals(false, arg.getValue().isWarnAboutUnstubbed());
@@ -36,13 +37,13 @@ public class WarningsPrinterImplTest extends TestBase {
     @Test
     public void shouldPassCorrectWarningFlag() {
         // given
-        WarningsPrinterImpl printer = new WarningsPrinterImpl(true, finder);
+        final WarningsPrinterImpl printer = new WarningsPrinterImpl(true, finder);
 
         // when
         printer.print(logger);
 
         // then
-        ArgumentCaptor<LoggingListener> arg = ArgumentCaptor.forClass(LoggingListener.class);
+        final ArgumentCaptor<LoggingListener> arg = ArgumentCaptor.forClass(LoggingListener.class);
         verify(finder).find(arg.capture());
         assertEquals(true, arg.getValue().isWarnAboutUnstubbed());
     }
@@ -50,10 +51,10 @@ public class WarningsPrinterImplTest extends TestBase {
     @Test
     public void shouldPrintToString() {
         // given
-        WarningsPrinterImpl printer = spy(new WarningsPrinterImpl(true, finder));
+        final WarningsPrinterImpl printer = spy(new WarningsPrinterImpl(true, finder));
 
         // when
-        String out = printer.print();
+        final String out = printer.print();
 
         // then
         verify(printer).print((MockitoLogger) notNull());

--- a/test/org/mockito/internal/exceptions/util/ScenarioPrinterTest.java
+++ b/test/org/mockito/internal/exceptions/util/ScenarioPrinterTest.java
@@ -4,7 +4,7 @@
  */
 package org.mockito.internal.exceptions.util;
 
-import static java.util.Arrays.*;
+import static java.util.Arrays.asList;
 
 import java.util.List;
 
@@ -13,7 +13,7 @@ import org.mockito.internal.invocation.InvocationBuilder;
 import org.mockito.invocation.Invocation;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class ScenarioPrinterTest extends TestBase {
 
     ScenarioPrinter sp = new ScenarioPrinter();
@@ -21,11 +21,11 @@ public class ScenarioPrinterTest extends TestBase {
     @Test
     public void shouldPrintInvocations() {
         //given
-        Invocation verified = new InvocationBuilder().simpleMethod().verified().toInvocation();
-        Invocation unverified = new InvocationBuilder().differentMethod().toInvocation();
+        final Invocation verified = new InvocationBuilder().simpleMethod().verified().toInvocation();
+        final Invocation unverified = new InvocationBuilder().differentMethod().toInvocation();
         
         //when
-        String out = sp.print((List) asList(verified, unverified));
+        final String out = sp.print((List) asList(verified, unverified));
         
         //then
         assertContains("1. -> at", out);
@@ -35,10 +35,10 @@ public class ScenarioPrinterTest extends TestBase {
     @Test
     public void shouldNotPrintInvocationsWhenSingleUnwanted() {
         //given
-        Invocation unverified = new InvocationBuilder().differentMethod().toInvocation();
+        final Invocation unverified = new InvocationBuilder().differentMethod().toInvocation();
         
         //when
-        String out = sp.print((List) asList(unverified));
+        final String out = sp.print((List) asList(unverified));
         
         //then
         assertContains("Actually, above is the only interaction with this mock.", out);

--- a/test/org/mockito/internal/handler/InvocationNotifierHandlerTest.java
+++ b/test/org/mockito/internal/handler/InvocationNotifierHandlerTest.java
@@ -4,6 +4,18 @@
  */
 package org.mockito.internal.handler;
 
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.text.ParseException;
+import java.util.ArrayList;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -19,34 +31,25 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.mockitousage.IMethods;
 
-import java.text.ParseException;
-import java.util.ArrayList;
-
-import static org.fest.assertions.Assertions.assertThat;
-import static org.junit.Assert.fail;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willThrow;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyList;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-
-
 @RunWith(MockitoJUnitRunner.class)
-@SuppressWarnings("unchecked")
+@SuppressWarnings({ "unchecked", "rawtypes", "unused" })
 public class InvocationNotifierHandlerTest {
     private static final String SOME_LOCATION = "some location";
     private static final RuntimeException SOME_EXCEPTION = new RuntimeException();
     private static final OutOfMemoryError SOME_ERROR = new OutOfMemoryError();
     private static final Answer SOME_ANSWER = mock(Answer.class);
 
+    @Mock
+    private InvocationListener listener1;
+    @Mock
+    private InvocationListener listener2;
+    @Spy
+    private CustomListener customListener;
 
-    @Mock private InvocationListener listener1;
-    @Mock private InvocationListener listener2;
-    @Spy private CustomListener customListener;
-
-    @Mock private Invocation invocation;
-    @Mock private MockHandlerImpl mockHandler;
+    @Mock
+    private Invocation invocation;
+    @Mock
+    private MockHandlerImpl mockHandler;
 
     private InvocationNotifierHandler notifier;
 
@@ -55,7 +58,7 @@ public class InvocationNotifierHandlerTest {
         notifier = new InvocationNotifierHandler(
                 mockHandler,
                 (MockSettingsImpl) new MockSettingsImpl().invocationListeners(customListener, listener1, listener2)
-        );
+                );
     }
 
     @Test
@@ -74,7 +77,7 @@ public class InvocationNotifierHandlerTest {
     @Test
     public void should_notify_all_listeners_when_called_delegate_handler_returns_ex() throws Throwable {
         // given
-        Exception computedException = new Exception("computed");
+        final Exception computedException = new Exception("computed");
         given(mockHandler.handle(invocation)).willReturn(computedException);
 
         // when
@@ -88,7 +91,7 @@ public class InvocationNotifierHandlerTest {
     @Test(expected = ParseException.class)
     public void should_notify_all_listeners_when_called_delegate_handler_throws_exception_and_rethrow_it() throws Throwable {
         // given
-        ParseException parseException = new ParseException("", 0);
+        final ParseException parseException = new ParseException("", 0);
         given(mockHandler.handle(invocation)).willThrow(parseException);
 
         // when
@@ -109,7 +112,7 @@ public class InvocationNotifierHandlerTest {
         try {
             notifier.handle(invocation);
             fail();
-        } catch (MockitoException me) {
+        } catch (final MockitoException me) {
             assertThat(me.getMessage())
                     .contains("invocation listener")
                     .contains("CustomListener")
@@ -132,7 +135,7 @@ public class InvocationNotifierHandlerTest {
     }
 
     private static class CustomListener implements InvocationListener {
-        public void reportInvocation(MethodInvocationReport methodInvocationReport) {
+        public void reportInvocation(final MethodInvocationReport methodInvocationReport) {
             // nop
         }
     }

--- a/test/org/mockito/internal/handler/MockHandlerFactoryTest.java
+++ b/test/org/mockito/internal/handler/MockHandlerFactoryTest.java
@@ -17,6 +17,7 @@ import org.mockitoutil.TestBase;
 /**
  * by Szczepan Faber, created at: 5/22/12
  */
+@SuppressWarnings("rawtypes")
 public class MockHandlerFactoryTest extends TestBase {
 
     IMethods mock = Mockito.mock(IMethods.class);
@@ -25,14 +26,14 @@ public class MockHandlerFactoryTest extends TestBase {
     //see issue 331
     public void handle_result_must_not_be_null_for_primitives() throws Throwable {
         //given:
-        MockCreationSettings settings = (MockCreationSettings) new MockSettingsImpl().defaultAnswer(new Returns(null));
-        InternalMockHandler handler = new MockHandlerFactory().create(settings);
+        final MockCreationSettings settings = (MockCreationSettings) new MockSettingsImpl().defaultAnswer(new Returns(null));
+        final InternalMockHandler handler = new MockHandlerFactory().create(settings);
 
         mock.intReturningMethod();
-        Invocation invocation = super.getLastInvocation();
+        final Invocation invocation = super.getLastInvocation();
 
         //when:
-        Object result = handler.handle(invocation);
+        final Object result = handler.handle(invocation);
 
         //then null value is not a valid result for a primitive
         assertNotNull(result);
@@ -43,14 +44,14 @@ public class MockHandlerFactoryTest extends TestBase {
     //see issue 331
     public void valid_handle_result_is_permitted() throws Throwable {
         //given:
-        MockCreationSettings settings = (MockCreationSettings) new MockSettingsImpl().defaultAnswer(new Returns(123));
-        InternalMockHandler handler = new MockHandlerFactory().create(settings);
+        final MockCreationSettings settings = (MockCreationSettings) new MockSettingsImpl().defaultAnswer(new Returns(123));
+        final InternalMockHandler handler = new MockHandlerFactory().create(settings);
 
         mock.intReturningMethod();
-        Invocation invocation = super.getLastInvocation();
+        final Invocation invocation = super.getLastInvocation();
 
         //when:
-        Object result = handler.handle(invocation);
+        final Object result = handler.handle(invocation);
 
         //then
         assertEquals(123, result);

--- a/test/org/mockito/internal/handler/MockHandlerImplTest.java
+++ b/test/org/mockito/internal/handler/MockHandlerImplTest.java
@@ -5,6 +5,13 @@
 
 package org.mockito.internal.handler;
 
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+import java.util.Arrays;
+
 import org.junit.Test;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.exceptions.misusing.InvalidUseOfMatchersException;
@@ -24,29 +31,21 @@ import org.mockito.listeners.InvocationListener;
 import org.mockito.listeners.MethodInvocationReport;
 import org.mockitoutil.TestBase;
 
-import java.util.Arrays;
-
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-
-@SuppressWarnings({"unchecked", "serial"})
+@SuppressWarnings({"rawtypes", "serial"})
 public class MockHandlerImplTest extends TestBase {
 
-    private StubbedInvocationMatcher stubbedInvocationMatcher = mock(StubbedInvocationMatcher.class);
-    private Invocation invocation = mock(InvocationImpl.class);
+    private final StubbedInvocationMatcher stubbedInvocationMatcher = mock(StubbedInvocationMatcher.class);
+    private final Invocation invocation = mock(InvocationImpl.class);
 
 
     @Test
     public void should_remove_verification_mode_even_when_invalid_matchers() throws Throwable {
         // given
-        Invocation invocation = new InvocationBuilder().toInvocation();
-        @SuppressWarnings("rawtypes")
-        MockHandlerImpl<?> handler = new MockHandlerImpl(new MockSettingsImpl());
+        final Invocation invocation = new InvocationBuilder().toInvocation();
+        final MockHandlerImpl<?> handler = new MockHandlerImpl(new MockSettingsImpl());
         handler.mockingProgress.verificationStarted(VerificationModeFactory.atLeastOnce());
         handler.matchersBinder = new MatchersBinder() {
-            public InvocationMatcher bindMatchers(ArgumentMatcherStorage argumentMatcherStorage, Invocation invocation) {
+            public InvocationMatcher bindMatchers(final ArgumentMatcherStorage argumentMatcherStorage, final Invocation invocation) {
                 throw new InvalidUseOfMatchersException();
             }
         };
@@ -57,7 +56,7 @@ public class MockHandlerImplTest extends TestBase {
 
             // then
             fail();
-        } catch (InvalidUseOfMatchersException ignored) {
+        } catch (final InvalidUseOfMatchersException ignored) {
         }
 
         assertNull(handler.mockingProgress.pullVerificationMode());
@@ -67,9 +66,9 @@ public class MockHandlerImplTest extends TestBase {
     @Test(expected = MockitoException.class)
     public void should_throw_mockito_exception_when_invocation_handler_throws_anything() throws Throwable {
         // given
-        InvocationListener throwingListener = mock(InvocationListener.class);
+        final InvocationListener throwingListener = mock(InvocationListener.class);
         doThrow(new Throwable()).when(throwingListener).reportInvocation(any(MethodInvocationReport.class));
-        MockHandlerImpl<?> handler = create_correctly_stubbed_handler(throwingListener);
+        final MockHandlerImpl<?> handler = create_correctly_stubbed_handler(throwingListener);
 
         // when
         handler.handle(invocation);
@@ -77,36 +76,36 @@ public class MockHandlerImplTest extends TestBase {
 
     @Test(expected = WrongTypeOfReturnValue.class)
     public void should_report_bogus_default_answer() throws Throwable {
-        MockSettingsImpl mockSettings = mock(MockSettingsImpl.class);
-        MockHandlerImpl<?> handler = new MockHandlerImpl(mockSettings);
+        final MockSettingsImpl mockSettings = mock(MockSettingsImpl.class);
+        final MockHandlerImpl<?> handler = new MockHandlerImpl(mockSettings);
         given(mockSettings.getDefaultAnswer()).willReturn(new Returns(AWrongType.WRONG_TYPE));
 
         @SuppressWarnings("unused") // otherwise cast is not done
+        final
         String there_should_not_be_a_CCE_here = (String) handler.handle(
                 new InvocationBuilder().method(Object.class.getDeclaredMethod("toString")).toInvocation()
         );
     }
 
-    private MockHandlerImpl<?> create_correctly_stubbed_handler(InvocationListener throwingListener) {
-        MockHandlerImpl<?> handler = create_handler_with_listeners(throwingListener);
+    private MockHandlerImpl<?> create_correctly_stubbed_handler(final InvocationListener throwingListener) {
+        final MockHandlerImpl<?> handler = create_handler_with_listeners(throwingListener);
         stub_ordinary_invocation_with_given_return_value(handler);
         return handler;
     }
 
-    private void stub_ordinary_invocation_with_given_return_value(MockHandlerImpl<?> handler) {
+    private void stub_ordinary_invocation_with_given_return_value(final MockHandlerImpl<?> handler) {
         stub_ordinary_invocation_with_invocation_matcher(handler, stubbedInvocationMatcher);
     }
 
 
-    private void stub_ordinary_invocation_with_invocation_matcher(MockHandlerImpl<?> handler, StubbedInvocationMatcher value) {
+    private void stub_ordinary_invocation_with_invocation_matcher(final MockHandlerImpl<?> handler, final StubbedInvocationMatcher value) {
         handler.invocationContainerImpl = mock(InvocationContainerImpl.class);
         given(handler.invocationContainerImpl.findAnswerFor(any(InvocationImpl.class))).willReturn(value);
     }
 
 
-    private MockHandlerImpl<?> create_handler_with_listeners(InvocationListener... listener) {
-        @SuppressWarnings("rawtypes")
-        MockHandlerImpl<?> handler = new MockHandlerImpl(mock(MockSettingsImpl.class));
+    private MockHandlerImpl<?> create_handler_with_listeners(final InvocationListener... listener) {
+        final MockHandlerImpl<?> handler = new MockHandlerImpl(mock(MockSettingsImpl.class));
         handler.matchersBinder = mock(MatchersBinder.class);
         given(handler.getMockSettings().getInvocationListeners()).willReturn(Arrays.asList(listener));
         return handler;

--- a/test/org/mockito/internal/invocation/ArgumentsComparatorTest.java
+++ b/test/org/mockito/internal/invocation/ArgumentsComparatorTest.java
@@ -4,17 +4,22 @@
  */
 package org.mockito.internal.invocation;
 
-import org.mockito.invocation.Invocation;
-import org.mockitoutil.TestBase;
-import org.junit.Test;
-import org.mockito.internal.matchers.*;
-import org.mockito.Mock;
-import org.mockitousage.IMethods;
-
-import java.util.List;
 import static java.util.Arrays.asList;
 
-@SuppressWarnings("unchecked")
+import java.util.List;
+
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.internal.matchers.Any;
+import org.mockito.internal.matchers.AnyVararg;
+import org.mockito.internal.matchers.Equals;
+import org.mockito.internal.matchers.InstanceOf;
+import org.mockito.internal.matchers.LocalizedMatcher;
+import org.mockito.invocation.Invocation;
+import org.mockitousage.IMethods;
+import org.mockitoutil.TestBase;
+
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class ArgumentsComparatorTest extends TestBase {
 
     @Mock IMethods mock;
@@ -23,11 +28,11 @@ public class ArgumentsComparatorTest extends TestBase {
     @Test
     public void shouldKnowWhenArgumentsMatch() {
         //given
-        Invocation invocation = new InvocationBuilder().args("1", 100).toInvocation();
-        InvocationMatcher invocationMatcher = new InvocationBuilder().args("1", 100).toInvocationMatcher();
+        final Invocation invocation = new InvocationBuilder().args("1", 100).toInvocation();
+        final InvocationMatcher invocationMatcher = new InvocationBuilder().args("1", 100).toInvocationMatcher();
 
         //when
-        boolean match = comparator.argumentsMatch(invocationMatcher, invocation);
+        final boolean match = comparator.argumentsMatch(invocationMatcher, invocation);
 
         //then
         assertTrue(match);
@@ -36,11 +41,11 @@ public class ArgumentsComparatorTest extends TestBase {
     @Test
     public void shouldKnowWhenArgsDifferent() {
         //given
-        Invocation invocation = new InvocationBuilder().args("1", 100).toInvocation();
-        InvocationMatcher invocationMatcher = new InvocationBuilder().args("100", 100).toInvocationMatcher();
+        final Invocation invocation = new InvocationBuilder().args("1", 100).toInvocation();
+        final InvocationMatcher invocationMatcher = new InvocationBuilder().args("100", 100).toInvocationMatcher();
 
         //when
-        boolean match = comparator.argumentsMatch(invocationMatcher, invocation);
+        final boolean match = comparator.argumentsMatch(invocationMatcher, invocation);
 
         //then
         assertFalse(match);
@@ -49,11 +54,11 @@ public class ArgumentsComparatorTest extends TestBase {
     @Test
     public void shouldKnowWhenActualArgsSizeIsDifferent() {
         //given
-        Invocation invocation = new InvocationBuilder().args("100", 100).toInvocation();
-        InvocationMatcher invocationMatcher = new InvocationBuilder().args("100").toInvocationMatcher();
+        final Invocation invocation = new InvocationBuilder().args("100", 100).toInvocation();
+        final InvocationMatcher invocationMatcher = new InvocationBuilder().args("100").toInvocationMatcher();
 
         //when
-        boolean match = comparator.argumentsMatch(invocationMatcher, invocation);
+        final boolean match = comparator.argumentsMatch(invocationMatcher, invocation);
 
         //then
         assertFalse(match);
@@ -62,11 +67,11 @@ public class ArgumentsComparatorTest extends TestBase {
     @Test
     public void shouldKnowWhenMatchersSizeIsDifferent() {
         //given
-        Invocation invocation = new InvocationBuilder().args("100").toInvocation();
-        InvocationMatcher invocationMatcher = new InvocationBuilder().args("100", 100).toInvocationMatcher();
+        final Invocation invocation = new InvocationBuilder().args("100").toInvocation();
+        final InvocationMatcher invocationMatcher = new InvocationBuilder().args("100", 100).toInvocationMatcher();
 
         //when
-        boolean match = comparator.argumentsMatch(invocationMatcher, invocation);
+        final boolean match = comparator.argumentsMatch(invocationMatcher, invocation);
 
         //then
         assertFalse(match);
@@ -76,11 +81,11 @@ public class ArgumentsComparatorTest extends TestBase {
     public void shouldKnowWhenVarargsMatch() {
         //given
         mock.varargs("1", "2", "3");
-        Invocation invocation = getLastInvocation();
-        InvocationMatcher invocationMatcher = new InvocationMatcher(invocation, (List) asList(new Equals("1"), Any.ANY, new InstanceOf(String.class)));
+        final Invocation invocation = getLastInvocation();
+        final InvocationMatcher invocationMatcher = new InvocationMatcher(invocation, (List) asList(new Equals("1"), Any.ANY, new InstanceOf(String.class)));
 
         //when
-        boolean match = comparator.argumentsMatch(invocationMatcher, invocation);
+        final boolean match = comparator.argumentsMatch(invocationMatcher, invocation);
 
         //then
         assertTrue(match);
@@ -90,11 +95,11 @@ public class ArgumentsComparatorTest extends TestBase {
     public void shouldKnowWhenVarargsDifferent() {
         //given
         mock.varargs("1", "2");
-        Invocation invocation = getLastInvocation();
-        InvocationMatcher invocationMatcher = new InvocationMatcher(invocation, (List) asList(new Equals("100"), Any.ANY));
+        final Invocation invocation = getLastInvocation();
+        final InvocationMatcher invocationMatcher = new InvocationMatcher(invocation, (List) asList(new Equals("100"), Any.ANY));
 
         //when
-        boolean match = comparator.argumentsMatch(invocationMatcher, invocation);
+        final boolean match = comparator.argumentsMatch(invocationMatcher, invocation);
 
         //then
         assertFalse(match);
@@ -104,11 +109,11 @@ public class ArgumentsComparatorTest extends TestBase {
     public void shouldNotAllowAnyObjectMatchEntireVararg() {
         //given
         mock.varargs("1", "2");
-        Invocation invocation = getLastInvocation();
-        InvocationMatcher invocationMatcher = new InvocationMatcher(invocation, (List) asList(Any.ANY));
+        final Invocation invocation = getLastInvocation();
+        final InvocationMatcher invocationMatcher = new InvocationMatcher(invocation, (List) asList(Any.ANY));
 
         //when
-        boolean match = comparator.argumentsMatch(invocationMatcher, invocation);
+        final boolean match = comparator.argumentsMatch(invocationMatcher, invocation);
 
         //then
         assertFalse(match);
@@ -118,11 +123,11 @@ public class ArgumentsComparatorTest extends TestBase {
     public void shouldAllowAnyVarargMatchEntireVararg() {
         //given
         mock.varargs("1", "2");
-        Invocation invocation = getLastInvocation();
-        InvocationMatcher invocationMatcher = new InvocationMatcher(invocation, (List) asList(AnyVararg.ANY_VARARG));
+        final Invocation invocation = getLastInvocation();
+        final InvocationMatcher invocationMatcher = new InvocationMatcher(invocation, asList(AnyVararg.ANY_VARARG));
 
         //when
-        boolean match = comparator.argumentsMatch(invocationMatcher, invocation);
+        final boolean match = comparator.argumentsMatch(invocationMatcher, invocation);
 
         //then
         assertTrue(match);
@@ -132,11 +137,11 @@ public class ArgumentsComparatorTest extends TestBase {
     public void shouldNotAllowAnyObjectWithMixedVarargs() {
         //given
         mock.mixedVarargs(1, "1", "2");
-        Invocation invocation = getLastInvocation();
-        InvocationMatcher invocationMatcher = new InvocationMatcher(invocation, (List) asList(new Equals(1)));
+        final Invocation invocation = getLastInvocation();
+        final InvocationMatcher invocationMatcher = new InvocationMatcher(invocation, (List) asList(new Equals(1)));
 
         //when
-        boolean match = comparator.argumentsMatch(invocationMatcher, invocation);
+        final boolean match = comparator.argumentsMatch(invocationMatcher, invocation);
 
         //then
         assertFalse(match);
@@ -146,11 +151,11 @@ public class ArgumentsComparatorTest extends TestBase {
     public void shouldAllowAnyObjectWithMixedVarargs() {
         //given
         mock.mixedVarargs(1, "1", "2");
-        Invocation invocation = getLastInvocation();
-        InvocationMatcher invocationMatcher = new InvocationMatcher(invocation, (List) asList(new Equals(1), AnyVararg.ANY_VARARG));
+        final Invocation invocation = getLastInvocation();
+        final InvocationMatcher invocationMatcher = new InvocationMatcher(invocation, asList(new Equals(1), AnyVararg.ANY_VARARG));
 
         //when
-        boolean match = comparator.argumentsMatch(invocationMatcher, invocation);
+        final boolean match = comparator.argumentsMatch(invocationMatcher, invocation);
 
         //then
         assertTrue(match);
@@ -160,11 +165,11 @@ public class ArgumentsComparatorTest extends TestBase {
     public void shouldNotMatchWhenSomeOtherArgumentDoesNotMatch() {
         //given
         mock.mixedVarargs(1, "1", "2");
-        Invocation invocation = getLastInvocation();
-        InvocationMatcher invocationMatcher = new InvocationMatcher(invocation, (List) asList(new Equals(100), AnyVararg.ANY_VARARG));
+        final Invocation invocation = getLastInvocation();
+        final InvocationMatcher invocationMatcher = new InvocationMatcher(invocation, asList(new Equals(100), AnyVararg.ANY_VARARG));
 
         //when
-        boolean match = comparator.argumentsMatch(invocationMatcher, invocation);
+        final boolean match = comparator.argumentsMatch(invocationMatcher, invocation);
 
         //then
         assertFalse(match);
@@ -174,11 +179,11 @@ public class ArgumentsComparatorTest extends TestBase {
     public void shouldAnyObjectVarargDealWithDifferentSizeOfArgs() {
         //given
         mock.mixedVarargs(1, "1", "2");
-        Invocation invocation = getLastInvocation();
-        InvocationMatcher invocationMatcher = new InvocationMatcher(invocation, (List) asList(new Equals(1)));
+        final Invocation invocation = getLastInvocation();
+        final InvocationMatcher invocationMatcher = new InvocationMatcher(invocation, (List) asList(new Equals(1)));
 
         //when
-        boolean match = comparator.argumentsMatch(invocationMatcher, invocation);
+        final boolean match = comparator.argumentsMatch(invocationMatcher, invocation);
 
         //then
         assertFalse(match);
@@ -188,11 +193,11 @@ public class ArgumentsComparatorTest extends TestBase {
     public void shouldMatchAnyVarargEvenIfOneOfTheArgsIsNull() {
         //given
         mock.mixedVarargs(null, null, "2");
-        Invocation invocation = getLastInvocation();
-        InvocationMatcher invocationMatcher = new InvocationMatcher(invocation, (List) asList(new Equals(null), AnyVararg.ANY_VARARG));
+        final Invocation invocation = getLastInvocation();
+        final InvocationMatcher invocationMatcher = new InvocationMatcher(invocation, asList(new Equals(null), AnyVararg.ANY_VARARG));
 
         //when
-        boolean match = comparator.argumentsMatch(invocationMatcher, invocation);
+        final boolean match = comparator.argumentsMatch(invocationMatcher, invocation);
 
         //then
         assertTrue(match);
@@ -202,11 +207,11 @@ public class ArgumentsComparatorTest extends TestBase {
     public void shouldMatchAnyVarargEvenIfMatcherIsDecorated() {
         //given
         mock.varargs("1", "2");
-        Invocation invocation = getLastInvocation();
-        InvocationMatcher invocationMatcher = new InvocationMatcher(invocation, (List) asList(new LocalizedMatcher(AnyVararg.ANY_VARARG)));
+        final Invocation invocation = getLastInvocation();
+        final InvocationMatcher invocationMatcher = new InvocationMatcher(invocation, (List) asList(new LocalizedMatcher(AnyVararg.ANY_VARARG)));
 
         //when
-        boolean match = comparator.argumentsMatch(invocationMatcher, invocation);
+        final boolean match = comparator.argumentsMatch(invocationMatcher, invocation);
 
         //then
         assertTrue(match);

--- a/test/org/mockito/internal/invocation/InvocationBuilder.java
+++ b/test/org/mockito/internal/invocation/InvocationBuilder.java
@@ -5,20 +5,19 @@
 
 package org.mockito.internal.invocation;
 
-import org.mockito.Mockito;
-import org.mockito.invocation.Invocation;
-import org.mockitousage.IMethods;
+import static java.util.Arrays.asList;
 
 import java.lang.reflect.Method;
 import java.util.LinkedList;
 import java.util.List;
 
-import static java.util.Arrays.asList;
+import org.mockito.Mockito;
+import org.mockito.invocation.Invocation;
+import org.mockitousage.IMethods;
 
 /**
  * Build an invocation.
  */
-@SuppressWarnings("unchecked")
 public class InvocationBuilder {
 
     private String methodName = "simpleMethod";
@@ -40,7 +39,7 @@ public class InvocationBuilder {
         if (method == null) {
             if (argTypes == null) {
                 argTypes = new LinkedList<Class<?>>();
-                for (Object arg : args) {
+                for (final Object arg : args) {
                     if (arg == null) {
                         argTypes.add(Object.class);
                     } else {
@@ -51,44 +50,44 @@ public class InvocationBuilder {
 
             try {
                 method = IMethods.class.getMethod(methodName, argTypes.toArray(new Class[argTypes.size()]));
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 throw new RuntimeException("builder only creates invocations of IMethods interface", e);
             }
         }
         
-        Invocation i = new InvocationImpl(mock, new SerializableMethod(method), args, sequenceNumber, null);
+        final Invocation i = new InvocationImpl(mock, new SerializableMethod(method), args, sequenceNumber, null);
         if (verified) {
             i.markVerified();
         }
         return i;
     }
 
-    public InvocationBuilder method(String methodName) {
+    public InvocationBuilder method(final String methodName) {
         this.methodName  = methodName;
         return this;
     }
 
-    public InvocationBuilder seq(int sequenceNumber) {
+    public InvocationBuilder seq(final int sequenceNumber) {
         this.sequenceNumber = sequenceNumber;
         return this;
     }
 
-    public InvocationBuilder args(Object ... args) {
+    public InvocationBuilder args(final Object ... args) {
         this.args = args;
         return this;
     }
     
-    public InvocationBuilder arg(Object o) {
+    public InvocationBuilder arg(final Object o) {
         this.args = new Object[] {o};
         return this;
     }
 
-    public InvocationBuilder mock(Object mock) {
+    public InvocationBuilder mock(final Object mock) {
         this.mock = mock;
         return this;
     }
 
-    public InvocationBuilder method(Method method) {
+    public InvocationBuilder method(final Method method) {
         this.method = method;
         return this;
     }
@@ -110,7 +109,7 @@ public class InvocationBuilder {
         return this.method("differentMethod");
     }
 
-    public InvocationBuilder argTypes(Class<?>... argTypes) {
+    public InvocationBuilder argTypes(final Class<?>... argTypes) {
         this.argTypes = asList(argTypes);
         return this;
     }

--- a/test/org/mockito/internal/invocation/InvocationImplTest.java
+++ b/test/org/mockito/internal/invocation/InvocationImplTest.java
@@ -5,6 +5,11 @@
 
 package org.mockito.internal.invocation;
 
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.exceptions.base.MockitoException;
@@ -15,12 +20,7 @@ import org.mockito.invocation.Invocation;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import java.lang.reflect.Method;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-@SuppressWarnings({"unchecked"})
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class InvocationImplTest extends TestBase {
 
     private Invocation invocation;
@@ -32,9 +32,9 @@ public class InvocationImplTest extends TestBase {
 
     @Test
     public void shouldKnowIfIsEqualTo() {
-        Invocation equal =                  new InvocationBuilder().args(" ").mock("mock").toInvocation();
-        Invocation nonEqual =               new InvocationBuilder().args("X").mock("mock").toInvocation();
-        Invocation withNewStringInstance =  new InvocationBuilder().args(new String(" ")).mock("mock").toInvocation();
+        final Invocation equal =                  new InvocationBuilder().args(" ").mock("mock").toInvocation();
+        final Invocation nonEqual =               new InvocationBuilder().args("X").mock("mock").toInvocation();
+        final Invocation withNewStringInstance =  new InvocationBuilder().args(new String(" ")).mock("mock").toInvocation();
 
         assertFalse(invocation.equals(null));
         assertFalse(invocation.equals(""));
@@ -45,7 +45,7 @@ public class InvocationImplTest extends TestBase {
     
     @Test
     public void shouldEqualToNotConsiderSequenceNumber() {
-        Invocation equal = new InvocationBuilder().args(" ").mock("mock").seq(2).toInvocation();
+        final Invocation equal = new InvocationBuilder().args(" ").mock("mock").seq(2).toInvocation();
         
         assertTrue(invocation.equals(equal));
         assertTrue(invocation.getSequenceNumber() != equal.getSequenceNumber());
@@ -53,7 +53,7 @@ public class InvocationImplTest extends TestBase {
     
     @Test
     public void shouldBeACitizenOfHashes() {
-        Map map = new HashMap();
+        final Map map = new HashMap();
         map.put(invocation, "one");
         assertEquals("one", map.get(invocation));
     }
@@ -90,7 +90,7 @@ public class InvocationImplTest extends TestBase {
     
     @Test
     public void shouldPrintNullIfArrayIsNull() throws Exception {
-        Method m = IMethods.class.getMethod("oneArray", Object[].class);
+        final Method m = IMethods.class.getMethod("oneArray", Object[].class);
         invocation = new InvocationBuilder().method(m).args((Object) null).toInvocation();
         assertThat(invocation.toString(), endsWith("oneArray(null);"));
     }
@@ -110,8 +110,8 @@ public class InvocationImplTest extends TestBase {
     
     @Test
     public void shouldTransformArgumentsToMatchers() throws Exception {
-        Invocation i = new InvocationBuilder().args("foo", new String[]{"bar"}).toInvocation();
-        List matchers = ArgumentsProcessor.argumentsToMatchers(i.getArguments());
+        final Invocation i = new InvocationBuilder().args("foo", new String[]{"bar"}).toInvocation();
+        final List matchers = ArgumentsProcessor.argumentsToMatchers(i.getArguments());
 
         assertEquals(2, matchers.size());
         assertEquals(Equals.class, matchers.get(0).getClass());
@@ -127,8 +127,8 @@ public class InvocationImplTest extends TestBase {
     @Test
     public void shouldBeAbleToCallRealMethod() throws Throwable {
         //when
-        Invocation invocation = invocationOf(Foo.class, "bark", new RealMethod() {
-            public Object invoke(Object target, Object[] arguments) throws Throwable {
+        final Invocation invocation = invocationOf(Foo.class, "bark", new RealMethod() {
+            public Object invoke(final Object target, final Object[] arguments) throws Throwable {
                 return new Foo().bark();
             }});
         //then
@@ -138,25 +138,25 @@ public class InvocationImplTest extends TestBase {
     @Test
     public void shouldScreamWhenCallingRealMethodOnInterface() throws Throwable {
         //given
-        Invocation invocationOnInterface = new InvocationBuilder().toInvocation();
+        final Invocation invocationOnInterface = new InvocationBuilder().toInvocation();
 
         try {
             //when
             invocationOnInterface.callRealMethod();
             //then
             fail();
-        } catch(MockitoException e) {}
+        } catch(final MockitoException e) {}
     }
     
     @Test
     public void shouldReturnCastedArgumentAt(){
         //given
-        int argument = 42;
-        Invocation invocationOnInterface = new InvocationBuilder().method("twoArgumentMethod").
+        final int argument = 42;
+        final Invocation invocationOnInterface = new InvocationBuilder().method("twoArgumentMethod").
             argTypes(int.class, int.class).args(1, argument).toInvocation();
 
         //when
-        int secondArgument = invocationOnInterface.getArgumentAt(1, int.class);
+        final int secondArgument = invocationOnInterface.getArgumentAt(1, int.class);
 
         //then
         assertTrue(secondArgument == argument);

--- a/test/org/mockito/internal/invocation/InvocationMatcherTest.java
+++ b/test/org/mockito/internal/invocation/InvocationMatcherTest.java
@@ -5,24 +5,28 @@
 
 package org.mockito.internal.invocation;
 
-import org.fest.assertions.Assertions;
-import org.hamcrest.Matcher;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.internal.matchers.*;
-import org.mockito.invocation.Invocation;
-import org.mockitousage.IMethods;
-import org.mockitoutil.TestBase;
+import static java.util.Arrays.asList;
 
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.Arrays.asList;
+import org.fest.assertions.Assertions;
+import org.hamcrest.Matcher;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.internal.matchers.AnyVararg;
+import org.mockito.internal.matchers.CapturingMatcher;
+import org.mockito.internal.matchers.Equals;
+import org.mockito.internal.matchers.LocalizedMatcher;
+import org.mockito.internal.matchers.NotNull;
+import org.mockito.invocation.Invocation;
+import org.mockitousage.IMethods;
+import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class InvocationMatcherTest extends TestBase {
 
     private InvocationMatcher simpleMethod;
@@ -35,10 +39,10 @@ public class InvocationMatcherTest extends TestBase {
 
     @Test
     public void should_be_a_citizen_of_hashes() throws Exception {
-        Invocation invocation = new InvocationBuilder().toInvocation();
-        Invocation invocationTwo = new InvocationBuilder().args("blah").toInvocation();
+        final Invocation invocation = new InvocationBuilder().toInvocation();
+        final Invocation invocationTwo = new InvocationBuilder().args("blah").toInvocation();
 
-        Map map = new HashMap();
+        final Map map = new HashMap();
         map.put(new InvocationMatcher(invocation), "one");
         map.put(new InvocationMatcher(invocationTwo), "two");
 
@@ -47,8 +51,8 @@ public class InvocationMatcherTest extends TestBase {
 
     @Test
     public void should_not_equal_if_number_of_arguments_differ() throws Exception {
-        InvocationMatcher withOneArg = new InvocationMatcher(new InvocationBuilder().args("test").toInvocation());
-        InvocationMatcher withTwoArgs = new InvocationMatcher(new InvocationBuilder().args("test", 100).toInvocation());
+        final InvocationMatcher withOneArg = new InvocationMatcher(new InvocationBuilder().args("test").toInvocation());
+        final InvocationMatcher withTwoArgs = new InvocationMatcher(new InvocationBuilder().args("test", 100).toInvocation());
 
         assertFalse(withOneArg.equals(null));
         assertFalse(withOneArg.equals(withTwoArgs));
@@ -56,10 +60,10 @@ public class InvocationMatcherTest extends TestBase {
 
     @Test
     public void should_to_string_with_matchers() throws Exception {
-        Matcher m = NotNull.NOT_NULL;
-        InvocationMatcher notNull = new InvocationMatcher(new InvocationBuilder().toInvocation(), asList(m));
-        Matcher mTwo = new Equals('x');
-        InvocationMatcher equals = new InvocationMatcher(new InvocationBuilder().toInvocation(), asList(mTwo));
+        final Matcher m = NotNull.NOT_NULL;
+        final InvocationMatcher notNull = new InvocationMatcher(new InvocationBuilder().toInvocation(), asList(m));
+        final Matcher mTwo = new Equals('x');
+        final InvocationMatcher equals = new InvocationMatcher(new InvocationBuilder().toInvocation(), asList(mTwo));
 
         assertContains("simpleMethod(notNull())", notNull.toString());
         assertContains("simpleMethod('x')", equals.toString());
@@ -67,45 +71,45 @@ public class InvocationMatcherTest extends TestBase {
 
     @Test
     public void should_know_if_is_similar_to() throws Exception {
-        Invocation same = new InvocationBuilder().mock(mock).simpleMethod().toInvocation();
+        final Invocation same = new InvocationBuilder().mock(mock).simpleMethod().toInvocation();
         assertTrue(simpleMethod.hasSimilarMethod(same));
 
-        Invocation different = new InvocationBuilder().mock(mock).differentMethod().toInvocation();
+        final Invocation different = new InvocationBuilder().mock(mock).differentMethod().toInvocation();
         assertFalse(simpleMethod.hasSimilarMethod(different));
     }
 
     @Test
     public void should_not_be_similar_to_verified_invocation() throws Exception {
-        Invocation verified = new InvocationBuilder().simpleMethod().verified().toInvocation();
+        final Invocation verified = new InvocationBuilder().simpleMethod().verified().toInvocation();
         assertFalse(simpleMethod.hasSimilarMethod(verified));
     }
 
     @Test
     public void should_not_be_similar_if_mocks_are_different() throws Exception {
-        Invocation onDifferentMock = new InvocationBuilder().simpleMethod().mock("different mock").toInvocation();
+        final Invocation onDifferentMock = new InvocationBuilder().simpleMethod().mock("different mock").toInvocation();
         assertFalse(simpleMethod.hasSimilarMethod(onDifferentMock));
     }
 
     @Test
     public void should_not_be_similar_if_is_overloaded_but_used_with_the_same_arg() throws Exception {
-        Method method = IMethods.class.getMethod("simpleMethod", String.class);
-        Method overloadedMethod = IMethods.class.getMethod("simpleMethod", Object.class);
+        final Method method = IMethods.class.getMethod("simpleMethod", String.class);
+        final Method overloadedMethod = IMethods.class.getMethod("simpleMethod", Object.class);
 
-        String sameArg = "test";
+        final String sameArg = "test";
 
-        InvocationMatcher invocation = new InvocationBuilder().method(method).arg(sameArg).toInvocationMatcher();
-        Invocation overloadedInvocation = new InvocationBuilder().method(overloadedMethod).arg(sameArg).toInvocation();
+        final InvocationMatcher invocation = new InvocationBuilder().method(method).arg(sameArg).toInvocationMatcher();
+        final Invocation overloadedInvocation = new InvocationBuilder().method(overloadedMethod).arg(sameArg).toInvocation();
 
         assertFalse(invocation.hasSimilarMethod(overloadedInvocation));
     }
 
     @Test
     public void should_be_similar_if_is_overloaded_but_used_with_different_arg() throws Exception {
-        Method method = IMethods.class.getMethod("simpleMethod", String.class);
-        Method overloadedMethod = IMethods.class.getMethod("simpleMethod", Object.class);
+        final Method method = IMethods.class.getMethod("simpleMethod", String.class);
+        final Method overloadedMethod = IMethods.class.getMethod("simpleMethod", Object.class);
 
-        InvocationMatcher invocation = new InvocationBuilder().mock(mock).method(method).arg("foo").toInvocationMatcher();
-        Invocation overloadedInvocation = new InvocationBuilder().mock(mock).method(overloadedMethod).arg("bar").toInvocation();
+        final InvocationMatcher invocation = new InvocationBuilder().mock(mock).method(method).arg("foo").toInvocationMatcher();
+        final Invocation overloadedInvocation = new InvocationBuilder().mock(mock).method(overloadedMethod).arg("bar").toInvocation();
 
         assertTrue(invocation.hasSimilarMethod(overloadedInvocation));
     }
@@ -113,9 +117,9 @@ public class InvocationMatcherTest extends TestBase {
     @Test
     public void should_capture_arguments_from_invocation() throws Exception {
         //given
-        Invocation invocation = new InvocationBuilder().args("1", 100).toInvocation();
-        CapturingMatcher capturingMatcher = new CapturingMatcher();
-        InvocationMatcher invocationMatcher = new InvocationMatcher(invocation, (List) asList(new Equals("1"), capturingMatcher));
+        final Invocation invocation = new InvocationBuilder().args("1", 100).toInvocation();
+        final CapturingMatcher capturingMatcher = new CapturingMatcher();
+        final InvocationMatcher invocationMatcher = new InvocationMatcher(invocation, (List) asList(new Equals("1"), capturingMatcher));
 
         //when
         invocationMatcher.captureArgumentsFrom(invocation);
@@ -129,11 +133,11 @@ public class InvocationMatcherTest extends TestBase {
     public void should_match_varargs_using_any_varargs() throws Exception {
         //given
         mock.varargs("1", "2");
-        Invocation invocation = getLastInvocation();
-        InvocationMatcher invocationMatcher = new InvocationMatcher(invocation, (List) asList(AnyVararg.ANY_VARARG));
+        final Invocation invocation = getLastInvocation();
+        final InvocationMatcher invocationMatcher = new InvocationMatcher(invocation, asList(AnyVararg.ANY_VARARG));
 
         //when
-        boolean match = invocationMatcher.matches(invocation);
+        final boolean match = invocationMatcher.matches(invocation);
 
         //then
         assertTrue(match);
@@ -143,9 +147,9 @@ public class InvocationMatcherTest extends TestBase {
     public void should_capture_varargs_as_vararg() throws Exception {
         //given
         mock.mixedVarargs(1, "a", "b");
-        Invocation invocation = getLastInvocation();
-        CapturingMatcher m = new CapturingMatcher();
-        InvocationMatcher invocationMatcher = new InvocationMatcher(invocation, (List) asList(new Equals(1), new LocalizedMatcher(m)));
+        final Invocation invocation = getLastInvocation();
+        final CapturingMatcher m = new CapturingMatcher();
+        final InvocationMatcher invocationMatcher = new InvocationMatcher(invocation, (List) asList(new Equals(1), new LocalizedMatcher(m)));
 
         //when
         invocationMatcher.captureArgumentsFrom(invocation);
@@ -158,10 +162,10 @@ public class InvocationMatcherTest extends TestBase {
     public void should_capture_arguments_when_args_count_does_NOT_match() throws Exception {
         //given
         mock.varargs();
-        Invocation invocation = getLastInvocation();
+        final Invocation invocation = getLastInvocation();
 
         //when
-        InvocationMatcher invocationMatcher = new InvocationMatcher(invocation, (List) asList(new LocalizedMatcher(AnyVararg.ANY_VARARG)));
+        final InvocationMatcher invocationMatcher = new InvocationMatcher(invocation, (List) asList(new LocalizedMatcher(AnyVararg.ANY_VARARG)));
 
         //then
         invocationMatcher.captureArgumentsFrom(invocation);
@@ -170,9 +174,9 @@ public class InvocationMatcherTest extends TestBase {
     @Test
     public void should_create_from_invocations() throws Exception {
         //given
-        Invocation i = new InvocationBuilder().toInvocation();
+        final Invocation i = new InvocationBuilder().toInvocation();
         //when
-        List<InvocationMatcher> out = InvocationMatcher.createFrom(asList(i));
+        final List<InvocationMatcher> out = InvocationMatcher.createFrom(asList(i));
         //then
         assertEquals(1, out.size());
         assertEquals(i, out.get(0).getInvocation());

--- a/test/org/mockito/internal/invocation/InvocationsFinderTest.java
+++ b/test/org/mockito/internal/invocation/InvocationsFinderTest.java
@@ -5,7 +5,7 @@
 
 package org.mockito.internal.invocation;
 
-import static org.mockitoutil.ExtraMatchers.*;
+import static org.mockitoutil.ExtraMatchers.hasExactlyInOrder;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -25,7 +25,7 @@ import org.mockitoutil.TestBase;
 
 public class InvocationsFinderTest extends TestBase {
     
-    private LinkedList<Invocation> invocations = new LinkedList<Invocation>();
+    private final LinkedList<Invocation> invocations = new LinkedList<Invocation>();
     private Invocation simpleMethodInvocation;
     private Invocation simpleMethodInvocationTwo;
     private Invocation differentMethodInvocation;
@@ -68,7 +68,7 @@ public class InvocationsFinderTest extends TestBase {
     @Test
     public void shouldFindFirstUnverifiedInOrder() throws Exception {
         //given
-        InOrderContextImpl context = new InOrderContextImpl();
+        final InOrderContextImpl context = new InOrderContextImpl();
         assertSame(simpleMethodInvocation, finder.findFirstUnverifiedInOrder(context, invocations));        
         
         //when
@@ -88,7 +88,7 @@ public class InvocationsFinderTest extends TestBase {
     @Test
     public void shouldFindFirstUnverifiedInOrderAndRespectSequenceNumber() throws Exception {
         //given
-        InOrderContextImpl context = new InOrderContextImpl();
+        final InOrderContextImpl context = new InOrderContextImpl();
         assertSame(simpleMethodInvocation, finder.findFirstUnverifiedInOrder(context, invocations));        
         
         //when
@@ -108,25 +108,25 @@ public class InvocationsFinderTest extends TestBase {
     
     @Test
     public void shouldFindFirstSimilarInvocationByName() throws Exception {
-        Invocation overloadedSimpleMethod = new InvocationBuilder().mock(mock).simpleMethod().arg("test").toInvocation();
+        final Invocation overloadedSimpleMethod = new InvocationBuilder().mock(mock).simpleMethod().arg("test").toInvocation();
         
-        Invocation found = finder.findSimilarInvocation(invocations, new InvocationMatcher(overloadedSimpleMethod));
+        final Invocation found = finder.findSimilarInvocation(invocations, new InvocationMatcher(overloadedSimpleMethod));
         assertSame(found, simpleMethodInvocation);
     }
     
     @Test
     public void shouldFindInvocationWithTheSameMethod() throws Exception {
-        Invocation overloadedDifferentMethod = new InvocationBuilder().differentMethod().arg("test").toInvocation();
+        final Invocation overloadedDifferentMethod = new InvocationBuilder().differentMethod().arg("test").toInvocation();
         
         invocations.add(overloadedDifferentMethod);
         
-        Invocation found = finder.findSimilarInvocation(invocations, new InvocationMatcher(overloadedDifferentMethod));
+        final Invocation found = finder.findSimilarInvocation(invocations, new InvocationMatcher(overloadedDifferentMethod));
         assertSame(found, overloadedDifferentMethod);
     }
     
     @Test
     public void shouldGetLastStackTrace() throws Exception {
-        Location last = finder.getLastLocation(invocations);
+        final Location last = finder.getLastLocation(invocations);
         assertSame(differentMethodInvocation.getLocation(), last);
         
         assertNull(finder.getLastLocation(Collections.<Invocation>emptyList()));
@@ -148,25 +148,25 @@ public class InvocationsFinderTest extends TestBase {
     
     @Test
     public void shouldFindMatchingChunk() throws Exception {
-        List<Invocation> chunk = finder.findMatchingChunk(invocations, new InvocationMatcher(simpleMethodInvocation), 2, context);
+        final List<Invocation> chunk = finder.findMatchingChunk(invocations, new InvocationMatcher(simpleMethodInvocation), 2, context);
         assertThat(chunk, hasExactlyInOrder(simpleMethodInvocation, simpleMethodInvocationTwo));
     }
     
     @Test
     public void shouldReturnAllChunksWhenModeIsAtLeastOnce() throws Exception {
-        Invocation simpleMethodInvocationThree = new InvocationBuilder().mock(mock).toInvocation();
+        final Invocation simpleMethodInvocationThree = new InvocationBuilder().mock(mock).toInvocation();
         invocations.add(simpleMethodInvocationThree);
         
-        List<Invocation> chunk = finder.findMatchingChunk(invocations, new InvocationMatcher(simpleMethodInvocation), 1, context);
+        final List<Invocation> chunk = finder.findMatchingChunk(invocations, new InvocationMatcher(simpleMethodInvocation), 1, context);
         assertThat(chunk, hasExactlyInOrder(simpleMethodInvocation, simpleMethodInvocationTwo, simpleMethodInvocationThree));
     }
     
     @Test
     public void shouldReturnAllChunksWhenWantedCountDoesntMatch() throws Exception {
-        Invocation simpleMethodInvocationThree = new InvocationBuilder().mock(mock).toInvocation();
+        final Invocation simpleMethodInvocationThree = new InvocationBuilder().mock(mock).toInvocation();
         invocations.add(simpleMethodInvocationThree);
         
-        List<Invocation> chunk = finder.findMatchingChunk(invocations, new InvocationMatcher(simpleMethodInvocation), 1, context);
+        final List<Invocation> chunk = finder.findMatchingChunk(invocations, new InvocationMatcher(simpleMethodInvocation), 1, context);
         assertThat(chunk, hasExactlyInOrder(simpleMethodInvocation, simpleMethodInvocationTwo, simpleMethodInvocationThree));
     }
     

--- a/test/org/mockito/internal/invocation/SerializableMethodTest.java
+++ b/test/org/mockito/internal/invocation/SerializableMethodTest.java
@@ -4,7 +4,7 @@
  */
 package org.mockito.internal.invocation;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
 
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectOutputStream;
@@ -30,7 +30,7 @@ public class SerializableMethodTest extends TestBase {
     
     @Test
     public void shouldBeSerializable() throws Exception {
-        ByteArrayOutputStream serialized = new ByteArrayOutputStream();
+        final ByteArrayOutputStream serialized = new ByteArrayOutputStream();
         new ObjectOutputStream(serialized).writeObject(method);
     }
     
@@ -66,7 +66,7 @@ public class SerializableMethodTest extends TestBase {
     
     @Test
     public void shouldNotBeEqualForSameMethodFromTwoDifferentClasses() throws Exception {
-        Method testBaseToStringMethod = String.class.getMethod("toString", args);
+        final Method testBaseToStringMethod = String.class.getMethod("toString", args);
         assertFalse(new SerializableMethod(testBaseToStringMethod).equals(method));
     }
     

--- a/test/org/mockito/internal/junit/JUnitRuleTest.java
+++ b/test/org/mockito/internal/junit/JUnitRuleTest.java
@@ -1,5 +1,9 @@
 package org.mockito.internal.junit;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
 import org.junit.Test;
 import org.junit.runners.model.Statement;
 import org.mockito.InjectMocks;
@@ -7,14 +11,11 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.exceptions.misusing.UnfinishedStubbingException;
-import org.mockito.internal.junit.JUnitRule;
-
-import static org.junit.Assert.*;
 
 public class JUnitRuleTest {
 
-    private JUnitRule jUnitRule = new JUnitRule();
-    private InjectTestCase injectTestCase = new InjectTestCase();
+    private final JUnitRule jUnitRule = new JUnitRule();
+    private final InjectTestCase injectTestCase = new InjectTestCase();
 
     @Test
     public void shouldInjectIntoTestCase() throws Throwable {
@@ -29,7 +30,7 @@ public class JUnitRuleTest {
         try {
             jUnitRule.apply(new ExceptionStatement(), injectTestCase).evaluate();
             fail("Should throw exception");
-        } catch (RuntimeException e) {
+        } catch (final RuntimeException e) {
             assertEquals("Correct message", "Statement exception", e.getMessage());
         }
     }
@@ -39,7 +40,7 @@ public class JUnitRuleTest {
         try {
             jUnitRule.apply(new UnfinishedStubbingStatement(), injectTestCase).evaluate();
             fail("Should detect invalid Mockito usage");
-        } catch (UnfinishedStubbingException e) {
+        } catch (final UnfinishedStubbingException e) {
         }
     }
 
@@ -59,7 +60,7 @@ public class JUnitRuleTest {
     private static class UnfinishedStubbingStatement extends Statement {
         @Override
         public void evaluate() throws Throwable {
-            InjectTestCase injectTestCase = new InjectTestCase();
+            final InjectTestCase injectTestCase = new InjectTestCase();
             MockitoAnnotations.initMocks(injectTestCase);
             injectTestCase.unfinishedStubbingThrowsException();
         }

--- a/test/org/mockito/internal/matchers/CapturingMatcherTest.java
+++ b/test/org/mockito/internal/matchers/CapturingMatcherTest.java
@@ -9,13 +9,13 @@ import org.junit.Test;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class CapturingMatcherTest extends TestBase {
 
     @Test
     public void should_capture_arguments() throws Exception {
         //given
-        CapturingMatcher m = new CapturingMatcher();
+        final CapturingMatcher m = new CapturingMatcher();
         
         //when
         m.captureFrom("foo");
@@ -28,7 +28,7 @@ public class CapturingMatcherTest extends TestBase {
     @Test
     public void should_know_last_captured_value() throws Exception {
         //given
-        CapturingMatcher m = new CapturingMatcher();
+        final CapturingMatcher m = new CapturingMatcher();
         
         //when
         m.captureFrom("foo");
@@ -41,13 +41,13 @@ public class CapturingMatcherTest extends TestBase {
     @Test
     public void should_scream_when_nothing_yet_captured() throws Exception {
         //given
-        CapturingMatcher m = new CapturingMatcher();
+        final CapturingMatcher m = new CapturingMatcher();
 
         try {
             //when
             m.getLastValue();
             //then
             fail();
-        } catch (MockitoException e) {}
+        } catch (final MockitoException e) {}
     }
 }

--- a/test/org/mockito/internal/matchers/EqualityTest.java
+++ b/test/org/mockito/internal/matchers/EqualityTest.java
@@ -21,7 +21,7 @@ public class EqualityTest extends TestBase {
         assertTrue(areEqual(new int[] {1}, new Integer[] {1}));
         assertTrue(areEqual(new Object[] {"1"}, new String[] {"1"}));
         Object badequals=new BadEquals();
-        assertTrue(areEqual(badequals,badequals));
+        assertTrue(areEqual(badequals, badequals));
 
         assertFalse(areEqual(new Object[9], new Object[10]));
         assertFalse(areEqual(new int[] {1, 2}, new int[] {1}));

--- a/test/org/mockito/internal/matchers/LocalizedMatcherTest.java
+++ b/test/org/mockito/internal/matchers/LocalizedMatcherTest.java
@@ -8,14 +8,14 @@ import org.hamcrest.Matcher;
 import org.junit.Test;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class LocalizedMatcherTest extends TestBase {
     
     @Test
     public void shouldMatchTypesWhenActualMatcherHasCorrectType() throws Exception {
         //when
-        ContainsExtraTypeInformation equals10 = new Equals(10);
-        LocalizedMatcher m = new LocalizedMatcher((Matcher) equals10);
+        final ContainsExtraTypeInformation equals10 = new Equals(10);
+        final LocalizedMatcher m = new LocalizedMatcher((Matcher) equals10);
         
         //then
         assertTrue(m.typeMatches(10));
@@ -25,7 +25,7 @@ public class LocalizedMatcherTest extends TestBase {
     @Test
     public void shouldNotMatchTypesWhenActualMatcherDoesNotHaveCorrectType() throws Exception {
         //when
-        LocalizedMatcher m = new LocalizedMatcher(Any.ANY);
+        final LocalizedMatcher m = new LocalizedMatcher(Any.ANY);
         
         //then
         assertFalse(m.typeMatches(10));
@@ -34,8 +34,8 @@ public class LocalizedMatcherTest extends TestBase {
     @Test
     public void shouldDescribeWithTypeInfoWhenActualMatcherHasCorrectType() throws Exception {
         //when
-        ContainsExtraTypeInformation equals10 = new Equals(10);
-        LocalizedMatcher m = new LocalizedMatcher((Matcher) equals10);
+        final ContainsExtraTypeInformation equals10 = new Equals(10);
+        final LocalizedMatcher m = new LocalizedMatcher((Matcher) equals10);
         
         //then
         assertEquals("(Integer) 10", describe(m.withExtraTypeInfo()));
@@ -44,7 +44,7 @@ public class LocalizedMatcherTest extends TestBase {
     @Test
     public void shouldNotDescribeWithTypeInfoWhenActualMatcherDoesNotHaveCorrectType() throws Exception {
         //when
-        LocalizedMatcher m = new LocalizedMatcher(Any.ANY);
+        final LocalizedMatcher m = new LocalizedMatcher(Any.ANY);
         
         //then
         assertSame(m, m.withExtraTypeInfo());
@@ -53,8 +53,8 @@ public class LocalizedMatcherTest extends TestBase {
     @Test
     public void shouldDelegateToCapturingMatcher() throws Exception {
         //given
-        CapturingMatcher capturingMatcher = new CapturingMatcher();
-        LocalizedMatcher m = new LocalizedMatcher(capturingMatcher);
+        final CapturingMatcher capturingMatcher = new CapturingMatcher();
+        final LocalizedMatcher m = new LocalizedMatcher(capturingMatcher);
         
         //when
         m.captureFrom("boo");

--- a/test/org/mockito/internal/matchers/MatchersPrinterTest.java
+++ b/test/org/mockito/internal/matchers/MatchersPrinterTest.java
@@ -11,27 +11,27 @@ import org.junit.Test;
 import org.mockito.internal.reporting.PrintSettings;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class MatchersPrinterTest extends TestBase {
 
     MatchersPrinter printer = new MatchersPrinter();
 
     @Test
     public void shouldGetArgumentsLine() {
-        String line = printer.getArgumentsLine((List) Arrays.asList(new Equals(1), new Equals(2)), new PrintSettings());
+        final String line = printer.getArgumentsLine((List) Arrays.asList(new Equals(1), new Equals(2)), new PrintSettings());
         assertEquals("(1, 2);", line);
     }
 
     @Test
     public void shouldGetArgumentsBlock() {
-        String line = printer.getArgumentsBlock((List) Arrays.asList(new Equals(1), new Equals(2)), new PrintSettings());
+        final String line = printer.getArgumentsBlock((List) Arrays.asList(new Equals(1), new Equals(2)), new PrintSettings());
         assertEquals("(\n    1,\n    2\n);", line);
     }
 
     @Test
     public void shouldDescribeTypeInfoOnlyMarkedMatchers() {
         //when
-        String line = printer.getArgumentsLine((List) Arrays.asList(new Equals(1L), new Equals(2)), PrintSettings.verboseMatchers(1));
+        final String line = printer.getArgumentsLine((List) Arrays.asList(new Equals(1L), new Equals(2)), PrintSettings.verboseMatchers(1));
         //then
         assertEquals("(1, (Integer) 2);", line);
     }
@@ -39,7 +39,7 @@ public class MatchersPrinterTest extends TestBase {
     @Test
     public void shouldGetVerboseArgumentsInBlock() {
         //when
-        String line = printer.getArgumentsBlock((List) Arrays.asList(new Equals(1L), new Equals(2)), PrintSettings.verboseMatchers(0, 1));
+        final String line = printer.getArgumentsBlock((List) Arrays.asList(new Equals(1L), new Equals(2)), PrintSettings.verboseMatchers(0, 1));
         //then
         assertEquals("(\n    (Long) 1,\n    (Integer) 2\n);", line);
     }
@@ -47,7 +47,7 @@ public class MatchersPrinterTest extends TestBase {
     @Test
     public void shouldGetVerboseArgumentsEvenIfSomeMatchersAreNotVerbose() {
         //when
-        String line = printer.getArgumentsLine((List) Arrays.asList(new Equals(1L), NotNull.NOT_NULL), PrintSettings.verboseMatchers(0));
+        final String line = printer.getArgumentsLine((List) Arrays.asList(new Equals(1L), NotNull.NOT_NULL), PrintSettings.verboseMatchers(0));
         //then
         assertEquals("((Long) 1, notNull());", line);
     }

--- a/test/org/mockito/internal/matchers/MatchersToStringTest.java
+++ b/test/org/mockito/internal/matchers/MatchersToStringTest.java
@@ -12,7 +12,7 @@ import org.hamcrest.Matcher;
 import org.junit.Test;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class MatchersToStringTest extends TestBase {
 
     @Test
@@ -43,7 +43,7 @@ public class MatchersToStringTest extends TestBase {
 
     @Test
     public void sameToStringWithObject() {
-        Object o = new Object() {
+        final Object o = new Object() {
             @Override
             public String toString() {
                 return "X";
@@ -65,7 +65,7 @@ public class MatchersToStringTest extends TestBase {
 
     @Test
     public void equalsToStringWithObject() {
-        Object o = new Object() {
+        final Object o = new Object() {
             @Override
             public String toString() {
                 return "X";
@@ -76,7 +76,7 @@ public class MatchersToStringTest extends TestBase {
 
     @Test
     public void orToString() {
-        List<Matcher> matchers = new ArrayList<Matcher>();
+        final List<Matcher> matchers = new ArrayList<Matcher>();
         matchers.add(new Equals(1));
         matchers.add(new Equals(2));
         assertEquals("or(1, 2)", describe(new Or(matchers)));
@@ -89,7 +89,7 @@ public class MatchersToStringTest extends TestBase {
 
     @Test
     public void andToString() {
-        List<Matcher> matchers = new ArrayList<Matcher>();
+        final List<Matcher> matchers = new ArrayList<Matcher>();
         matchers.add(new Equals(1));
         matchers.add(new Equals(2));
         assertEquals("and(1, 2)", describe(new And(matchers)));

--- a/test/org/mockito/internal/matchers/VarargCapturingMatcherTest.java
+++ b/test/org/mockito/internal/matchers/VarargCapturingMatcherTest.java
@@ -1,18 +1,19 @@
 package org.mockito.internal.matchers;
 
 
-import org.junit.Test;
-import org.mockito.exceptions.base.MockitoException;
-
 import static java.util.Arrays.asList;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
+import org.junit.Test;
+import org.mockito.exceptions.base.MockitoException;
+
+@SuppressWarnings("rawtypes")
 public class VarargCapturingMatcherTest {
     @Test
     public void should_capture_simple_arguments() throws Exception {
         //given
-        VarargCapturingMatcher m = new VarargCapturingMatcher();
+        final VarargCapturingMatcher m = new VarargCapturingMatcher();
 
         //when
         m.captureFrom("foo");
@@ -25,7 +26,7 @@ public class VarargCapturingMatcherTest {
     @Test
     public void should_know_last_captured_vararg() throws Exception {
         //given
-        VarargCapturingMatcher m = new VarargCapturingMatcher();
+        final VarargCapturingMatcher m = new VarargCapturingMatcher();
 
         //when
         m.captureFrom(new Object[] { "foo", "bar" });
@@ -38,7 +39,7 @@ public class VarargCapturingMatcherTest {
     @Test
     public void can_capture_primitive_varargs() throws Exception {
         //given
-        VarargCapturingMatcher m = new VarargCapturingMatcher();
+        final VarargCapturingMatcher m = new VarargCapturingMatcher();
 
         //when
         m.captureFrom(new int[] { 1, 2, 3 });
@@ -50,13 +51,13 @@ public class VarargCapturingMatcherTest {
     @Test
     public void should_scream_when_nothing_yet_captured() throws Exception {
         //given
-        VarargCapturingMatcher m = new VarargCapturingMatcher();
+        final VarargCapturingMatcher m = new VarargCapturingMatcher();
 
         try {
             //when
             m.getLastVarargs();
             //then
             fail();
-        } catch (MockitoException e) {}
+        } catch (final MockitoException e) {}
     }
 }

--- a/test/org/mockito/internal/matchers/apachecommons/EqualsBuilderTest.java
+++ b/test/org/mockito/internal/matchers/apachecommons/EqualsBuilderTest.java
@@ -20,34 +20,42 @@ import org.mockitoutil.TestBase;
  * @version $Id: EqualsBuilderTest.java 611543 2008-01-13 07:00:22Z bayard $
  */
 public class EqualsBuilderTest extends TestBase {
-    
+
     @Test
     public void testname() throws Exception {
-        
+
     }
 
     static class TestObject {
         private int a;
+
         public TestObject() {
         }
-        public TestObject(int a) {
+
+        public TestObject(final int a) {
             this.a = a;
         }
-        public boolean equals(Object o) {
-            if (o == null) { return false; }
-            if (o == this) { return true; }
+
+        public boolean equals(final Object o) {
+            if (o == null) {
+                return false;
+            }
+            if (o == this) {
+                return true;
+            }
             if (o.getClass() != getClass()) {
                 return false;
             }
 
-            TestObject rhs = (TestObject) o;
+            final TestObject rhs = (TestObject) o;
             return (a == rhs.a);
         }
+
         public int hashCode() {
             return super.hashCode();
         }
 
-        public void setA(int a) {
+        public void setA(final int a) {
             this.a = a;
         }
 
@@ -58,28 +66,36 @@ public class EqualsBuilderTest extends TestBase {
 
     static class TestSubObject extends TestObject {
         private int b;
+
         public TestSubObject() {
             super(0);
         }
-        public TestSubObject(int a, int b) {
+
+        public TestSubObject(final int a, final int b) {
             super(a);
             this.b = b;
         }
-        public boolean equals(Object o) {
-            if (o == null) { return false; }
-            if (o == this) { return true; }
+
+        public boolean equals(final Object o) {
+            if (o == null) {
+                return false;
+            }
+            if (o == this) {
+                return true;
+            }
             if (o.getClass() != getClass()) {
                 return false;
             }
 
-            TestSubObject rhs = (TestSubObject) o;
+            final TestSubObject rhs = (TestSubObject) o;
             return super.equals(o) && (b == rhs.b);
         }
+
         public int hashCode() {
             return 1;
         }
 
-        public void setB(int b) {
+        public void setB(final int b) {
             this.b = b;
         }
 
@@ -87,17 +103,18 @@ public class EqualsBuilderTest extends TestBase {
             return b;
         }
     }
-    
+
     static class TestEmptySubObject extends TestObject {
-        public TestEmptySubObject(int a) {
+        public TestEmptySubObject(final int a) {
             super(a);
         }
     }
-    
+
     @SuppressWarnings("unused")
     static class TestTSubObject extends TestObject {
         private transient int t;
-        public TestTSubObject(int a, int t) {
+
+        public TestTSubObject(final int a, final int t) {
             super(a);
             this.t = t;
         }
@@ -106,7 +123,8 @@ public class EqualsBuilderTest extends TestBase {
     @SuppressWarnings("unused")
     static class TestTTSubObject extends TestTSubObject {
         private transient int tt;
-        public TestTTSubObject(int a, int t, int tt) {
+
+        public TestTTSubObject(final int a, final int t, final int tt) {
             super(a, t);
             this.tt = tt;
         }
@@ -114,8 +132,9 @@ public class EqualsBuilderTest extends TestBase {
 
     @SuppressWarnings("unused")
     static class TestTTLeafObject extends TestTTSubObject {
-        private int leafValue;
-        public TestTTLeafObject(int a, int t, int tt, int leafValue) {
+        private final int leafValue;
+
+        public TestTTLeafObject(final int a, final int t, final int tt, final int leafValue) {
             super(a, t, tt);
             this.leafValue = leafValue;
         }
@@ -123,20 +142,24 @@ public class EqualsBuilderTest extends TestBase {
 
     static class TestTSubObject2 extends TestObject {
         private transient int t;
-        public TestTSubObject2(int a, int t) {
+
+        public TestTSubObject2(final int a, final int t) {
             super(a);
         }
+
         public int getT() {
             return t;
         }
-        public void setT(int t) {
+
+        public void setT(final int t) {
             this.t = t;
         }
     }
 
-    @Test public void testReflectionEquals() {
-        TestObject o1 = new TestObject(4);
-        TestObject o2 = new TestObject(5);
+    @Test
+    public void testReflectionEquals() {
+        final TestObject o1 = new TestObject(4);
+        final TestObject o2 = new TestObject(5);
         assertTrue(EqualsBuilder.reflectionEquals(o1, o1));
         assertTrue(!EqualsBuilder.reflectionEquals(o1, o2));
         o2.setA(4);
@@ -148,8 +171,9 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(!EqualsBuilder.reflectionEquals(null, o2));
         assertTrue(EqualsBuilder.reflectionEquals((Object) null, (Object) null));
     }
-    
-    @Test public void testReflectionHierarchyEquals() {
+
+    @Test
+    public void testReflectionHierarchyEquals() {
         testReflectionHierarchyEquals(false);
         testReflectionHierarchyEquals(true);
         // Transients
@@ -160,19 +184,19 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(!EqualsBuilder.reflectionEquals(new TestTTLeafObject(0, 2, 3, 4), new TestTTLeafObject(1, 2, 3, 4), true));
     }
 
-  private void testReflectionHierarchyEquals(boolean testTransients) {
-        TestObject to1 = new TestObject(4);
-        TestObject to1Bis = new TestObject(4);
-        TestObject to1Ter = new TestObject(4);
-        TestObject to2 = new TestObject(5);
-        TestEmptySubObject teso = new TestEmptySubObject(4);
-        TestTSubObject ttso = new TestTSubObject(4, 1);
-        TestTTSubObject tttso = new TestTTSubObject(4, 1, 2);
-        TestTTLeafObject ttlo = new TestTTLeafObject(4, 1, 2, 3);
-        TestSubObject tso1 = new TestSubObject(1, 4);
-        TestSubObject tso1bis = new TestSubObject(1, 4);
-        TestSubObject tso1ter = new TestSubObject(1, 4);
-        TestSubObject tso2 = new TestSubObject(2, 5);
+    private void testReflectionHierarchyEquals(final boolean testTransients) {
+        final TestObject to1 = new TestObject(4);
+        final TestObject to1Bis = new TestObject(4);
+        final TestObject to1Ter = new TestObject(4);
+        final TestObject to2 = new TestObject(5);
+        final TestEmptySubObject teso = new TestEmptySubObject(4);
+        final TestTSubObject ttso = new TestTSubObject(4, 1);
+        final TestTTSubObject tttso = new TestTTSubObject(4, 1, 2);
+        final TestTTLeafObject ttlo = new TestTTLeafObject(4, 1, 2, 3);
+        final TestSubObject tso1 = new TestSubObject(1, 4);
+        final TestSubObject tso1bis = new TestSubObject(1, 4);
+        final TestSubObject tso1ter = new TestSubObject(1, 4);
+        final TestSubObject tso2 = new TestSubObject(2, 5);
 
         testReflectionEqualsEquivalenceRelationship(to1, to1Bis, to1Ter, to2, new TestObject(), testTransients);
         testReflectionEqualsEquivalenceRelationship(tso1, tso1bis, tso1ter, tso2, new TestSubObject(), testTransients);
@@ -193,14 +217,48 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(EqualsBuilder.reflectionEquals(to1, teso, testTransients));
         assertTrue(EqualsBuilder.reflectionEquals(teso, to1, testTransients));
 
-        assertTrue(EqualsBuilder.reflectionEquals(to1, ttso, false)); // Force testTransients = false for this assert
-        assertTrue(EqualsBuilder.reflectionEquals(ttso, to1, false)); // Force testTransients = false for this assert
+        assertTrue(EqualsBuilder.reflectionEquals(to1, ttso, false)); // Force
+                                                                      // testTransients
+                                                                      // = false
+                                                                      // for
+                                                                      // this
+                                                                      // assert
+        assertTrue(EqualsBuilder.reflectionEquals(ttso, to1, false)); // Force
+                                                                      // testTransients
+                                                                      // = false
+                                                                      // for
+                                                                      // this
+                                                                      // assert
 
-        assertTrue(EqualsBuilder.reflectionEquals(to1, tttso, false)); // Force testTransients = false for this assert
-        assertTrue(EqualsBuilder.reflectionEquals(tttso, to1, false)); // Force testTransients = false for this assert
+        assertTrue(EqualsBuilder.reflectionEquals(to1, tttso, false)); // Force
+                                                                       // testTransients
+                                                                       // =
+                                                                       // false
+                                                                       // for
+                                                                       // this
+                                                                       // assert
+        assertTrue(EqualsBuilder.reflectionEquals(tttso, to1, false)); // Force
+                                                                       // testTransients
+                                                                       // =
+                                                                       // false
+                                                                       // for
+                                                                       // this
+                                                                       // assert
 
-        assertTrue(EqualsBuilder.reflectionEquals(ttso, tttso, false)); // Force testTransients = false for this assert
-        assertTrue(EqualsBuilder.reflectionEquals(tttso, ttso, false)); // Force testTransients = false for this assert
+        assertTrue(EqualsBuilder.reflectionEquals(ttso, tttso, false)); // Force
+                                                                        // testTransients
+                                                                        // =
+                                                                        // false
+                                                                        // for
+                                                                        // this
+                                                                        // assert
+        assertTrue(EqualsBuilder.reflectionEquals(tttso, ttso, false)); // Force
+                                                                        // testTransients
+                                                                        // =
+                                                                        // false
+                                                                        // for
+                                                                        // this
+                                                                        // assert
 
         // mix super and sub types: NOT equals
         assertTrue(!EqualsBuilder.reflectionEquals(new TestObject(0), new TestEmptySubObject(1), testTransients));
@@ -225,19 +283,25 @@ public class EqualsBuilderTest extends TestBase {
      * <li>consistency</li>
      * <li>non-null reference</li>
      * </ul>
-     * @param to a TestObject
-     * @param toBis a TestObject, equal to to and toTer
-     * @param toTer Left hand side, equal to to and toBis
-     * @param to2 a different TestObject
-     * @param oToChange a TestObject that will be changed
+     * 
+     * @param to
+     *            a TestObject
+     * @param toBis
+     *            a TestObject, equal to to and toTer
+     * @param toTer
+     *            Left hand side, equal to to and toBis
+     * @param to2
+     *            a different TestObject
+     * @param oToChange
+     *            a TestObject that will be changed
      */
     private void testReflectionEqualsEquivalenceRelationship(
-        TestObject to,
-        TestObject toBis,
-        TestObject toTer,
-        TestObject to2,
-        TestObject oToChange,
-        boolean testTransients) {
+            final TestObject to,
+            final TestObject toBis,
+            final TestObject toTer,
+            final TestObject to2,
+            final TestObject oToChange,
+            final boolean testTransients) {
 
         // reflection test
         assertTrue(EqualsBuilder.reflectionEquals(to, to, testTransients));
@@ -247,8 +311,7 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(EqualsBuilder.reflectionEquals(to, toBis, testTransients) && EqualsBuilder.reflectionEquals(toBis, to, testTransients));
 
         // transitive test
-        assertTrue(
-            EqualsBuilder.reflectionEquals(to, toBis, testTransients)
+        assertTrue(EqualsBuilder.reflectionEquals(to, toBis, testTransients)
                 && EqualsBuilder.reflectionEquals(toBis, toTer, testTransients)
                 && EqualsBuilder.reflectionEquals(to, toTer, testTransients));
 
@@ -274,68 +337,76 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(EqualsBuilder.reflectionEquals((Object) null, (Object) null, testTransients));
     }
 
-    @Test public void testSuper() {
-        TestObject o1 = new TestObject(4);
-        TestObject o2 = new TestObject(5);
+    @Test
+    public void testSuper() {
+        final TestObject o1 = new TestObject(4);
+        final TestObject o2 = new TestObject(5);
         assertEquals(true, new EqualsBuilder().appendSuper(true).append(o1, o1).isEquals());
         assertEquals(false, new EqualsBuilder().appendSuper(false).append(o1, o1).isEquals());
         assertEquals(false, new EqualsBuilder().appendSuper(true).append(o1, o2).isEquals());
         assertEquals(false, new EqualsBuilder().appendSuper(false).append(o1, o2).isEquals());
     }
 
-    @Test public void testObject() {
-        TestObject o1 = new TestObject(4);
-        TestObject o2 = new TestObject(5);
+    @Test
+    public void testObject() {
+        final TestObject o1 = new TestObject(4);
+        final TestObject o2 = new TestObject(5);
         assertTrue(new EqualsBuilder().append(o1, o1).isEquals());
         assertTrue(!new EqualsBuilder().append(o1, o2).isEquals());
         o2.setA(4);
         assertTrue(new EqualsBuilder().append(o1, o2).isEquals());
 
         assertTrue(!new EqualsBuilder().append(o1, this).isEquals());
-        
+
         assertTrue(!new EqualsBuilder().append(o1, null).isEquals());
         assertTrue(!new EqualsBuilder().append(null, o2).isEquals());
         assertTrue(new EqualsBuilder().append((Object) null, (Object) null).isEquals());
     }
 
-    @Test public void testLong() {
-        long o1 = 1L;
-        long o2 = 2L;
+    @Test
+    public void testLong() {
+        final long o1 = 1L;
+        final long o2 = 2L;
         assertTrue(new EqualsBuilder().append(o1, o1).isEquals());
         assertTrue(!new EqualsBuilder().append(o1, o2).isEquals());
     }
 
-    @Test public void testInt() {
-        int o1 = 1;
-        int o2 = 2;
+    @Test
+    public void testInt() {
+        final int o1 = 1;
+        final int o2 = 2;
         assertTrue(new EqualsBuilder().append(o1, o1).isEquals());
         assertTrue(!new EqualsBuilder().append(o1, o2).isEquals());
     }
 
-    @Test public void testShort() {
-        short o1 = 1;
-        short o2 = 2;
+    @Test
+    public void testShort() {
+        final short o1 = 1;
+        final short o2 = 2;
         assertTrue(new EqualsBuilder().append(o1, o1).isEquals());
         assertTrue(!new EqualsBuilder().append(o1, o2).isEquals());
     }
 
-    @Test public void testChar() {
-        char o1 = 1;
-        char o2 = 2;
+    @Test
+    public void testChar() {
+        final char o1 = 1;
+        final char o2 = 2;
         assertTrue(new EqualsBuilder().append(o1, o1).isEquals());
         assertTrue(!new EqualsBuilder().append(o1, o2).isEquals());
     }
 
-    @Test public void testByte() {
-        byte o1 = 1;
-        byte o2 = 2;
+    @Test
+    public void testByte() {
+        final byte o1 = 1;
+        final byte o2 = 2;
         assertTrue(new EqualsBuilder().append(o1, o1).isEquals());
         assertTrue(!new EqualsBuilder().append(o1, o2).isEquals());
     }
 
-    @Test public void testDouble() {
-        double o1 = 1;
-        double o2 = 2;
+    @Test
+    public void testDouble() {
+        final double o1 = 1;
+        final double o2 = 2;
         assertTrue(new EqualsBuilder().append(o1, o1).isEquals());
         assertTrue(!new EqualsBuilder().append(o1, o2).isEquals());
         assertTrue(!new EqualsBuilder().append(o1, Double.NaN).isEquals());
@@ -343,9 +414,10 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(new EqualsBuilder().append(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY).isEquals());
     }
 
-    @Test public void testFloat() {
-        float o1 = 1;
-        float o2 = 2;
+    @Test
+    public void testFloat() {
+        final float o1 = 1;
+        final float o2 = 2;
         assertTrue(new EqualsBuilder().append(o1, o1).isEquals());
         assertTrue(!new EqualsBuilder().append(o1, o2).isEquals());
         assertTrue(!new EqualsBuilder().append(o1, Float.NaN).isEquals());
@@ -354,30 +426,34 @@ public class EqualsBuilderTest extends TestBase {
     }
 
     // https://issues.apache.org/jira/browse/LANG-393
-    @Test public void testBigDecimal() {
-        BigDecimal o1 = new BigDecimal("2.0");
-        BigDecimal o2 = new BigDecimal("2.00");
+    @Test
+    public void testBigDecimal() {
+        final BigDecimal o1 = new BigDecimal("2.0");
+        final BigDecimal o2 = new BigDecimal("2.00");
         assertTrue(new EqualsBuilder().append(o1, o1).isEquals());
         assertTrue(new EqualsBuilder().append(o1, o2).isEquals());
     }
 
-    @Test public void testAccessors() {
-        EqualsBuilder equalsBuilder = new EqualsBuilder();
+    @Test
+    public void testAccessors() {
+        final EqualsBuilder equalsBuilder = new EqualsBuilder();
         assertTrue(equalsBuilder.isEquals());
         equalsBuilder.setEquals(true);
         assertTrue(equalsBuilder.isEquals());
         equalsBuilder.setEquals(false);
         assertFalse(equalsBuilder.isEquals());
     }
-    
-    @Test public void testBoolean() {
-        boolean o1 = true;
-        boolean o2 = false;
+
+    @Test
+    public void testBoolean() {
+        final boolean o1 = true;
+        final boolean o2 = false;
         assertTrue(new EqualsBuilder().append(o1, o1).isEquals());
         assertTrue(!new EqualsBuilder().append(o1, o2).isEquals());
     }
 
-    @Test public void testObjectArray() {
+    @Test
+    public void testObjectArray() {
         TestObject[] obj1 = new TestObject[3];
         obj1[0] = new TestObject(4);
         obj1[1] = new TestObject(5);
@@ -386,7 +462,7 @@ public class EqualsBuilderTest extends TestBase {
         obj2[0] = new TestObject(4);
         obj2[1] = new TestObject(5);
         obj2[2] = null;
-        
+
         assertTrue(new EqualsBuilder().append(obj1, obj1).isEquals());
         assertTrue(new EqualsBuilder().append(obj2, obj2).isEquals());
         assertTrue(new EqualsBuilder().append(obj1, obj2).isEquals());
@@ -398,14 +474,15 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(!new EqualsBuilder().append(obj1, obj2).isEquals());
         obj1[2] = null;
         assertTrue(new EqualsBuilder().append(obj1, obj2).isEquals());
-                       
+
         obj2 = null;
         assertTrue(!new EqualsBuilder().append(obj1, obj2).isEquals());
         obj1 = null;
         assertTrue(new EqualsBuilder().append(obj1, obj2).isEquals());
     }
 
-    @Test public void testLongArray() {
+    @Test
+    public void testLongArray() {
         long[] obj1 = new long[2];
         obj1[0] = 5L;
         obj1[1] = 6L;
@@ -423,7 +500,8 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(new EqualsBuilder().append(obj1, obj2).isEquals());
     }
 
-    @Test public void testIntArray() {
+    @Test
+    public void testIntArray() {
         int[] obj1 = new int[2];
         obj1[0] = 5;
         obj1[1] = 6;
@@ -441,7 +519,8 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(new EqualsBuilder().append(obj1, obj2).isEquals());
     }
 
-    @Test public void testShortArray() {
+    @Test
+    public void testShortArray() {
         short[] obj1 = new short[2];
         obj1[0] = 5;
         obj1[1] = 6;
@@ -459,7 +538,8 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(new EqualsBuilder().append(obj1, obj2).isEquals());
     }
 
-    @Test public void testCharArray() {
+    @Test
+    public void testCharArray() {
         char[] obj1 = new char[2];
         obj1[0] = 5;
         obj1[1] = 6;
@@ -477,7 +557,8 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(new EqualsBuilder().append(obj1, obj2).isEquals());
     }
 
-    @Test public void testByteArray() {
+    @Test
+    public void testByteArray() {
         byte[] obj1 = new byte[2];
         obj1[0] = 5;
         obj1[1] = 6;
@@ -495,7 +576,8 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(new EqualsBuilder().append(obj1, obj2).isEquals());
     }
 
-    @Test public void testDoubleArray() {
+    @Test
+    public void testDoubleArray() {
         double[] obj1 = new double[2];
         obj1[0] = 5;
         obj1[1] = 6;
@@ -513,7 +595,8 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(new EqualsBuilder().append(obj1, obj2).isEquals());
     }
 
-    @Test public void testFloatArray() {
+    @Test
+    public void testFloatArray() {
         float[] obj1 = new float[2];
         obj1[0] = 5;
         obj1[1] = 6;
@@ -531,7 +614,8 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(new EqualsBuilder().append(obj1, obj2).isEquals());
     }
 
-    @Test public void testBooleanArray() {
+    @Test
+    public void testBooleanArray() {
         boolean[] obj1 = new boolean[2];
         obj1[0] = true;
         obj1[1] = false;
@@ -549,9 +633,10 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(new EqualsBuilder().append(obj1, obj2).isEquals());
     }
 
-    @Test public void testMultiLongArray() {
-        long[][] array1 = new long[2][2];
-        long[][] array2 = new long[2][2];
+    @Test
+    public void testMultiLongArray() {
+        final long[][] array1 = new long[2][2];
+        final long[][] array2 = new long[2][2];
         for (int i = 0; i < array1.length; ++i) {
             for (int j = 0; j < array1[0].length; j++) {
                 array1[i][j] = (i + 1) * (j + 1);
@@ -564,9 +649,10 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(!new EqualsBuilder().append(array1, array2).isEquals());
     }
 
-    @Test public void testMultiIntArray() {
-        int[][] array1 = new int[2][2];
-        int[][] array2 = new int[2][2];
+    @Test
+    public void testMultiIntArray() {
+        final int[][] array1 = new int[2][2];
+        final int[][] array2 = new int[2][2];
         for (int i = 0; i < array1.length; ++i) {
             for (int j = 0; j < array1[0].length; j++) {
                 array1[i][j] = (i + 1) * (j + 1);
@@ -579,9 +665,10 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(!new EqualsBuilder().append(array1, array2).isEquals());
     }
 
-    @Test public void testMultiShortArray() {
-        short[][] array1 = new short[2][2];
-        short[][] array2 = new short[2][2];
+    @Test
+    public void testMultiShortArray() {
+        final short[][] array1 = new short[2][2];
+        final short[][] array2 = new short[2][2];
         for (short i = 0; i < array1.length; ++i) {
             for (short j = 0; j < array1[0].length; j++) {
                 array1[i][j] = i;
@@ -594,9 +681,10 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(!new EqualsBuilder().append(array1, array2).isEquals());
     }
 
-    @Test public void testMultiCharArray() {
-        char[][] array1 = new char[2][2];
-        char[][] array2 = new char[2][2];
+    @Test
+    public void testMultiCharArray() {
+        final char[][] array1 = new char[2][2];
+        final char[][] array2 = new char[2][2];
         for (char i = 0; i < array1.length; ++i) {
             for (char j = 0; j < array1[0].length; j++) {
                 array1[i][j] = i;
@@ -609,9 +697,10 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(!new EqualsBuilder().append(array1, array2).isEquals());
     }
 
-    @Test public void testMultiByteArray() {
-        byte[][] array1 = new byte[2][2];
-        byte[][] array2 = new byte[2][2];
+    @Test
+    public void testMultiByteArray() {
+        final byte[][] array1 = new byte[2][2];
+        final byte[][] array2 = new byte[2][2];
         for (byte i = 0; i < array1.length; ++i) {
             for (byte j = 0; j < array1[0].length; j++) {
                 array1[i][j] = i;
@@ -623,9 +712,11 @@ public class EqualsBuilderTest extends TestBase {
         array1[1][1] = 0;
         assertTrue(!new EqualsBuilder().append(array1, array2).isEquals());
     }
-    @Test public void testMultiFloatArray() {
-        float[][] array1 = new float[2][2];
-        float[][] array2 = new float[2][2];
+
+    @Test
+    public void testMultiFloatArray() {
+        final float[][] array1 = new float[2][2];
+        final float[][] array2 = new float[2][2];
         for (int i = 0; i < array1.length; ++i) {
             for (int j = 0; j < array1[0].length; j++) {
                 array1[i][j] = (i + 1) * (j + 1);
@@ -638,9 +729,10 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(!new EqualsBuilder().append(array1, array2).isEquals());
     }
 
-    @Test public void testMultiDoubleArray() {
-        double[][] array1 = new double[2][2];
-        double[][] array2 = new double[2][2];
+    @Test
+    public void testMultiDoubleArray() {
+        final double[][] array1 = new double[2][2];
+        final double[][] array2 = new double[2][2];
         for (int i = 0; i < array1.length; ++i) {
             for (int j = 0; j < array1[0].length; j++) {
                 array1[i][j] = (i + 1) * (j + 1);
@@ -653,9 +745,10 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(!new EqualsBuilder().append(array1, array2).isEquals());
     }
 
-    @Test public void testMultiBooleanArray() {
-        boolean[][] array1 = new boolean[2][2];
-        boolean[][] array2 = new boolean[2][2];
+    @Test
+    public void testMultiBooleanArray() {
+        final boolean[][] array1 = new boolean[2][2];
+        final boolean[][] array2 = new boolean[2][2];
         for (int i = 0; i < array1.length; ++i) {
             for (int j = 0; j < array1[0].length; j++) {
                 array1[i][j] = (i == 1) || (j == 1);
@@ -666,18 +759,19 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(new EqualsBuilder().append(array1, array2).isEquals());
         array1[1][1] = false;
         assertTrue(!new EqualsBuilder().append(array1, array2).isEquals());
-        
+
         // compare 1 dim to 2.
-        boolean[] array3 = new boolean[]{true, true};
+        final boolean[] array3 = new boolean[] { true, true };
         assertFalse(new EqualsBuilder().append(array1, array3).isEquals());
         assertFalse(new EqualsBuilder().append(array3, array1).isEquals());
         assertFalse(new EqualsBuilder().append(array2, array3).isEquals());
         assertFalse(new EqualsBuilder().append(array3, array2).isEquals());
     }
 
-    @Test public void testRaggedArray() {
-        long[][] array1 = new long[2][];
-        long[][] array2 = new long[2][];
+    @Test
+    public void testRaggedArray() {
+        final long[][] array1 = new long[2][];
+        final long[][] array2 = new long[2][];
         for (int i = 0; i < array1.length; ++i) {
             array1[i] = new long[2];
             array2[i] = new long[2];
@@ -692,9 +786,10 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(!new EqualsBuilder().append(array1, array2).isEquals());
     }
 
-    @Test public void testMixedArray() {
-        Object[] array1 = new Object[2];
-        Object[] array2 = new Object[2];
+    @Test
+    public void testMixedArray() {
+        final Object[] array1 = new Object[2];
+        final Object[] array2 = new Object[2];
         for (int i = 0; i < array1.length; ++i) {
             array1[i] = new long[2];
             array2[i] = new long[2];
@@ -709,15 +804,16 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(!new EqualsBuilder().append(array1, array2).isEquals());
     }
 
-    @Test public void testObjectArrayHiddenByObject() {
-        TestObject[] array1 = new TestObject[2];
+    @Test
+    public void testObjectArrayHiddenByObject() {
+        final TestObject[] array1 = new TestObject[2];
         array1[0] = new TestObject(4);
         array1[1] = new TestObject(5);
-        TestObject[] array2 = new TestObject[2];
+        final TestObject[] array2 = new TestObject[2];
         array2[0] = new TestObject(4);
         array2[1] = new TestObject(5);
-        Object obj1 = array1;
-        Object obj2 = array2;
+        final Object obj1 = array1;
+        final Object obj2 = array2;
         assertTrue(new EqualsBuilder().append(obj1, obj1).isEquals());
         assertTrue(new EqualsBuilder().append(obj1, array1).isEquals());
         assertTrue(new EqualsBuilder().append(obj1, obj2).isEquals());
@@ -726,15 +822,16 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(!new EqualsBuilder().append(obj1, obj2).isEquals());
     }
 
-    @Test public void testLongArrayHiddenByObject() {
-        long[] array1 = new long[2];
+    @Test
+    public void testLongArrayHiddenByObject() {
+        final long[] array1 = new long[2];
         array1[0] = 5L;
         array1[1] = 6L;
-        long[] array2 = new long[2];
+        final long[] array2 = new long[2];
         array2[0] = 5L;
         array2[1] = 6L;
-        Object obj1 = array1;
-        Object obj2 = array2;
+        final Object obj1 = array1;
+        final Object obj2 = array2;
         assertTrue(new EqualsBuilder().append(obj1, obj1).isEquals());
         assertTrue(new EqualsBuilder().append(obj1, array1).isEquals());
         assertTrue(new EqualsBuilder().append(obj1, obj2).isEquals());
@@ -743,15 +840,16 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(!new EqualsBuilder().append(obj1, obj2).isEquals());
     }
 
-    @Test public void testIntArrayHiddenByObject() {
-        int[] array1 = new int[2];
+    @Test
+    public void testIntArrayHiddenByObject() {
+        final int[] array1 = new int[2];
         array1[0] = 5;
         array1[1] = 6;
-        int[] array2 = new int[2];
+        final int[] array2 = new int[2];
         array2[0] = 5;
         array2[1] = 6;
-        Object obj1 = array1;
-        Object obj2 = array2;
+        final Object obj1 = array1;
+        final Object obj2 = array2;
         assertTrue(new EqualsBuilder().append(obj1, obj1).isEquals());
         assertTrue(new EqualsBuilder().append(obj1, array1).isEquals());
         assertTrue(new EqualsBuilder().append(obj1, obj2).isEquals());
@@ -760,15 +858,16 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(!new EqualsBuilder().append(obj1, obj2).isEquals());
     }
 
-    @Test public void testShortArrayHiddenByObject() {
-        short[] array1 = new short[2];
+    @Test
+    public void testShortArrayHiddenByObject() {
+        final short[] array1 = new short[2];
         array1[0] = 5;
         array1[1] = 6;
-        short[] array2 = new short[2];
+        final short[] array2 = new short[2];
         array2[0] = 5;
         array2[1] = 6;
-        Object obj1 = array1;
-        Object obj2 = array2;
+        final Object obj1 = array1;
+        final Object obj2 = array2;
         assertTrue(new EqualsBuilder().append(obj1, obj1).isEquals());
         assertTrue(new EqualsBuilder().append(obj1, array1).isEquals());
         assertTrue(new EqualsBuilder().append(obj1, obj2).isEquals());
@@ -777,15 +876,16 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(!new EqualsBuilder().append(obj1, obj2).isEquals());
     }
 
-    @Test public void testCharArrayHiddenByObject() {
-        char[] array1 = new char[2];
+    @Test
+    public void testCharArrayHiddenByObject() {
+        final char[] array1 = new char[2];
         array1[0] = 5;
         array1[1] = 6;
-        char[] array2 = new char[2];
+        final char[] array2 = new char[2];
         array2[0] = 5;
         array2[1] = 6;
-        Object obj1 = array1;
-        Object obj2 = array2;
+        final Object obj1 = array1;
+        final Object obj2 = array2;
         assertTrue(new EqualsBuilder().append(obj1, obj1).isEquals());
         assertTrue(new EqualsBuilder().append(obj1, array1).isEquals());
         assertTrue(new EqualsBuilder().append(obj1, obj2).isEquals());
@@ -794,15 +894,16 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(!new EqualsBuilder().append(obj1, obj2).isEquals());
     }
 
-    @Test public void testByteArrayHiddenByObject() {
-        byte[] array1 = new byte[2];
+    @Test
+    public void testByteArrayHiddenByObject() {
+        final byte[] array1 = new byte[2];
         array1[0] = 5;
         array1[1] = 6;
-        byte[] array2 = new byte[2];
+        final byte[] array2 = new byte[2];
         array2[0] = 5;
         array2[1] = 6;
-        Object obj1 = array1;
-        Object obj2 = array2;
+        final Object obj1 = array1;
+        final Object obj2 = array2;
         assertTrue(new EqualsBuilder().append(obj1, obj1).isEquals());
         assertTrue(new EqualsBuilder().append(obj1, array1).isEquals());
         assertTrue(new EqualsBuilder().append(obj1, obj2).isEquals());
@@ -811,15 +912,16 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(!new EqualsBuilder().append(obj1, obj2).isEquals());
     }
 
-    @Test public void testDoubleArrayHiddenByObject() {
-        double[] array1 = new double[2];
+    @Test
+    public void testDoubleArrayHiddenByObject() {
+        final double[] array1 = new double[2];
         array1[0] = 5;
         array1[1] = 6;
-        double[] array2 = new double[2];
+        final double[] array2 = new double[2];
         array2[0] = 5;
         array2[1] = 6;
-        Object obj1 = array1;
-        Object obj2 = array2;
+        final Object obj1 = array1;
+        final Object obj2 = array2;
         assertTrue(new EqualsBuilder().append(obj1, obj1).isEquals());
         assertTrue(new EqualsBuilder().append(obj1, array1).isEquals());
         assertTrue(new EqualsBuilder().append(obj1, obj2).isEquals());
@@ -828,15 +930,16 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(!new EqualsBuilder().append(obj1, obj2).isEquals());
     }
 
-    @Test public void testFloatArrayHiddenByObject() {
-        float[] array1 = new float[2];
+    @Test
+    public void testFloatArrayHiddenByObject() {
+        final float[] array1 = new float[2];
         array1[0] = 5;
         array1[1] = 6;
-        float[] array2 = new float[2];
+        final float[] array2 = new float[2];
         array2[0] = 5;
         array2[1] = 6;
-        Object obj1 = array1;
-        Object obj2 = array2;
+        final Object obj1 = array1;
+        final Object obj2 = array2;
         assertTrue(new EqualsBuilder().append(obj1, obj1).isEquals());
         assertTrue(new EqualsBuilder().append(obj1, array1).isEquals());
         assertTrue(new EqualsBuilder().append(obj1, obj2).isEquals());
@@ -845,15 +948,16 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(!new EqualsBuilder().append(obj1, obj2).isEquals());
     }
 
-    @Test public void testBooleanArrayHiddenByObject() {
-        boolean[] array1 = new boolean[2];
+    @Test
+    public void testBooleanArrayHiddenByObject() {
+        final boolean[] array1 = new boolean[2];
         array1[0] = true;
         array1[1] = false;
-        boolean[] array2 = new boolean[2];
+        final boolean[] array2 = new boolean[2];
         array2[0] = true;
         array2[1] = false;
-        Object obj1 = array1;
-        Object obj2 = array2;
+        final Object obj1 = array1;
+        final Object obj2 = array2;
         assertTrue(new EqualsBuilder().append(obj1, obj1).isEquals());
         assertTrue(new EqualsBuilder().append(obj1, array1).isEquals());
         assertTrue(new EqualsBuilder().append(obj1, obj2).isEquals());
@@ -861,15 +965,15 @@ public class EqualsBuilderTest extends TestBase {
         array1[1] = true;
         assertTrue(!new EqualsBuilder().append(obj1, obj2).isEquals());
     }
-    
-    public static class TestACanEqualB {
-        private int a;
 
-        public TestACanEqualB(int a) {
+    public static class TestACanEqualB {
+        private final int a;
+
+        public TestACanEqualB(final int a) {
             this.a = a;
         }
 
-        public boolean equals(Object o) {
+        public boolean equals(final Object o) {
             if (o == this) {
                 return true;
             }
@@ -881,6 +985,7 @@ public class EqualsBuilderTest extends TestBase {
             }
             return false;
         }
+
         public int hashCode() {
             return 1;
         }
@@ -891,13 +996,13 @@ public class EqualsBuilderTest extends TestBase {
     }
 
     public static class TestBCanEqualA {
-        private int b;
+        private final int b;
 
-        public TestBCanEqualA(int b) {
+        public TestBCanEqualA(final int b) {
             this.b = b;
         }
 
-        public boolean equals(Object o) {
+        public boolean equals(final Object o) {
             if (o == this) {
                 return true;
             }
@@ -909,23 +1014,26 @@ public class EqualsBuilderTest extends TestBase {
             }
             return false;
         }
+
         public int hashCode() {
             return 1;
-        }        
+        }
 
         public int getB() {
             return this.b;
         }
     }
-    
+
     /**
-     * Tests two instances of classes that can be equal and that are not "related". The two classes are not subclasses
-     * of each other and do not share a parent aside from Object.
-     * See http://issues.apache.org/bugzilla/show_bug.cgi?id=33069
+     * Tests two instances of classes that can be equal and that are not
+     * "related". The two classes are not subclasses of each other and do not
+     * share a parent aside from Object. See
+     * http://issues.apache.org/bugzilla/show_bug.cgi?id=33069
      */
-    @Test public void testUnrelatedClasses() {
-        Object[] x = new Object[]{new TestACanEqualB(1)};
-        Object[] y = new Object[]{new TestBCanEqualA(1)};
+    @Test
+    public void testUnrelatedClasses() {
+        final Object[] x = new Object[] { new TestACanEqualB(1) };
+        final Object[] y = new Object[] { new TestBCanEqualA(1) };
 
         // sanity checks:
         assertTrue(Arrays.equals(x, x));
@@ -942,50 +1050,53 @@ public class EqualsBuilderTest extends TestBase {
         assertTrue(new EqualsBuilder().append(x, y).isEquals());
         assertTrue(new EqualsBuilder().append(y, x).isEquals());
     }
-    
+
     /**
      * Test from http://issues.apache.org/bugzilla/show_bug.cgi?id=33067
      */
-    @Test public void testNpeForNullElement() {
-        Object[] x1 = new Object[] { new Integer(1), null, new Integer(3) };
-        Object[] x2 = new Object[] { new Integer(1), new Integer(2), new Integer(3) };
+    @Test
+    public void testNpeForNullElement() {
+        final Object[] x1 = new Object[] { new Integer(1), null, new Integer(3) };
+        final Object[] x2 = new Object[] { new Integer(1), new Integer(2), new Integer(3) };
 
         // causes an NPE in 2.0 according to:
         // http://issues.apache.org/bugzilla/show_bug.cgi?id=33067
         new EqualsBuilder().append(x1, x2);
     }
 
-    @Test public void testReflectionEqualsExcludeFields() throws Exception {
-        TestObjectWithMultipleFields x1 = new TestObjectWithMultipleFields(1, 2, 3);
-        TestObjectWithMultipleFields x2 = new TestObjectWithMultipleFields(1, 3, 4);
+    @Test
+    public void testReflectionEqualsExcludeFields() throws Exception {
+        final TestObjectWithMultipleFields x1 = new TestObjectWithMultipleFields(1, 2, 3);
+        final TestObjectWithMultipleFields x2 = new TestObjectWithMultipleFields(1, 3, 4);
 
         // not equal when including all fields
         assertTrue(!EqualsBuilder.reflectionEquals(x1, x2));
 
-        // doesn't barf on null, empty array, or non-existent field, but still tests as not equal
+        // doesn't barf on null, empty array, or non-existent field, but still
+        // tests as not equal
         assertTrue(!EqualsBuilder.reflectionEquals(x1, x2, (String[]) null));
         assertTrue(!EqualsBuilder.reflectionEquals(x1, x2, new String[] {}));
-        assertTrue(!EqualsBuilder.reflectionEquals(x1, x2, new String[] {"xxx"}));
+        assertTrue(!EqualsBuilder.reflectionEquals(x1, x2, new String[] { "xxx" }));
 
         // not equal if only one of the differing fields excluded
-        assertTrue(!EqualsBuilder.reflectionEquals(x1, x2, new String[] {"two"}));
-        assertTrue(!EqualsBuilder.reflectionEquals(x1, x2, new String[] {"three"}));
+        assertTrue(!EqualsBuilder.reflectionEquals(x1, x2, new String[] { "two" }));
+        assertTrue(!EqualsBuilder.reflectionEquals(x1, x2, new String[] { "three" }));
 
         // equal if both differing fields excluded
-        assertTrue(EqualsBuilder.reflectionEquals(x1, x2, new String[] {"two", "three"}));
+        assertTrue(EqualsBuilder.reflectionEquals(x1, x2, new String[] { "two", "three" }));
 
         // still equal as long as both differing fields are among excluded
-        assertTrue(EqualsBuilder.reflectionEquals(x1, x2, new String[] {"one", "two", "three"}));
-        assertTrue(EqualsBuilder.reflectionEquals(x1, x2, new String[] {"one", "two", "three", "xxx"}));
+        assertTrue(EqualsBuilder.reflectionEquals(x1, x2, new String[] { "one", "two", "three" }));
+        assertTrue(EqualsBuilder.reflectionEquals(x1, x2, new String[] { "one", "two", "three", "xxx" }));
     }
 
     @SuppressWarnings("unused")
     static class TestObjectWithMultipleFields {
-        private TestObject one;
-        private TestObject two;
-        private TestObject three;
+        private final TestObject one;
+        private final TestObject two;
+        private final TestObject three;
 
-        public TestObjectWithMultipleFields(int one, int two, int three) {
+        public TestObjectWithMultipleFields(final int one, final int two, final int three) {
             this.one = new TestObject(one);
             this.two = new TestObject(two);
             this.three = new TestObject(three);

--- a/test/org/mockito/internal/progress/MockingProgressImplTest.java
+++ b/test/org/mockito/internal/progress/MockingProgressImplTest.java
@@ -5,21 +5,19 @@
 
 package org.mockito.internal.progress;
 
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.exceptions.base.MockitoException;
-import org.mockito.internal.creation.MockSettingsImpl;
 import org.mockito.internal.listeners.MockingStartedListener;
 import org.mockito.internal.verification.VerificationModeFactory;
 import org.mockito.verification.VerificationMode;
 import org.mockitoutil.TestBase;
-
-import java.util.List;
-
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.notNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
 public class MockingProgressImplTest extends TestBase {
 
@@ -34,7 +32,7 @@ public class MockingProgressImplTest extends TestBase {
     public void shouldStartVerificationAndPullVerificationMode() throws Exception {
         assertNull(mockingProgress.pullVerificationMode());
         
-        VerificationMode mode = VerificationModeFactory.times(19);
+        final VerificationMode mode = VerificationModeFactory.times(19);
         
         mockingProgress.verificationStarted(mode);
         
@@ -49,13 +47,13 @@ public class MockingProgressImplTest extends TestBase {
         try {
             mockingProgress.verificationStarted(VerificationModeFactory.atLeastOnce());
             fail();
-        } catch (MockitoException e) {}
+        } catch (final MockitoException e) {}
     }
 
     @Test
     public void shouldNotifyListenerWhenMockingStarted() throws Exception {
         //given
-        MockingStartedListener listener = mock(MockingStartedListener.class);
+        final MockingStartedListener listener = mock(MockingStartedListener.class);
         mockingProgress.setListener(listener);
 
         //when

--- a/test/org/mockito/internal/runners/RunnerFactoryTest.java
+++ b/test/org/mockito/internal/runners/RunnerFactoryTest.java
@@ -4,17 +4,24 @@
  */
 package org.mockito.internal.runners;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.is;
 
+import java.lang.reflect.InvocationTargetException;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runners.model.InitializationError;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.runners.util.RunnerProvider;
 import org.mockitoutil.TestBase;
 
-import java.lang.reflect.InvocationTargetException;
-
 public class RunnerFactoryTest extends TestBase {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     static class ClassProviderStub extends RunnerProvider {
         @Override
@@ -25,97 +32,106 @@ public class RunnerFactoryTest extends TestBase {
 
     @Test
     public void shouldCreateRunnerForJUnit44() throws Exception {
-        //given
-        RunnerProvider provider = new RunnerProvider() {
+        // given
+        final RunnerProvider provider = new RunnerProvider() {
             public boolean isJUnit45OrHigherAvailable() {
                 return false;
             }
         };
-        RunnerFactory factory = new RunnerFactory(provider);
-        
-        //when
-        RunnerImpl runner = factory.create(RunnerFactoryTest.class);
-        
-        //then
+        final RunnerFactory factory = new RunnerFactory(provider);
+
+        // when
+        final RunnerImpl runner = factory.create(RunnerFactoryTest.class);
+
+        // then
         assertThat(runner, is(JUnit44RunnerImpl.class));
     }
-    
+
     @Test
-    public void shouldCreateRunnerForJUnit45()  throws Exception{
-        //given
-        RunnerProvider provider = new RunnerProvider() {
+    public void shouldCreateRunnerForJUnit45() throws Exception {
+        // given
+        final RunnerProvider provider = new RunnerProvider() {
             public boolean isJUnit45OrHigherAvailable() {
                 return true;
             }
         };
-        RunnerFactory factory = new RunnerFactory(provider);
-        
-        //when
-        RunnerImpl runner = factory.create(RunnerFactoryTest.class);
-        
-        //then
+        final RunnerFactory factory = new RunnerFactory(provider);
+
+        // when
+        final RunnerImpl runner = factory.create(RunnerFactoryTest.class);
+
+        // then
         assertThat(runner, is(JUnit45AndHigherRunnerImpl.class));
     }
-    
+
     @Test
-    public void
-    shouldThrowMeaningfulMockitoExceptionIfNoValidJUnitFound()  throws Exception{
-        //given
-        RunnerProvider provider = new RunnerProvider() {
+    public void shouldThrowMeaningfulMockitoExceptionIfNoValidJUnitFound() throws Exception {
+        // given
+        final RunnerProvider provider = new RunnerProvider() {
             public boolean isJUnit45OrHigherAvailable() {
                 return false;
             }
-            public RunnerImpl newInstance(String runnerClassName, Class<?> constructorParam) throws Exception {
+
+            public RunnerImpl newInstance(final String runnerClassName, final Class<?> constructorParam) throws Exception {
                 throw new InitializationError("Where is JUnit, dude?");
             }
         };
-        RunnerFactory factory = new RunnerFactory(provider);
-        
-        try {
-            //when
-            factory.create(RunnerFactoryTest.class);
-            fail();
-        } catch (MockitoException e) {
-            //then
-            assertContains("upgrade your JUnit version", e.getMessage());
-        }
+        final RunnerFactory factory = new RunnerFactory(provider);
+
+        // then
+        thrown.expect(MockitoException.class);
+        thrown.expectMessage(new BaseMatcher<String>() {
+
+            public boolean matches(final Object arg0) {
+                return ((String) arg0).contains("upgrade your JUnit version");
+            }
+
+            public void describeTo(final Description arg0) {
+            }
+        });
+
+        // when
+        factory.create(RunnerFactoryTest.class);
     }
 
-    static class NoTestMethods {}
-
-    @Test
-    public void shouldSaySomethingMeaningfulWhenNoTestMethods()  throws Exception{
-        //given
-        RunnerFactory factory = new RunnerFactory(new RunnerProvider());
-
-        //when
-        try {
-            factory.create(NoTestMethods.class);
-            fail();
-        }
-        //then
-        catch (MockitoException e) {
-            assertContains("No tests", e.getMessage());
-        }
+    static class NoTestMethods {
     }
 
     @Test
-    public void shouldForwardInvocationTargetException()  throws Exception{
-        //given
-        RunnerFactory factory = new RunnerFactory(new RunnerProvider()
+    public void shouldSaySomethingMeaningfulWhenNoTestMethods() throws Exception {
+        // given
+        final RunnerFactory factory = new RunnerFactory(new RunnerProvider());
+
+        thrown.expect(MockitoException.class);
+        thrown.expectMessage(new BaseMatcher<String>() {
+
+            public boolean matches(final Object arg0) {
+                return ((String) arg0).contains("No tests");
+            }
+
+            public void describeTo(final Description arg0) {
+            }
+        });
+
+        // when
+        factory.create(NoTestMethods.class);
+    }
+
+    @Test
+    public void shouldForwardInvocationTargetException() throws Exception {
+        // given
+        final RunnerFactory factory = new RunnerFactory(new RunnerProvider()
         {
             @Override
-            public RunnerImpl newInstance(String runnerClassName, Class<?> constructorParam) throws Exception {
+            public RunnerImpl newInstance(final String runnerClassName, final Class<?> constructorParam) throws Exception {
                 throw new InvocationTargetException(new RuntimeException());
             }
         });
 
-        //when
-        try {
-            factory.create(this.getClass());
-            fail();
-        }
-        //then
-        catch (InvocationTargetException e) {}
+        // then
+        thrown.expect(InvocationTargetException.class);
+
+        // when
+        factory.create(this.getClass());
     }
 }

--- a/test/org/mockito/internal/stubbing/InvocationContainerImplStubbingTest.java
+++ b/test/org/mockito/internal/stubbing/InvocationContainerImplStubbingTest.java
@@ -18,6 +18,7 @@ import org.mockito.internal.stubbing.answers.ThrowsException;
 import org.mockito.invocation.Invocation;
 import org.mockitoutil.TestBase;
 
+@SuppressWarnings("rawtypes")
 public class InvocationContainerImplStubbingTest extends TestBase {
 
     private InvocationContainerImpl invocationContainerImpl;
@@ -45,7 +46,7 @@ public class InvocationContainerImplStubbingTest extends TestBase {
         try {
             invocationContainerImpl.addAnswer(new ThrowsException(new Exception()));
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             state.validateState();
         }
     }
@@ -62,7 +63,7 @@ public class InvocationContainerImplStubbingTest extends TestBase {
         invocationContainerImpl.setInvocationForPotentialStubbing(new InvocationMatcher(simpleMethod));
         invocationContainerImpl.addAnswer(new Returns("simpleMethod"));
 
-        Invocation differentMethod = new InvocationBuilder().differentMethod().toInvocation();
+        final Invocation differentMethod = new InvocationBuilder().differentMethod().toInvocation();
         invocationContainerImpl.setInvocationForPotentialStubbing(new InvocationMatcher(differentMethod));
         invocationContainerImpl.addAnswer(new ThrowsException(new MyException()));
 
@@ -71,7 +72,7 @@ public class InvocationContainerImplStubbingTest extends TestBase {
         try {
             invocationContainerImpl.answerTo(differentMethod);
             fail();
-        } catch (MyException e) {}
+        } catch (final MyException e) {}
     }
 
     @Test
@@ -79,7 +80,7 @@ public class InvocationContainerImplStubbingTest extends TestBase {
         invocationContainerImplStubOnly.setInvocationForPotentialStubbing(new InvocationMatcher(simpleMethod));
         invocationContainerImplStubOnly.addAnswer(new Returns("simpleMethod"));
 
-        Invocation differentMethod = new InvocationBuilder().differentMethod().toInvocation();
+        final Invocation differentMethod = new InvocationBuilder().differentMethod().toInvocation();
         invocationContainerImplStubOnly.setInvocationForPotentialStubbing(new InvocationMatcher(differentMethod));
         invocationContainerImplStubOnly.addAnswer(new ThrowsException(new MyException()));
 
@@ -88,7 +89,7 @@ public class InvocationContainerImplStubbingTest extends TestBase {
         try {
             invocationContainerImplStubOnly.answerTo(differentMethod);
             fail();
-        } catch (MyException e) {}
+        } catch (final MyException e) {}
     }
 
     @Test
@@ -99,7 +100,7 @@ public class InvocationContainerImplStubbingTest extends TestBase {
         try {
             invocationContainerImpl.answerTo(simpleMethod);
             fail();
-        } catch (MyException e) {}
+        } catch (final MyException e) {}
     }
 
     @Test
@@ -109,7 +110,7 @@ public class InvocationContainerImplStubbingTest extends TestBase {
         try {
             invocationContainerImpl.setMethodForStubbing(new InvocationMatcher(simpleMethod));
             fail();
-        } catch (MockitoException e) {}
+        } catch (final MockitoException e) {}
     }
 
     @Test
@@ -117,7 +118,7 @@ public class InvocationContainerImplStubbingTest extends TestBase {
         try {
             invocationContainerImpl.addAnswer(new ThrowsException(null));
             fail();
-        } catch (MockitoException e) {}
+        } catch (final MockitoException e) {}
     }
 
     @SuppressWarnings("serial")

--- a/test/org/mockito/internal/stubbing/InvocationContainerImplTest.java
+++ b/test/org/mockito/internal/stubbing/InvocationContainerImplTest.java
@@ -4,7 +4,15 @@
  */
 package org.mockito.internal.stubbing;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.LinkedList;
+import java.util.concurrent.CountDownLatch;
+
 import org.junit.Test;
+import org.mockito.internal.creation.MockSettingsImpl;
 import org.mockito.internal.invocation.InvocationBuilder;
 import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockito.internal.progress.ThreadSafeMockingProgress;
@@ -12,24 +20,15 @@ import org.mockito.internal.stubbing.answers.Returns;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsEmptyValues;
 import org.mockito.invocation.Invocation;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import org.mockito.internal.creation.MockSettingsImpl;
-import org.mockito.mock.MockCreationSettings;
-
-import java.util.LinkedList;
-import java.util.concurrent.CountDownLatch;
-
-import static org.junit.Assert.*;
-
 /**
  * Author: Szczepan Faber
  */
+@SuppressWarnings("rawtypes")
 public class InvocationContainerImplTest {
 
     InvocationContainerImpl container = new InvocationContainerImpl(new ThreadSafeMockingProgress(), new MockSettingsImpl());
     InvocationContainerImpl containerStubOnly =
-      new InvocationContainerImpl(new ThreadSafeMockingProgress(), (MockCreationSettings) new MockSettingsImpl().stubOnly());
+      new InvocationContainerImpl(new ThreadSafeMockingProgress(), new MockSettingsImpl().stubOnly());
     Invocation invocation = new InvocationBuilder().toInvocation();
     LinkedList<Throwable> exceptions = new LinkedList<Throwable>();
 
@@ -46,14 +45,14 @@ public class InvocationContainerImplTest {
     //works 50% of the time
     private void doShouldBeThreadSafe(final InvocationContainerImpl c) throws Throwable {
         //given
-        Thread[] t = new Thread[200];
+        final Thread[] t = new Thread[200];
         final CountDownLatch starter = new CountDownLatch(200);
         for (int i = 0; i < t.length; i++ ) {
             t[i] = new Thread() {
                 public void run() {
                     try {
                         starter.await(); //NOPMD
-                    } catch (InterruptedException e) {
+                    } catch (final InterruptedException e) {
                         throw new RuntimeException(e);
                     }
                     c.setInvocationForPotentialStubbing(new InvocationMatcher(invocation));
@@ -62,7 +61,7 @@ public class InvocationContainerImplTest {
                 }
             };
             t[i].setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
-                public void uncaughtException(Thread t, Throwable e) {
+                public void uncaughtException(final Thread t, final Throwable e) {
                     exceptions.add(e);
                 }
             });
@@ -72,7 +71,7 @@ public class InvocationContainerImplTest {
         }
 
         //when
-        for (Thread aT : t) {
+        for (final Thread aT : t) {
             aT.join();
         }
 

--- a/test/org/mockito/internal/stubbing/answers/AnswersValidatorTest.java
+++ b/test/org/mockito/internal/stubbing/answers/AnswersValidatorTest.java
@@ -4,6 +4,14 @@
  */
 package org.mockito.internal.stubbing.answers;
 
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.nio.charset.CharacterCodingException;
+import java.util.ArrayList;
+
 import org.junit.Test;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.exceptions.misusing.WrongTypeOfReturnValue;
@@ -11,26 +19,18 @@ import org.mockito.internal.MockitoCore;
 import org.mockito.internal.invocation.InvocationBuilder;
 import org.mockito.invocation.Invocation;
 
-import java.io.IOException;
-import java.nio.charset.CharacterCodingException;
-import java.util.ArrayList;
-
-import static org.fest.assertions.Assertions.assertThat;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class AnswersValidatorTest {
 
-    private AnswersValidator validator = new AnswersValidator();
-    private Invocation invocation = new InvocationBuilder().method("canThrowException").toInvocation();
+    private final AnswersValidator validator = new AnswersValidator();
+    private final Invocation invocation = new InvocationBuilder().method("canThrowException").toInvocation();
 
     @Test
     public void should_validate_null_throwable() throws Throwable {
         try {
             validator.validate(new ThrowsException(null), new InvocationBuilder().toInvocation());
             fail();
-        } catch (MockitoException expected) {}
+        } catch (final MockitoException expected) {}
     }
 
     @Test
@@ -94,21 +94,21 @@ public class AnswersValidatorTest {
     @Test
     public void should_fail_when_calling_real_method_on_interface() throws Throwable {
         //given
-        Invocation invocationOnInterface = new InvocationBuilder().method("simpleMethod").toInvocation();
+        final Invocation invocationOnInterface = new InvocationBuilder().method("simpleMethod").toInvocation();
         try {
             //when
             validator.validate(new CallsRealMethods(), invocationOnInterface);
             //then
             fail();
-        } catch (MockitoException expected) {}
+        } catch (final MockitoException expected) {}
     }
 
     @Test
     public void should_be_OK_when_calling_real_method_on_concrete_class() throws Throwable {
         //given
-        ArrayList mock = mock(ArrayList.class);
+        final ArrayList mock = mock(ArrayList.class);
         mock.clear();
-        Invocation invocationOnClass = new MockitoCore().getLastInvocation();
+        final Invocation invocationOnClass = new MockitoCore().getLastInvocation();
         //when
         validator.validate(new CallsRealMethods(), invocationOnClass);
         //then no exception is thrown
@@ -145,7 +145,7 @@ public class AnswersValidatorTest {
         try {
             validator.validate(new ReturnsArgumentAt(30), new InvocationBuilder().method("oneArg").arg("A").toInvocation());
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             assertThat(e.getMessage())
                     .containsIgnoringCase("invalid argument index")
                     .containsIgnoringCase("iMethods.oneArg")
@@ -163,7 +163,7 @@ public class AnswersValidatorTest {
                     new InvocationBuilder().simpleMethod().toInvocation()
             );
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             assertThat(e.getMessage())
                     .containsIgnoringCase("invalid argument index")
                     .containsIgnoringCase("iMethods.simpleMethod")
@@ -183,7 +183,7 @@ public class AnswersValidatorTest {
                                            .toInvocation()
             );
             fail();
-        } catch (WrongTypeOfReturnValue e) {
+        } catch (final WrongTypeOfReturnValue e) {
             assertThat(e.getMessage())
                     .containsIgnoringCase("argument of type")
                     .containsIgnoringCase("Object")
@@ -202,7 +202,7 @@ public class AnswersValidatorTest {
                     AWrongType.WRONG_TYPE
             );
             fail();
-        } catch (WrongTypeOfReturnValue e) {
+        } catch (final WrongTypeOfReturnValue e) {
             assertThat(e.getMessage())
                     .containsIgnoringCase("Default answer returned a result with the wrong type")
                     .containsIgnoringCase("AWrongType cannot be returned by toString()")

--- a/test/org/mockito/internal/stubbing/answers/MethodInfoTest.java
+++ b/test/org/mockito/internal/stubbing/answers/MethodInfoTest.java
@@ -4,13 +4,14 @@
  */
 package org.mockito.internal.stubbing.answers;
 
-import org.junit.Test;
-import org.mockito.internal.invocation.InvocationBuilder;
-import org.mockito.invocation.Invocation;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.nio.charset.CharacterCodingException;
 
-import static org.junit.Assert.*;
+import org.junit.Test;
+import org.mockito.internal.invocation.InvocationBuilder;
+import org.mockito.invocation.Invocation;
 
 /**
  * by Szczepan Faber, created at: 3/31/12
@@ -20,8 +21,8 @@ public class MethodInfoTest {
     @Test
     public void shouldKnowValidThrowables() throws Exception {
         //when
-        Invocation invocation = new InvocationBuilder().method("canThrowException").toInvocation();
-        MethodInfo info = new MethodInfo(invocation);
+        final Invocation invocation = new InvocationBuilder().method("canThrowException").toInvocation();
+        final MethodInfo info = new MethodInfo(invocation);
 
         //then
         assertFalse(info.isValidException(new Exception()));

--- a/test/org/mockito/internal/stubbing/defaultanswers/HasPrimitiveMethods.java
+++ b/test/org/mockito/internal/stubbing/defaultanswers/HasPrimitiveMethods.java
@@ -4,7 +4,6 @@
  */
 package org.mockito.internal.stubbing.defaultanswers;
 
-@SuppressWarnings("unused")
 interface HasPrimitiveMethods {
     boolean booleanMethod();
     char charMethod();

--- a/test/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValuesTest.java
+++ b/test/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValuesTest.java
@@ -6,6 +6,7 @@
 package org.mockito.internal.stubbing.defaultanswers;
 
 import static org.mockito.Mockito.mock;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -21,11 +22,12 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+
 import org.junit.Test;
 import org.mockito.invocation.Invocation;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class ReturnsEmptyValuesTest extends TestBase {
 
     ReturnsEmptyValues values = new ReturnsEmptyValues();
@@ -70,25 +72,25 @@ public class ReturnsEmptyValuesTest extends TestBase {
 
     @Test public void should_return_non_zero_for_compareTo_method() {
         //given
-        Date d = mock(Date.class);
+        final Date d = mock(Date.class);
         d.compareTo(new Date());
-        Invocation compareTo = this.getLastInvocation();
+        final Invocation compareTo = this.getLastInvocation();
 
         //when
-        Object result = values.answer(compareTo);
+        final Object result = values.answer(compareTo);
         
         //then
-        assertTrue(result != (Object) 0);
+        assertNotEquals(0, result);
     }
 
     @Test public void should_return_zero_if_mock_is_compared_to_itself() {
         //given
-        Date d = mock(Date.class);
+        final Date d = mock(Date.class);
         d.compareTo(d);
-        Invocation compareTo = this.getLastInvocation();
+        final Invocation compareTo = this.getLastInvocation();
 
         //when
-        Object result = values.answer(compareTo);
+        final Object result = values.answer(compareTo);
 
         //then
         assertEquals(0, result);

--- a/test/org/mockito/internal/stubbing/defaultanswers/ReturnsGenericDeepStubsTest.java
+++ b/test/org/mockito/internal/stubbing/defaultanswers/ReturnsGenericDeepStubsTest.java
@@ -4,95 +4,95 @@
  */
 package org.mockito.internal.stubbing.defaultanswers;
 
-import org.junit.Test;
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
 
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.fest.assertions.Assertions.assertThat;
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
-import static org.mockito.Mockito.mock;
+import org.junit.Test;
 
 @SuppressWarnings("unused")
 public class ReturnsGenericDeepStubsTest {
     interface ListOfInteger extends List<Integer> {}
 
     interface GenericsNest<K extends Comparable<K> & Cloneable> extends Map<K, Set<Number>> {
-        Set<Number> remove(Object key); // override with fixed ParameterizedType
+        Set<Number> remove(final Object key); // override with fixed ParameterizedType
         List<? super Number> returningWildcard();
         Map<String, K> returningNonMockableNestedGeneric();
         K returningK();
         <O extends K> List<O> paramTypeWithTypeParams();
-        <S extends Appendable, T extends S> T twoTypeParams(S s);
+        <S extends Appendable, T extends S> T twoTypeParams(final S s);
         <O extends K> O typeVarWithTypeParams();
         Number returnsNormalType();
     }
 
     @Test
     public void generic_deep_mock_frenzy__look_at_these_chained_calls() throws Exception {
-        GenericsNest<?> mock = mock(GenericsNest.class, RETURNS_DEEP_STUBS);
+        final GenericsNest<?> mock = mock(GenericsNest.class, RETURNS_DEEP_STUBS);
 
-        Set<? extends Map.Entry<? extends Cloneable, Set<Number>>> entries = mock.entrySet();
-        Iterator<? extends Map.Entry<? extends Cloneable, Set<Number>>> entriesIterator = mock.entrySet().iterator();
-        Map.Entry<? extends Cloneable, Set<Number>> nextEntry = mock.entrySet().iterator().next();
+        final Set<? extends Map.Entry<? extends Cloneable, Set<Number>>> entries = mock.entrySet();
+        final Iterator<? extends Map.Entry<? extends Cloneable, Set<Number>>> entriesIterator = mock.entrySet().iterator();
+        final Map.Entry<? extends Cloneable, Set<Number>> nextEntry = mock.entrySet().iterator().next();
 
-        Cloneable cloneableKey = mock.entrySet().iterator().next().getKey();
-        Comparable<?> comparableKey = mock.entrySet().iterator().next().getKey();
+        final Cloneable cloneableKey = mock.entrySet().iterator().next().getKey();
+        final Comparable<?> comparableKey = mock.entrySet().iterator().next().getKey();
 
-        Set<Number> value = mock.entrySet().iterator().next().getValue();
-        Iterator<Number> numbersIterator = mock.entrySet().iterator().next().getValue().iterator();
-        Number number = mock.entrySet().iterator().next().getValue().iterator().next();
+        final Set<Number> value = mock.entrySet().iterator().next().getValue();
+        final Iterator<Number> numbersIterator = mock.entrySet().iterator().next().getValue().iterator();
+        final Number number = mock.entrySet().iterator().next().getValue().iterator().next();
     }
 
     @Test
     public void can_create_mock_from_multiple_type_variable_bounds_when_return_type_of_parameterized_method_is_a_parameterizedtype_that_is_referencing_a_typevar_on_class() throws Exception {
-        GenericsNest<?> mock = mock(GenericsNest.class, RETURNS_DEEP_STUBS);
+        final GenericsNest<?> mock = mock(GenericsNest.class, RETURNS_DEEP_STUBS);
 
-        Cloneable cloneable_bound_that_is_declared_on_typevar_K_in_the_class_which_is_referenced_by_typevar_O_declared_on_the_method =
+        final Cloneable cloneable_bound_that_is_declared_on_typevar_K_in_the_class_which_is_referenced_by_typevar_O_declared_on_the_method =
                 mock.paramTypeWithTypeParams().get(0);
-        Comparable<?> comparable_bound_that_is_declared_on_typevar_K_in_the_class_which_is_referenced_by_typevar_O_declared_on_the_method =
+        final Comparable<?> comparable_bound_that_is_declared_on_typevar_K_in_the_class_which_is_referenced_by_typevar_O_declared_on_the_method =
                 mock.paramTypeWithTypeParams().get(0);
     }
 
     @Test
     public void can_create_mock_from_multiple_type_variable_bounds_when_method_return_type_is_referencing_a_typevar_on_class() throws Exception {
-        GenericsNest<?> mock = mock(GenericsNest.class, RETURNS_DEEP_STUBS);
+        final GenericsNest<?> mock = mock(GenericsNest.class, RETURNS_DEEP_STUBS);
 
-        Cloneable cloneable_bound_of_typevar_K = mock.returningK();
-        Comparable<?> comparable_bound_of_typevar_K = mock.returningK();
+        final Cloneable cloneable_bound_of_typevar_K = mock.returningK();
+        final Comparable<?> comparable_bound_of_typevar_K = mock.returningK();
     }
 
     @Test
     public void can_create_mock_from_multiple_type_variable_bounds_when_return_type_of_parameterized_method_is_a_typevar_that_is_referencing_a_typevar_on_class() throws Exception {
-        GenericsNest<?> mock = mock(GenericsNest.class, RETURNS_DEEP_STUBS);
+        final GenericsNest<?> mock = mock(GenericsNest.class, RETURNS_DEEP_STUBS);
 
-        Cloneable cloneable_bound_of_typevar_K_referenced_by_typevar_O = (Cloneable) mock.typeVarWithTypeParams();
-        Comparable<?> comparable_bound_of_typevar_K_referenced_by_typevar_O = (Comparable) mock.typeVarWithTypeParams();
+        final Cloneable cloneable_bound_of_typevar_K_referenced_by_typevar_O = mock.typeVarWithTypeParams();
+        final Comparable<?> comparable_bound_of_typevar_K_referenced_by_typevar_O = mock.typeVarWithTypeParams();
     }
 
     @Test
     public void can_create_mock_from_return_types_declared_with_a_bounded_wildcard() throws Exception {
-        GenericsNest<?> mock = mock(GenericsNest.class, RETURNS_DEEP_STUBS);
+        final GenericsNest<?> mock = mock(GenericsNest.class, RETURNS_DEEP_STUBS);
 
-        List<? super Integer> objects = mock.returningWildcard();
-        Number type_that_is_the_upper_bound_of_the_wildcard = (Number) mock.returningWildcard().get(45);
+        final List<? super Integer> objects = mock.returningWildcard();
+        final Number type_that_is_the_upper_bound_of_the_wildcard = (Number) mock.returningWildcard().get(45);
         type_that_is_the_upper_bound_of_the_wildcard.floatValue();
     }
 
     @Test
     public void can_still_work_with_raw_type_in_the_return_type() throws Exception {
-        GenericsNest<?> mock = mock(GenericsNest.class, RETURNS_DEEP_STUBS);
+        final GenericsNest<?> mock = mock(GenericsNest.class, RETURNS_DEEP_STUBS);
 
-        Number the_raw_type_that_should_be_returned = mock.returnsNormalType();
+        final Number the_raw_type_that_should_be_returned = mock.returnsNormalType();
         the_raw_type_that_should_be_returned.floatValue();
     }
 
     @Test
     public void will_return_default_value_on_non_mockable_nested_generic() throws Exception {
-        GenericsNest<?> genericsNest = mock(GenericsNest.class, RETURNS_DEEP_STUBS);
-        ListOfInteger listOfInteger = mock(ListOfInteger.class, RETURNS_DEEP_STUBS);
+        final GenericsNest<?> genericsNest = mock(GenericsNest.class, RETURNS_DEEP_STUBS);
+        final ListOfInteger listOfInteger = mock(ListOfInteger.class, RETURNS_DEEP_STUBS);
 
         assertThat(genericsNest.returningNonMockableNestedGeneric().keySet().iterator().next()).isNull();
         assertThat(listOfInteger.get(25)).isEqualTo(0);
@@ -100,10 +100,10 @@ public class ReturnsGenericDeepStubsTest {
 
     @Test(expected = ClassCastException.class)
     public void as_expected_fail_with_a_CCE_on_callsite_when_erasure_takes_place_for_example___StringBuilder_is_subject_to_erasure() throws Exception {
-        GenericsNest<?> mock = mock(GenericsNest.class, RETURNS_DEEP_STUBS);
+        final GenericsNest<?> mock = mock(GenericsNest.class, RETURNS_DEEP_STUBS);
 
         // following assignment needed to create a ClassCastException on the call site (i.e. : here)
-        StringBuilder stringBuilder_assignment_that_should_throw_a_CCE =
+        final StringBuilder stringBuilder_assignment_that_should_throw_a_CCE =
                 mock.twoTypeParams(new StringBuilder()).append(2).append(3);
     }
 }

--- a/test/org/mockito/internal/stubbing/defaultanswers/ReturnsGenericDeepStubsTest.java
+++ b/test/org/mockito/internal/stubbing/defaultanswers/ReturnsGenericDeepStubsTest.java
@@ -35,7 +35,7 @@ public class ReturnsGenericDeepStubsTest {
         GenericsNest<?> mock = mock(GenericsNest.class, RETURNS_DEEP_STUBS);
 
         Set<? extends Map.Entry<? extends Cloneable, Set<Number>>> entries = mock.entrySet();
-        Iterator<? extends Map.Entry<? extends Cloneable,Set<Number>>> entriesIterator = mock.entrySet().iterator();
+        Iterator<? extends Map.Entry<? extends Cloneable, Set<Number>>> entriesIterator = mock.entrySet().iterator();
         Map.Entry<? extends Cloneable, Set<Number>> nextEntry = mock.entrySet().iterator().next();
 
         Cloneable cloneableKey = mock.entrySet().iterator().next().getKey();

--- a/test/org/mockito/internal/stubbing/defaultanswers/ReturnsMocksTest.java
+++ b/test/org/mockito/internal/stubbing/defaultanswers/ReturnsMocksTest.java
@@ -9,7 +9,7 @@ import org.mockito.internal.util.MockUtil;
 import org.mockitoutil.TestBase;
 
 public class ReturnsMocksTest extends TestBase {
-    private ReturnsMocks values = new ReturnsMocks();
+    private final ReturnsMocks values = new ReturnsMocks();
 
     interface FooInterface {
     }
@@ -22,13 +22,13 @@ public class ReturnsMocksTest extends TestBase {
 
     @Test
     public void should_return_mock_value_for_interface() throws Exception {
-        Object interfaceMock = values.returnValueFor(FooInterface.class);
+        final Object interfaceMock = values.returnValueFor(FooInterface.class);
         assertTrue(new MockUtil().isMock(interfaceMock));
     }
 
     @Test
     public void should_return_mock_value_for_class() throws Exception {
-        Object classMock = values.returnValueFor(BarClass.class);
+        final Object classMock = values.returnValueFor(BarClass.class);
         assertTrue(new MockUtil().isMock(classMock));
     }
 
@@ -39,7 +39,7 @@ public class ReturnsMocksTest extends TestBase {
 
     @Test
     public void should_return_the_usual_default_values_for_primitives() throws Throwable {
-        ReturnsMocks answer = new ReturnsMocks();
+        final ReturnsMocks answer = new ReturnsMocks();
         assertEquals(false, answer.answer(invocationOf(HasPrimitiveMethods.class, "booleanMethod")));
         assertEquals((char) 0, answer.answer(invocationOf(HasPrimitiveMethods.class, "charMethod")));
         assertEquals((byte) 0, answer.answer(invocationOf(HasPrimitiveMethods.class, "byteMethod")));
@@ -50,7 +50,6 @@ public class ReturnsMocksTest extends TestBase {
         assertEquals(0d, answer.answer(invocationOf(HasPrimitiveMethods.class, "doubleMethod")));
     }
 
-    @SuppressWarnings("unused")
     interface StringMethods {
         String stringMethod();
         String[] stringArrayMethod();
@@ -58,7 +57,7 @@ public class ReturnsMocksTest extends TestBase {
     
     @Test
     public void should_return_empty_array() throws Throwable {
-        String[] ret = (String[]) values.answer(invocationOf(StringMethods.class, "stringArrayMethod"));
+        final String[] ret = (String[]) values.answer(invocationOf(StringMethods.class, "stringArrayMethod"));
         
         assertTrue(ret.getClass().isArray());
         assertTrue(ret.length == 0);

--- a/test/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNullsTest.java
+++ b/test/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNullsTest.java
@@ -13,7 +13,7 @@ public class ReturnsSmartNullsTest extends TestBase {
 
     @Test
     public void should_return_the_usual_default_values_for_primitives() throws Throwable {
-        Answer<Object> answer = new ReturnsSmartNulls();
+        final Answer<Object> answer = new ReturnsSmartNulls();
         assertEquals(false  ,   answer.answer(invocationOf(HasPrimitiveMethods.class, "booleanMethod")));
         assertEquals((char) 0,  answer.answer(invocationOf(HasPrimitiveMethods.class, "charMethod")));
         assertEquals((byte) 0,  answer.answer(invocationOf(HasPrimitiveMethods.class, "byteMethod")));
@@ -24,29 +24,28 @@ public class ReturnsSmartNullsTest extends TestBase {
         assertEquals(0d,        answer.answer(invocationOf(HasPrimitiveMethods.class, "doubleMethod")));
     }
 
-    @SuppressWarnings("unused")
     interface Foo {
         Foo get();
-        Foo withArgs(String oneArg, String otherArg);
+        Foo withArgs(final String oneArg, final String otherArg);
     }
 
     @Test
     public void should_return_an_object_that_fails_on_any_method_invocation_for_non_primitives() throws Throwable {
-        Answer<Object> answer = new ReturnsSmartNulls();
+        final Answer<Object> answer = new ReturnsSmartNulls();
 
-        Foo smartNull = (Foo) answer.answer(invocationOf(Foo.class, "get"));
+        final Foo smartNull = (Foo) answer.answer(invocationOf(Foo.class, "get"));
 
         try {
             smartNull.get();
             fail();
-        } catch (SmartNullPointerException expected) {}
+        } catch (final SmartNullPointerException expected) {}
     }
 
     @Test
     public void should_return_an_object_that_allows_object_methods() throws Throwable {
-        Answer<Object> answer = new ReturnsSmartNulls();
+        final Answer<Object> answer = new ReturnsSmartNulls();
 
-        Foo smartNull = (Foo) answer.answer(invocationOf(Foo.class, "get"));
+        final Foo smartNull = (Foo) answer.answer(invocationOf(Foo.class, "get"));
 
         assertContains("SmartNull returned by", smartNull + "");
         assertContains("foo.get()", smartNull + "");
@@ -54,9 +53,9 @@ public class ReturnsSmartNullsTest extends TestBase {
 
     @Test
     public void should_print_the_parameters_when_calling_a_method_with_args() throws Throwable {
-        Answer<Object> answer = new ReturnsSmartNulls();
+        final Answer<Object> answer = new ReturnsSmartNulls();
 
-        Foo smartNull = (Foo) answer.answer(invocationOf(Foo.class, "withArgs", "oompa", "lumpa"));
+        final Foo smartNull = (Foo) answer.answer(invocationOf(Foo.class, "withArgs", "oompa", "lumpa"));
 
         assertContains("foo.withArgs", smartNull + "");
         assertContains("oompa", smartNull + "");
@@ -65,14 +64,14 @@ public class ReturnsSmartNullsTest extends TestBase {
 
     @Test
     public void should_print_the_parameters_on_SmartNullPointerException_message() throws Throwable {
-        Answer<Object> answer = new ReturnsSmartNulls();
+        final Answer<Object> answer = new ReturnsSmartNulls();
 
-        Foo smartNull = (Foo) answer.answer(invocationOf(Foo.class, "withArgs", "oompa", "lumpa"));
+        final Foo smartNull = (Foo) answer.answer(invocationOf(Foo.class, "withArgs", "oompa", "lumpa"));
 
         try {
             smartNull.get();
             fail();
-        } catch (SmartNullPointerException e) {
+        } catch (final SmartNullPointerException e) {
             assertContains("oompa", e.getMessage());
             assertContains("lumpa", e.getMessage());
         }

--- a/test/org/mockito/internal/util/DecamelizerTest.java
+++ b/test/org/mockito/internal/util/DecamelizerTest.java
@@ -5,7 +5,7 @@
 
 package org.mockito.internal.util;
 
-import static org.mockito.internal.util.Decamelizer.*;
+import static org.mockito.internal.util.Decamelizer.decamelizeMatcher;
 
 import org.junit.Test;
 import org.mockitoutil.TestBase;

--- a/test/org/mockito/internal/util/DefaultMockingDetailsTest.java
+++ b/test/org/mockito/internal/util/DefaultMockingDetailsTest.java
@@ -1,16 +1,22 @@
 package org.mockito.internal.util;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockingDetails;
+import static org.mockito.Mockito.withSettings;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Observer;
+import java.util.Set;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.exceptions.misusing.NotAMockException;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import java.util.*;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
 
 @SuppressWarnings("unchecked")
 @RunWith(MockitoJUnitRunner.class)
@@ -53,7 +59,7 @@ public class DefaultMockingDetailsTest {
 
     @Test
     public void should_get_extra_interfaces() throws Exception {
-        Bar loup = mock(Bar.class, withSettings().extraInterfaces(List.class, Observer.class));
+        final Bar loup = mock(Bar.class, withSettings().extraInterfaces(List.class, Observer.class));
         assertEquals(setOf(Observer.class, List.class), mockingDetails(loup).getExtraInterfaces());
     }
 
@@ -62,7 +68,7 @@ public class DefaultMockingDetailsTest {
         mockingDetails("not a mock").getExtraInterfaces();
     }
 
-    private <T> Set<T> setOf(T... items) {
+    private <T> Set<T> setOf(final T... items) {
         return new HashSet<T>(Arrays.asList(items));
     }
 

--- a/test/org/mockito/internal/util/MockCreationValidatorTest.java
+++ b/test/org/mockito/internal/util/MockCreationValidatorTest.java
@@ -4,20 +4,20 @@
  */
 package org.mockito.internal.util;
 
-import org.junit.Test;
-import org.mockito.exceptions.base.MockitoException;
-import org.mockitousage.IMethods;
+import static java.util.Arrays.asList;
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Observer;
 
-import static java.util.Arrays.asList;
-import static org.fest.assertions.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import org.junit.Test;
+import org.mockito.exceptions.base.MockitoException;
+import org.mockitousage.IMethods;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class MockCreationValidatorTest {
 
     final class FinalClass {}
@@ -29,7 +29,7 @@ public class MockCreationValidatorTest {
             //when
             validator.validateExtraInterfaces(IMethods.class, (Collection) asList(IMethods.class));
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             //then
             assertThat(e.getMessage()).contains("You mocked following type: IMethods");
         }
@@ -61,13 +61,13 @@ public class MockCreationValidatorTest {
     @Test(expected = MockitoException.class)
     public void should_not_allow_serializable_with_Object_that_dont_implement_Serializable() {
         class NonSerializableInnerClassThatHaveAHiddenOneArgConstructor {}
-        boolean serializable = true;
+        final boolean serializable = true;
         validator.validateSerializable(NonSerializableInnerClassThatHaveAHiddenOneArgConstructor.class, serializable);
     }
 
     @Test
     public void should_allow_serializable_with_interfaces_or_Serializable_objects() {
-        boolean serializable = true;
+        final boolean serializable = true;
         validator.validateSerializable(Observer.class, serializable);
         validator.validateSerializable(Integer.class, serializable);
     }

--- a/test/org/mockito/internal/util/MockUtilTest.java
+++ b/test/org/mockito/internal/util/MockUtilTest.java
@@ -6,8 +6,10 @@
 package org.mockito.internal.util;
 
 import static org.mockito.Mockito.withSettings;
+
 import java.util.ArrayList;
 import java.util.List;
+
 import org.fest.assertions.Assertions;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -15,14 +17,14 @@ import org.mockito.exceptions.base.MockitoException;
 import org.mockito.exceptions.misusing.NotAMockException;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class MockUtilTest extends TestBase {
 
-    private MockUtil mockUtil = new MockUtil();
+    private final MockUtil mockUtil = new MockUtil();
 
     @Test
     public void should_get_handler() {
-        List mock = Mockito.mock(List.class);
+        final List mock = Mockito.mock(List.class);
         assertNotNull(mockUtil.getMockHandler(mock));
     }
 
@@ -38,7 +40,7 @@ public class MockUtilTest extends TestBase {
 
     @Test
     public void should_get_mock_settings() {
-        List mock = Mockito.mock(List.class);
+        final List mock = Mockito.mock(List.class);
         assertNotNull(mockUtil.getMockSettings(mock));
     }
 
@@ -61,7 +63,7 @@ public class MockUtilTest extends TestBase {
 
     @Test
     public void should_redefine_MockName_if_default() {
-        List mock = Mockito.mock(List.class);
+        final List mock = Mockito.mock(List.class);
         mockUtil.maybeRedefineMockName(mock, "newName");
 
         Assertions.assertThat(mockUtil.getMockName(mock).toString()).isEqualTo("newName");
@@ -69,7 +71,7 @@ public class MockUtilTest extends TestBase {
 
     @Test
     public void should_not_redefine_MockName_if_default() {
-        List mock = Mockito.mock(List.class, "original");
+        final List mock = Mockito.mock(List.class, "original");
         mockUtil.maybeRedefineMockName(mock, "newName");
 
         Assertions.assertThat(mockUtil.getMockName(mock).toString()).isEqualTo("original");

--- a/test/org/mockito/internal/util/ObjectMethodsGuruTest.java
+++ b/test/org/mockito/internal/util/ObjectMethodsGuruTest.java
@@ -4,12 +4,13 @@
  */
 package org.mockito.internal.util;
 
+import java.util.Date;
+
 import org.junit.Test;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import java.util.Date;
-
+@SuppressWarnings("rawtypes")
 public class ObjectMethodsGuruTest extends TestBase {
 
     ObjectMethodsGuru guru = new ObjectMethodsGuru();
@@ -37,14 +38,14 @@ public class ObjectMethodsGuruTest extends TestBase {
     }
 
     interface HasCompareToButDoesNotImplementComparable {
-        public int compareTo(HasCompareToButDoesNotImplementComparable other);
+        int compareTo(final HasCompareToButDoesNotImplementComparable other);
     }
 
     interface HasCompare extends Comparable {
-        public int foo(HasCompare other);
-        public int compareTo(HasCompare other, String redHerring);
-        public int compareTo(String redHerring);
-        public int compareTo(HasCompare redHerring);
+        int foo(final HasCompare other);
+        int compareTo(final HasCompare other, final String redHerring);
+        int compareTo(final String redHerring);
+        int compareTo(final HasCompare redHerring);
     }
 
     @Test

--- a/test/org/mockito/internal/util/collections/ListUtilTest.java
+++ b/test/org/mockito/internal/util/collections/ListUtilTest.java
@@ -5,24 +5,24 @@
 
 package org.mockito.internal.util.collections;
 
-import org.junit.Test;
-import org.mockito.internal.util.collections.ListUtil.Filter;
-import org.mockitoutil.TestBase;
+import static java.util.Arrays.asList;
+import static org.mockitoutil.ExtraMatchers.hasExactlyInOrder;
 
 import java.util.LinkedList;
 import java.util.List;
 
-import static java.util.Arrays.asList;
-import static org.mockitoutil.ExtraMatchers.hasExactlyInOrder;
+import org.junit.Test;
+import org.mockito.internal.util.collections.ListUtil.Filter;
+import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class ListUtilTest extends TestBase {
 
     @Test
     public void shouldFilterList() throws Exception {
-        List list = asList("one", "x", "two", "x", "three");
-        List filtered = ListUtil.filter(list, new Filter() {
-            public boolean isOut(Object object) {
+        final List list = asList("one", "x", "two", "x", "three");
+        final List filtered = ListUtil.filter(list, new Filter() {
+            public boolean isOut(final Object object) {
                 return object == "x";
             }
         });
@@ -32,8 +32,8 @@ public class ListUtilTest extends TestBase {
     
     @Test
     public void shouldReturnEmptyIfEmptyListGiven() throws Exception {
-        List list = new LinkedList();
-        List filtered = ListUtil.filter(list, null);
+        final List list = new LinkedList();
+        final List filtered = ListUtil.filter(list, null);
         assertTrue(filtered.isEmpty());
     }
 }

--- a/test/org/mockito/internal/util/reflection/AccessibilityChangerTest.java
+++ b/test/org/mockito/internal/util/reflection/AccessibilityChangerTest.java
@@ -5,19 +5,20 @@
 
 package org.mockito.internal.util.reflection;
 
-import org.junit.Ignore;
-import org.junit.Test;
-
 import java.lang.reflect.Field;
 import java.util.Observable;
 
+import org.junit.Ignore;
+import org.junit.Test;
+
 public class AccessibilityChangerTest {
 
+    @SuppressWarnings("unused")
     private Observable whatever;
 
     @Test
     public void should_enable_and_safely_disable() throws Exception {
-        AccessibilityChanger changer = new AccessibilityChanger();
+        final AccessibilityChanger changer = new AccessibilityChanger();
         changer.enableAccess(field("whatever"));
         changer.safelyDisableAccess(field("whatever"));
     }
@@ -28,7 +29,7 @@ public class AccessibilityChangerTest {
         new AccessibilityChanger().safelyDisableAccess(field("whatever"));
     }
 
-    private Field field(String fieldName) throws NoSuchFieldException {
+    private Field field(final String fieldName) throws NoSuchFieldException {
         return this.getClass().getDeclaredField(fieldName);
     }
 }

--- a/test/org/mockito/internal/util/reflection/BeanPropertySetterTest.java
+++ b/test/org/mockito/internal/util/reflection/BeanPropertySetterTest.java
@@ -4,28 +4,31 @@
  */
 package org.mockito.internal.util.reflection;
 
-import org.fest.assertions.Assertions;
-import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.lang.reflect.Field;
 import java.util.UUID;
 
-import static org.junit.Assert.*;
+import org.fest.assertions.Assertions;
+import org.junit.Test;
 
-
+@SuppressWarnings("unused")
 public class BeanPropertySetterTest {
 
     @Test
     public void use_the_correct_setter_on_the_target() throws Exception {
         // given
-        SomeBean someBean = new SomeBean();
-        Field theField = someBean.getClass().getDeclaredField("theField");
-        File valueToInject = new File("path");
+        final SomeBean someBean = new SomeBean();
+        final Field theField = someBean.getClass().getDeclaredField("theField");
+        final File valueToInject = new File("path");
 
         // when
-        boolean injected = new BeanPropertySetter(someBean, theField, true).set(valueToInject);
+        final boolean injected = new BeanPropertySetter(someBean, theField, true).set(valueToInject);
 
         // then
         assertTrue(injected);
@@ -36,12 +39,12 @@ public class BeanPropertySetterTest {
     @Test
     public void use_the_setter_on_the_target_when_field_name_begins_by_at_least_2_caps() throws Exception {
         // given
-        BeanWithWeirdFields someBean = new BeanWithWeirdFields();
-        Field theField = someBean.getClass().getDeclaredField("UUID");
-        UUID valueToInject = new UUID(0L, 0L);
+        final BeanWithWeirdFields someBean = new BeanWithWeirdFields();
+        final Field theField = someBean.getClass().getDeclaredField("UUID");
+        final UUID valueToInject = new UUID(0L, 0L);
 
         // when
-        boolean injected = new BeanPropertySetter(someBean, theField, true).set(valueToInject);
+        final boolean injected = new BeanPropertySetter(someBean, theField, true).set(valueToInject);
 
         // then
         assertTrue(injected);
@@ -52,12 +55,12 @@ public class BeanPropertySetterTest {
     @Test
     public void should_not_fail_if_bean_class_declares_only_the_setter_for_the_property() throws Exception {
         // given
-        SomeBeanWithJustASetter someBean = new SomeBeanWithJustASetter();
-        Field theField = someBean.getClass().getDeclaredField("theField");
-        File valueToInject = new File("path");
+        final SomeBeanWithJustASetter someBean = new SomeBeanWithJustASetter();
+        final Field theField = someBean.getClass().getDeclaredField("theField");
+        final File valueToInject = new File("path");
 
         // when
-        boolean injected = new BeanPropertySetter(someBean, theField, true).set(valueToInject);
+        final boolean injected = new BeanPropertySetter(someBean, theField, true).set(valueToInject);
 
         // then
         assertTrue(injected);
@@ -67,15 +70,15 @@ public class BeanPropertySetterTest {
     @Test
     public void should_fail_if_matching_setter_cannot_be_found_and_if_report_failure_is_true() throws Exception {
         // given
-        SomeBeanWithNoSetterMatchingFieldType bean = new SomeBeanWithNoSetterMatchingFieldType();
-        Field theField = bean.getClass().getDeclaredField("theField");
-        File valueToInject = new File("path");
+        final SomeBeanWithNoSetterMatchingFieldType bean = new SomeBeanWithNoSetterMatchingFieldType();
+        final Field theField = bean.getClass().getDeclaredField("theField");
+        final File valueToInject = new File("path");
 
         try {
             // when
             new BeanPropertySetter(bean, theField, true).set(valueToInject);
             fail();
-        } catch (Exception e) {
+        } catch (final Exception e) {
             // then
             Assertions.assertThat(e.getMessage()).contains("setter not found");
         }
@@ -84,12 +87,12 @@ public class BeanPropertySetterTest {
     @Test
     public void return_false_if_no_setter_was_found() throws Exception {
         // given
-        SomeBeanWithJustAGetter bean = new SomeBeanWithJustAGetter();
-        Field theField = bean.getClass().getDeclaredField("theField");
-        File valueToInject = new File("path");
+        final SomeBeanWithJustAGetter bean = new SomeBeanWithJustAGetter();
+        final Field theField = bean.getClass().getDeclaredField("theField");
+        final File valueToInject = new File("path");
 
         // when
-        boolean injected = new BeanPropertySetter(bean, theField).set(valueToInject);
+        final boolean injected = new BeanPropertySetter(bean, theField).set(valueToInject);
 
         // then
         assertFalse(injected);
@@ -98,12 +101,12 @@ public class BeanPropertySetterTest {
     @Test
     public void return_false_if_no_setter_was_found_and_if_reportNoSetterFound_is_false() throws Exception {
         // given
-        SomeBeanWithNoSetterMatchingFieldType bean = new SomeBeanWithNoSetterMatchingFieldType();
-        Field theField = bean.getClass().getDeclaredField("theField");
-        File valueToInject = new File("path");
+        final SomeBeanWithNoSetterMatchingFieldType bean = new SomeBeanWithNoSetterMatchingFieldType();
+        final Field theField = bean.getClass().getDeclaredField("theField");
+        final File valueToInject = new File("path");
 
         // when
-        boolean injected = new BeanPropertySetter(bean, theField, false).set(valueToInject);
+        final boolean injected = new BeanPropertySetter(bean, theField, false).set(valueToInject);
 
         // then
         assertFalse(injected);
@@ -153,9 +156,9 @@ public class BeanPropertySetterTest {
         private UUID UUID;
         boolean theFieldSetterWasUSed;
 
-        public void setUUID(UUID UUID) {
+        public void setUUID(final UUID uuid) {
             theFieldSetterWasUSed = true;
-            this.UUID = UUID;
+            this.UUID = uuid;
         }
     }
 

--- a/test/org/mockito/internal/util/reflection/FieldInitializerTest.java
+++ b/test/org/mockito/internal/util/reflection/FieldInitializerTest.java
@@ -4,24 +4,29 @@
  */
 package org.mockito.internal.util.reflection;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.util.reflection.FieldInitializer.ConstructorArgumentResolver;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-
-import static org.junit.Assert.*;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-
 
 
 public class FieldInitializerTest {
 
-    private StaticClass alreadyInstantiated = new StaticClass();
+    private final StaticClass alreadyInstantiated = new StaticClass();
     private StaticClass noConstructor;
     private StaticClassWithDefaultConstructor defaultConstructor;
     private StaticClassWithPrivateDefaultConstructor privateDefaultConstructor;
@@ -30,15 +35,15 @@ public class FieldInitializerTest {
     private AbstractStaticClass abstractType;
     private Interface interfaceType;
     private InnerClassType innerClassType;
-    private AbstractStaticClass instantiatedAbstractType = new ConcreteStaticClass();
-    private Interface instantiatedInterfaceType =  new ConcreteStaticClass();
-    private InnerClassType instantiatedInnerClassType = new InnerClassType();
+    private final AbstractStaticClass instantiatedAbstractType = new ConcreteStaticClass();
+    private final Interface instantiatedInterfaceType =  new ConcreteStaticClass();
+    private final InnerClassType instantiatedInnerClassType = new InnerClassType();
 
     @Test
     public void should_keep_same_instance_if_field_initialized() throws Exception {
         final StaticClass backupInstance = alreadyInstantiated;
-        FieldInitializer fieldInitializer = new FieldInitializer(this, field("alreadyInstantiated"));
-        FieldInitializationReport report = fieldInitializer.initialize();
+        final FieldInitializer fieldInitializer = new FieldInitializer(this, field("alreadyInstantiated"));
+        final FieldInitializationReport report = fieldInitializer.initialize();
 
         assertSame(backupInstance, report.fieldInstance());
         assertFalse(report.fieldWasInitialized());
@@ -47,8 +52,8 @@ public class FieldInitializerTest {
 
     @Test
     public void should_instantiate_field_when_type_has_no_constructor() throws Exception {
-        FieldInitializer fieldInitializer = new FieldInitializer(this, field("noConstructor"));
-        FieldInitializationReport report = fieldInitializer.initialize();
+        final FieldInitializer fieldInitializer = new FieldInitializer(this, field("noConstructor"));
+        final FieldInitializationReport report = fieldInitializer.initialize();
 
         assertNotNull(report.fieldInstance());
         assertTrue(report.fieldWasInitialized());
@@ -57,8 +62,8 @@ public class FieldInitializerTest {
 
     @Test
     public void should_instantiate_field_with_default_constructor() throws Exception {
-        FieldInitializer fieldInitializer = new FieldInitializer(this, field("defaultConstructor"));
-        FieldInitializationReport report = fieldInitializer.initialize();
+        final FieldInitializer fieldInitializer = new FieldInitializer(this, field("defaultConstructor"));
+        final FieldInitializationReport report = fieldInitializer.initialize();
 
         assertNotNull(report.fieldInstance());
         assertTrue(report.fieldWasInitialized());
@@ -67,8 +72,8 @@ public class FieldInitializerTest {
 
     @Test
     public void should_instantiate_field_with_private_default_constructor() throws Exception {
-        FieldInitializer fieldInitializer = new FieldInitializer(this, field("privateDefaultConstructor"));
-        FieldInitializationReport report = fieldInitializer.initialize();
+        final FieldInitializer fieldInitializer = new FieldInitializer(this, field("privateDefaultConstructor"));
+        final FieldInitializationReport report = fieldInitializer.initialize();
 
         assertNotNull(report.fieldInstance());
         assertTrue(report.fieldWasInitialized());
@@ -77,18 +82,18 @@ public class FieldInitializerTest {
 
     @Test(expected = MockitoException.class)
     public void should_fail_to_instantiate_field_if_no_default_constructor() throws Exception {
-        FieldInitializer fieldInitializer = new FieldInitializer(this, field("noDefaultConstructor"));
+        final FieldInitializer fieldInitializer = new FieldInitializer(this, field("noDefaultConstructor"));
         fieldInitializer.initialize();
     }
 
     @Test
     public void should_fail_to_instantiate_field_if_default_constructor_throws_exception() throws Exception {
-        FieldInitializer fieldInitializer = new FieldInitializer(this, field("throwingExDefaultConstructor"));
+        final FieldInitializer fieldInitializer = new FieldInitializer(this, field("throwingExDefaultConstructor"));
         try {
             fieldInitializer.initialize();
             fail();
-        } catch (MockitoException e) {
-            InvocationTargetException ite = (InvocationTargetException) e.getCause();
+        } catch (final MockitoException e) {
+            final InvocationTargetException ite = (InvocationTargetException) e.getCause();
             assertTrue(ite.getTargetException() instanceof NullPointerException);
             assertEquals("business logic failed", ite.getTargetException().getMessage());
         }
@@ -123,7 +128,7 @@ public class FieldInitializerTest {
             @InjectMocks LocalType field;
         }
 
-        TheTestWithLocalType testWithLocalType = new TheTestWithLocalType();
+        final TheTestWithLocalType testWithLocalType = new TheTestWithLocalType();
 
         // when
         new FieldInitializer(testWithLocalType, testWithLocalType.getClass().getDeclaredField("field"));
@@ -138,7 +143,7 @@ public class FieldInitializerTest {
             @InjectMocks LocalType field = new LocalType();
         }
 
-        TheTestWithLocalType testWithLocalType = new TheTestWithLocalType();
+        final TheTestWithLocalType testWithLocalType = new TheTestWithLocalType();
 
         // when
         new FieldInitializer(testWithLocalType, testWithLocalType.getClass().getDeclaredField("field"));
@@ -156,7 +161,7 @@ public class FieldInitializerTest {
 
     @Test
     public void can_instantiate_class_with_parameterized_constructor() throws Exception {
-        ConstructorArgumentResolver resolver = given(mock(ConstructorArgumentResolver.class).resolveTypeInstances(any(Class[].class)))
+        final ConstructorArgumentResolver resolver = given(mock(ConstructorArgumentResolver.class).resolveTypeInstances(any(Class[].class)))
                         .willReturn(new Object[]{null}).getMock();
 
         new FieldInitializer(this, field("noDefaultConstructor"), resolver).initialize();
@@ -164,7 +169,7 @@ public class FieldInitializerTest {
         assertNotNull(noDefaultConstructor);
     }
 
-    private Field field(String fieldName) throws NoSuchFieldException {
+    private Field field(final String fieldName) throws NoSuchFieldException {
         return this.getClass().getDeclaredField(fieldName);
     }
 
@@ -180,7 +185,7 @@ public class FieldInitializerTest {
     }
 
     static class StaticClassWithoutDefaultConstructor {
-        private StaticClassWithoutDefaultConstructor(String param) { }
+        private StaticClassWithoutDefaultConstructor(final String param) { }
     }
 
     static class StaticClassThrowingExceptionDefaultConstructor {
@@ -189,7 +194,7 @@ public class FieldInitializerTest {
         }
     }
     
-    static abstract class AbstractStaticClass {
+    abstract static class AbstractStaticClass {
         public AbstractStaticClass() {}
     }
 

--- a/test/org/mockito/internal/util/reflection/FieldInitializerTest.java
+++ b/test/org/mockito/internal/util/reflection/FieldInitializerTest.java
@@ -22,8 +22,7 @@ import org.mockito.InjectMocks;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.util.reflection.FieldInitializer.ConstructorArgumentResolver;
 
-
-
+@SuppressWarnings("unused")
 public class FieldInitializerTest {
 
     private final StaticClass alreadyInstantiated = new StaticClass();

--- a/test/org/mockito/internal/util/reflection/GenericMasterTest.java
+++ b/test/org/mockito/internal/util/reflection/GenericMasterTest.java
@@ -4,18 +4,23 @@
  */
 package org.mockito.internal.util.reflection;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
-import java.util.*;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
+@SuppressWarnings("rawtypes")
 public class GenericMasterTest {
-    
+
     GenericMaster m = new GenericMaster();
-    
+
     List<String> one;
     Set<Integer> two;
     Map<Double, String> map;
@@ -23,16 +28,32 @@ public class GenericMasterTest {
     List<Set<String>> nested;
     List<Set<Collection<String>>> multiNested;
 
-    public interface ListSet extends List<Set> {}
-    public interface MapNumberString extends Map<Number, String> {}
-    public class HashMapNumberString<K extends Number> extends HashMap<K, String> {}
+    public interface ListSet extends List<Set> {
+    }
 
-    public List<Number> numberList() { return null; }
-    public Comparable<Number> numberComparable() { return null; }
-    public List rawList() { return null; }
-    public List<? extends Type> typeList() { return null; }
+    public interface MapNumberString extends Map<Number, String> {
+    }
 
+    public class HashMapNumberString<K extends Number> extends HashMap<K, String> {
 
+        private static final long serialVersionUID = -4267582335384921708L;
+    }
+
+    public List<Number> numberList() {
+        return null;
+    }
+
+    public Comparable<Number> numberComparable() {
+        return null;
+    }
+
+    public List rawList() {
+        return null;
+    }
+
+    public List<? extends Type> typeList() {
+        return null;
+    }
 
     @Test
     public void should_find_generic_class() throws Exception {
@@ -40,19 +61,19 @@ public class GenericMasterTest {
         assertEquals(Integer.class, m.getGenericType(field("two")));
         assertEquals(Double.class, m.getGenericType(field("map")));
     }
-    
+
     @Test
     public void should_get_object_for_non_generic() throws Exception {
         assertEquals(Object.class, m.getGenericType(field("nonGeneric")));
     }
-    
+
     @Test
     public void should_deal_with_nested_generics() throws Exception {
         assertEquals(Set.class, m.getGenericType(field("nested")));
         assertEquals(Set.class, m.getGenericType(field("multiNested")));
     }
 
-    private Field field(String fieldName) throws SecurityException, NoSuchFieldException {
+    private Field field(final String fieldName) throws SecurityException, NoSuchFieldException {
         return this.getClass().getDeclaredField(fieldName);
     }
 

--- a/test/org/mockito/internal/util/reflection/GenericMetadataSupportTest.java
+++ b/test/org/mockito/internal/util/reflection/GenericMetadataSupportTest.java
@@ -36,7 +36,7 @@ public class GenericMetadataSupportTest {
     interface ListOfAnyNumbers<N extends Number & Cloneable> extends List<N> {}
 
     interface GenericsNest<K extends Comparable<K> & Cloneable> extends Map<K, Set<Number>> {
-        Set<Number> remove(Object key); // override with fixed ParameterizedType
+        Set<Number> remove(final Object key); // override with fixed ParameterizedType
         List<? super Integer> returning_wildcard_with_class_lower_bound();
         List<? super K> returning_wildcard_with_typeVar_lower_bound();
         List<? extends K> returning_wildcard_with_typeVar_upper_bound();
@@ -46,11 +46,12 @@ public class GenericMetadataSupportTest {
         <O extends K> O typeVar_with_type_params();
     }
 
+    @SuppressWarnings("serial")
     static class StringList extends ArrayList<String> { }
 
     @Test
     public void typeVariable_of_self_type() {
-        GenericMetadataSupport genericMetadata = inferFrom(GenericsSelfReference.class).resolveGenericReturnType(firstNamedMethod("self", GenericsSelfReference.class));
+        final GenericMetadataSupport genericMetadata = inferFrom(GenericsSelfReference.class).resolveGenericReturnType(firstNamedMethod("self", GenericsSelfReference.class));
 
         assertThat(genericMetadata.rawType()).isEqualTo(GenericsSelfReference.class);
     }
@@ -92,7 +93,7 @@ public class GenericMetadataSupportTest {
 
     @Test
     public void typeVariable_return_type_of____iterator____resolved_to_Iterator_and_type_argument_to_String() throws Exception {
-        GenericMetadataSupport genericMetadata = inferFrom(StringList.class).resolveGenericReturnType(firstNamedMethod("iterator", StringList.class));
+        final GenericMetadataSupport genericMetadata = inferFrom(StringList.class).resolveGenericReturnType(firstNamedMethod("iterator", StringList.class));
 
         assertThat(genericMetadata.rawType()).isEqualTo(Iterator.class);
         assertThat(genericMetadata.actualTypeArguments().values()).contains(String.class);
@@ -100,7 +101,7 @@ public class GenericMetadataSupportTest {
 
     @Test
     public void typeVariable_return_type_of____get____resolved_to_Set_and_type_argument_to_Number() throws Exception {
-        GenericMetadataSupport genericMetadata = inferFrom(GenericsNest.class).resolveGenericReturnType(firstNamedMethod("get", GenericsNest.class));
+        final GenericMetadataSupport genericMetadata = inferFrom(GenericsNest.class).resolveGenericReturnType(firstNamedMethod("get", GenericsNest.class));
 
         assertThat(genericMetadata.rawType()).isEqualTo(Set.class);
         assertThat(genericMetadata.actualTypeArguments().values()).contains(Number.class);
@@ -108,16 +109,16 @@ public class GenericMetadataSupportTest {
 
     @Test
     public void bounded_typeVariable_return_type_of____returningK____resolved_to_Comparable_and_with_BoundedType() throws Exception {
-        GenericMetadataSupport genericMetadata = inferFrom(GenericsNest.class).resolveGenericReturnType(firstNamedMethod("returningK", GenericsNest.class));
+        final GenericMetadataSupport genericMetadata = inferFrom(GenericsNest.class).resolveGenericReturnType(firstNamedMethod("returningK", GenericsNest.class));
 
         assertThat(genericMetadata.rawType()).isEqualTo(Comparable.class);
-        GenericMetadataSupport extraInterface_0 = inferFrom(genericMetadata.extraInterfaces().get(0));
+        final GenericMetadataSupport extraInterface_0 = inferFrom(genericMetadata.extraInterfaces().get(0));
         assertThat(extraInterface_0.rawType()).isEqualTo(Cloneable.class);
     }
 
     @Test
     public void fixed_ParamType_return_type_of____remove____resolved_to_Set_and_type_argument_to_Number() throws Exception {
-        GenericMetadataSupport genericMetadata = inferFrom(GenericsNest.class).resolveGenericReturnType(firstNamedMethod("remove", GenericsNest.class));
+        final GenericMetadataSupport genericMetadata = inferFrom(GenericsNest.class).resolveGenericReturnType(firstNamedMethod("remove", GenericsNest.class));
 
         assertThat(genericMetadata.rawType()).isEqualTo(Set.class);
         assertThat(genericMetadata.actualTypeArguments().values()).contains(Number.class);
@@ -125,35 +126,35 @@ public class GenericMetadataSupportTest {
 
     @Test
     public void paramType_return_type_of____values____resolved_to_Collection_and_type_argument_to_Parameterized_Set() throws Exception {
-        GenericMetadataSupport genericMetadata = inferFrom(GenericsNest.class).resolveGenericReturnType(firstNamedMethod("values", GenericsNest.class));
+        final GenericMetadataSupport genericMetadata = inferFrom(GenericsNest.class).resolveGenericReturnType(firstNamedMethod("values", GenericsNest.class));
 
         assertThat(genericMetadata.rawType()).isEqualTo(Collection.class);
-        GenericMetadataSupport fromTypeVariableE = inferFrom(typeVariableValue(genericMetadata.actualTypeArguments(), "E"));
+        final GenericMetadataSupport fromTypeVariableE = inferFrom(typeVariableValue(genericMetadata.actualTypeArguments(), "E"));
         assertThat(fromTypeVariableE.rawType()).isEqualTo(Set.class);
         assertThat(fromTypeVariableE.actualTypeArguments().values()).contains(Number.class);
     }
 
     @Test
     public void paramType_with_type_parameters_return_type_of____paramType_with_type_params____resolved_to_Collection_and_type_argument_to_Parameterized_Set() throws Exception {
-        GenericMetadataSupport genericMetadata = inferFrom(GenericsNest.class).resolveGenericReturnType(firstNamedMethod("paramType_with_type_params", GenericsNest.class));
+        final GenericMetadataSupport genericMetadata = inferFrom(GenericsNest.class).resolveGenericReturnType(firstNamedMethod("paramType_with_type_params", GenericsNest.class));
 
         assertThat(genericMetadata.rawType()).isEqualTo(List.class);
-        Type firstBoundOfE = ((GenericMetadataSupport.TypeVarBoundedType) typeVariableValue(genericMetadata.actualTypeArguments(), "E")).firstBound();
+        final Type firstBoundOfE = ((GenericMetadataSupport.TypeVarBoundedType) typeVariableValue(genericMetadata.actualTypeArguments(), "E")).firstBound();
         assertThat(inferFrom(firstBoundOfE).rawType()).isEqualTo(Comparable.class);
     }
 
     @Test
     public void typeVariable_with_type_parameters_return_type_of____typeVar_with_type_params____resolved_K_hence_to_Comparable_and_with_BoundedType() throws Exception {
-        GenericMetadataSupport genericMetadata = inferFrom(GenericsNest.class).resolveGenericReturnType(firstNamedMethod("typeVar_with_type_params", GenericsNest.class));
+        final GenericMetadataSupport genericMetadata = inferFrom(GenericsNest.class).resolveGenericReturnType(firstNamedMethod("typeVar_with_type_params", GenericsNest.class));
 
         assertThat(genericMetadata.rawType()).isEqualTo(Comparable.class);
-        GenericMetadataSupport extraInterface_0 = inferFrom(genericMetadata.extraInterfaces().get(0));
+        final GenericMetadataSupport extraInterface_0 = inferFrom(genericMetadata.extraInterfaces().get(0));
         assertThat(extraInterface_0.rawType()).isEqualTo(Cloneable.class);
     }
 
     @Test
     public void class_return_type_of____append____resolved_to_StringBuilder_and_type_arguments() throws Exception {
-        GenericMetadataSupport genericMetadata = inferFrom(StringBuilder.class).resolveGenericReturnType(firstNamedMethod("append", StringBuilder.class));
+        final GenericMetadataSupport genericMetadata = inferFrom(StringBuilder.class).resolveGenericReturnType(firstNamedMethod("append", StringBuilder.class));
 
         assertThat(genericMetadata.rawType()).isEqualTo(StringBuilder.class);
         assertThat(genericMetadata.actualTypeArguments()).isEmpty();
@@ -163,30 +164,30 @@ public class GenericMetadataSupportTest {
 
     @Test
     public void paramType_with_wildcard_return_type_of____returning_wildcard_with_class_lower_bound____resolved_to_List_and_type_argument_to_Integer() throws Exception {
-        GenericMetadataSupport genericMetadata = inferFrom(GenericsNest.class).resolveGenericReturnType(firstNamedMethod("returning_wildcard_with_class_lower_bound", GenericsNest.class));
+        final GenericMetadataSupport genericMetadata = inferFrom(GenericsNest.class).resolveGenericReturnType(firstNamedMethod("returning_wildcard_with_class_lower_bound", GenericsNest.class));
 
         assertThat(genericMetadata.rawType()).isEqualTo(List.class);
-        GenericMetadataSupport.BoundedType boundedType = (GenericMetadataSupport.BoundedType) typeVariableValue(genericMetadata.actualTypeArguments(), "E");
+        final GenericMetadataSupport.BoundedType boundedType = (GenericMetadataSupport.BoundedType) typeVariableValue(genericMetadata.actualTypeArguments(), "E");
         assertThat(boundedType.firstBound()).isEqualTo(Integer.class);
         assertThat(boundedType.interfaceBounds()).isEmpty();
     }
 
     @Test
     public void paramType_with_wildcard_return_type_of____returning_wildcard_with_typeVar_lower_bound____resolved_to_List_and_type_argument_to_Integer() throws Exception {
-        GenericMetadataSupport genericMetadata = inferFrom(GenericsNest.class).resolveGenericReturnType(firstNamedMethod("returning_wildcard_with_typeVar_lower_bound", GenericsNest.class));
+        final GenericMetadataSupport genericMetadata = inferFrom(GenericsNest.class).resolveGenericReturnType(firstNamedMethod("returning_wildcard_with_typeVar_lower_bound", GenericsNest.class));
 
         assertThat(genericMetadata.rawType()).isEqualTo(List.class);
-        GenericMetadataSupport.BoundedType boundedType = (GenericMetadataSupport.BoundedType) typeVariableValue(genericMetadata.actualTypeArguments(), "E");
+        final GenericMetadataSupport.BoundedType boundedType = (GenericMetadataSupport.BoundedType) typeVariableValue(genericMetadata.actualTypeArguments(), "E");
 
         assertThat(inferFrom(boundedType.firstBound()).rawType()).isEqualTo(Comparable.class);
         assertThat(boundedType.interfaceBounds()).contains(Cloneable.class);    }
 
     @Test
     public void paramType_with_wildcard_return_type_of____returning_wildcard_with_typeVar_upper_bound____resolved_to_List_and_type_argument_to_Integer() throws Exception {
-        GenericMetadataSupport genericMetadata = inferFrom(GenericsNest.class).resolveGenericReturnType(firstNamedMethod("returning_wildcard_with_typeVar_upper_bound", GenericsNest.class));
+        final GenericMetadataSupport genericMetadata = inferFrom(GenericsNest.class).resolveGenericReturnType(firstNamedMethod("returning_wildcard_with_typeVar_upper_bound", GenericsNest.class));
 
         assertThat(genericMetadata.rawType()).isEqualTo(List.class);
-        GenericMetadataSupport.BoundedType boundedType = (GenericMetadataSupport.BoundedType) typeVariableValue(genericMetadata.actualTypeArguments(), "E");
+        final GenericMetadataSupport.BoundedType boundedType = (GenericMetadataSupport.BoundedType) typeVariableValue(genericMetadata.actualTypeArguments(), "E");
 
         assertThat(inferFrom(boundedType.firstBound()).rawType()).isEqualTo(Comparable.class);
         assertThat(boundedType.interfaceBounds()).contains(Cloneable.class);
@@ -194,8 +195,9 @@ public class GenericMetadataSupportTest {
 
 
 
-    private Type typeVariableValue(Map<TypeVariable, Type> typeVariables, String typeVariableName) {
-        for (Map.Entry<TypeVariable, Type> typeVariableTypeEntry : typeVariables.entrySet()) {
+    @SuppressWarnings("rawtypes")
+    private Type typeVariableValue(final Map<TypeVariable, Type> typeVariables, final String typeVariableName) {
+        for (final Map.Entry<TypeVariable, Type> typeVariableTypeEntry : typeVariables.entrySet()) {
             if (typeVariableTypeEntry.getKey().getName().equals(typeVariableName)) {
                 return typeVariableTypeEntry.getValue();
             }
@@ -205,9 +207,9 @@ public class GenericMetadataSupportTest {
         return null; // unreachable
     }
 
-    private Method firstNamedMethod(String methodName, Class<?> clazz) {
-        for (Method method : clazz.getMethods()) {
-            boolean protect_against_different_jdk_ordering_avoiding_bridge_methods = !method.isBridge();
+    private Method firstNamedMethod(final String methodName, final Class<?> clazz) {
+        for (final Method method : clazz.getMethods()) {
+            final boolean protect_against_different_jdk_ordering_avoiding_bridge_methods = !method.isBridge();
             if (method.getName().contains(methodName) && protect_against_different_jdk_ordering_avoiding_bridge_methods) {
                 return method;
             }

--- a/test/org/mockito/internal/util/reflection/LenientCopyToolTest.java
+++ b/test/org/mockito/internal/util/reflection/LenientCopyToolTest.java
@@ -4,8 +4,12 @@
  */
 package org.mockito.internal.util.reflection;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import java.lang.reflect.Field;
 import java.util.LinkedList;
@@ -13,10 +17,10 @@ import java.util.LinkedList;
 import org.junit.Test;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class LenientCopyToolTest extends TestBase {
 
-    private LenientCopyTool tool = new LenientCopyTool();
+    private final LenientCopyTool tool = new LenientCopyTool();
 
     static class InheritMe {
         protected String protectedInherited = "protected";
@@ -34,7 +38,7 @@ public class LenientCopyToolTest extends TestBase {
         public SomeOtherObject instancePublicField = new SomeOtherObject();
         final int finalField;
 
-        public SomeObject(int finalField) {
+        public SomeObject(final int finalField) {
             this.finalField = finalField;
         }
     }
@@ -42,7 +46,7 @@ public class LenientCopyToolTest extends TestBase {
     public static class SomeOtherObject {
     }
 
-    private SomeObject from = new SomeObject(100);
+    private final SomeObject from = new SomeObject(100);
     private SomeObject to = mock(SomeObject.class);
 
     @Test
@@ -74,8 +78,8 @@ public class LenientCopyToolTest extends TestBase {
     @Test
     public void shouldShallowCopyLinkedListIntoMock() throws Exception {
         // given
-        LinkedList fromList = new LinkedList();
-        LinkedList toList = mock(LinkedList.class);
+        final LinkedList fromList = new LinkedList();
+        final LinkedList toList = mock(LinkedList.class);
 
         // when
         tool.copyToMock(fromList, toList);

--- a/test/org/mockito/internal/util/reflection/ParameterizedConstructorInstantiatorTest.java
+++ b/test/org/mockito/internal/util/reflection/ParameterizedConstructorInstantiatorTest.java
@@ -5,6 +5,17 @@
 
 package org.mockito.internal.util.reflection;
 
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.Observer;
+import java.util.Set;
 
 import org.junit.After;
 import org.junit.Test;
@@ -16,20 +27,7 @@ import org.mockito.internal.util.reflection.FieldInitializer.ConstructorArgument
 import org.mockito.internal.util.reflection.FieldInitializer.ParameterizedConstructorInstantiator;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.util.Map;
-import java.util.Observer;
-import java.util.Set;
-
-import static org.fest.assertions.Assertions.assertThat;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-
-
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unused", "rawtypes"})
 @RunWith(MockitoJUnitRunner.class)
 public class ParameterizedConstructorInstantiatorTest {
 
@@ -49,7 +47,8 @@ public class ParameterizedConstructorInstantiatorTest {
         withVarargConstructor = null;
     }
 
-    @Mock private ConstructorArgumentResolver resolver;
+    @Mock
+    private ConstructorArgumentResolver resolver;
 
     @Test
     public void should_be_created_with_an_argument_resolver() throws Exception {
@@ -61,16 +60,16 @@ public class ParameterizedConstructorInstantiatorTest {
         try {
             new ParameterizedConstructorInstantiator(this, field("withNoArgConstructor"), resolver).instantiate();
             fail();
-        } catch (MockitoException me) {
+        } catch (final MockitoException me) {
             assertThat(me.getMessage()).contains("no parameterized constructor").contains("withNoArgConstructor").contains("NoArgConstructor");
         }
     }
 
     @Test
     public void should_instantiate_type_if_resolver_provide_matching_types() throws Exception {
-        Observer observer = mock(Observer.class);
-        Map map = mock(Map.class);
-        given(resolver.resolveTypeInstances(Matchers.<Class<?>[]>anyVararg())).willReturn(new Object[]{ observer, map });
+        final Observer observer = mock(Observer.class);
+        final Map map = mock(Map.class);
+        given(resolver.resolveTypeInstances(Matchers.<Class<?>[]> anyVararg())).willReturn(new Object[] { observer, map });
 
         new ParameterizedConstructorInstantiator(this, field("withMultipleConstructor"), resolver).instantiate();
 
@@ -81,64 +80,71 @@ public class ParameterizedConstructorInstantiatorTest {
 
     @Test
     public void should_fail_if_an_argument_instance_type_do_not_match_wanted_type() throws Exception {
-        Observer observer = mock(Observer.class);
-        Set wrongArg = mock(Set.class);
-        given(resolver.resolveTypeInstances(Matchers.<Class<?>[]>anyVararg())).willReturn(new Object[]{ observer, wrongArg });
+        final Observer observer = mock(Observer.class);
+        final Set wrongArg = mock(Set.class);
+        given(resolver.resolveTypeInstances(Matchers.<Class<?>[]> anyVararg())).willReturn(new Object[] { observer, wrongArg });
 
         try {
             new ParameterizedConstructorInstantiator(this, field("withMultipleConstructor"), resolver).instantiate();
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             assertThat(e.getMessage()).contains("argResolver").contains("incorrect types");
         }
     }
 
     @Test
     public void should_report_failure_if_constructor_throws_exception() throws Exception {
-        given(resolver.resolveTypeInstances(Matchers.<Class<?>[]>anyVararg())).willReturn(new Object[]{ null });
+        given(resolver.resolveTypeInstances(Matchers.<Class<?>[]> anyVararg())).willReturn(new Object[] { null });
 
         try {
             new ParameterizedConstructorInstantiator(this, field("withThrowingConstructor"), resolver).instantiate();
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             assertThat(e.getMessage()).contains("constructor").contains("raised an exception");
         }
     }
 
     @Test
     public void should_instantiate_type_with_vararg_constructor() throws Exception {
-        Observer[] vararg = new Observer[] {  };
-        given(resolver.resolveTypeInstances(Matchers.<Class<?>[]>anyVararg())).willReturn(new Object[]{ "", vararg});
+        final Observer[] vararg = new Observer[] {};
+        given(resolver.resolveTypeInstances(Matchers.<Class<?>[]> anyVararg())).willReturn(new Object[] { "", vararg });
 
         new ParameterizedConstructorInstantiator(this, field("withVarargConstructor"), resolver).instantiate();
 
         assertNotNull(withVarargConstructor);
     }
 
-    private Field field(String fieldName) throws NoSuchFieldException {
-        Field field = this.getClass().getDeclaredField(fieldName);
+    private Field field(final String fieldName) throws NoSuchFieldException {
+        final Field field = this.getClass().getDeclaredField(fieldName);
         field.setAccessible(true);
         return field;
     }
 
     private static class NoArgConstructor {
-        NoArgConstructor() { }
+        NoArgConstructor() {
+        }
     }
 
     private static class OneConstructor {
-        public OneConstructor(Observer observer) { }
+        public OneConstructor(final Observer observer) {
+        }
     }
 
     private static class ThrowingConstructor {
-        public ThrowingConstructor(Observer observer) throws IOException { throw new IOException(); }
+        public ThrowingConstructor(final Observer observer) throws IOException {
+            throw new IOException();
+        }
     }
 
     private static class MultipleConstructor extends OneConstructor {
         Observer observer;
         Map map;
 
-        public MultipleConstructor(Observer observer) { this(observer, null); }
-        public MultipleConstructor(Observer observer, Map map) {
+        public MultipleConstructor(final Observer observer) {
+            this(observer, null);
+        }
+
+        public MultipleConstructor(final Observer observer, final Map map) {
             super(observer);
             this.observer = observer;
             this.map = map;
@@ -146,6 +152,7 @@ public class ParameterizedConstructorInstantiatorTest {
     }
 
     private static class VarargConstructor {
-        VarargConstructor(String whatever, Observer... observers) { }
+        VarargConstructor(final String whatever, final Observer... observers) {
+        }
     }
 }

--- a/test/org/mockito/internal/util/reflection/SuperTypesLastSorterTest.java
+++ b/test/org/mockito/internal/util/reflection/SuperTypesLastSorterTest.java
@@ -1,11 +1,16 @@
 package org.mockito.internal.util.reflection;
 
-import org.junit.Test;
+import static org.fest.assertions.Assertions.assertThat;
 
 import java.lang.reflect.Field;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
-import static org.fest.assertions.Assertions.assertThat;
+import org.junit.Test;
 
 @SuppressWarnings("unused")
 public class SuperTypesLastSorterTest {
@@ -14,12 +19,12 @@ public class SuperTypesLastSorterTest {
      * continue to work.
      */
     private static Comparator<Field> cmp = new Comparator<Field>() {
-        public int compare(Field o1, Field o2) {
+        public int compare(final Field o1, final Field o2) {
             if (o1.equals(o2)) {
                 return 0;
             }
 
-            List<Field> l = new SuperTypesLastSorter().sort(Arrays.asList(o1, o2));
+            final List<Field> l = new SuperTypesLastSorter().sort(Arrays.asList(o1, o2));
 
             if (l.get(0) == o1) {
                 return -1;
@@ -60,7 +65,7 @@ public class SuperTypesLastSorterTest {
 
     @Test
     public void using_Collections_dot_sort() throws Exception {
-        List<Field> unsortedFields = Arrays.asList(
+        final List<Field> unsortedFields = Arrays.asList(
                 field("objectB"),
                 field("integerB"),
                 field("numberA"),
@@ -69,7 +74,7 @@ public class SuperTypesLastSorterTest {
                 field("integerA")
         );
 
-        List<Field> sortedFields = new SuperTypesLastSorter().sort(unsortedFields);
+        final List<Field> sortedFields = new SuperTypesLastSorter().sort(unsortedFields);
 
         assertThat(sortedFields).containsSequence(
                 field("integerA"),
@@ -84,7 +89,7 @@ public class SuperTypesLastSorterTest {
 
     @Test
     public void issue_352_order_was_different_between_JDK6_and_JDK7() throws Exception {
-        List<Field> unsortedFields = Arrays.asList(
+        final List<Field> unsortedFields = Arrays.asList(
                 field("objectB"),
                 field("objectA")
         );
@@ -111,8 +116,8 @@ public class SuperTypesLastSorterTest {
      * Assert that these fields sort in the same order no matter which order
      * they start in.
      */
-    private static void assertSortConsistently(Field a, Field b, Field c) {
-        Field[][] initialOrderings = {
+    private static void assertSortConsistently(final Field a, final Field b, final Field c) {
+        final Field[][] initialOrderings = {
                 {a, b, c},
                 {a, c, b},
                 {b, a, c},
@@ -121,16 +126,16 @@ public class SuperTypesLastSorterTest {
                 {c, b, a}
         };
 
-        Set<List<Field>> results = new HashSet<List<Field>>();
+        final Set<List<Field>> results = new HashSet<List<Field>>();
 
-        for (Field[] o : initialOrderings) {
+        for (final Field[] o : initialOrderings) {
             results.add(new SuperTypesLastSorter().sort(Arrays.asList(o)));
         }
 
         assertThat(results).hasSize(1);
     }
 
-    private Field field(String field) throws NoSuchFieldException {
+    private Field field(final String field) throws NoSuchFieldException {
         return getClass().getDeclaredField(field);
     }
 }

--- a/test/org/mockito/internal/verification/NoMoreInteractionsTest.java
+++ b/test/org/mockito/internal/verification/NoMoreInteractionsTest.java
@@ -4,6 +4,9 @@
  */
 package org.mockito.internal.verification;
 
+import static java.util.Arrays.asList;
+import static org.mockito.Mockito.mock;
+
 import org.fest.assertions.Assertions;
 import org.junit.Test;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
@@ -18,9 +21,7 @@ import org.mockito.invocation.Invocation;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static java.util.Arrays.asList;
-import static org.mockito.Mockito.mock;
-
+@SuppressWarnings("rawtypes")
 public class NoMoreInteractionsTest extends TestBase {
 
     InOrderContextImpl context = new InOrderContextImpl();
@@ -28,8 +29,8 @@ public class NoMoreInteractionsTest extends TestBase {
     @Test
     public void shouldVerifyInOrder() {
         //given
-        NoMoreInteractions n = new NoMoreInteractions();
-        Invocation i = new InvocationBuilder().toInvocation();
+        final NoMoreInteractions n = new NoMoreInteractions();
+        final Invocation i = new InvocationBuilder().toInvocation();
         assertFalse(context.isVerified(i));
 
         try {
@@ -37,14 +38,14 @@ public class NoMoreInteractionsTest extends TestBase {
             n.verifyInOrder(new VerificationDataInOrderImpl(context, asList(i), null));
             //then
             fail();
-        } catch(VerificationInOrderFailure e) {}
+        } catch(final VerificationInOrderFailure e) {}
     }
 
     @Test
     public void shouldVerifyInOrderAndPass() {
         //given
-        NoMoreInteractions n = new NoMoreInteractions();
-        Invocation i = new InvocationBuilder().toInvocation();
+        final NoMoreInteractions n = new NoMoreInteractions();
+        final Invocation i = new InvocationBuilder().toInvocation();
         context.markVerified(i);
         assertTrue(context.isVerified(i));
 
@@ -56,9 +57,9 @@ public class NoMoreInteractionsTest extends TestBase {
     @Test
     public void shouldVerifyInOrderMultipleInvoctions() {
         //given
-        NoMoreInteractions n = new NoMoreInteractions();
-        Invocation i = new InvocationBuilder().seq(1).toInvocation();
-        Invocation i2 = new InvocationBuilder().seq(2).toInvocation();
+        final NoMoreInteractions n = new NoMoreInteractions();
+        final Invocation i = new InvocationBuilder().seq(1).toInvocation();
+        final Invocation i2 = new InvocationBuilder().seq(2).toInvocation();
 
         //when
         context.markVerified(i2);
@@ -70,25 +71,25 @@ public class NoMoreInteractionsTest extends TestBase {
     @Test
     public void shouldVerifyInOrderMultipleInvoctionsAndThrow() {
         //given
-        NoMoreInteractions n = new NoMoreInteractions();
-        Invocation i = new InvocationBuilder().seq(1).toInvocation();
-        Invocation i2 = new InvocationBuilder().seq(2).toInvocation();
+        final NoMoreInteractions n = new NoMoreInteractions();
+        final Invocation i = new InvocationBuilder().seq(1).toInvocation();
+        final Invocation i2 = new InvocationBuilder().seq(2).toInvocation();
 
         try {
             //when
             n.verifyInOrder(new VerificationDataInOrderImpl(context, asList(i, i2), null));
             fail();
-        } catch (VerificationInOrderFailure e) {}
+        } catch (final VerificationInOrderFailure e) {}
     }
 
     @Test
     public void noMoreInteractionsExceptionMessageShouldDescribeMock() {
         //given
-        NoMoreInteractions n = new NoMoreInteractions();
-        IMethods mock = mock(IMethods.class, "a mock");
-        InvocationMatcher i = new InvocationBuilder().mock(mock).toInvocationMatcher();
+        final NoMoreInteractions n = new NoMoreInteractions();
+        final IMethods mock = mock(IMethods.class, "a mock");
+        final InvocationMatcher i = new InvocationBuilder().mock(mock).toInvocationMatcher();
 
-        InvocationContainerImpl invocations =
+        final InvocationContainerImpl invocations =
             new InvocationContainerImpl(new ThreadSafeMockingProgress(), new MockSettingsImpl());
         invocations.setInvocationForPotentialStubbing(i);
 
@@ -97,7 +98,7 @@ public class NoMoreInteractionsTest extends TestBase {
             n.verify(new VerificationDataImpl(invocations, null));
             //then
             fail();
-        } catch (NoInteractionsWanted e) {
+        } catch (final NoInteractionsWanted e) {
             Assertions.assertThat(e.toString()).contains(mock.toString());
         }
     }
@@ -105,16 +106,16 @@ public class NoMoreInteractionsTest extends TestBase {
     @Test
     public void noMoreInteractionsInOrderExceptionMessageShouldDescribeMock() {
         //given
-        NoMoreInteractions n = new NoMoreInteractions();
-        IMethods mock = mock(IMethods.class, "a mock");
-        Invocation i = new InvocationBuilder().mock(mock).toInvocation();
+        final NoMoreInteractions n = new NoMoreInteractions();
+        final IMethods mock = mock(IMethods.class, "a mock");
+        final Invocation i = new InvocationBuilder().mock(mock).toInvocation();
 
         try {
             //when
             n.verifyInOrder(new VerificationDataInOrderImpl(context, asList(i), null));
             //then
             fail();
-        } catch (VerificationInOrderFailure e) {
+        } catch (final VerificationInOrderFailure e) {
             Assertions.assertThat(e.toString()).contains(mock.toString());
         }
     }

--- a/test/org/mockito/internal/verification/OnlyTest.java
+++ b/test/org/mockito/internal/verification/OnlyTest.java
@@ -4,7 +4,9 @@
  */
 package org.mockito.internal.verification;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.List;
@@ -24,7 +26,7 @@ public class OnlyTest {
         private final Invocation invocation;
         private final InvocationMatcher wanted;
 
-        public VerificationDataStub(InvocationMatcher wanted, Invocation invocation) {
+        public VerificationDataStub(final InvocationMatcher wanted, final Invocation invocation) {
             this.invocation = invocation;
             this.wanted = wanted;
         }
@@ -41,7 +43,7 @@ public class OnlyTest {
     @Test
     public void shouldMarkAsVerified() {
         //given
-        Invocation invocation = new InvocationBuilder().toInvocation();
+        final Invocation invocation = new InvocationBuilder().toInvocation();
         assertFalse(invocation.isVerified());
         
         //when
@@ -54,14 +56,14 @@ public class OnlyTest {
     @Test
     public void shouldNotMarkAsVerifiedWhenAssertionFailed() {
         //given
-        Invocation invocation = new InvocationBuilder().toInvocation();
+        final Invocation invocation = new InvocationBuilder().toInvocation();
         assertFalse(invocation.isVerified());
         
         //when
         try {
             only.verify(new VerificationDataStub(new InvocationBuilder().toInvocationMatcher(), invocation));
             fail();
-        } catch (MockitoAssertionError e) {}
+        } catch (final MockitoAssertionError e) {}
         
         //then
         assertFalse(invocation.isVerified());

--- a/test/org/mockito/internal/verification/argumentmatching/ArgumentMatchingToolTest.java
+++ b/test/org/mockito/internal/verification/argumentmatching/ArgumentMatchingToolTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 import org.mockito.internal.matchers.Equals;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings({"unchecked","serial"})
+@SuppressWarnings({"unchecked", "serial"})
 public class ArgumentMatchingToolTest extends TestBase {
 
     private ArgumentMatchingTool tool = new ArgumentMatchingTool();

--- a/test/org/mockito/internal/verification/argumentmatching/ArgumentMatchingToolTest.java
+++ b/test/org/mockito/internal/verification/argumentmatching/ArgumentMatchingToolTest.java
@@ -14,18 +14,18 @@ import org.junit.Test;
 import org.mockito.internal.matchers.Equals;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings({"unchecked", "serial"})
+@SuppressWarnings({"unchecked", "rawtypes", "serial"})
 public class ArgumentMatchingToolTest extends TestBase {
 
-    private ArgumentMatchingTool tool = new ArgumentMatchingTool();
+    private final ArgumentMatchingTool tool = new ArgumentMatchingTool();
 
     @Test
     public void shouldNotFindAnySuspiciousMatchersWhenNumberOfArgumentsDoesntMatch() {
         //given
-        List<Matcher> matchers = (List) Arrays.asList(new Equals(1));
+        final List<Matcher> matchers = (List) Arrays.asList(new Equals(1));
 
         //when
-        Integer[] suspicious = tool.getSuspiciouslyNotMatchingArgsIndexes(matchers, new Object[] {10, 20});
+        final Integer[] suspicious = tool.getSuspiciouslyNotMatchingArgsIndexes(matchers, new Object[] {10, 20});
         
         //then
         assertEquals(0, suspicious.length);
@@ -34,10 +34,10 @@ public class ArgumentMatchingToolTest extends TestBase {
     @Test
     public void shouldNotFindAnySuspiciousMatchersWhenArgumentsMatch() {
         //given
-        List<Matcher> matchers = (List) Arrays.asList(new Equals(10), new Equals(20));
+        final List<Matcher> matchers = (List) Arrays.asList(new Equals(10), new Equals(20));
         
         //when
-        Integer[] suspicious = tool.getSuspiciouslyNotMatchingArgsIndexes(matchers, new Object[] {10, 20});
+        final Integer[] suspicious = tool.getSuspiciouslyNotMatchingArgsIndexes(matchers, new Object[] {10, 20});
         
         //then
         assertEquals(0, suspicious.length);
@@ -46,12 +46,12 @@ public class ArgumentMatchingToolTest extends TestBase {
     @Test
     public void shouldFindSuspiciousMatchers() {
         //given
-        Equals matcherInt20 = new Equals(20);
-        Long longPretendingAnInt = new Long(20);
+        final Equals matcherInt20 = new Equals(20);
+        final Long longPretendingAnInt = new Long(20);
         
         //when
-        List<Matcher> matchers = (List) Arrays.asList(new Equals(10), matcherInt20);
-        Integer[] suspicious = tool.getSuspiciouslyNotMatchingArgsIndexes(matchers, new Object[] {10, longPretendingAnInt});
+        final List<Matcher> matchers = (List) Arrays.asList(new Equals(10), matcherInt20);
+        final Integer[] suspicious = tool.getSuspiciouslyNotMatchingArgsIndexes(matchers, new Object[] {10, longPretendingAnInt});
         
         //then
         assertEquals(1, suspicious.length);
@@ -61,16 +61,16 @@ public class ArgumentMatchingToolTest extends TestBase {
     @Test
     public void shouldNotFindSuspiciousMatchersWhenTypesAreTheSame() {
         //given
-        Equals matcherWithBadDescription = new Equals(20) {
-            public void describeTo(Description desc) {
+        final Equals matcherWithBadDescription = new Equals(20) {
+            public void describeTo(final Description desc) {
                 //let's pretend we have the same description as the toString() of the argument
                 desc.appendText("10");
             }
         };
-        Integer argument = 10;
+        final Integer argument = 10;
         
         //when
-        Integer[] suspicious = tool.getSuspiciouslyNotMatchingArgsIndexes((List) Arrays.asList(matcherWithBadDescription), new Object[] {argument});
+        final Integer[] suspicious = tool.getSuspiciouslyNotMatchingArgsIndexes((List) Arrays.asList(matcherWithBadDescription), new Object[] {argument});
         
         //then
         assertEquals(0, suspicious.length);
@@ -79,7 +79,7 @@ public class ArgumentMatchingToolTest extends TestBase {
     @Test
     public void shouldWorkFineWhenGivenArgIsNull() {
         //when
-        Integer[] suspicious = tool.getSuspiciouslyNotMatchingArgsIndexes((List) Arrays.asList(new Equals(20)), new Object[] {null});
+        final Integer[] suspicious = tool.getSuspiciouslyNotMatchingArgsIndexes((List) Arrays.asList(new Equals(20)), new Object[] {null});
         
         //then
         assertEquals(0, suspicious.length);
@@ -88,16 +88,16 @@ public class ArgumentMatchingToolTest extends TestBase {
     @Test
     public void shouldUseMatchersSafely() {
         //given
-        List<Matcher> matchers = (List) Arrays.asList(new BaseMatcher() {
-            public boolean matches(Object item) {
+        final List<Matcher> matchers = (List) Arrays.asList(new BaseMatcher() {
+            public boolean matches(final Object item) {
                 throw new ClassCastException("nasty matcher");
             }
 
-            public void describeTo(Description description) {
+            public void describeTo(final Description description) {
             }});
         
         //when
-        Integer[] suspicious = tool.getSuspiciouslyNotMatchingArgsIndexes(matchers, new Object[] {10});
+        final Integer[] suspicious = tool.getSuspiciouslyNotMatchingArgsIndexes(matchers, new Object[] {10});
         
         //then
         assertEquals(0, suspicious.length);

--- a/test/org/mockito/internal/verification/checkers/AtLeastXNumberOfInvocationsCheckerTest.java
+++ b/test/org/mockito/internal/verification/checkers/AtLeastXNumberOfInvocationsCheckerTest.java
@@ -10,7 +10,10 @@ import static org.mockito.Matchers.eq;
 
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.mockito.internal.invocation.*;
+import org.mockito.internal.invocation.CapturesArgumentsFromInvocation;
+import org.mockito.internal.invocation.InvocationBuilder;
+import org.mockito.internal.invocation.InvocationMarker;
+import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockito.invocation.Invocation;
 import org.mockitoutil.TestBase;
 
@@ -19,10 +22,10 @@ public class AtLeastXNumberOfInvocationsCheckerTest extends TestBase {
     @Test
     public void shouldMarkActualInvocationsAsVerified() {
         //given
-        AtLeastXNumberOfInvocationsChecker c = new AtLeastXNumberOfInvocationsChecker();
+        final AtLeastXNumberOfInvocationsChecker c = new AtLeastXNumberOfInvocationsChecker();
         c.invocationMarker = Mockito.mock(InvocationMarker.class);
-        Invocation invocation = new InvocationBuilder().simpleMethod().toInvocation();
-        Invocation invocationTwo = new InvocationBuilder().differentMethod().toInvocation();
+        final Invocation invocation = new InvocationBuilder().simpleMethod().toInvocation();
+        final Invocation invocationTwo = new InvocationBuilder().differentMethod().toInvocation();
 
         //when
         c.check(asList(invocation, invocationTwo), new InvocationMatcher(invocation), 1);

--- a/test/org/mockito/internal/verification/checkers/MissingInvocationCheckerTest.java
+++ b/test/org/mockito/internal/verification/checkers/MissingInvocationCheckerTest.java
@@ -5,7 +5,7 @@
 
 package org.mockito.internal.verification.checkers;
 
-import static java.util.Arrays.*;
+import static java.util.Arrays.asList;
 
 import java.util.List;
 
@@ -77,7 +77,7 @@ public class MissingInvocationCheckerTest extends TestBase {
     @Test
     public void shouldReportWantedInvocationDiffersFromActual() {
         assertTrue(finderStub.actualToReturn.isEmpty());
-        Invocation actualInvocation = new InvocationBuilder().toInvocation();
+        final Invocation actualInvocation = new InvocationBuilder().toInvocation();
         finderStub.similarToReturn = actualInvocation;
         
         checker.check(invocations, wanted);
@@ -94,11 +94,11 @@ public class MissingInvocationCheckerTest extends TestBase {
         private Location actualLocation;
         
         @Override
-        public void wantedButNotInvoked(DescribedInvocation wanted, List<? extends DescribedInvocation> invocations) {
+        public void wantedButNotInvoked(final DescribedInvocation wanted, final List<? extends DescribedInvocation> invocations) {
             this.wanted = wanted;
         }
         
-        @Override public void argumentsAreDifferent(String wanted, String actual, Location actualLocation) {
+        @Override public void argumentsAreDifferent(final String wanted, final String actual, final Location actualLocation) {
                     this.wanted = wanted;
                     this.actual = actual;
                     this.actualLocation = actualLocation;

--- a/test/org/mockito/internal/verification/checkers/MissingInvocationInOrderCheckerTest.java
+++ b/test/org/mockito/internal/verification/checkers/MissingInvocationInOrderCheckerTest.java
@@ -5,7 +5,7 @@
 
 package org.mockito.internal.verification.checkers;
 
-import static java.util.Arrays.*;
+import static java.util.Arrays.asList;
 
 import java.util.LinkedList;
 
@@ -30,7 +30,7 @@ public class MissingInvocationInOrderCheckerTest extends TestBase {
     private InvocationMatcher wanted;
     private LinkedList<Invocation> invocations;
     private InvocationsFinderStub finderStub;
-    private InOrderContext context = new InOrderContextImpl();
+    private final InOrderContext context = new InOrderContextImpl();
     
     @Before
     public void setup() {
@@ -44,7 +44,7 @@ public class MissingInvocationInOrderCheckerTest extends TestBase {
 
     @Test
     public void shouldPassWhenMatchingInteractionFound() throws Exception {
-        Invocation actual = new InvocationBuilder().toInvocation();
+        final Invocation actual = new InvocationBuilder().toInvocation();
         finderStub.allMatchingUnverifiedChunksToReturn.add(actual);
         
         checker.check(invocations, wanted, new VerificationModeBuilder().inOrder(), context);
@@ -63,7 +63,7 @@ public class MissingInvocationInOrderCheckerTest extends TestBase {
         assertTrue(finderStub.findInvocations(invocations, wanted).isEmpty());
         finderStub.similarToReturn = new InvocationBuilder().toInvocation();
         checker.check(invocations, wanted, new VerificationModeBuilder().inOrder(), context);
-        SmartPrinter printer = new SmartPrinter(wanted, finderStub.similarToReturn, 0);
+        final SmartPrinter printer = new SmartPrinter(wanted, finderStub.similarToReturn, 0);
         assertEquals(printer.getWanted(), reporterStub.wantedString);
         assertEquals(printer.getActual(), reporterStub.actual);
         assertEquals(finderStub.similarToReturn.getLocation(), reporterStub.actualLocation);
@@ -71,7 +71,7 @@ public class MissingInvocationInOrderCheckerTest extends TestBase {
     
     @Test
     public void shouldReportWantedDiffersFromActual() throws Exception {
-        Invocation previous = new InvocationBuilder().toInvocation();
+        final Invocation previous = new InvocationBuilder().toInvocation();
         finderStub.previousInOrderToReturn = previous;
         
         checker.check(invocations, wanted, new VerificationModeBuilder().inOrder(), context);
@@ -87,16 +87,16 @@ public class MissingInvocationInOrderCheckerTest extends TestBase {
         private String actual;
         private Location actualLocation;
         
-        @Override public void wantedButNotInvokedInOrder(DescribedInvocation wanted, DescribedInvocation previous) {
+        @Override public void wantedButNotInvokedInOrder(final DescribedInvocation wanted, final DescribedInvocation previous) {
             this.wanted = wanted;
             this.previous = previous;
         }
         
-        @Override public void wantedButNotInvoked(DescribedInvocation wanted) {
+        @Override public void wantedButNotInvoked(final DescribedInvocation wanted) {
             this.wanted = wanted;
         }
 
-        @Override public void argumentsAreDifferent(String wanted, String actual, Location actualLocation) {
+        @Override public void argumentsAreDifferent(final String wanted, final String actual, final Location actualLocation) {
             this.wantedString = wanted;
             this.actual = actual;
             this.actualLocation = actualLocation;

--- a/test/org/mockito/internal/verification/checkers/NumberOfInvocationsCheckerTest.java
+++ b/test/org/mockito/internal/verification/checkers/NumberOfInvocationsCheckerTest.java
@@ -5,7 +5,7 @@
 
 package org.mockito.internal.verification.checkers;
 
-import static java.util.Arrays.*;
+import static java.util.Arrays.asList;
 
 import java.util.LinkedList;
 
@@ -50,8 +50,8 @@ public class NumberOfInvocationsCheckerTest extends TestBase {
 
     @Test
     public void shouldReportWithLastInvocationStackTrace() throws Exception {
-        Invocation first = new InvocationBuilder().toInvocation();
-        Invocation second = new InvocationBuilder().toInvocation();
+        final Invocation first = new InvocationBuilder().toInvocation();
+        final Invocation second = new InvocationBuilder().toInvocation();
         
         finderStub.actualToReturn.addAll(asList(first, second));
         
@@ -71,9 +71,9 @@ public class NumberOfInvocationsCheckerTest extends TestBase {
     
     @Test
     public void shouldReportWithFirstUndesiredInvocationStackTrace() throws Exception {
-        Invocation first = new InvocationBuilder().toInvocation();
-        Invocation second = new InvocationBuilder().toInvocation();
-        Invocation third = new InvocationBuilder().toInvocation();
+        final Invocation first = new InvocationBuilder().toInvocation();
+        final Invocation second = new InvocationBuilder().toInvocation();
+        final Invocation third = new InvocationBuilder().toInvocation();
         
         finderStub.actualToReturn.addAll(asList(first, second, third));
         
@@ -96,7 +96,7 @@ public class NumberOfInvocationsCheckerTest extends TestBase {
     
     @Test
     public void shouldReportNeverWantedButInvoked() throws Exception {
-        Invocation invocation = new InvocationBuilder().toInvocation();
+        final Invocation invocation = new InvocationBuilder().toInvocation();
         finderStub.actualToReturn.add(invocation);
         
         checker.check(invocations, wanted, 0);
@@ -107,7 +107,7 @@ public class NumberOfInvocationsCheckerTest extends TestBase {
     
     @Test
     public void shouldMarkInvocationsAsVerified() throws Exception {
-        Invocation invocation = new InvocationBuilder().toInvocation();
+        final Invocation invocation = new InvocationBuilder().toInvocation();
         finderStub.actualToReturn.add(invocation);
         assertFalse(invocation.isVerified());
         
@@ -121,14 +121,14 @@ public class NumberOfInvocationsCheckerTest extends TestBase {
         private int actualCount;
         private DescribedInvocation wanted;
         private Location location;
-        @Override public void tooLittleActualInvocations(org.mockito.internal.reporting.Discrepancy discrepancy, DescribedInvocation wanted, Location lastActualLocation) {
+        @Override public void tooLittleActualInvocations(final org.mockito.internal.reporting.Discrepancy discrepancy, final DescribedInvocation wanted, final Location lastActualLocation) {
                     this.wantedCount = discrepancy.getWantedCount();
                     this.actualCount = discrepancy.getActualCount();
                     this.wanted = wanted;
                     this.location = lastActualLocation;
         }
         
-        @Override public void tooManyActualInvocations(int wantedCount, int actualCount, DescribedInvocation wanted, Location firstUndesired) {
+        @Override public void tooManyActualInvocations(final int wantedCount, final int actualCount, final DescribedInvocation wanted, final Location firstUndesired) {
                     this.wantedCount = wantedCount;
                     this.actualCount = actualCount;
                     this.wanted = wanted;
@@ -136,7 +136,7 @@ public class NumberOfInvocationsCheckerTest extends TestBase {
         }
         
         @Override
-        public void neverWantedButInvoked(DescribedInvocation wanted, Location firstUndesired) {
+        public void neverWantedButInvoked(final DescribedInvocation wanted, final Location firstUndesired) {
             this.wanted = wanted;
             this.location = firstUndesired;
         }

--- a/test/org/mockito/internal/verification/checkers/NumberOfInvocationsInOrderCheckerTest.java
+++ b/test/org/mockito/internal/verification/checkers/NumberOfInvocationsInOrderCheckerTest.java
@@ -5,7 +5,7 @@
 
 package org.mockito.internal.verification.checkers;
 
-import static java.util.Arrays.*;
+import static java.util.Arrays.asList;
 
 import java.util.LinkedList;
 
@@ -13,7 +13,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.exceptions.Reporter;
 import org.mockito.exceptions.verification.VerificationInOrderFailure;
-import org.mockito.internal.invocation.InvocationImpl;
 import org.mockito.internal.invocation.InvocationBuilder;
 import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockito.internal.verification.InOrderContextImpl;
@@ -28,7 +27,7 @@ public class NumberOfInvocationsInOrderCheckerTest extends TestBase {
     private InvocationMatcher wanted;
     private LinkedList<Invocation> invocations;
     private InvocationsFinderStub finderStub;
-    private InOrderContext context = new InOrderContextImpl();
+    private final InOrderContext context = new InOrderContextImpl();
     
     @Before
     public void setup() {
@@ -55,14 +54,14 @@ public class NumberOfInvocationsInOrderCheckerTest extends TestBase {
     
     @Test
     public void shouldReportTooLittleInvocations() throws Exception {
-        Invocation first = new InvocationBuilder().toInvocation();
-        Invocation second = new InvocationBuilder().toInvocation();
+        final Invocation first = new InvocationBuilder().toInvocation();
+        final Invocation second = new InvocationBuilder().toInvocation();
         finderStub.validMatchingChunkToReturn.addAll(asList(first, second)); 
         
         try {
             checker.check(invocations, wanted, 4, context);
             fail();
-        } catch (VerificationInOrderFailure e) {
+        } catch (final VerificationInOrderFailure e) {
             assertContains("Wanted 4 times", e.getMessage());
             assertContains("But was 2 times", e.getMessage());
         }
@@ -70,14 +69,14 @@ public class NumberOfInvocationsInOrderCheckerTest extends TestBase {
     
     @Test
     public void shouldReportTooManyInvocations() throws Exception {
-        Invocation first = new InvocationBuilder().toInvocation();
-        Invocation second = new InvocationBuilder().toInvocation();
+        final Invocation first = new InvocationBuilder().toInvocation();
+        final Invocation second = new InvocationBuilder().toInvocation();
         finderStub.validMatchingChunkToReturn.addAll(asList(first, second)); 
         
         try {
             checker.check(invocations, wanted, 1, context);
             fail();
-        } catch (VerificationInOrderFailure e) {
+        } catch (final VerificationInOrderFailure e) {
             assertContains("Wanted 1 time", e.getMessage());
             assertContains("But was 2 times", e.getMessage());
         }
@@ -85,7 +84,7 @@ public class NumberOfInvocationsInOrderCheckerTest extends TestBase {
     
     @Test
     public void shouldMarkAsVerifiedInOrder() throws Exception {
-        Invocation invocation = new InvocationBuilder().toInvocation();
+        final Invocation invocation = new InvocationBuilder().toInvocation();
         assertFalse(context.isVerified(invocation));
         finderStub.validMatchingChunkToReturn.addAll(asList(invocation)); 
         

--- a/test/org/mockito/runners/ConsoleSpammingMockitoJUnitRunnerTest.java
+++ b/test/org/mockito/runners/ConsoleSpammingMockitoJUnitRunnerTest.java
@@ -19,6 +19,7 @@ public class ConsoleSpammingMockitoJUnitRunnerTest extends TestBase {
     
     private ConsoleSpammingMockitoJUnitRunner runner;
     private MockitoLoggerStub loggerStub;
+    @SuppressWarnings("unused")
     private RunNotifier notifier;
 
     @Before
@@ -40,7 +41,7 @@ public class ConsoleSpammingMockitoJUnitRunnerTest extends TestBase {
         });
         
         //when
-        Description description = runner.getDescription();
+        final Description description = runner.getDescription();
         
         //then
         assertEquals(expectedDescription, description);
@@ -50,7 +51,7 @@ public class ConsoleSpammingMockitoJUnitRunnerTest extends TestBase {
         
         StringBuilder loggedInfo = new StringBuilder();
         
-        public void log(Object what) {
+        public void log(final Object what) {
             super.log(what);
             loggedInfo.append(what);
         }
@@ -66,9 +67,9 @@ public class ConsoleSpammingMockitoJUnitRunnerTest extends TestBase {
             return null;
         }
 
-        public void run(RunNotifier notifier) {}
+        public void run(final RunNotifier notifier) {}
 
-        public void filter(Filter filter) throws NoTestsRemainException {}
+        public void filter(final Filter filter) throws NoTestsRemainException {}
 
     }
 }

--- a/test/org/mockito/runners/RunnersValidateFrameworkUsageTest.java
+++ b/test/org/mockito/runners/RunnersValidateFrameworkUsageTest.java
@@ -4,7 +4,8 @@
  */
 package org.mockito.runners;
 
-import static org.mockitoutil.ExtraMatchers.*;
+import static org.mockitoutil.ExtraMatchers.clazz;
+import static org.mockitoutil.ExtraMatchers.contains;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -20,7 +21,7 @@ import org.mockitoutil.TestBase;
 public class RunnersValidateFrameworkUsageTest extends TestBase {
     
     private Runner runner;
-    private RunNotifierStub notifier = new RunNotifierStub();
+    private final RunNotifierStub notifier = new RunNotifierStub();
     
     public static class DummyTest extends TestBase {
         @Test public void dummy() throws Exception {}
@@ -28,10 +29,10 @@ public class RunnersValidateFrameworkUsageTest extends TestBase {
 
     public class RunNotifierStub extends RunNotifier {
 
-        private List<RunListener> addedListeners = new LinkedList<RunListener>();
+        private final List<RunListener> addedListeners = new LinkedList<RunListener>();
 
         @Override
-        public void addListener(RunListener listener) {
+        public void addListener(final RunListener listener) {
             addedListeners.add(listener);
         }
     }

--- a/test/org/mockito/verification/TimeoutTest.java
+++ b/test/org/mockito/verification/TimeoutTest.java
@@ -4,6 +4,13 @@
  */
 package org.mockito.verification;
 
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mock;
@@ -11,8 +18,6 @@ import org.mockito.exceptions.base.MockitoAssertionError;
 import org.mockito.internal.util.Timer;
 import org.mockito.internal.verification.VerificationDataImpl;
 import org.mockitoutil.TestBase;
-
-import static org.mockito.Mockito.*;
 
 public class TimeoutTest extends TestBase {
     
@@ -24,21 +29,21 @@ public class TimeoutTest extends TestBase {
 
     @Test
     public void should_pass_when_verification_passes() {
-        Timeout t = new Timeout(1, mode, timer);
+        final Timeout t = new Timeout(1, mode, timer);
 
         when(timer.isCounting()).thenReturn(true);
         doNothing().when(mode).verify(data);
 
         t.verify(data);
 
-        InOrder inOrder = inOrder(timer);
+        final InOrder inOrder = inOrder(timer);
         inOrder.verify(timer).start();
         inOrder.verify(timer).isCounting();
     }
 
     @Test
     public void should_fail_because_verification_fails() {
-        Timeout t = new Timeout(1, mode, timer);
+        final Timeout t = new Timeout(1, mode, timer);
 
         when(timer.isCounting()).thenReturn(true, true, true, false);
         doThrow(error).
@@ -49,14 +54,14 @@ public class TimeoutTest extends TestBase {
         try {
             t.verify(data);
             fail();
-        } catch (MockitoAssertionError e) {}
+        } catch (final MockitoAssertionError e) {}
 
         verify(timer, times(4)).isCounting();
     }
     
     @Test
     public void should_pass_even_if_first_verification_fails() {
-        Timeout t = new Timeout(1, mode, timer);
+        final Timeout t = new Timeout(1, mode, timer);
 
         when(timer.isCounting()).thenReturn(true, true, true, false);
         doThrow(error).
@@ -70,7 +75,7 @@ public class TimeoutTest extends TestBase {
 
     @Test
     public void should_try_to_verify_correct_number_of_times() {
-        Timeout t = new Timeout(10, mode, timer);
+        final Timeout t = new Timeout(10, mode, timer);
         
         doThrow(error).when(mode).verify(data);
         when(timer.isCounting()).thenReturn(true, true, true, true, true, false);
@@ -78,7 +83,7 @@ public class TimeoutTest extends TestBase {
         try {
             t.verify(data);
             fail();
-        } catch (MockitoAssertionError e) {}
+        } catch (final MockitoAssertionError e) {}
 
         verify(mode, times(5)).verify(data);
     }

--- a/test/org/mockitousage/PlaygroundTest.java
+++ b/test/org/mockitousage/PlaygroundTest.java
@@ -5,9 +5,6 @@
 
 package org.mockitousage;
 
-import static org.mockito.Mockito.*;
-
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockitoutil.TestBase;
@@ -25,7 +22,7 @@ public class PlaygroundTest extends TestBase {
     }
     
     class Boo {
-        final public Object withLong(long y) {
+        public final Object withLong(final long y) {
                          return "";
         }
 

--- a/test/org/mockitousage/PlaygroundWithDemoOfUnclonedParametersProblemTest.java
+++ b/test/org/mockitousage/PlaygroundWithDemoOfUnclonedParametersProblemTest.java
@@ -20,7 +20,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class PlaygroundWithDemoOfUnclonedParametersProblemTest extends TestBase {
 
     ImportManager importManager;
@@ -36,46 +36,46 @@ public class PlaygroundWithDemoOfUnclonedParametersProblemTest extends TestBase 
 
     @Test
     public void shouldIncludeInitialLog() {
-        //given
-        int importType = 0;
-        Date currentDate = new GregorianCalendar(2009, 10, 12).getTime();
+        // given
+        final int importType = 0;
+        final Date currentDate = new GregorianCalendar(2009, 10, 12).getTime();
 
-        ImportLogBean initialLog = new ImportLogBean(currentDate, importType);
+        final ImportLogBean initialLog = new ImportLogBean(currentDate, importType);
         initialLog.setStatus(1);
 
         given(importLogDao.anyImportRunningOrRunnedToday(importType, currentDate)).willReturn(false);
         willAnswer(byCheckingLogEquals(initialLog)).given(importLogDao).include(any(ImportLogBean.class));
 
-        //when
+        // when
         importManager.startImportProcess(importType, currentDate);
 
-        //then
+        // then
         verify(importLogDao).include(any(ImportLogBean.class));
     }
 
     @Test
     public void shouldAlterFinalLog() {
-        //given
-        int importType = 0;
-        Date currentDate = new GregorianCalendar(2009, 10, 12).getTime();
+        // given
+        final int importType = 0;
+        final Date currentDate = new GregorianCalendar(2009, 10, 12).getTime();
 
-        ImportLogBean finalLog = new ImportLogBean(currentDate, importType);
+        final ImportLogBean finalLog = new ImportLogBean(currentDate, importType);
         finalLog.setStatus(9);
 
         given(importLogDao.anyImportRunningOrRunnedToday(importType, currentDate)).willReturn(false);
         willAnswer(byCheckingLogEquals(finalLog)).given(importLogDao).alter(any(ImportLogBean.class));
 
-        //when
+        // when
         importManager.startImportProcess(importType, currentDate);
 
-        //then
+        // then
         verify(importLogDao).alter(any(ImportLogBean.class));
     }
 
     private Answer byCheckingLogEquals(final ImportLogBean status) {
         return new Answer() {
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                ImportLogBean bean = (ImportLogBean) invocation.getArguments()[0];
+            public Object answer(final InvocationOnMock invocation) throws Throwable {
+                final ImportLogBean bean = (ImportLogBean) invocation.getArguments()[0];
                 assertEquals(status, bean);
                 return null;
             }
@@ -84,45 +84,46 @@ public class PlaygroundWithDemoOfUnclonedParametersProblemTest extends TestBase 
 
     public class ImportManager {
 
-        public ImportManager(ImportLogDao pImportLogDao) {
+        public ImportManager(final ImportLogDao pImportLogDao) {
             super();
             importLogDao = pImportLogDao;
         }
 
         private ImportLogDao importLogDao = null;
 
-        public void startImportProcess(int importType, Date date) {
+        public void startImportProcess(final int importType, final Date date) {
             ImportLogBean importLogBean = null;
 
             try {
                 importLogBean = createResume(importType, date);
                 if (isOkToImport(importType, date)) {
                     // get the right handler
-                    //importLogBean = ImportHandlerFactory.singleton().getImportHandler(importType).processImport(importLogBean);
+                    // importLogBean =
+                    // ImportHandlerFactory.singleton().getImportHandler(importType).processImport(importLogBean);
                     // 2 = ok
                     importLogBean.setStatus(2);
                 } else {
                     // 5 = failed - is there a running process
                     importLogBean.setStatus(9);
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 // 9 = failed - exception
                 if (importLogBean != null) {
-					importLogBean.setStatus(9);
-				}
+                    importLogBean.setStatus(9);
+                }
             } finally {
                 if (importLogBean != null) {
-					finalizeResume(importLogBean);
-				}
+                    finalizeResume(importLogBean);
+                }
             }
         }
 
-        private boolean isOkToImport(int importType, Date date) {
+        private boolean isOkToImport(final int importType, final Date date) {
             return importLogDao.anyImportRunningOrRunnedToday(importType, date);
         }
 
-        private ImportLogBean createResume(int importType, Date date) {
-            ImportLogBean importLogBean = new ImportLogBean(date,
+        private ImportLogBean createResume(final int importType, final Date date) {
+            final ImportLogBean importLogBean = new ImportLogBean(date,
                     importType);
             // 1 = running
             importLogBean.setStatus(1);
@@ -130,46 +131,56 @@ public class PlaygroundWithDemoOfUnclonedParametersProblemTest extends TestBase 
             return importLogBean;
         }
 
-        private void finalizeResume(ImportLogBean importLogBean) {
+        private void finalizeResume(final ImportLogBean importLogBean) {
             importLogDao.alter(importLogBean);
         }
     }
 
     private interface ImportLogDao {
-        public boolean anyImportRunningOrRunnedToday(int importType, Date currentDate);
+        boolean anyImportRunningOrRunnedToday(final int importType, final Date currentDate);
 
-        void include(ImportLogBean importLogBean);
+        void include(final ImportLogBean importLogBean);
 
-        void alter(ImportLogBean importLogBean);
+        void alter(final ImportLogBean importLogBean);
     }
 
     private class IImportHandler {
     }
 
     private class ImportLogBean {
-        private Date currentDate;
-        private int importType;
+        private final Date currentDate;
+        private final int importType;
         private int status;
 
-        public ImportLogBean(Date currentDate, int importType) {
+        public ImportLogBean(final Date currentDate, final int importType) {
             this.currentDate = currentDate;
             this.importType = importType;
         }
 
-        public void setStatus(int status) {
+        public void setStatus(final int status) {
             this.status = status;
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof ImportLogBean)) return false;
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof ImportLogBean)) {
+                return false;
+            }
 
-            ImportLogBean that = (ImportLogBean) o;
+            final ImportLogBean that = (ImportLogBean) o;
 
-            if (importType != that.importType) return false;
-            if (status != that.status) return false;
-            if (currentDate != null ? !currentDate.equals(that.currentDate) : that.currentDate != null) return false;
+            if (importType != that.importType) {
+                return false;
+            }
+            if (status != that.status) {
+                return false;
+            }
+            if (currentDate != null ? !currentDate.equals(that.currentDate) : that.currentDate != null) {
+                return false;
+            }
 
             return true;
         }

--- a/test/org/mockitousage/PlaygroundWithDemoOfUnclonedParametersProblemTest.java
+++ b/test/org/mockitousage/PlaygroundWithDemoOfUnclonedParametersProblemTest.java
@@ -107,11 +107,13 @@ public class PlaygroundWithDemoOfUnclonedParametersProblemTest extends TestBase 
                 }
             } catch (Exception e) {
                 // 9 = failed - exception
-                if (importLogBean != null)
-                    importLogBean.setStatus(9);
+                if (importLogBean != null) {
+					importLogBean.setStatus(9);
+				}
             } finally {
-                if (importLogBean != null)
-                    finalizeResume(importLogBean);
+                if (importLogBean != null) {
+					finalizeResume(importLogBean);
+				}
             }
         }
 

--- a/test/org/mockitousage/annotation/AnnotationsTest.java
+++ b/test/org/mockitousage/annotation/AnnotationsTest.java
@@ -5,7 +5,7 @@
 
 package org.mockitousage.annotation;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -23,19 +23,24 @@ import org.mockito.exceptions.base.MockitoException;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class AnnotationsTest extends TestBase {
 
     @Retention(RetentionPolicy.RUNTIME)
-    public @interface NotAMock {}
+    public @interface NotAMock {
+    }
 
-    @Mock List list;
-    @Mock final Map map = new HashMap();
-        
-    @NotAMock Set notAMock;
+    @Mock
+    List list;
+    @Mock
+    final Map map = new HashMap();
+
+    @NotAMock
+    Set notAMock;
 
     @SuppressWarnings("deprecation")
-    @MockitoAnnotations.Mock List listTwo;
+    @MockitoAnnotations.Mock
+    List listTwo;
 
     @Before
     public void setup() {
@@ -58,7 +63,7 @@ public class AnnotationsTest extends TestBase {
         try {
             MockitoAnnotations.initMocks(null);
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             assertEquals("testClass cannot be null. For info how to use @Mock annotations see examples in javadoc for MockitoAnnotations class",
                     e.getMessage());
         }
@@ -66,34 +71,39 @@ public class AnnotationsTest extends TestBase {
 
     @Test
     public void shouldLookForAnnotatedMocksInSuperClasses() throws Exception {
-        Sub sub = new Sub();
+        final Sub sub = new Sub();
         MockitoAnnotations.initMocks(sub);
 
         assertNotNull(sub.getMock());
         assertNotNull(sub.getBaseMock());
         assertNotNull(sub.getSuperBaseMock());
     }
-    
-    @Mock(answer = Answers.RETURNS_MOCKS, name = "i have a name") IMethods namedAndReturningMocks;
-    @Mock(answer = Answers.RETURNS_DEFAULTS) IMethods returningDefaults;
-    @Mock(extraInterfaces = {List.class}) IMethods hasExtraInterfaces;
-    @Mock() IMethods noExtraConfig;
+
+    @Mock(answer = Answers.RETURNS_MOCKS, name = "i have a name")
+    IMethods namedAndReturningMocks;
+    @Mock(answer = Answers.RETURNS_DEFAULTS)
+    IMethods returningDefaults;
+    @Mock(extraInterfaces = { List.class })
+    IMethods hasExtraInterfaces;
+    @Mock()
+    IMethods noExtraConfig;
 
     @Test
     public void shouldInitMocksWithGivenSettings() throws Exception {
         assertEquals("i have a name", namedAndReturningMocks.toString());
         assertNotNull(namedAndReturningMocks.iMethodsReturningMethod());
-       
+
         assertEquals("returningDefaults", returningDefaults.toString());
-        assertEquals(0, returningDefaults.intReturningMethod()); 
-        
+        assertEquals(0, returningDefaults.intReturningMethod());
+
         assertTrue(hasExtraInterfaces instanceof List);
-        
-        assertEquals(0, noExtraConfig.intReturningMethod());        
+
+        assertEquals(0, noExtraConfig.intReturningMethod());
     }
 
     class SuperBase {
-        @Mock private IMethods mock;
+        @Mock
+        private IMethods mock;
 
         public IMethods getSuperBaseMock() {
             return mock;
@@ -101,7 +111,8 @@ public class AnnotationsTest extends TestBase {
     }
 
     class Base extends SuperBase {
-        @Mock private IMethods mock;
+        @Mock
+        private IMethods mock;
 
         public IMethods getBaseMock() {
             return mock;
@@ -109,7 +120,8 @@ public class AnnotationsTest extends TestBase {
     }
 
     class Sub extends Base {
-        @Mock private IMethods mock;
+        @Mock
+        private IMethods mock;
 
         public IMethods getMock() {
             return mock;

--- a/test/org/mockitousage/annotation/CaptorAnnotationBasicTest.java
+++ b/test/org/mockitousage/annotation/CaptorAnnotationBasicTest.java
@@ -5,7 +5,7 @@
 
 package org.mockitousage.annotation;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -17,14 +17,14 @@ import org.mockito.Mock;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class CaptorAnnotationBasicTest extends TestBase {
 
     public class Person {
         private final String name;
         private final String surname;
 
-        public Person(String name, String surname) {
+        public Person(final String name, final String surname) {
             this.name = name;
             this.surname = surname;
         }
@@ -39,12 +39,12 @@ public class CaptorAnnotationBasicTest extends TestBase {
     }
 
     public interface PeopleRepository {
-        public void save(Person capture);
+        void save(final Person capture);
     }
     
     @Mock PeopleRepository peopleRepository;           
     
-    private void createPerson(String name, String surname) {
+    private void createPerson(final String name, final String surname) {
         peopleRepository.save(new Person(name, surname));
     }      
     
@@ -54,7 +54,7 @@ public class CaptorAnnotationBasicTest extends TestBase {
         createPerson("Wes", "Williams");
         
         //then
-        ArgumentCaptor<Person> captor = ArgumentCaptor.forClass(Person.class);
+        final ArgumentCaptor<Person> captor = ArgumentCaptor.forClass(Person.class);
         verify(peopleRepository).save(captor.capture());
         assertEquals("Wes", captor.getValue().getName());
         assertEquals("Williams", captor.getValue().getSurname());
@@ -92,7 +92,7 @@ public class CaptorAnnotationBasicTest extends TestBase {
     @Test
     public void shouldCaptureGenericList() {
         //given
-        List<String> list = new LinkedList<String>();
+        final List<String> list = new LinkedList<String>();
         mock.listArgMethod(list);
                 
         //when

--- a/test/org/mockitousage/annotation/CaptorAnnotationTest.java
+++ b/test/org/mockitousage/annotation/CaptorAnnotationTest.java
@@ -21,7 +21,7 @@ import org.mockito.exceptions.base.MockitoException;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class CaptorAnnotationTest extends TestBase {
 
     @Retention(RetentionPolicy.RUNTIME)
@@ -44,7 +44,7 @@ public class CaptorAnnotationTest extends TestBase {
     Set notAMock;
 
     public interface MockInterface {
-        void testMe(String simple, List<List<String>> genericList);
+        void testMe(final String simple, final List<List<String>> genericList);
     }
 
     @Test
@@ -59,8 +59,8 @@ public class CaptorAnnotationTest extends TestBase {
         assertNull(notAMock);
 
         // use captors in the field to be sure they are cool
-        String argForFinalCaptor = "Hello";
-        ArrayList<List<String>> argForGenericsCaptor = new ArrayList<List<String>>();
+        final String argForFinalCaptor = "Hello";
+        final ArrayList<List<String>> argForGenericsCaptor = new ArrayList<List<String>>();
 
         mockInterface.testMe(argForFinalCaptor, argForGenericsCaptor);
 
@@ -81,7 +81,7 @@ public class CaptorAnnotationTest extends TestBase {
         try {
             MockitoAnnotations.initMocks(new WrongType());
             fail();
-        } catch (MockitoException e) {}
+        } catch (final MockitoException e) {}
     }
 
     public static class ToManyAnnotations {
@@ -95,7 +95,7 @@ public class CaptorAnnotationTest extends TestBase {
         try {
             MockitoAnnotations.initMocks(new ToManyAnnotations());
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             assertContains("missingGenericsField", e.getMessage());
             assertContains("multiple Mockito annotations", e.getMessage());            
         }
@@ -106,13 +106,13 @@ public class CaptorAnnotationTest extends TestBase {
         try {
             MockitoAnnotations.initMocks(null);
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
         }
     }
 
     @Test
     public void shouldLookForAnnotatedCaptorsInSuperClasses() throws Exception {
-        Sub sub = new Sub();
+        final Sub sub = new Sub();
         MockitoAnnotations.initMocks(sub);
 
         assertNotNull(sub.getCaptor());

--- a/test/org/mockitousage/annotation/CaptorAnnotationUnhappyPathTest.java
+++ b/test/org/mockitousage/annotation/CaptorAnnotationUnhappyPathTest.java
@@ -14,7 +14,7 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class CaptorAnnotationUnhappyPathTest extends TestBase {
     
     @Captor List notACaptorField;
@@ -31,7 +31,7 @@ public class CaptorAnnotationUnhappyPathTest extends TestBase {
             //when
             MockitoAnnotations.initMocks(this);
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             //then
             assertContains("notACaptorField", e.getMessage());
             assertContains("wrong type", e.getMessage());

--- a/test/org/mockitousage/annotation/DeprecatedMockAnnotationTest.java
+++ b/test/org/mockitousage/annotation/DeprecatedMockAnnotationTest.java
@@ -6,14 +6,14 @@
 package org.mockitousage.annotation;
 
 
+import static org.junit.Assert.assertNotNull;
+
+import java.awt.List;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.MockitoAnnotations;
-
-import java.awt.*;
-
-import static org.junit.Assert.assertNotNull;
 
 public class DeprecatedMockAnnotationTest {
 

--- a/test/org/mockitousage/annotation/InjectionOfInlinedMockDeclarationTest.java
+++ b/test/org/mockitousage/annotation/InjectionOfInlinedMockDeclarationTest.java
@@ -4,26 +4,29 @@
  */
 package org.mockitousage.annotation;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.runners.MockitoJUnitRunner;
-
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.runners.MockitoJUnitRunner;
+
 @RunWith(MockitoJUnitRunner.class)
 public class InjectionOfInlinedMockDeclarationTest {
 
-    @InjectMocks private Receiver receiver;
-    @InjectMocks private Receiver spiedReceiver = spy(new Receiver());
+    @InjectMocks
+    private Receiver receiver;
+    @InjectMocks
+    private final Receiver spiedReceiver = spy(new Receiver());
 
-    private Antenna oldAntenna = mock(Antenna.class);
-    private Antenna satelliteAntenna = mock(Antenna.class);
-    private Antenna antenna = mock(Antenna.class, "dvbtAntenna");
-    private Tuner tuner = spy(new Tuner());
+    private final Antenna oldAntenna = mock(Antenna.class);
+    private final Antenna satelliteAntenna = mock(Antenna.class);
+    private final Antenna antenna = mock(Antenna.class, "dvbtAntenna");
+    @SuppressWarnings("unused")
+    private final Tuner tuner = spy(new Tuner());
 
     @Test
     public void mock_declared_fields_shall_be_injected_too() throws Exception {
@@ -44,7 +47,6 @@ public class InjectionOfInlinedMockDeclarationTest {
         assertSame(antenna, receiver.dvbtAntenna);
     }
 
-
     @Test
     public void inject_mocks_even_in_declared_spy() throws Exception {
         assertNotNull(spiedReceiver.oldAntenna);
@@ -58,10 +60,15 @@ public class InjectionOfInlinedMockDeclarationTest {
         Antenna dvbtAntenna;
         Tuner tuner;
 
-        public boolean tune() { return true; }
+        public boolean tune() {
+            return true;
+        }
     }
 
-    private static class Antenna { }
-    private static class Tuner { }
+    private static class Antenna {
+    }
+
+    private static class Tuner {
+    }
 
 }

--- a/test/org/mockitousage/annotation/MockInjectionUsingConstructorIssue421Test.java
+++ b/test/org/mockitousage/annotation/MockInjectionUsingConstructorIssue421Test.java
@@ -5,7 +5,7 @@
 
 package org.mockitousage.annotation;
 
-import static org.fest.assertions.Assertions.*;
+import static org.fest.assertions.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,10 +31,10 @@ public class MockInjectionUsingConstructorIssue421Test {
 
         private ArticleCalculator calculator;
 
-        public Issue421(int a) {
+        public Issue421(final int a) {
         }
 
-        public Issue421(ArticleCalculator calculator) {
+        public Issue421(final ArticleCalculator calculator) {
             this.calculator = calculator;
         }
 

--- a/test/org/mockitousage/annotation/MockInjectionUsingConstructorTest.java
+++ b/test/org/mockitousage/annotation/MockInjectionUsingConstructorTest.java
@@ -5,6 +5,16 @@
 
 package org.mockitousage.annotation;
 
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.internal.TextListener;
@@ -21,16 +31,10 @@ import org.mockitousage.examples.use.ArticleCalculator;
 import org.mockitousage.examples.use.ArticleDatabase;
 import org.mockitousage.examples.use.ArticleManager;
 
-import java.util.List;
-import java.util.Set;
-
-import static org.fest.assertions.Assertions.assertThat;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.when;
-
+@SuppressWarnings("rawtypes")
 @RunWith(MockitoJUnitRunner.class)
 public class MockInjectionUsingConstructorTest {
-    private MockUtil mockUtil = new MockUtil();
+    private final MockUtil mockUtil = new MockUtil();
 
     @Mock private ArticleCalculator calculator;
     @Mock private ArticleDatabase database;
@@ -61,7 +65,7 @@ public class MockInjectionUsingConstructorTest {
     @Test
     public void constructor_is_called_for_each_test_in_test_class() throws Exception {
         // given
-        JUnitCore jUnitCore = new JUnitCore();
+        final JUnitCore jUnitCore = new JUnitCore();
         jUnitCore.addListener(new TextListener(System.out));
 
         // when
@@ -83,7 +87,7 @@ public class MockInjectionUsingConstructorTest {
         try {
             MockitoAnnotations.initMocks(new ATest());
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             assertThat(e.getMessage()).contains("failingConstructor").contains("constructor").contains("threw an exception");
             assertThat(e.getCause()).isInstanceOf(IllegalStateException.class);
         }
@@ -101,15 +105,17 @@ public class MockInjectionUsingConstructorTest {
         @Test public void test_2() { }
         @Test public void test_3() { }
 
+        @SuppressWarnings("unused")
         private static class some_class_with_parametered_constructor {
-            public some_class_with_parametered_constructor(List collaborator) {
+            public some_class_with_parametered_constructor(final List collaborator) {
                 constructor_instantiation++;
             }
         }
     }
 
+    @SuppressWarnings("unused")
     private static class FailingConstructor {
-        FailingConstructor(Set set) {
+        FailingConstructor(final Set set) {
             throw new IllegalStateException("always fail");
         }
     }

--- a/test/org/mockitousage/annotation/MockInjectionUsingSetterOrPropertyTest.java
+++ b/test/org/mockitousage/annotation/MockInjectionUsingSetterOrPropertyTest.java
@@ -4,6 +4,11 @@
  */
 package org.mockitousage.annotation;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
 import org.fest.assertions.Assertions;
 import org.junit.Before;
 import org.junit.Test;
@@ -16,40 +21,53 @@ import org.mockito.internal.util.MockUtil;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
-
-@SuppressWarnings({"unchecked", "unused"})
+@SuppressWarnings("rawtypes")
 public class MockInjectionUsingSetterOrPropertyTest extends TestBase {
 
-    private SuperUnderTesting superUnderTestWithoutInjection = new SuperUnderTesting();
-    @InjectMocks private SuperUnderTesting superUnderTest = new SuperUnderTesting();
-    @InjectMocks private BaseUnderTesting baseUnderTest = new BaseUnderTesting();
-    @InjectMocks private SubUnderTesting subUnderTest = new SubUnderTesting();
-    @InjectMocks private OtherBaseUnderTesting otherBaseUnderTest = new OtherBaseUnderTesting();
-    @InjectMocks private HasTwoFieldsWithSameType hasTwoFieldsWithSameType = new HasTwoFieldsWithSameType();
+    private final SuperUnderTesting superUnderTestWithoutInjection = new SuperUnderTesting();
+    @InjectMocks
+    private final SuperUnderTesting superUnderTest = new SuperUnderTesting();
+    @InjectMocks
+    private final BaseUnderTesting baseUnderTest = new BaseUnderTesting();
+    @InjectMocks
+    private final SubUnderTesting subUnderTest = new SubUnderTesting();
+    @InjectMocks
+    private final OtherBaseUnderTesting otherBaseUnderTest = new OtherBaseUnderTesting();
+    @InjectMocks
+    private final HasTwoFieldsWithSameType hasTwoFieldsWithSameType = new HasTwoFieldsWithSameType();
 
-    private BaseUnderTesting baseUnderTestingInstance = new BaseUnderTesting();
-    @InjectMocks private BaseUnderTesting initializedBase = baseUnderTestingInstance;
-    @InjectMocks private BaseUnderTesting notInitializedBase;
+    private final BaseUnderTesting baseUnderTestingInstance = new BaseUnderTesting();
+    @InjectMocks
+    private final BaseUnderTesting initializedBase = baseUnderTestingInstance;
+    @InjectMocks
+    private BaseUnderTesting notInitializedBase;
 
-    @Spy @InjectMocks private SuperUnderTesting initializedSpy = new SuperUnderTesting();
-    @Spy @InjectMocks private SuperUnderTesting notInitializedSpy;
+    @Spy
+    @InjectMocks
+    private final SuperUnderTesting initializedSpy = new SuperUnderTesting();
+    @Spy
+    @InjectMocks
+    private SuperUnderTesting notInitializedSpy;
 
-    @Mock private Map map;
-    @Mock private List list;
-    @Mock private Set histogram1;
-    @Mock private Set histogram2;
-    @Mock private IMethods candidate2;
+    @Mock
+    private Map map;
+    @Mock
+    private List list;
+    @Mock
+    private Set histogram1;
+    @Mock
+    private Set histogram2;
+    @Mock
+    private IMethods candidate2;
 
-    @Spy private TreeSet searchTree = new TreeSet();
-    private MockUtil mockUtil = new MockUtil();
+    @Spy
+    private final TreeSet searchTree = new TreeSet();
+    private final MockUtil mockUtil = new MockUtil();
 
     @Before
     public void enforces_new_instances() {
-        // initMocks called in TestBase Before method, so instances are not the same
+        // initMocks called in TestBase Before method, so instances are not the
+        // same
         MockitoAnnotations.initMocks(this);
     }
 
@@ -127,46 +145,60 @@ public class MockInjectionUsingSetterOrPropertyTest extends TestBase {
 
     @Test
     public void should_report_nicely() throws Exception {
-        Object failing = new Object() {
-            @InjectMocks ThrowingConstructor failingConstructor;
+        final Object failing = new Object() {
+            @InjectMocks
+            ThrowingConstructor failingConstructor;
         };
         try {
             MockitoAnnotations.initMocks(failing);
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             Assertions.assertThat(e.getMessage()).contains("failingConstructor").contains("constructor").contains("threw an exception");
             Assertions.assertThat(e.getCause()).isInstanceOf(RuntimeException.class);
         }
     }
 
     static class ThrowingConstructor {
-        ThrowingConstructor() { throw new RuntimeException("aha"); }
+        ThrowingConstructor() {
+            throw new RuntimeException("aha");
+        }
     }
 
     static class SuperUnderTesting {
         private List aList;
 
-        public List getAList() { return aList; }
+        public List getAList() {
+            return aList;
+        }
     }
 
     static class BaseUnderTesting extends SuperUnderTesting {
         private Map aMap;
 
-        public Map getAMap() { return aMap; }
+        public Map getAMap() {
+            return aMap;
+        }
     }
 
     static class OtherBaseUnderTesting extends SuperUnderTesting {
         private TreeSet searchTree;
 
-        public TreeSet getSearchTree() { return searchTree; }
+        public TreeSet getSearchTree() {
+            return searchTree;
+        }
     }
 
     static class SubUnderTesting extends BaseUnderTesting {
         private Set histogram1;
         private Set histogram2;
 
-        public Set getHistogram1() { return histogram1; }
-        public Set getHistogram2() { return histogram2; }
+        public Set getHistogram1() {
+            return histogram1;
+        }
+
+        public Set getHistogram2() {
+            return histogram2;
+        }
     }
 
     static class HasTwoFieldsWithSameType {

--- a/test/org/mockitousage/annotation/SpyAnnotationInitializedInBaseClassTest.java
+++ b/test/org/mockitousage/annotation/SpyAnnotationInitializedInBaseClassTest.java
@@ -13,7 +13,7 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class SpyAnnotationInitializedInBaseClassTest extends TestBase {
     
     class BaseClass {
@@ -25,7 +25,7 @@ public class SpyAnnotationInitializedInBaseClassTest extends TestBase {
     @Test
     public void shouldInitSpiesInBaseClass() throws Exception {
         //given
-        SubClass subClass = new SubClass();
+        final SubClass subClass = new SubClass();
         //when
         MockitoAnnotations.initMocks(subClass);
         //then

--- a/test/org/mockitousage/annotation/SpyAnnotationTest.java
+++ b/test/org/mockitousage/annotation/SpyAnnotationTest.java
@@ -8,11 +8,13 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+
 import org.fest.assertions.Assertions;
 import org.junit.Rule;
 import org.junit.Test;
@@ -23,17 +25,20 @@ import org.mockito.Spy;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings({"unchecked", "unused"})
+@SuppressWarnings({ "rawtypes", "unused" })
 public class SpyAnnotationTest extends TestBase {
 
-    @Spy final List spiedList = new ArrayList();
+    @Spy
+    final List spiedList = new ArrayList();
 
-    @Spy NestedClassWithNoArgConstructor staticTypeWithNoArgConstructor;
+    @Spy
+    NestedClassWithNoArgConstructor staticTypeWithNoArgConstructor;
 
     @Spy
     NestedClassWithoutDefinedConstructor staticTypeWithoutDefinedConstructor;
-  
-    @Rule public final ExpectedException shouldThrow = ExpectedException.none();
+
+    @Rule
+    public final ExpectedException shouldThrow = ExpectedException.none();
 
     @Test
     public void should_init_spy_by_instance() throws Exception {
@@ -53,14 +58,15 @@ public class SpyAnnotationTest extends TestBase {
     @Test
     public void should_prevent_spying_on_interfaces() throws Exception {
         class WithSpy {
-            @Spy List<String> list;
+            @Spy
+            List<String> list;
         }
 
-        WithSpy withSpy = new WithSpy();
+        final WithSpy withSpy = new WithSpy();
         try {
             MockitoAnnotations.initMocks(withSpy);
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             Assertions.assertThat(e.getMessage()).contains("is an interface and it cannot be spied on");
         }
     }
@@ -68,14 +74,15 @@ public class SpyAnnotationTest extends TestBase {
     @Test
     public void should_allow_spying_on_interfaces_when_instance_is_concrete() throws Exception {
         class WithSpy {
-            @Spy List<String> list = new LinkedList<String>();
+            @Spy
+            List<String> list = new LinkedList<String>();
         }
 
-        WithSpy withSpy = new WithSpy();
-        //when
+        final WithSpy withSpy = new WithSpy();
+        // when
         MockitoAnnotations.initMocks(withSpy);
 
-        //then
+        // then
         verify(withSpy.list, never()).clear();
     }
 
@@ -89,11 +96,11 @@ public class SpyAnnotationTest extends TestBase {
         try {
             MockitoAnnotations.initMocks(new FailingSpy());
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             Assertions.assertThat(e.getMessage()).contains("0-arg constructor");
         }
     }
-    
+
     @Test
     public void should_report_when_constructor_is_explosive() throws Exception {
         class FailingSpy {
@@ -104,7 +111,7 @@ public class SpyAnnotationTest extends TestBase {
         try {
             MockitoAnnotations.initMocks(new FailingSpy());
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             Assertions.assertThat(e.getMessage()).contains("Unable to create mock instance");
         }
     }
@@ -112,44 +119,48 @@ public class SpyAnnotationTest extends TestBase {
     @Test
     public void should_spy_abstract_class() throws Exception {
         class SpyAbstractClass {
-            @Spy AbstractList<String> list;
-            
-            List<String> asSingletonList(String s) {
+            @Spy
+            AbstractList<String> list;
+
+            List<String> asSingletonList(final String s) {
                 when(list.size()).thenReturn(1);
                 when(list.get(0)).thenReturn(s);
                 return list;
             }
         }
-        SpyAbstractClass withSpy = new SpyAbstractClass();
+        final SpyAbstractClass withSpy = new SpyAbstractClass();
         MockitoAnnotations.initMocks(withSpy);
         assertEquals(Arrays.asList("a"), withSpy.asSingletonList("a"));
     }
 
     @Test
     public void should_spy_inner_class() throws Exception {
-         
-     class WithMockAndSpy {
-            @Spy private InnerStrength strength;
-            @Mock private List<String> list;
+
+        class WithMockAndSpy {
+            @Spy
+            private InnerStrength strength;
+            @Mock
+            private List<String> list;
 
             abstract class InnerStrength {
                 private final String name;
 
                 InnerStrength() {
-                    // Make sure that @Mock fields are always injected before @Spy fields.
+                    // Make sure that @Mock fields are always injected before
+                    // @Spy fields.
                     assertNotNull(list);
                     // Make sure constructor is indeed called.
                     this.name = "inner";
                 }
-                
+
                 abstract String strength();
-                
+
                 String fullStrength() {
                     return name + " " + strength();
                 }
             }
         }
-        WithMockAndSpy outer = new WithMockAndSpy();
+        final WithMockAndSpy outer = new WithMockAndSpy();
         MockitoAnnotations.initMocks(outer);
         when(outer.strength.strength()).thenReturn("strength");
         assertEquals("inner strength", outer.strength.fullStrength());
@@ -163,31 +174,40 @@ public class SpyAnnotationTest extends TestBase {
     @Test
     public void should_report_when_encosing_instance_is_needed() throws Exception {
         class Outer {
-            class Inner {}
+            class Inner {
+            }
         }
         class WithSpy {
-            @Spy private Outer.Inner inner;
+            @Spy
+            private Outer.Inner inner;
         }
         try {
             MockitoAnnotations.initMocks(new WithSpy());
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             assertContains("@Spy annotation can only initialize inner classes", e.getMessage());
         }
     }
 
-    static class NestedClassWithoutDefinedConstructor { }
+    static class NestedClassWithoutDefinedConstructor {
+    }
 
     static class NestedClassWithNoArgConstructor {
-        NestedClassWithNoArgConstructor() { }
-        NestedClassWithNoArgConstructor(String f) { }
+        NestedClassWithNoArgConstructor() {
+        }
+
+        NestedClassWithNoArgConstructor(final String f) {
+        }
     }
 
     static class NoValidConstructor {
-        NoValidConstructor(String f) { }
+        NoValidConstructor(final String f) {
+        }
     }
 
     static class ThrowingConstructor {
-        ThrowingConstructor() { throw new RuntimeException("boo!"); }
+        ThrowingConstructor() {
+            throw new RuntimeException("boo!");
+        }
     }
 }

--- a/test/org/mockitousage/annotation/SpyInjectionTest.java
+++ b/test/org/mockitousage/annotation/SpyInjectionTest.java
@@ -12,7 +12,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Spy;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class SpyInjectionTest extends TestBase {
 
     @Spy List spy = new LinkedList();
@@ -20,7 +20,7 @@ public class SpyInjectionTest extends TestBase {
     
     static class HasSpy {
         private List spy;
-        public void setSpy(List spy) {
+        public void setSpy(final List spy) {
             this.spy = spy;
         }        
     }

--- a/test/org/mockitousage/annotation/WrongSetOfAnnotationsTest.java
+++ b/test/org/mockitousage/annotation/WrongSetOfAnnotationsTest.java
@@ -5,6 +5,7 @@
 package org.mockitousage.annotation;
 
 import java.util.List;
+
 import org.fest.assertions.Assertions;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -16,7 +17,7 @@ import org.mockito.Spy;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings({"unchecked", "unused"})
+@SuppressWarnings("rawtypes")
 public class WrongSetOfAnnotationsTest extends TestBase {
 
     @Test(expected=MockitoException.class)
@@ -31,26 +32,16 @@ public class WrongSetOfAnnotationsTest extends TestBase {
         try {
             MockitoAnnotations.initMocks(new Object() { @InjectMocks @Spy List mock; });
             fail();
-        } catch (MockitoException me) {
+        } catch (final MockitoException me) {
             Assertions.assertThat(me.getMessage()).contains("'List' is an interface");
         }
         try {
             MockitoAnnotations.initMocks(new Object() { @Spy List mock; });
             fail();
-        } catch (MockitoException me) {
+        } catch (final MockitoException me) {
             Assertions.assertThat(me.getMessage()).contains("'List' is an interface");
         }
     }
-
-//    @Test
-//    public void should_allow_Spy_and_InjectMocks() throws Exception {
-//        MockitoAnnotations.initMocks(new Object() {
-//            @InjectMocks
-//            @Spy
-//            WithDependency mock;
-//        });
-//    }
-//    static class WithDependency { List list; }
 
     @Test(expected=MockitoException.class)
     public void should_not_allow_Mock_and_InjectMocks() throws Exception {

--- a/test/org/mockitousage/basicapi/MockAccessTest.java
+++ b/test/org/mockitousage/basicapi/MockAccessTest.java
@@ -5,28 +5,29 @@
 package org.mockitousage.basicapi;
 
 
-import org.junit.Test;
-
-import java.util.Set;
-
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.Set;
+
+import org.junit.Test;
+
+@SuppressWarnings("rawtypes")
 public class MockAccessTest {
 
     @Test
     public void shouldAllowStubbedMockReferenceAccess() throws Exception {
-        Set expectedMock = mock(Set.class);
+        final Set expectedMock = mock(Set.class);
 
-        Set returnedMock = when(expectedMock.isEmpty()).thenReturn(false).getMock();
+        final Set returnedMock = when(expectedMock.isEmpty()).thenReturn(false).getMock();
 
         assertEquals(expectedMock, returnedMock);
     }
 
     @Test
     public void stubbedMockShouldWorkAsUsual() throws Exception {
-        Set returnedMock = when(mock(Set.class).isEmpty()).thenReturn(false, true).getMock();
+        final Set returnedMock = when(mock(Set.class).isEmpty()).thenReturn(false, true).getMock();
 
         assertEquals(false, returnedMock.isEmpty());
         assertEquals(true, returnedMock.isEmpty());

--- a/test/org/mockitousage/basicapi/MockingDetailsTest.java
+++ b/test/org/mockitousage/basicapi/MockingDetailsTest.java
@@ -4,13 +4,16 @@
  */
 package org.mockitousage.basicapi;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockingDetails;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.withSettings;
+
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockitoutil.TestBase;
-
-import static org.mockito.Mockito.*;
 
 public class MockingDetailsTest extends TestBase {
     

--- a/test/org/mockitousage/basicapi/MocksCreationTest.java
+++ b/test/org/mockitousage/basicapi/MocksCreationTest.java
@@ -5,6 +5,16 @@
 
 package org.mockitousage.basicapi;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.Mockito.RETURNS_SMART_NULLS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.exceptions.base.MockitoException;
@@ -12,14 +22,7 @@ import org.mockito.exceptions.verification.SmartNullPointerException;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.mockito.Mockito.*;
-
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class MocksCreationTest extends TestBase {
 
     private class HasPrivateConstructor {};
@@ -32,13 +35,13 @@ public class MocksCreationTest extends TestBase {
     @Test
     public void shouldCombineMockNameAndSmartNulls() {
         //given
-        IMethods mock = mock(IMethods.class, withSettings()
+        final IMethods mock = mock(IMethods.class, withSettings()
             .defaultAnswer(RETURNS_SMART_NULLS)
             .name("great mockie"));    
         
         //when
-        IMethods smartNull = mock.iMethodsReturningMethod();
-        String name = mock.toString();
+        final IMethods smartNull = mock.iMethodsReturningMethod();
+        final String name = mock.toString();
         
         //then
         assertContains("great mockie", name);
@@ -46,18 +49,18 @@ public class MocksCreationTest extends TestBase {
         try {
             smartNull.simpleMethod();
             fail();
-        } catch(SmartNullPointerException e) {}
+        } catch(final SmartNullPointerException e) {}
     }
     
     @Test
     public void shouldCombineMockNameAndExtraInterfaces() {
         //given
-        IMethods mock = mock(IMethods.class, withSettings()
+        final IMethods mock = mock(IMethods.class, withSettings()
                 .extraInterfaces(List.class)
                 .name("great mockie"));
         
         //when
-        String name = mock.toString();
+        final String name = mock.toString();
         
         //then
         assertContains("great mockie", name);
@@ -68,10 +71,10 @@ public class MocksCreationTest extends TestBase {
     @Test
     public void shouldSpecifyMockNameViaSettings() {
         //given
-        IMethods mock = mock(IMethods.class, withSettings().name("great mockie"));
+        final IMethods mock = mock(IMethods.class, withSettings().name("great mockie"));
 
         //when
-        String name = mock.toString();
+        final String name = mock.toString();
         
         //then
         assertContains("great mockie", name);
@@ -80,18 +83,18 @@ public class MocksCreationTest extends TestBase {
     @Test
     public void shouldScreamWhenSpyCreatedWithWrongType() {
         //given
-        List list = new LinkedList();
+        final List list = new LinkedList();
         try {
             //when
             mock(List.class, withSettings().spiedInstance(list));
             fail();
             //then
-        } catch (MockitoException e) {}
+        } catch (final MockitoException e) {}
     }
 
     @Test
     public void shouldAllowCreatingSpiesWithCorrectType() {
-        List list = new LinkedList();
+        final List list = new LinkedList();
         mock(LinkedList.class, withSettings().spiedInstance(list));
     }
 

--- a/test/org/mockitousage/basicapi/MocksSerializationForAnnotationTest.java
+++ b/test/org/mockitousage/basicapi/MocksSerializationForAnnotationTest.java
@@ -18,12 +18,14 @@ import static org.mockito.Mockito.withSettings;
 import static org.mockitoutil.SimpleSerializationUtil.deserializeMock;
 import static org.mockitoutil.SimpleSerializationUtil.serializeAndBack;
 import static org.mockitoutil.SimpleSerializationUtil.serializeMock;
+
 import java.io.ByteArrayOutputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Observable;
+
 import org.fest.assertions.Assertions;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -37,28 +39,35 @@ import org.mockito.stubbing.Answer;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings({"unchecked", "serial"})
+@SuppressWarnings({ "unchecked", "serial", "rawtypes" })
 public class MocksSerializationForAnnotationTest extends TestBase implements Serializable {
 
     private static final long serialVersionUID = 6160482220413048624L;
 
-    @Mock Any any;
-    @Mock(serializable=true) Bar barMock;
-    @Mock(serializable=true) IMethods imethodsMock;
-    @Mock(serializable=true) IMethods imethodsMock2;
-    @Mock(serializable=true) Any anyMock;
-    @Mock(serializable=true) AlreadySerializable alreadySerializableMock;
-    @Mock(extraInterfaces={List.class}, serializable=true) IMethods imethodsWithExtraInterfacesMock;
-    
+    @Mock
+    Any any;
+    @Mock(serializable = true)
+    Bar barMock;
+    @Mock(serializable = true)
+    IMethods imethodsMock;
+    @Mock(serializable = true)
+    IMethods imethodsMock2;
+    @Mock(serializable = true)
+    Any anyMock;
+    @Mock(serializable = true)
+    AlreadySerializable alreadySerializableMock;
+    @Mock(extraInterfaces = { List.class }, serializable = true)
+    IMethods imethodsWithExtraInterfacesMock;
+
     @Test
     public void should_allow_throws_exception_to_be_serializable() throws Exception {
         // given
         when(barMock.doSomething()).thenAnswer(new ThrowsException(new RuntimeException()));
 
-        //when-serialize then-deserialize
+        // when-serialize then-deserialize
         serializeAndBack(barMock);
     }
-    
+
     @Test
     public void should_allow_mock_to_be_serializable() throws Exception {
         // when-serialize then-deserialize
@@ -71,78 +80,78 @@ public class MocksSerializationForAnnotationTest extends TestBase implements Ser
         when(imethodsMock.booleanReturningMethod()).thenReturn(true);
 
         // when
-        ByteArrayOutputStream serialized = serializeMock(imethodsMock);
+        final ByteArrayOutputStream serialized = serializeMock(imethodsMock);
 
         // then
-        IMethods readObject = deserializeMock(serialized, IMethods.class);
+        final IMethods readObject = deserializeMock(serialized, IMethods.class);
         assertTrue(readObject.booleanReturningMethod());
     }
 
     @Test
     public void should_allow_mock_and_string_value_to_be_serializable() throws Exception {
         // given
-        String value = "value";
+        final String value = "value";
         when(imethodsMock.stringReturningMethod()).thenReturn(value);
 
         // when
-        ByteArrayOutputStream serialized = serializeMock(imethodsMock);
+        final ByteArrayOutputStream serialized = serializeMock(imethodsMock);
 
         // then
-        IMethods readObject = deserializeMock(serialized, IMethods.class);
+        final IMethods readObject = deserializeMock(serialized, IMethods.class);
         assertEquals(value, readObject.stringReturningMethod());
     }
 
     @Test
     public void should_all_mock_and_serializable_value_to_be_serialized() throws Exception {
         // given
-        List<?> value = Collections.emptyList();
+        final List<?> value = Collections.emptyList();
         when(imethodsMock.objectReturningMethodNoArgs()).thenReturn(value);
 
         // when
-        ByteArrayOutputStream serialized = serializeMock(imethodsMock);
+        final ByteArrayOutputStream serialized = serializeMock(imethodsMock);
 
         // then
-        IMethods readObject = deserializeMock(serialized, IMethods.class);
+        final IMethods readObject = deserializeMock(serialized, IMethods.class);
         assertEquals(value, readObject.objectReturningMethodNoArgs());
     }
 
     @Test
     public void should_serialize_method_call_with_parameters_that_are_serializable() throws Exception {
-        List<?> value = Collections.emptyList();
+        final List<?> value = Collections.emptyList();
         when(imethodsMock.objectArgMethod(value)).thenReturn(value);
 
         // when
-        ByteArrayOutputStream serialized = serializeMock(imethodsMock);
+        final ByteArrayOutputStream serialized = serializeMock(imethodsMock);
 
         // then
-        IMethods readObject = deserializeMock(serialized, IMethods.class);
+        final IMethods readObject = deserializeMock(serialized, IMethods.class);
         assertEquals(value, readObject.objectArgMethod(value));
     }
 
     @Test
     public void should_serialize_method_calls_using_any_string_matcher() throws Exception {
-        List<?> value = Collections.emptyList();
+        final List<?> value = Collections.emptyList();
         when(imethodsMock.objectArgMethod(anyString())).thenReturn(value);
 
         // when
-        ByteArrayOutputStream serialized = serializeMock(imethodsMock);
+        final ByteArrayOutputStream serialized = serializeMock(imethodsMock);
 
         // then
-        IMethods readObject = deserializeMock(serialized, IMethods.class);
+        final IMethods readObject = deserializeMock(serialized, IMethods.class);
         assertEquals(value, readObject.objectArgMethod(""));
     }
 
     @Test
     public void should_verify_called_n_times_for_serialized_mock() throws Exception {
-        List<?> value = Collections.emptyList();
+        final List<?> value = Collections.emptyList();
         when(imethodsMock.objectArgMethod(anyString())).thenReturn(value);
         imethodsMock.objectArgMethod("");
 
         // when
-        ByteArrayOutputStream serialized = serializeMock(imethodsMock);
+        final ByteArrayOutputStream serialized = serializeMock(imethodsMock);
 
         // then
-        IMethods readObject = deserializeMock(serialized, IMethods.class);
+        final IMethods readObject = deserializeMock(serialized, IMethods.class);
         verify(readObject, times(1)).objectArgMethod("");
     }
 
@@ -151,15 +160,16 @@ public class MocksSerializationForAnnotationTest extends TestBase implements Ser
 
         // when
         imethodsMock.simpleMethod(1);
-        ByteArrayOutputStream serialized = serializeMock(imethodsMock);
-        IMethods readObject = deserializeMock(serialized, IMethods.class);
+        final ByteArrayOutputStream serialized = serializeMock(imethodsMock);
+        final IMethods readObject = deserializeMock(serialized, IMethods.class);
         readObject.simpleMethod(1);
 
         // then
         verify(readObject, times(2)).simpleMethod(1);
 
-        //this test is working because it seems that java serialization mechanism replaces all instances
-        //of serialized object in the object graph (if there are any)
+        // this test is working because it seems that java serialization
+        // mechanism replaces all instances
+        // of serialized object in the object graph (if there are any)
     }
 
     class Bar implements Serializable {
@@ -172,6 +182,7 @@ public class MocksSerializationForAnnotationTest extends TestBase implements Ser
 
     class Foo implements Serializable {
         Bar bar;
+
         Foo() {
             bar = new Bar();
             bar.foo = this;
@@ -180,21 +191,21 @@ public class MocksSerializationForAnnotationTest extends TestBase implements Ser
 
     @Test
     public void should_serialization_work() throws Exception {
-        //given
+        // given
         Foo foo = new Foo();
-        //when
+        // when
         foo = serializeAndBack(foo);
-        //then
+        // then
         assertSame(foo, foo.bar.foo);
     }
 
     @Test
     public void should_stub_even_if_some_methods_called_after_serialization() throws Exception {
-        //given
+        // given
         // when
         when(imethodsMock.simpleMethod(1)).thenReturn("foo");
-        ByteArrayOutputStream serialized = serializeMock(imethodsMock);
-        IMethods readObject = deserializeMock(serialized, IMethods.class);
+        final ByteArrayOutputStream serialized = serializeMock(imethodsMock);
+        final IMethods readObject = deserializeMock(serialized, IMethods.class);
         when(readObject.simpleMethod(2)).thenReturn("bar");
 
         // then
@@ -208,28 +219,28 @@ public class MocksSerializationForAnnotationTest extends TestBase implements Ser
         imethodsMock2.arrayReturningMethod();
 
         // when
-        ByteArrayOutputStream serialized = serializeMock(imethodsMock);
-        ByteArrayOutputStream serialized2 = serializeMock(imethodsMock2);
+        final ByteArrayOutputStream serialized = serializeMock(imethodsMock);
+        final ByteArrayOutputStream serialized2 = serializeMock(imethodsMock2);
 
         // then
-        IMethods readObject = deserializeMock(serialized, IMethods.class);
-        IMethods readObject2 = deserializeMock(serialized2, IMethods.class);
-        InOrder inOrder = inOrder(readObject, readObject2);
+        final IMethods readObject = deserializeMock(serialized, IMethods.class);
+        final IMethods readObject2 = deserializeMock(serialized2, IMethods.class);
+        final InOrder inOrder = inOrder(readObject, readObject2);
         inOrder.verify(readObject).arrayReturningMethod();
         inOrder.verify(readObject2).arrayReturningMethod();
     }
 
     @Test
     public void should_remember_interactions_for_serialized_mock() throws Exception {
-        List<?> value = Collections.emptyList();
+        final List<?> value = Collections.emptyList();
         when(imethodsMock.objectArgMethod(anyString())).thenReturn(value);
         imethodsMock.objectArgMethod("happened");
 
         // when
-        ByteArrayOutputStream serialized = serializeMock(imethodsMock);
+        final ByteArrayOutputStream serialized = serializeMock(imethodsMock);
 
         // then
-        IMethods readObject = deserializeMock(serialized, IMethods.class);
+        final IMethods readObject = deserializeMock(serialized, IMethods.class);
         verify(readObject, never()).objectArgMethod("never happened");
     }
 
@@ -237,23 +248,24 @@ public class MocksSerializationForAnnotationTest extends TestBase implements Ser
     public void should_serialize_with_stubbing_callback() throws Exception {
 
         // given
-        CustomAnswersMustImplementSerializableForSerializationToWork answer = 
-            new CustomAnswersMustImplementSerializableForSerializationToWork();
+        final CustomAnswersMustImplementSerializableForSerializationToWork answer =
+                new CustomAnswersMustImplementSerializableForSerializationToWork();
         answer.string = "return value";
         when(imethodsMock.objectArgMethod(anyString())).thenAnswer(answer);
 
         // when
-        ByteArrayOutputStream serialized = serializeMock(imethodsMock);
+        final ByteArrayOutputStream serialized = serializeMock(imethodsMock);
 
         // then
-        IMethods readObject = deserializeMock(serialized, IMethods.class);
+        final IMethods readObject = deserializeMock(serialized, IMethods.class);
         assertEquals(answer.string, readObject.objectArgMethod(""));
     }
 
     static class CustomAnswersMustImplementSerializableForSerializationToWork
-        implements Answer<Object>, Serializable {
+            implements Answer<Object>, Serializable {
         private String string;
-        public Object answer(InvocationOnMock invocation) throws Throwable {
+
+        public Object answer(final InvocationOnMock invocation) throws Throwable {
             invocation.getArguments();
             invocation.getMock();
             return string;
@@ -263,44 +275,45 @@ public class MocksSerializationForAnnotationTest extends TestBase implements Ser
     @Test
     public void should_serialize_with_real_object_spy() throws Exception {
         // given
-        List<Object> list = new ArrayList<Object>();
-        List<Object> spy = mock(ArrayList.class, withSettings()
-                        .spiedInstance(list)
-                        .defaultAnswer(CALLS_REAL_METHODS)
-                        .serializable());
+        final List<Object> list = new ArrayList<Object>();
+        final List<Object> spy = mock(ArrayList.class, withSettings()
+                .spiedInstance(list)
+                .defaultAnswer(CALLS_REAL_METHODS)
+                .serializable());
         when(spy.size()).thenReturn(100);
 
         // when
-        ByteArrayOutputStream serialized = serializeMock(spy);
+        final ByteArrayOutputStream serialized = serializeMock(spy);
 
         // then
-        List<?> readObject = deserializeMock(serialized, List.class);
+        final List<?> readObject = deserializeMock(serialized, List.class);
         assertEquals(100, readObject.size());
     }
 
     @Test
     public void should_serialize_object_mock() throws Exception {
         // when
-        ByteArrayOutputStream serialized = serializeMock(any);
+        final ByteArrayOutputStream serialized = serializeMock(any);
 
         // then
         deserializeMock(serialized, Any.class);
     }
-    
+
     @Test
     public void should_serialize_real_partial_mock() throws Exception {
         // given
         when(anyMock.matches(anyObject())).thenCallRealMethod();
 
         // when
-        ByteArrayOutputStream serialized = serializeMock(anyMock);
+        final ByteArrayOutputStream serialized = serializeMock(anyMock);
 
         // then
-        Any readObject = deserializeMock(serialized, Any.class);
+        final Any readObject = deserializeMock(serialized, Any.class);
         readObject.matches("");
     }
 
-    class AlreadySerializable implements Serializable {}
+    class AlreadySerializable implements Serializable {
+    }
 
     @Test
     public void should_serialize_already_serializable_class() throws Exception {
@@ -313,34 +326,34 @@ public class MocksSerializationForAnnotationTest extends TestBase implements Ser
         // then
         assertEquals("foo", alreadySerializableMock.toString());
     }
-    
+
     @Test
     public void should_be_serialize_and_have_extra_interfaces() throws Exception {
-        //then
+        // then
         Assertions.assertThat((Object) serializeAndBack((List) imethodsWithExtraInterfacesMock))
                 .isInstanceOf(List.class)
                 .isInstanceOf(IMethods.class);
     }
 
-
-
     static class NotSerializableAndNoDefaultConstructor {
-        NotSerializableAndNoDefaultConstructor(Observable o) { super(); }
+        NotSerializableAndNoDefaultConstructor(final Observable o) {
+            super();
+        }
     }
-    
+
     public static class FailTestClass {
-        @Mock(serializable=true)
+        @Mock(serializable = true)
         NotSerializableAndNoDefaultConstructor notSerializableAndNoDefaultConstructor;
     }
-    
+
     @Test
     public void should_fail_when_serializable_used_with_type_that_dont_implements_Serializable_and_dont_declare_a_no_arg_constructor() throws Exception {
         try {
-            FailTestClass testClass = new FailTestClass();
+            final FailTestClass testClass = new FailTestClass();
             MockitoAnnotations.initMocks(testClass);
             serializeAndBack(testClass.notSerializableAndNoDefaultConstructor);
             fail("should have thrown an exception to say the object is not serializable");
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             Assertions.assertThat(e.getMessage())
                     .contains(NotSerializableAndNoDefaultConstructor.class.getSimpleName())
                     .contains("serializable()")
@@ -349,20 +362,20 @@ public class MocksSerializationForAnnotationTest extends TestBase implements Ser
         }
     }
 
-
-
     static class SerializableAndNoDefaultConstructor implements Serializable {
-        SerializableAndNoDefaultConstructor(Observable o) { super(); }
+        SerializableAndNoDefaultConstructor(final Observable o) {
+            super();
+        }
     }
 
     public static class TestClassThatHoldValidField {
-        @Mock(serializable=true)
+        @Mock(serializable = true)
         SerializableAndNoDefaultConstructor serializableAndNoDefaultConstructor;
     }
 
     @Test
     public void should_be_able_to_serialize_type_that_implements_Serializable_but_but_dont_declare_a_no_arg_constructor() throws Exception {
-        TestClassThatHoldValidField testClass = new TestClassThatHoldValidField();
+        final TestClassThatHoldValidField testClass = new TestClassThatHoldValidField();
         MockitoAnnotations.initMocks(testClass);
 
         serializeAndBack(testClass.serializableAndNoDefaultConstructor);

--- a/test/org/mockitousage/basicapi/MocksSerializationForAnnotationTest.java
+++ b/test/org/mockitousage/basicapi/MocksSerializationForAnnotationTest.java
@@ -48,7 +48,7 @@ public class MocksSerializationForAnnotationTest extends TestBase implements Ser
     @Mock(serializable=true) IMethods imethodsMock2;
     @Mock(serializable=true) Any anyMock;
     @Mock(serializable=true) AlreadySerializable alreadySerializableMock;
-    @Mock(extraInterfaces={List.class},serializable=true) IMethods imethodsWithExtraInterfacesMock;
+    @Mock(extraInterfaces={List.class}, serializable=true) IMethods imethodsWithExtraInterfacesMock;
     
     @Test
     public void should_allow_throws_exception_to_be_serializable() throws Exception {

--- a/test/org/mockitousage/basicapi/MocksSerializationTest.java
+++ b/test/org/mockitousage/basicapi/MocksSerializationTest.java
@@ -5,10 +5,10 @@
 
 package org.mockitousage.basicapi;
 
+import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
-import static org.mockito.Mockito.anyObject;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.withSettings;
 import static org.mockitoutil.SimpleSerializationUtil.deserializeMock;
 import static org.mockitoutil.SimpleSerializationUtil.serializeAndBack;
 import static org.mockitoutil.SimpleSerializationUtil.serializeMock;
+
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
@@ -26,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Observable;
+
 import org.fest.assertions.Assertions;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -39,7 +41,7 @@ import org.mockitousage.IMethods;
 import org.mockitoutil.SimpleSerializationUtil;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings({"unchecked", "serial"})
+@SuppressWarnings({ "unchecked", "serial", "rawtypes" })
 public class MocksSerializationTest extends TestBase implements Serializable {
 
     private static final long serialVersionUID = 6160482220413048624L;
@@ -47,7 +49,7 @@ public class MocksSerializationTest extends TestBase implements Serializable {
     @Test
     public void should_allow_throws_exception_to_be_serializable() throws Exception {
         // given
-        Bar mock = mock(Bar.class, new ThrowsException(new RuntimeException()));
+        final Bar mock = mock(Bar.class, new ThrowsException(new RuntimeException()));
         // when-serialize then-deserialize
         serializeAndBack(mock);
     }
@@ -55,18 +57,17 @@ public class MocksSerializationTest extends TestBase implements Serializable {
     @Test
     public void should_allow_method_delegation() throws Exception {
         // given
-        Bar barMock = mock(Bar.class, withSettings().serializable());
-        Foo fooMock = mock(Foo.class);
+        final Bar barMock = mock(Bar.class, withSettings().serializable());
         when(barMock.doSomething()).thenAnswer(new ThrowsException(new RuntimeException()));
 
-        //when-serialize then-deserialize
+        // when-serialize then-deserialize
         serializeAndBack(barMock);
     }
 
     @Test
     public void should_allow_mock_to_be_serializable() throws Exception {
         // given
-        IMethods mock = mock(IMethods.class, withSettings().serializable());
+        final IMethods mock = mock(IMethods.class, withSettings().serializable());
 
         // when-serialize then-deserialize
         serializeAndBack(mock);
@@ -75,106 +76,107 @@ public class MocksSerializationTest extends TestBase implements Serializable {
     @Test
     public void should_allow_mock_and_boolean_value_to_serializable() throws Exception {
         // given
-        IMethods mock = mock(IMethods.class, withSettings().serializable());
+        final IMethods mock = mock(IMethods.class, withSettings().serializable());
         when(mock.booleanReturningMethod()).thenReturn(true);
 
         // when
-        ByteArrayOutputStream serialized = serializeMock(mock);
+        final ByteArrayOutputStream serialized = serializeMock(mock);
 
         // then
-        IMethods readObject = deserializeMock(serialized, IMethods.class);
+        final IMethods readObject = deserializeMock(serialized, IMethods.class);
         assertTrue(readObject.booleanReturningMethod());
     }
 
     @Test
     public void should_allow_mock_and_string_value_to_be_serializable() throws Exception {
         // given
-        IMethods mock = mock(IMethods.class, withSettings().serializable());
-        String value = "value";
+        final IMethods mock = mock(IMethods.class, withSettings().serializable());
+        final String value = "value";
         when(mock.stringReturningMethod()).thenReturn(value);
 
         // when
-        ByteArrayOutputStream serialized = serializeMock(mock);
+        final ByteArrayOutputStream serialized = serializeMock(mock);
 
         // then
-        IMethods readObject = deserializeMock(serialized, IMethods.class);
+        final IMethods readObject = deserializeMock(serialized, IMethods.class);
         assertEquals(value, readObject.stringReturningMethod());
     }
 
     @Test
     public void should_all_mock_and_serializable_value_to_be_serialized() throws Exception {
         // given
-        IMethods mock = mock(IMethods.class, withSettings().serializable());
-        List<?> value = Collections.emptyList();
+        final IMethods mock = mock(IMethods.class, withSettings().serializable());
+        final List<?> value = Collections.emptyList();
         when(mock.objectReturningMethodNoArgs()).thenReturn(value);
 
         // when
-        ByteArrayOutputStream serialized = serializeMock(mock);
+        final ByteArrayOutputStream serialized = serializeMock(mock);
 
         // then
-        IMethods readObject = deserializeMock(serialized, IMethods.class);
+        final IMethods readObject = deserializeMock(serialized, IMethods.class);
         assertEquals(value, readObject.objectReturningMethodNoArgs());
     }
 
     @Test
     public void should_serialize_method_call_with_parameters_that_are_serializable() throws Exception {
-        IMethods mock = mock(IMethods.class, withSettings().serializable());
-        List<?> value = Collections.emptyList();
+        final IMethods mock = mock(IMethods.class, withSettings().serializable());
+        final List<?> value = Collections.emptyList();
         when(mock.objectArgMethod(value)).thenReturn(value);
 
         // when
-        ByteArrayOutputStream serialized = serializeMock(mock);
+        final ByteArrayOutputStream serialized = serializeMock(mock);
 
         // then
-        IMethods readObject = deserializeMock(serialized, IMethods.class);
+        final IMethods readObject = deserializeMock(serialized, IMethods.class);
         assertEquals(value, readObject.objectArgMethod(value));
     }
 
     @Test
     public void should_serialize_method_calls_using_any_string_matcher() throws Exception {
-        IMethods mock = mock(IMethods.class, withSettings().serializable());
-        List<?> value = Collections.emptyList();
+        final IMethods mock = mock(IMethods.class, withSettings().serializable());
+        final List<?> value = Collections.emptyList();
         when(mock.objectArgMethod(anyString())).thenReturn(value);
 
         // when
-        ByteArrayOutputStream serialized = serializeMock(mock);
+        final ByteArrayOutputStream serialized = serializeMock(mock);
 
         // then
-        IMethods readObject = deserializeMock(serialized, IMethods.class);
+        final IMethods readObject = deserializeMock(serialized, IMethods.class);
         assertEquals(value, readObject.objectArgMethod(""));
     }
 
     @Test
     public void should_verify_called_n_times_for_serialized_mock() throws Exception {
-        IMethods mock = mock(IMethods.class, withSettings().serializable());
-        List<?> value = Collections.emptyList();
+        final IMethods mock = mock(IMethods.class, withSettings().serializable());
+        final List<?> value = Collections.emptyList();
         when(mock.objectArgMethod(anyString())).thenReturn(value);
         mock.objectArgMethod("");
 
         // when
-        ByteArrayOutputStream serialized = serializeMock(mock);
+        final ByteArrayOutputStream serialized = serializeMock(mock);
 
         // then
-        IMethods readObject = deserializeMock(serialized, IMethods.class);
+        final IMethods readObject = deserializeMock(serialized, IMethods.class);
         verify(readObject, times(1)).objectArgMethod("");
     }
 
     @Test
     public void should_verify_even_if_some_methods_called_after_serialization() throws Exception {
-        //given
-        IMethods mock = mock(IMethods.class, withSettings().serializable());
+        // given
+        final IMethods mock = mock(IMethods.class, withSettings().serializable());
 
         // when
         mock.simpleMethod(1);
-        ByteArrayOutputStream serialized = serializeMock(mock);
-        IMethods readObject = deserializeMock(serialized, IMethods.class);
+        final ByteArrayOutputStream serialized = serializeMock(mock);
+        final IMethods readObject = deserializeMock(serialized, IMethods.class);
         readObject.simpleMethod(1);
 
         // then
         verify(readObject, times(2)).simpleMethod(1);
 
-        //this test is working because it seems that java serialization mechanism replaces all instances
-        //of serialized object in the object graph (if there are any)
+        // this test is working because it seems that java serialization
+        // mechanism replaces all instances
+        // of serialized object in the object graph (if there are any)
     }
 
     class Bar implements Serializable {
@@ -187,6 +189,7 @@ public class MocksSerializationTest extends TestBase implements Serializable {
 
     class Foo implements Serializable {
         Bar bar;
+
         Foo() {
             bar = new Bar();
             bar.foo = this;
@@ -195,23 +198,23 @@ public class MocksSerializationTest extends TestBase implements Serializable {
 
     @Test
     public void should_serialization_work() throws Exception {
-        //given
+        // given
         Foo foo = new Foo();
-        //when
+        // when
         foo = serializeAndBack(foo);
-        //then
+        // then
         assertSame(foo, foo.bar.foo);
     }
 
     @Test
     public void should_stub_even_if_some_methods_called_after_serialization() throws Exception {
-        //given
-        IMethods mock = mock(IMethods.class, withSettings().serializable());
+        // given
+        final IMethods mock = mock(IMethods.class, withSettings().serializable());
 
         // when
         when(mock.simpleMethod(1)).thenReturn("foo");
-        ByteArrayOutputStream serialized = serializeMock(mock);
-        IMethods readObject = deserializeMock(serialized, IMethods.class);
+        final ByteArrayOutputStream serialized = serializeMock(mock);
+        final IMethods readObject = deserializeMock(serialized, IMethods.class);
         when(readObject.simpleMethod(2)).thenReturn("bar");
 
         // then
@@ -221,35 +224,35 @@ public class MocksSerializationTest extends TestBase implements Serializable {
 
     @Test
     public void should_verify_call_order_for_serialized_mock() throws Exception {
-        IMethods mock = mock(IMethods.class, withSettings().serializable());
-        IMethods mock2 = mock(IMethods.class, withSettings().serializable());
+        final IMethods mock = mock(IMethods.class, withSettings().serializable());
+        final IMethods mock2 = mock(IMethods.class, withSettings().serializable());
         mock.arrayReturningMethod();
         mock2.arrayReturningMethod();
 
         // when
-        ByteArrayOutputStream serialized = serializeMock(mock);
-        ByteArrayOutputStream serialized2 = serializeMock(mock2);
+        final ByteArrayOutputStream serialized = serializeMock(mock);
+        final ByteArrayOutputStream serialized2 = serializeMock(mock2);
 
         // then
-        IMethods readObject = deserializeMock(serialized, IMethods.class);
-        IMethods readObject2 = deserializeMock(serialized2, IMethods.class);
-        InOrder inOrder = inOrder(readObject, readObject2);
+        final IMethods readObject = deserializeMock(serialized, IMethods.class);
+        final IMethods readObject2 = deserializeMock(serialized2, IMethods.class);
+        final InOrder inOrder = inOrder(readObject, readObject2);
         inOrder.verify(readObject).arrayReturningMethod();
         inOrder.verify(readObject2).arrayReturningMethod();
     }
 
     @Test
     public void should_remember_interactions_for_serialized_mock() throws Exception {
-        IMethods mock = mock(IMethods.class, withSettings().serializable());
-        List<?> value = Collections.emptyList();
+        final IMethods mock = mock(IMethods.class, withSettings().serializable());
+        final List<?> value = Collections.emptyList();
         when(mock.objectArgMethod(anyString())).thenReturn(value);
         mock.objectArgMethod("happened");
 
         // when
-        ByteArrayOutputStream serialized = serializeMock(mock);
+        final ByteArrayOutputStream serialized = serializeMock(mock);
 
         // then
-        IMethods readObject = deserializeMock(serialized, IMethods.class);
+        final IMethods readObject = deserializeMock(serialized, IMethods.class);
         verify(readObject, never()).objectArgMethod("never happened");
     }
 
@@ -257,24 +260,25 @@ public class MocksSerializationTest extends TestBase implements Serializable {
     public void should_serialize_with_stubbing_callback() throws Exception {
 
         // given
-        IMethods mock = mock(IMethods.class, withSettings().serializable());
-        CustomAnswersMustImplementSerializableForSerializationToWork answer =
+        final IMethods mock = mock(IMethods.class, withSettings().serializable());
+        final CustomAnswersMustImplementSerializableForSerializationToWork answer =
                 new CustomAnswersMustImplementSerializableForSerializationToWork();
         answer.string = "return value";
         when(mock.objectArgMethod(anyString())).thenAnswer(answer);
 
         // when
-        ByteArrayOutputStream serialized = serializeMock(mock);
+        final ByteArrayOutputStream serialized = serializeMock(mock);
 
         // then
-        IMethods readObject = deserializeMock(serialized, IMethods.class);
+        final IMethods readObject = deserializeMock(serialized, IMethods.class);
         assertEquals(answer.string, readObject.objectArgMethod(""));
     }
 
     class CustomAnswersMustImplementSerializableForSerializationToWork
             implements Answer<Object>, Serializable {
         private String string;
-        public Object answer(InvocationOnMock invocation) throws Throwable {
+
+        public Object answer(final InvocationOnMock invocation) throws Throwable {
             invocation.getArguments();
             invocation.getMock();
             return string;
@@ -284,28 +288,28 @@ public class MocksSerializationTest extends TestBase implements Serializable {
     @Test
     public void should_serialize_with_real_object_spy() throws Exception {
         // given
-        List<Object> list = new ArrayList<Object>();
-        List<Object> spy = mock(ArrayList.class, withSettings()
+        final List<Object> list = new ArrayList<Object>();
+        final List<Object> spy = mock(ArrayList.class, withSettings()
                 .spiedInstance(list)
                 .defaultAnswer(CALLS_REAL_METHODS)
                 .serializable());
         when(spy.size()).thenReturn(100);
 
         // when
-        ByteArrayOutputStream serialized = serializeMock(spy);
+        final ByteArrayOutputStream serialized = serializeMock(spy);
 
         // then
-        List<?> readObject = deserializeMock(serialized, List.class);
+        final List<?> readObject = deserializeMock(serialized, List.class);
         assertEquals(100, readObject.size());
     }
 
     @Test
     public void should_serialize_object_mock() throws Exception {
         // given
-        Any mock = mock(Any.class);
+        final Any mock = mock(Any.class);
 
         // when
-        ByteArrayOutputStream serialized = serializeMock(mock);
+        final ByteArrayOutputStream serialized = serializeMock(mock);
 
         // then
         deserializeMock(serialized, Any.class);
@@ -314,18 +318,19 @@ public class MocksSerializationTest extends TestBase implements Serializable {
     @Test
     public void should_serialize_real_partial_mock() throws Exception {
         // given
-        Any mock = mock(Any.class, withSettings().serializable());
+        final Any mock = mock(Any.class, withSettings().serializable());
         when(mock.matches(anyObject())).thenCallRealMethod();
 
         // when
-        ByteArrayOutputStream serialized = serializeMock(mock);
+        final ByteArrayOutputStream serialized = serializeMock(mock);
 
         // then
-        Any readObject = deserializeMock(serialized, Any.class);
+        final Any readObject = deserializeMock(serialized, Any.class);
         readObject.matches("");
     }
 
-    class AlreadySerializable implements Serializable {}
+    class AlreadySerializable implements Serializable {
+    }
 
     @Test
     public void should_serialize_already_serializable_class() throws Exception {
@@ -342,11 +347,11 @@ public class MocksSerializationTest extends TestBase implements Serializable {
 
     @Test
     public void should_be_serialize_and_have_extra_interfaces() throws Exception {
-        //when
-        IMethods mock = mock(IMethods.class, withSettings().serializable().extraInterfaces(List.class));
-        IMethods mockTwo = mock(IMethods.class, withSettings().extraInterfaces(List.class).serializable());
+        // when
+        final IMethods mock = mock(IMethods.class, withSettings().serializable().extraInterfaces(List.class));
+        final IMethods mockTwo = mock(IMethods.class, withSettings().extraInterfaces(List.class).serializable());
 
-        //then
+        // then
         Assertions.assertThat((Object) serializeAndBack((List) mock))
                 .isInstanceOf(List.class)
                 .isInstanceOf(IMethods.class);
@@ -355,10 +360,10 @@ public class MocksSerializationTest extends TestBase implements Serializable {
                 .isInstanceOf(IMethods.class);
     }
 
-
-
     static class NotSerializableAndNoDefaultConstructor {
-        NotSerializableAndNoDefaultConstructor(Observable o) { super(); }
+        NotSerializableAndNoDefaultConstructor(final Observable o) {
+            super();
+        }
     }
 
     @Test
@@ -366,7 +371,7 @@ public class MocksSerializationTest extends TestBase implements Serializable {
         try {
             serializeAndBack(mock(NotSerializableAndNoDefaultConstructor.class, withSettings().serializable()));
             fail("should have thrown an exception to say the object is not serializable");
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             Assertions.assertThat(e.getMessage())
                     .contains(NotSerializableAndNoDefaultConstructor.class.getSimpleName())
                     .contains("serializable()")
@@ -375,10 +380,10 @@ public class MocksSerializationTest extends TestBase implements Serializable {
         }
     }
 
-
-
     static class SerializableAndNoDefaultConstructor implements Serializable {
-        SerializableAndNoDefaultConstructor(Observable o) { super(); }
+        SerializableAndNoDefaultConstructor(final Observable o) {
+            super();
+        }
     }
 
     @Test
@@ -386,35 +391,36 @@ public class MocksSerializationTest extends TestBase implements Serializable {
         serializeAndBack(mock(SerializableAndNoDefaultConstructor.class));
     }
 
-
-
     public static class AClassWithPrivateNoArgConstructor {
-        private AClassWithPrivateNoArgConstructor() {}
-        List returningSomething() { return Collections.emptyList(); }
+        private AClassWithPrivateNoArgConstructor() {
+        }
+
+        List returningSomething() {
+            return Collections.emptyList();
+        }
     }
 
     @Test
     public void private_constructor_currently_not_supported_at_the_moment_at_deserialization_time() throws Exception {
         // given
-        AClassWithPrivateNoArgConstructor mockWithPrivateConstructor = Mockito.mock(
+        final AClassWithPrivateNoArgConstructor mockWithPrivateConstructor = Mockito.mock(
                 AClassWithPrivateNoArgConstructor.class,
                 Mockito.withSettings().serializable()
-        );
+                );
 
         try {
             // when
             SimpleSerializationUtil.serializeAndBack(mockWithPrivateConstructor);
             fail("should have thrown an ObjectStreamException or a subclass of it");
-        } catch (ObjectStreamException e) {
+        } catch (final ObjectStreamException e) {
             // then
             Assertions.assertThat(e.toString()).contains("no valid constructor");
         }
     }
 
-
     @Test
     public void BUG_ISSUE_399_try_some_mocks_with_current_answers() throws Exception {
-        IMethods iMethods = mock(IMethods.class, withSettings().serializable().defaultAnswer(RETURNS_DEEP_STUBS));
+        final IMethods iMethods = mock(IMethods.class, withSettings().serializable().defaultAnswer(RETURNS_DEEP_STUBS));
 
         when(iMethods.iMethodsReturningMethod().linkedListReturningMethod().contains(anyString())).thenReturn(false);
 

--- a/test/org/mockitousage/basicapi/ReplacingObjectMethodsTest.java
+++ b/test/org/mockitousage/basicapi/ReplacingObjectMethodsTest.java
@@ -5,7 +5,8 @@
 
 package org.mockitousage.basicapi;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
 
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -18,16 +19,16 @@ public class ReplacingObjectMethodsTest extends TestBase {
     
     @Test
     public void shouldProvideMockyImplementationOfToString() {
-        DummyClass dummyClass = Mockito.mock(DummyClass.class);
+        final DummyClass dummyClass = Mockito.mock(DummyClass.class);
         assertEquals("Mock for DummyClass, hashCode: " + dummyClass.hashCode(), dummyClass.toString());
-        DummyInterface dummyInterface = Mockito.mock(DummyInterface.class);
+        final DummyInterface dummyInterface = Mockito.mock(DummyInterface.class);
         assertEquals("Mock for DummyInterface, hashCode: " + dummyInterface.hashCode(), dummyInterface.toString());
     }
     
     @Test 
     public void shouldReplaceObjectMethods() {
-        Object mock = Mockito.mock(ObjectMethodsOverridden.class);
-        Object otherMock = Mockito.mock(ObjectMethodsOverridden.class);
+        final Object mock = Mockito.mock(ObjectMethodsOverridden.class);
+        final Object otherMock = Mockito.mock(ObjectMethodsOverridden.class);
         
         assertThat(mock, equalTo(mock));
         assertThat(mock, not(equalTo(otherMock)));
@@ -39,8 +40,8 @@ public class ReplacingObjectMethodsTest extends TestBase {
     
     @Test 
     public void shouldReplaceObjectMethodsWhenOverridden() {
-        Object mock = Mockito.mock(ObjectMethodsOverriddenSubclass.class);
-        Object otherMock = Mockito.mock(ObjectMethodsOverriddenSubclass.class);
+        final Object mock = Mockito.mock(ObjectMethodsOverriddenSubclass.class);
+        final Object otherMock = Mockito.mock(ObjectMethodsOverriddenSubclass.class);
         
         assertThat(mock, equalTo(mock));
         assertThat(mock, not(equalTo(otherMock)));
@@ -51,7 +52,7 @@ public class ReplacingObjectMethodsTest extends TestBase {
     }
     
     public static class ObjectMethodsOverridden {
-        public boolean equals(Object o) {
+        public boolean equals(final Object o) {
             throw new RuntimeException("Should not be called. MethodInterceptorFilter provides implementation");
         }
         public int hashCode() {

--- a/test/org/mockitousage/basicapi/ResetTest.java
+++ b/test/org/mockitousage/basicapi/ResetTest.java
@@ -4,8 +4,15 @@
  */
 package org.mockitousage.basicapi;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.RETURNS_MOCKS;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 import org.mockito.Mock;
@@ -28,7 +35,7 @@ public class ResetTest extends TestBase {
         try {
             when(null).thenReturn("anything");
             fail();
-        } catch (MissingMethodInvocationException e) {
+        } catch (final MissingMethodInvocationException e) {
         }
     }
 
@@ -60,7 +67,7 @@ public class ResetTest extends TestBase {
 
     @Test
     public void shouldRemoveStubbingToString() throws Exception {
-        IMethods mockTwo = mock(IMethods.class);
+        final IMethods mockTwo = mock(IMethods.class);
         when(mockTwo.toString()).thenReturn("test");
         reset(mockTwo);
         assertContains("Mock for IMethods", mockTwo.toString());
@@ -76,8 +83,8 @@ public class ResetTest extends TestBase {
 
     @Test
     public void shouldNotAffectMockName() {
-        IMethods mock = mock(IMethods.class, "mockie");
-        IMethods mockTwo = mock(IMethods.class);
+        final IMethods mock = mock(IMethods.class, "mockie");
+        final IMethods mockTwo = mock(IMethods.class);
         reset(mock);
         assertContains("Mock for IMethods", "" + mockTwo);
         assertEquals("mockie", "" + mock);
@@ -99,7 +106,7 @@ public class ResetTest extends TestBase {
         try {
             reset(mockTwo);
             fail();
-        } catch (UnfinishedVerificationException e) {}
+        } catch (final UnfinishedVerificationException e) {}
     }
     
     @Test

--- a/test/org/mockitousage/basicapi/UsingVarargsTest.java
+++ b/test/org/mockitousage/basicapi/UsingVarargsTest.java
@@ -5,8 +5,12 @@
 
 package org.mockitousage.basicapi;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.stubVoid;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 
@@ -19,158 +23,174 @@ import org.mockitoutil.TestBase;
 
 public class UsingVarargsTest extends TestBase {
 
-    private interface IVarArgs {
-        void withStringVarargs(int value, String... s);
-        String withStringVarargsReturningString(int value, String... s);
-        void withObjectVarargs(int value, Object... o);
-        boolean withBooleanVarargs(int value, boolean... b);
-        int foo(Object ... objects);
-    }
-    
-    @Mock IVarArgs mock;
+	private interface IVarArgs {
+		void withStringVarargs(final int value, final String... s);
 
-    @SuppressWarnings("deprecation")
-    @Test
-    public void shouldStubStringVarargs() {
-        when(mock.withStringVarargsReturningString(1)).thenReturn("1");
-        when(mock.withStringVarargsReturningString(2, "1", "2", "3")).thenReturn("2");
-        
-        RuntimeException expected = new RuntimeException();
-        stubVoid(mock).toThrow(expected).on().withStringVarargs(3, "1", "2", "3", "4");
+		String withStringVarargsReturningString(final int value, final String... s);
 
-        assertEquals("1", mock.withStringVarargsReturningString(1));
-        assertEquals(null, mock.withStringVarargsReturningString(2));
-        
-        assertEquals("2", mock.withStringVarargsReturningString(2, "1", "2", "3"));
-        assertEquals(null, mock.withStringVarargsReturningString(2, "1", "2"));
-        assertEquals(null, mock.withStringVarargsReturningString(2, "1", "2", "3", "4"));
-        assertEquals(null, mock.withStringVarargsReturningString(2, "1", "2", "9999"));
-        
-        mock.withStringVarargs(3, "1", "2", "3", "9999");
-        mock.withStringVarargs(9999, "1", "2", "3", "4");
-        
-        try {
-            mock.withStringVarargs(3, "1", "2", "3", "4");
-            fail();
-        } catch (Exception e) {
-            assertEquals(expected, e);
-        }
-    }
-    
-    @Test
-    public void shouldStubBooleanVarargs() {
-        when(mock.withBooleanVarargs(1)).thenReturn(true);
-        when(mock.withBooleanVarargs(1, true, false)).thenReturn(true);
-        
-        assertEquals(true, mock.withBooleanVarargs(1));
-        assertEquals(false, mock.withBooleanVarargs(9999));
-        
-        assertEquals(true, mock.withBooleanVarargs(1, true, false));
-        assertEquals(false, mock.withBooleanVarargs(1, true, false, true));
-        assertEquals(false, mock.withBooleanVarargs(2, true, false));
-        assertEquals(false, mock.withBooleanVarargs(1, true));
-        assertEquals(false, mock.withBooleanVarargs(1, false, false));
-    }
-    
-    @Test
-    public void shouldVerifyStringVarargs() {
-        mock.withStringVarargs(1);
-        mock.withStringVarargs(2, "1", "2", "3");
-        mock.withStringVarargs(3, "1", "2", "3", "4");
+		void withObjectVarargs(final int value, final Object... o);
 
-        verify(mock).withStringVarargs(1);
-        verify(mock).withStringVarargs(2, "1", "2", "3");
-        try {
-            verify(mock).withStringVarargs(2, "1", "2", "79", "4");
-            fail();
-        } catch (ArgumentsAreDifferent e) {}
-    }
+		boolean withBooleanVarargs(final int value, final boolean... b);
 
-    @Test
-    public void shouldVerifyObjectVarargs() {
-        mock.withObjectVarargs(1);
-        mock.withObjectVarargs(2, "1", new ArrayList<Object>(), new Integer(1));
-        mock.withObjectVarargs(3, new Integer(1));
+		int foo(final Object... objects);
+	}
 
-        verify(mock).withObjectVarargs(1);
-        verify(mock).withObjectVarargs(2, "1", new ArrayList<Object>(), new Integer(1));
-        try {
-            verifyNoMoreInteractions(mock);
-            fail();
-        } catch (NoInteractionsWanted e) {}
-    }
+	@Mock
+	IVarArgs mock;
 
-    @Test
-    public void shouldVerifyBooleanVarargs() {
-        mock.withBooleanVarargs(1);
-        mock.withBooleanVarargs(2, true, false, true);
-        mock.withBooleanVarargs(3, true, true, true);
+	@SuppressWarnings("deprecation")
+	@Test
+	public void shouldStubStringVarargs() {
+		when(mock.withStringVarargsReturningString(1)).thenReturn("1");
+		when(mock.withStringVarargsReturningString(2, "1", "2", "3"))
+				.thenReturn("2");
 
-        verify(mock).withBooleanVarargs(1);
-        verify(mock).withBooleanVarargs(2, true, false, true);
-        try {
-            verify(mock).withBooleanVarargs(3, true, true, true, true);
-            fail();
-        } catch (ArgumentsAreDifferent e) {}
-    }
-    
-    @Test
-    public void shouldVerifyWithAnyObject() {
-        Foo foo = Mockito.mock(Foo.class);
-        foo.varArgs("");        
-        Mockito.verify(foo).varArgs((String[]) Mockito.anyObject());
-        Mockito.verify(foo).varArgs((String) Mockito.anyObject());
-    }   
-    
-    @Test
-    public void shouldVerifyWithNullVarArgArray() {
-        Foo foo = Mockito.mock(Foo.class);
-        foo.varArgs((String[]) null);    
-        Mockito.verify(foo).varArgs((String[]) Mockito.anyObject());
-        Mockito.verify(foo).varArgs((String[]) null);
-    }  
-    
-    public class Foo {      
-        public void varArgs(String... args) {}       
-    }
-    
-    interface MixedVarargs {
-        String doSomething(String one, String... varargs);
-        String doSomething(String one, String two, String... varargs);
-    }
+		final RuntimeException expected = new RuntimeException();
+		stubVoid(mock).toThrow(expected).on()
+				.withStringVarargs(3, "1", "2", "3", "4");
 
-    @SuppressWarnings("all")
-    @Test
-    //See bug #31
-    public void shouldStubCorrectlyWhenMixedVarargsUsed() {
-        MixedVarargs mixedVarargs = mock(MixedVarargs.class);
-        when(mixedVarargs.doSomething("hello", (String[])null)).thenReturn("hello");
-        when(mixedVarargs.doSomething("goodbye", (String[])null)).thenReturn("goodbye");
+		assertEquals("1", mock.withStringVarargsReturningString(1));
+		assertEquals(null, mock.withStringVarargsReturningString(2));
 
-        String result = mixedVarargs.doSomething("hello",(String[]) null);
-        assertEquals("hello", result);
-        
-        verify(mixedVarargs).doSomething("hello", (String[])null);
-    }
-    
-    @SuppressWarnings("all")
-    @Test
-    public void shouldStubCorrectlyWhenDoubleStringAndMixedVarargsUsed() {
-        MixedVarargs mixedVarargs = mock(MixedVarargs.class);
-        when(mixedVarargs.doSomething("one", "two", (String[])null)).thenReturn("hello");
-        when(mixedVarargs.doSomething("1", "2", (String[])null)).thenReturn("goodbye");
+		assertEquals("2",
+				mock.withStringVarargsReturningString(2, "1", "2", "3"));
+		assertEquals(null, mock.withStringVarargsReturningString(2, "1", "2"));
+		assertEquals(null,
+				mock.withStringVarargsReturningString(2, "1", "2", "3", "4"));
+		assertEquals(null,
+				mock.withStringVarargsReturningString(2, "1", "2", "9999"));
 
-        String result = mixedVarargs.doSomething("one", "two", (String[])null);
-        assertEquals("hello", result);
-    }
-    
-    @Test
-    //See bug #157
-    public void shouldMatchEasilyEmptyVararg() throws Exception {
-        //when
-        when(mock.foo(anyVararg())).thenReturn(-1);
+		mock.withStringVarargs(3, "1", "2", "3", "9999");
+		mock.withStringVarargs(9999, "1", "2", "3", "4");
 
-        //then
-        assertEquals(-1, mock.foo());
-    } 
+		try {
+			mock.withStringVarargs(3, "1", "2", "3", "4");
+			fail();
+		} catch (final Exception e) {
+			assertEquals(expected, e);
+		}
+	}
+
+	@Test
+	public void shouldStubBooleanVarargs() {
+		when(mock.withBooleanVarargs(1)).thenReturn(true);
+		when(mock.withBooleanVarargs(1, true, false)).thenReturn(true);
+
+		assertEquals(true, mock.withBooleanVarargs(1));
+		assertEquals(false, mock.withBooleanVarargs(9999));
+
+		assertEquals(true, mock.withBooleanVarargs(1, true, false));
+		assertEquals(false, mock.withBooleanVarargs(1, true, false, true));
+		assertEquals(false, mock.withBooleanVarargs(2, true, false));
+		assertEquals(false, mock.withBooleanVarargs(1, true));
+		assertEquals(false, mock.withBooleanVarargs(1, false, false));
+	}
+
+	@Test
+	public void shouldVerifyStringVarargs() {
+		mock.withStringVarargs(1);
+		mock.withStringVarargs(2, "1", "2", "3");
+		mock.withStringVarargs(3, "1", "2", "3", "4");
+
+		verify(mock).withStringVarargs(1);
+		verify(mock).withStringVarargs(2, "1", "2", "3");
+		try {
+			verify(mock).withStringVarargs(2, "1", "2", "79", "4");
+			fail();
+		} catch (final ArgumentsAreDifferent e) {
+		}
+	}
+
+	@Test
+	public void shouldVerifyObjectVarargs() {
+		mock.withObjectVarargs(1);
+		mock.withObjectVarargs(2, "1", new ArrayList<Object>(), new Integer(1));
+		mock.withObjectVarargs(3, new Integer(1));
+
+		verify(mock).withObjectVarargs(1);
+		verify(mock).withObjectVarargs(2, "1", new ArrayList<Object>(),
+				new Integer(1));
+		try {
+			verifyNoMoreInteractions(mock);
+			fail();
+		} catch (final NoInteractionsWanted e) {
+		}
+	}
+
+	@Test
+	public void shouldVerifyBooleanVarargs() {
+		mock.withBooleanVarargs(1);
+		mock.withBooleanVarargs(2, true, false, true);
+		mock.withBooleanVarargs(3, true, true, true);
+
+		verify(mock).withBooleanVarargs(1);
+		verify(mock).withBooleanVarargs(2, true, false, true);
+		try {
+			verify(mock).withBooleanVarargs(3, true, true, true, true);
+			fail();
+		} catch (final ArgumentsAreDifferent e) {
+		}
+	}
+
+	@Test
+	public void shouldVerifyWithAnyObject() {
+		final Foo foo = Mockito.mock(Foo.class);
+		foo.varArgs("");
+		Mockito.verify(foo).varArgs((String[]) Mockito.anyObject());
+		Mockito.verify(foo).varArgs((String) Mockito.anyObject());
+	}
+
+	@Test
+	public void shouldVerifyWithNullVarArgArray() {
+		final Foo foo = Mockito.mock(Foo.class);
+		foo.varArgs((String[]) null);
+		Mockito.verify(foo).varArgs((String[]) Mockito.anyObject());
+		Mockito.verify(foo).varArgs((String[]) null);
+	}
+
+	public class Foo {
+		public void varArgs(final String... args) {
+		}
+	}
+
+	interface MixedVarargs {
+		String doSomething(final String one, final String... varargs);
+
+		String doSomething(final String one, final String two, final String... varargs);
+	}
+
+	@SuppressWarnings("all")
+	@Test
+	// See bug #31
+	public void shouldStubCorrectlyWhenMixedVarargsUsed() {
+		final MixedVarargs mixedVarargs = mock(MixedVarargs.class);
+        when(mixedVarargs.doSomething("hello", (String[]) null)).thenReturn("hello");
+        when(mixedVarargs.doSomething("goodbye", (String[]) null)).thenReturn("goodbye");
+
+		final String result = mixedVarargs.doSomething("hello", (String[]) null);
+		assertEquals("hello", result);
+
+		verify(mixedVarargs).doSomething("hello", (String[]) null);
+	}
+
+	@SuppressWarnings("all")
+	@Test
+	public void shouldStubCorrectlyWhenDoubleStringAndMixedVarargsUsed() {
+		final MixedVarargs mixedVarargs = mock(MixedVarargs.class);
+        when(mixedVarargs.doSomething("one", "two", (String[]) null)).thenReturn("hello");
+        when(mixedVarargs.doSomething("1", "2", (String[]) null)).thenReturn("goodbye");
+
+		final String result = mixedVarargs.doSomething("one", "two", (String[]) null);
+		assertEquals("hello", result);
+	}
+
+	@Test
+	// See bug #157
+	public void shouldMatchEasilyEmptyVararg() throws Exception {
+		// when
+		when(mock.foo(anyVararg())).thenReturn(-1);
+
+		// then
+		assertEquals(-1, mock.foo());
+	}
 }

--- a/test/org/mockitousage/basicapi/UsingVarargsTest.java
+++ b/test/org/mockitousage/basicapi/UsingVarargsTest.java
@@ -23,174 +23,174 @@ import org.mockitoutil.TestBase;
 
 public class UsingVarargsTest extends TestBase {
 
-	private interface IVarArgs {
-		void withStringVarargs(final int value, final String... s);
+    private interface IVarArgs {
+        void withStringVarargs(final int value, final String... s);
 
-		String withStringVarargsReturningString(final int value, final String... s);
+        String withStringVarargsReturningString(final int value, final String... s);
 
-		void withObjectVarargs(final int value, final Object... o);
+        void withObjectVarargs(final int value, final Object... o);
 
-		boolean withBooleanVarargs(final int value, final boolean... b);
+        boolean withBooleanVarargs(final int value, final boolean... b);
 
-		int foo(final Object... objects);
-	}
+        int foo(final Object... objects);
+    }
 
-	@Mock
-	IVarArgs mock;
+    @Mock
+    IVarArgs mock;
 
-	@SuppressWarnings("deprecation")
-	@Test
-	public void shouldStubStringVarargs() {
-		when(mock.withStringVarargsReturningString(1)).thenReturn("1");
-		when(mock.withStringVarargsReturningString(2, "1", "2", "3"))
-				.thenReturn("2");
+    @SuppressWarnings("deprecation")
+    @Test
+    public void shouldStubStringVarargs() {
+        when(mock.withStringVarargsReturningString(1)).thenReturn("1");
+        when(mock.withStringVarargsReturningString(2, "1", "2", "3"))
+                .thenReturn("2");
 
-		final RuntimeException expected = new RuntimeException();
-		stubVoid(mock).toThrow(expected).on()
-				.withStringVarargs(3, "1", "2", "3", "4");
+        final RuntimeException expected = new RuntimeException();
+        stubVoid(mock).toThrow(expected).on()
+                .withStringVarargs(3, "1", "2", "3", "4");
 
-		assertEquals("1", mock.withStringVarargsReturningString(1));
-		assertEquals(null, mock.withStringVarargsReturningString(2));
+        assertEquals("1", mock.withStringVarargsReturningString(1));
+        assertEquals(null, mock.withStringVarargsReturningString(2));
 
-		assertEquals("2",
-				mock.withStringVarargsReturningString(2, "1", "2", "3"));
-		assertEquals(null, mock.withStringVarargsReturningString(2, "1", "2"));
-		assertEquals(null,
-				mock.withStringVarargsReturningString(2, "1", "2", "3", "4"));
-		assertEquals(null,
-				mock.withStringVarargsReturningString(2, "1", "2", "9999"));
+        assertEquals("2",
+                mock.withStringVarargsReturningString(2, "1", "2", "3"));
+        assertEquals(null, mock.withStringVarargsReturningString(2, "1", "2"));
+        assertEquals(null,
+                mock.withStringVarargsReturningString(2, "1", "2", "3", "4"));
+        assertEquals(null,
+                mock.withStringVarargsReturningString(2, "1", "2", "9999"));
 
-		mock.withStringVarargs(3, "1", "2", "3", "9999");
-		mock.withStringVarargs(9999, "1", "2", "3", "4");
+        mock.withStringVarargs(3, "1", "2", "3", "9999");
+        mock.withStringVarargs(9999, "1", "2", "3", "4");
 
-		try {
-			mock.withStringVarargs(3, "1", "2", "3", "4");
-			fail();
-		} catch (final Exception e) {
-			assertEquals(expected, e);
-		}
-	}
+        try {
+            mock.withStringVarargs(3, "1", "2", "3", "4");
+            fail();
+        } catch (final Exception e) {
+            assertEquals(expected, e);
+        }
+    }
 
-	@Test
-	public void shouldStubBooleanVarargs() {
-		when(mock.withBooleanVarargs(1)).thenReturn(true);
-		when(mock.withBooleanVarargs(1, true, false)).thenReturn(true);
+    @Test
+    public void shouldStubBooleanVarargs() {
+        when(mock.withBooleanVarargs(1)).thenReturn(true);
+        when(mock.withBooleanVarargs(1, true, false)).thenReturn(true);
 
-		assertEquals(true, mock.withBooleanVarargs(1));
-		assertEquals(false, mock.withBooleanVarargs(9999));
+        assertEquals(true, mock.withBooleanVarargs(1));
+        assertEquals(false, mock.withBooleanVarargs(9999));
 
-		assertEquals(true, mock.withBooleanVarargs(1, true, false));
-		assertEquals(false, mock.withBooleanVarargs(1, true, false, true));
-		assertEquals(false, mock.withBooleanVarargs(2, true, false));
-		assertEquals(false, mock.withBooleanVarargs(1, true));
-		assertEquals(false, mock.withBooleanVarargs(1, false, false));
-	}
+        assertEquals(true, mock.withBooleanVarargs(1, true, false));
+        assertEquals(false, mock.withBooleanVarargs(1, true, false, true));
+        assertEquals(false, mock.withBooleanVarargs(2, true, false));
+        assertEquals(false, mock.withBooleanVarargs(1, true));
+        assertEquals(false, mock.withBooleanVarargs(1, false, false));
+    }
 
-	@Test
-	public void shouldVerifyStringVarargs() {
-		mock.withStringVarargs(1);
-		mock.withStringVarargs(2, "1", "2", "3");
-		mock.withStringVarargs(3, "1", "2", "3", "4");
+    @Test
+    public void shouldVerifyStringVarargs() {
+        mock.withStringVarargs(1);
+        mock.withStringVarargs(2, "1", "2", "3");
+        mock.withStringVarargs(3, "1", "2", "3", "4");
 
-		verify(mock).withStringVarargs(1);
-		verify(mock).withStringVarargs(2, "1", "2", "3");
-		try {
-			verify(mock).withStringVarargs(2, "1", "2", "79", "4");
-			fail();
-		} catch (final ArgumentsAreDifferent e) {
-		}
-	}
+        verify(mock).withStringVarargs(1);
+        verify(mock).withStringVarargs(2, "1", "2", "3");
+        try {
+            verify(mock).withStringVarargs(2, "1", "2", "79", "4");
+            fail();
+        } catch (final ArgumentsAreDifferent e) {
+        }
+    }
 
-	@Test
-	public void shouldVerifyObjectVarargs() {
-		mock.withObjectVarargs(1);
-		mock.withObjectVarargs(2, "1", new ArrayList<Object>(), new Integer(1));
-		mock.withObjectVarargs(3, new Integer(1));
+    @Test
+    public void shouldVerifyObjectVarargs() {
+        mock.withObjectVarargs(1);
+        mock.withObjectVarargs(2, "1", new ArrayList<Object>(), new Integer(1));
+        mock.withObjectVarargs(3, new Integer(1));
 
-		verify(mock).withObjectVarargs(1);
-		verify(mock).withObjectVarargs(2, "1", new ArrayList<Object>(),
-				new Integer(1));
-		try {
-			verifyNoMoreInteractions(mock);
-			fail();
-		} catch (final NoInteractionsWanted e) {
-		}
-	}
+        verify(mock).withObjectVarargs(1);
+        verify(mock).withObjectVarargs(2, "1", new ArrayList<Object>(),
+                new Integer(1));
+        try {
+            verifyNoMoreInteractions(mock);
+            fail();
+        } catch (final NoInteractionsWanted e) {
+        }
+    }
 
-	@Test
-	public void shouldVerifyBooleanVarargs() {
-		mock.withBooleanVarargs(1);
-		mock.withBooleanVarargs(2, true, false, true);
-		mock.withBooleanVarargs(3, true, true, true);
+    @Test
+    public void shouldVerifyBooleanVarargs() {
+        mock.withBooleanVarargs(1);
+        mock.withBooleanVarargs(2, true, false, true);
+        mock.withBooleanVarargs(3, true, true, true);
 
-		verify(mock).withBooleanVarargs(1);
-		verify(mock).withBooleanVarargs(2, true, false, true);
-		try {
-			verify(mock).withBooleanVarargs(3, true, true, true, true);
-			fail();
-		} catch (final ArgumentsAreDifferent e) {
-		}
-	}
+        verify(mock).withBooleanVarargs(1);
+        verify(mock).withBooleanVarargs(2, true, false, true);
+        try {
+            verify(mock).withBooleanVarargs(3, true, true, true, true);
+            fail();
+        } catch (final ArgumentsAreDifferent e) {
+        }
+    }
 
-	@Test
-	public void shouldVerifyWithAnyObject() {
-		final Foo foo = Mockito.mock(Foo.class);
-		foo.varArgs("");
-		Mockito.verify(foo).varArgs((String[]) Mockito.anyObject());
-		Mockito.verify(foo).varArgs((String) Mockito.anyObject());
-	}
+    @Test
+    public void shouldVerifyWithAnyObject() {
+        final Foo foo = Mockito.mock(Foo.class);
+        foo.varArgs("");
+        Mockito.verify(foo).varArgs((String[]) Mockito.anyObject());
+        Mockito.verify(foo).varArgs((String) Mockito.anyObject());
+    }
 
-	@Test
-	public void shouldVerifyWithNullVarArgArray() {
-		final Foo foo = Mockito.mock(Foo.class);
-		foo.varArgs((String[]) null);
-		Mockito.verify(foo).varArgs((String[]) Mockito.anyObject());
-		Mockito.verify(foo).varArgs((String[]) null);
-	}
+    @Test
+    public void shouldVerifyWithNullVarArgArray() {
+        final Foo foo = Mockito.mock(Foo.class);
+        foo.varArgs((String[]) null);
+        Mockito.verify(foo).varArgs((String[]) Mockito.anyObject());
+        Mockito.verify(foo).varArgs((String[]) null);
+    }
 
-	public class Foo {
-		public void varArgs(final String... args) {
-		}
-	}
+    public class Foo {
+        public void varArgs(final String... args) {
+        }
+    }
 
-	interface MixedVarargs {
-		String doSomething(final String one, final String... varargs);
+    interface MixedVarargs {
+        String doSomething(final String one, final String... varargs);
 
-		String doSomething(final String one, final String two, final String... varargs);
-	}
+        String doSomething(final String one, final String two, final String... varargs);
+    }
 
-	@SuppressWarnings("all")
-	@Test
-	// See bug #31
-	public void shouldStubCorrectlyWhenMixedVarargsUsed() {
-		final MixedVarargs mixedVarargs = mock(MixedVarargs.class);
+    @SuppressWarnings("all")
+    @Test
+    // See bug #31
+    public void shouldStubCorrectlyWhenMixedVarargsUsed() {
+        final MixedVarargs mixedVarargs = mock(MixedVarargs.class);
         when(mixedVarargs.doSomething("hello", (String[]) null)).thenReturn("hello");
         when(mixedVarargs.doSomething("goodbye", (String[]) null)).thenReturn("goodbye");
 
-		final String result = mixedVarargs.doSomething("hello", (String[]) null);
-		assertEquals("hello", result);
+        final String result = mixedVarargs.doSomething("hello", (String[]) null);
+        assertEquals("hello", result);
 
-		verify(mixedVarargs).doSomething("hello", (String[]) null);
-	}
+        verify(mixedVarargs).doSomething("hello", (String[]) null);
+    }
 
-	@SuppressWarnings("all")
-	@Test
-	public void shouldStubCorrectlyWhenDoubleStringAndMixedVarargsUsed() {
-		final MixedVarargs mixedVarargs = mock(MixedVarargs.class);
+    @SuppressWarnings("all")
+    @Test
+    public void shouldStubCorrectlyWhenDoubleStringAndMixedVarargsUsed() {
+        final MixedVarargs mixedVarargs = mock(MixedVarargs.class);
         when(mixedVarargs.doSomething("one", "two", (String[]) null)).thenReturn("hello");
         when(mixedVarargs.doSomething("1", "2", (String[]) null)).thenReturn("goodbye");
 
-		final String result = mixedVarargs.doSomething("one", "two", (String[]) null);
-		assertEquals("hello", result);
-	}
+        final String result = mixedVarargs.doSomething("one", "two", (String[]) null);
+        assertEquals("hello", result);
+    }
 
-	@Test
-	// See bug #157
-	public void shouldMatchEasilyEmptyVararg() throws Exception {
-		// when
-		when(mock.foo(anyVararg())).thenReturn(-1);
+    @Test
+    // See bug #157
+    public void shouldMatchEasilyEmptyVararg() throws Exception {
+        // when
+        when(mock.foo(anyVararg())).thenReturn(-1);
 
-		// then
-		assertEquals(-1, mock.foo());
-	}
+        // then
+        assertEquals(-1, mock.foo());
+    }
 }

--- a/test/org/mockitousage/bugs/AIOOBExceptionWithAtLeastTest.java
+++ b/test/org/mockitousage/bugs/AIOOBExceptionWithAtLeastTest.java
@@ -7,7 +7,9 @@ package org.mockitousage.bugs;
 
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import org.junit.Test;
 import org.mockitoutil.TestBase;
@@ -16,14 +18,14 @@ import org.mockitoutil.TestBase;
 public class AIOOBExceptionWithAtLeastTest extends TestBase {
 
     interface IProgressMonitor {
-        void beginTask(String s, int i);
-        void worked(int i);
+        void beginTask(final String s, final int i);
+        void worked(final int i);
         void done();
     }
 
     @Test
     public void testCompleteProgress() throws Exception {
-        IProgressMonitor progressMonitor = mock(IProgressMonitor.class);
+        final IProgressMonitor progressMonitor = mock(IProgressMonitor.class);
 
         progressMonitor.beginTask("foo", 12);
         progressMonitor.worked(10);

--- a/test/org/mockitousage/bugs/ActualInvocationHasNullArgumentNPEBugTest.java
+++ b/test/org/mockitousage/bugs/ActualInvocationHasNullArgumentNPEBugTest.java
@@ -5,8 +5,10 @@
 
 package org.mockitousage.bugs;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 import org.mockitoutil.TestBase;
@@ -14,13 +16,13 @@ import org.mockitoutil.TestBase;
 public class ActualInvocationHasNullArgumentNPEBugTest extends TestBase {
     
     public interface Fun {
-        String doFun(String something);
+        String doFun(final String something);
     }
 
     @Test
     public void shouldAllowPassingNullArgument() {
         //given
-        Fun mockFun = mock(Fun.class);
+        final Fun mockFun = mock(Fun.class);
         when(mockFun.doFun((String) anyObject())).thenReturn("value");
 
         //when
@@ -30,7 +32,7 @@ public class ActualInvocationHasNullArgumentNPEBugTest extends TestBase {
         try {
             verify(mockFun).doFun("hello");
             fail();
-        } catch(AssertionError r) {
+        } catch(final AssertionError r) {
             //it's ok, we just want to reproduce the bug
         }
     }

--- a/test/org/mockitousage/bugs/AtLeastMarksAllInvocationsVerified.java
+++ b/test/org/mockitousage/bugs/AtLeastMarksAllInvocationsVerified.java
@@ -4,9 +4,13 @@
  */
 package org.mockitousage.bugs;
 
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
 import org.junit.Test;
 import org.mockitoutil.TestBase;
-import static org.mockito.Mockito.*;
 
 // see issue 112
 public class AtLeastMarksAllInvocationsVerified extends TestBase {
@@ -20,7 +24,7 @@ public class AtLeastMarksAllInvocationsVerified extends TestBase {
 
     @Test(expected = org.mockito.exceptions.verification.NoInteractionsWanted.class)
     public void shouldFailBecauseDisallowedMethodWasCalled(){
-        SomeMethods someMethods = mock(SomeMethods.class);
+        final SomeMethods someMethods = mock(SomeMethods.class);
 
         someMethods.allowedMethod();
         someMethods.disallowedMethod();

--- a/test/org/mockitousage/bugs/BridgeMethodsHitAgainTest.java
+++ b/test/org/mockitousage/bugs/BridgeMethodsHitAgainTest.java
@@ -5,14 +5,10 @@
 
 package org.mockitousage.bugs;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 import org.mockitoutil.TestBase;
-
-import static org.mockito.Mockito.*;
 
 //see issue 101
 public class BridgeMethodsHitAgainTest extends TestBase {
@@ -34,14 +30,14 @@ public class BridgeMethodsHitAgainTest extends TestBase {
   @Test
   public void basicCheck() {
     Mockito.when((someSubInterface).factory()).thenReturn(extendedFactory);
-    SomeInterface si = someSubInterface;
+    final SomeInterface si = someSubInterface;
     assertTrue(si.factory() != null);
   }
 
   @Test
   public void checkWithExtraCast() {
     Mockito.when(((SomeInterface) someSubInterface).factory()).thenReturn(extendedFactory);
-    SomeInterface si = someSubInterface;
+    final SomeInterface si = someSubInterface;
     assertTrue(si.factory() != null);
   }
 }

--- a/test/org/mockitousage/bugs/CaptorAnnotationAutoboxingTest.java
+++ b/test/org/mockitousage/bugs/CaptorAnnotationAutoboxingTest.java
@@ -5,7 +5,8 @@
 
 package org.mockitousage.bugs;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -17,8 +18,8 @@ import org.mockitoutil.TestBase;
 public class CaptorAnnotationAutoboxingTest extends TestBase {
     
     interface Fun {
-        void doFun(double prmitive);
-        void moreFun(int howMuch);
+        void doFun(final double prmitive);
+        void moreFun(final int howMuch);
     }
     
     @Mock Fun fun;
@@ -31,7 +32,7 @@ public class CaptorAnnotationAutoboxingTest extends TestBase {
         
         //then
         verify(fun).doFun(captor.capture());
-        assertEquals((Double) 1.0, captor.getValue());
+        assertEquals(1.0, captor.getValue());
     }
 
     @Captor ArgumentCaptor<Integer> intCaptor;

--- a/test/org/mockitousage/bugs/ClassCastExOnVerifyZeroInteractionsTest.java
+++ b/test/org/mockitousage/bugs/ClassCastExOnVerifyZeroInteractionsTest.java
@@ -1,14 +1,15 @@
 package org.mockitousage.bugs;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
 import org.junit.Test;
 import org.mockito.exceptions.misusing.WrongTypeOfReturnValue;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyZeroInteractions;
-
+@SuppressWarnings("rawtypes")
 public class ClassCastExOnVerifyZeroInteractionsTest {
     public interface TestMock {
         boolean m1();
@@ -16,8 +17,8 @@ public class ClassCastExOnVerifyZeroInteractionsTest {
 
     @Test(expected = NoInteractionsWanted.class)
     public void should_not_throw_ClassCastException_when_mock_verification_fails() {
-        TestMock test = mock(TestMock.class, new Answer() {
-            public Object answer(InvocationOnMock invocation) throws Throwable {
+        final TestMock test = mock(TestMock.class, new Answer() {
+            public Object answer(final InvocationOnMock invocation) throws Throwable {
                 return false;
             }
         });
@@ -27,8 +28,8 @@ public class ClassCastExOnVerifyZeroInteractionsTest {
 
     @Test(expected = WrongTypeOfReturnValue.class)
     public void should_report_bogus_default_answer() throws Exception {
-        TestMock test = mock(TestMock.class, new Answer() {
-            public Object answer(InvocationOnMock invocation) throws Throwable {
+        final TestMock test = mock(TestMock.class, new Answer() {
+            public Object answer(final InvocationOnMock invocation) throws Throwable {
                 return false;
             }
         });

--- a/test/org/mockitousage/bugs/ConcurrentModificationExceptionOnMultiThreadedVerificationTest.java
+++ b/test/org/mockitousage/bugs/ConcurrentModificationExceptionOnMultiThreadedVerificationTest.java
@@ -8,10 +8,12 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -40,8 +42,8 @@ public class ConcurrentModificationExceptionOnMultiThreadedVerificationTest {
 
     @Test
     public void shouldSuccessfullyVerifyConcurrentInvocationsWithTimeout() throws Exception {
-        int potentialOverhead = 1000; // Leave 1000ms extra before timing out as leeway for test overheads
-        int expectedMaxTestLength = TIMES * INTERVAL_MILLIS + potentialOverhead;
+        final int potentialOverhead = 1000; // Leave 1000ms extra before timing out as leeway for test overheads
+        final int expectedMaxTestLength = TIMES * INTERVAL_MILLIS + potentialOverhead;
 
         reset(target);
         startInvocations();
@@ -62,7 +64,7 @@ public class ConcurrentModificationExceptionOnMultiThreadedVerificationTest {
     public class TargetInvoker implements Callable<Object> {
         private final int seq;
 
-        TargetInvoker(int seq) {
+        TargetInvoker(final int seq) {
             this.seq = seq;
         }
         
@@ -71,7 +73,7 @@ public class ConcurrentModificationExceptionOnMultiThreadedVerificationTest {
             for (int i = 0; i < TIMES; i++) {
                 Thread.yield();
                 target.targetMethod("arg");
-                Thread.sleep((long) INTERVAL_MILLIS);
+                Thread.sleep(INTERVAL_MILLIS);
             }
             System.err.println("finished" + seq);
             return seq;
@@ -80,7 +82,7 @@ public class ConcurrentModificationExceptionOnMultiThreadedVerificationTest {
     }
     
     public interface ITarget {
-        public String targetMethod(String arg);
+        String targetMethod(final String arg);
     }
     
 }

--- a/test/org/mockitousage/bugs/CovariantOverrideTest.java
+++ b/test/org/mockitousage/bugs/CovariantOverrideTest.java
@@ -5,10 +5,12 @@
 
 package org.mockitousage.bugs;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.junit.Test;
 import org.mockitoutil.TestBase;
-
-import static org.mockito.Mockito.*;
 
 //see issue 101
 public class CovariantOverrideTest extends TestBase {
@@ -24,30 +26,30 @@ public class CovariantOverrideTest extends TestBase {
 
     @Test 
     public void returnFoo1() {
-        ReturnsObject mock = mock(ReturnsObject.class);
+        final ReturnsObject mock = mock(ReturnsObject.class);
         when(mock.callMe()).thenReturn("foo");
         assertEquals("foo", mock.callMe()); // Passes
     }
 
     @Test 
     public void returnFoo2() {
-        ReturnsString mock = mock(ReturnsString.class);
+        final ReturnsString mock = mock(ReturnsString.class);
         when(mock.callMe()).thenReturn("foo");
         assertEquals("foo", mock.callMe()); // Passes
     }
 
     @Test 
     public void returnFoo3() {
-        ReturnsObject mock = mock(ReturnsString.class);
+        final ReturnsObject mock = mock(ReturnsString.class);
         when(mock.callMe()).thenReturn("foo");
         assertEquals("foo", mock.callMe()); // Passes
     }
 
     @Test 
     public void returnFoo4() {
-        ReturnsString mock = mock(ReturnsString.class);
+        final ReturnsString mock = mock(ReturnsString.class);
         mock.callMe(); // covariant override not generated
-        ReturnsObject mock2 = mock; // Switch to base type to call covariant override
+        final ReturnsObject mock2 = mock; // Switch to base type to call covariant override
         verify(mock2).callMe(); // Fails: java.lang.AssertionError: expected:<foo> but was:<null>
     }
 }

--- a/test/org/mockitousage/bugs/FinalHashCodeAndEqualsRaiseNPEInInitMocksTest.java
+++ b/test/org/mockitousage/bugs/FinalHashCodeAndEqualsRaiseNPEInInitMocksTest.java
@@ -4,14 +4,15 @@
  */
 package org.mockitousage.bugs;
 
+import java.nio.charset.Charset;
+
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import java.nio.charset.Charset;
-
 // issue 327
+@SuppressWarnings("unused")
 public class FinalHashCodeAndEqualsRaiseNPEInInitMocksTest {
     @Mock private Charset charset;
     @InjectMocks private FieldCharsetHolder fieldCharsetHolder;
@@ -27,7 +28,7 @@ public class FinalHashCodeAndEqualsRaiseNPEInInitMocksTest {
     }
 
     private static class ConstructorCharsetHolder {
-        public ConstructorCharsetHolder(Charset charset) {
+        public ConstructorCharsetHolder(final Charset charset) {
         }
     }
 }

--- a/test/org/mockitousage/bugs/IOOBExceptionShouldNotBeThrownWhenNotCodingFluentlyTest.java
+++ b/test/org/mockitousage/bugs/IOOBExceptionShouldNotBeThrownWhenNotCodingFluentlyTest.java
@@ -4,32 +4,33 @@
  */
 package org.mockitousage.bugs;
 
-import org.junit.Test;
-import org.mockito.exceptions.base.MockitoException;
-import org.mockito.stubbing.OngoingStubbing;
-
-import java.util.Map;
-
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.Map;
+
+import org.junit.Test;
+import org.mockito.exceptions.base.MockitoException;
+import org.mockito.stubbing.OngoingStubbing;
+
 public class IOOBExceptionShouldNotBeThrownWhenNotCodingFluentlyTest {
 
+    @SuppressWarnings("unchecked")
     @Test
     public void second_stubbing_throws_IndexOutOfBoundsException() throws Exception {
-        Map<String, String> map = mock(Map.class);
+        final Map<String, String> map = mock(Map.class);
 
-        OngoingStubbing<String> mapOngoingStubbing = when(map.get(anyString()));
+        final OngoingStubbing<String> mapOngoingStubbing = when(map.get(anyString()));
 
         mapOngoingStubbing.thenReturn("first stubbing");
 
         try {
             mapOngoingStubbing.thenReturn("second stubbing");
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             assertThat(e.getMessage())
                     .contains("Incorrect use of API detected here")
                     .contains(this.getClass().getSimpleName());

--- a/test/org/mockitousage/bugs/InheritedGenericsPolimorphicCallTest.java
+++ b/test/org/mockitousage/bugs/InheritedGenericsPolimorphicCallTest.java
@@ -5,7 +5,7 @@
 
 package org.mockitousage.bugs;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
@@ -19,12 +19,12 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 //see issue 200
 public class InheritedGenericsPolimorphicCallTest extends TestBase {
 
     protected interface MyIterable<T> extends Iterable<T> {
-        public MyIterator<T> iterator();
+        MyIterator<T> iterator();
     }
 
     protected interface MyIterator<T> extends Iterator<T> {
@@ -53,8 +53,8 @@ public class InheritedGenericsPolimorphicCallTest extends TestBase {
     public void shouldWorkExactlyAsJavaProxyWould() {
         //given
         final List<Method> methods = new LinkedList<Method>();
-        InvocationHandler handler = new InvocationHandler() {
-        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        final InvocationHandler handler = new InvocationHandler() {
+        public Object invoke(final Object proxy, final Method method, final Object[] args) throws Throwable {
             methods.add(method);
             return null;
         }};

--- a/test/org/mockitousage/bugs/ListenersLostOnResetMockTest.java
+++ b/test/org/mockitousage/bugs/ListenersLostOnResetMockTest.java
@@ -5,21 +5,26 @@
 package org.mockitousage.bugs;
 
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
+
+import java.util.List;
+
 import org.junit.Test;
 import org.mockito.listeners.InvocationListener;
 import org.mockito.listeners.MethodInvocationReport;
 
-import java.util.List;
-
-import static org.mockito.Mockito.*;
-
+@SuppressWarnings("rawtypes")
 public class ListenersLostOnResetMockTest {
 
     @Test
     public void listener() throws Exception {
-        InvocationListener invocationListener = mock(InvocationListener.class);
+        final InvocationListener invocationListener = mock(InvocationListener.class);
 
-        List mockedList = mock(List.class, withSettings().invocationListeners(invocationListener));
+        final List mockedList = mock(List.class, withSettings().invocationListeners(invocationListener));
         reset(mockedList);
 
         mockedList.clear();

--- a/test/org/mockitousage/bugs/MultipleInOrdersTest.java
+++ b/test/org/mockitousage/bugs/MultipleInOrdersTest.java
@@ -4,28 +4,29 @@
  */
 package org.mockitousage.bugs;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertNotSame;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
 
 import java.util.List;
 
 import org.junit.Test;
 import org.mockito.InOrder;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class MultipleInOrdersTest {
     
     @Test
     public void inOrderTest(){
-        List list= mock(List.class);
+        final List list= mock(List.class);
         
         list.add("a");
         list.add("x");
         list.add("b");
         list.add("y");
         
-        InOrder inOrder = inOrder(list);
-        InOrder inAnotherOrder = inOrder(list);
+        final InOrder inOrder = inOrder(list);
+        final InOrder inAnotherOrder = inOrder(list);
         assertNotSame(inOrder, inAnotherOrder);
         
         inOrder.verify(list).add("a");

--- a/test/org/mockitousage/bugs/MultithreadedStubbingHalfManualTest.java
+++ b/test/org/mockitousage/bugs/MultithreadedStubbingHalfManualTest.java
@@ -4,9 +4,10 @@
  */
 package org.mockitousage.bugs;
 
-import static java.util.Collections.*;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static java.util.Collections.synchronizedList;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -19,15 +20,16 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 @Ignore
+@SuppressWarnings({"rawtypes", "unchecked", "unused"})
 public class MultithreadedStubbingHalfManualTest {
 
     /**
      * Class with two methods, one of them is repeatedly mocked while another is repeatedly called.
      */
     public interface ToMock {
-        public Integer getValue(Integer param);
+        Integer getValue(final Integer param);
 
-        public List<Integer> getValues(Integer param);
+        List<Integer> getValues(final Integer param);
     }
 
     /**
@@ -35,7 +37,7 @@ public class MultithreadedStubbingHalfManualTest {
      */
     private Executor executor;
 
-    private List exceptions = synchronizedList(new LinkedList());
+    private final List exceptions = synchronizedList(new LinkedList());
 
     @Before
     public void setUp() {
@@ -54,7 +56,7 @@ public class MultithreadedStubbingHalfManualTest {
                 while (true) {
                     try {
                         Thread.sleep((long) (Math.random() * 10));
-                    } catch (InterruptedException e) {
+                    } catch (final InterruptedException e) {
                     }
                     if (!toMock.getValues(0).isEmpty()) {
                         fail("Shouldn't happen, were just making sure it wasn't optimized away...");
@@ -69,9 +71,9 @@ public class MultithreadedStubbingHalfManualTest {
     //it is not strictly a bug because Mockito does not support simultanous stubbing (see FAQ)
     //however I decided to synchronize some calls in order to make the exceptions nicer 
     public void tryToRevealTheProblem() {
-        ToMock toMock = mock(ToMock.class);
+        final ToMock toMock = mock(ToMock.class);
         for (int i = 0; i < 100; i++) {
-            int j = i % 11;
+            final int j = i % 11;
 
             // Repeated mocking
             when(toMock.getValue(i)).thenReturn(j);
@@ -83,14 +85,14 @@ public class MultithreadedStubbingHalfManualTest {
                     // Scheduling invocation
                     this.executor.execute(getConflictingRunnable(toMock));
                     break;
-                } catch (RejectedExecutionException ex) {
+                } catch (final RejectedExecutionException ex) {
                     fail();
                 }
             }
 
             try {
                 Thread.sleep(10 / ((i % 10) + 1)); //NOPMD
-            } catch (InterruptedException e) {
+            } catch (final InterruptedException e) {
             }
         }
     }

--- a/test/org/mockitousage/bugs/NPEOnAnyClassMatcherAutounboxTest.java
+++ b/test/org/mockitousage/bugs/NPEOnAnyClassMatcherAutounboxTest.java
@@ -5,21 +5,23 @@
 
 package org.mockitousage.bugs;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
 import org.junit.Test;
 import org.mockitoutil.TestBase;
-
-import static org.mockito.Mockito.*;
 
 //see issue 221
 public class NPEOnAnyClassMatcherAutounboxTest extends TestBase {
 
     interface Foo {
-        void bar(long id);
+        void bar(final long id);
     }
 
     @Test
     public void shouldNotThrowNPE() {
-        Foo f = mock(Foo.class);
+        final Foo f = mock(Foo.class);
         f.bar(1);
         verify(f).bar(any(Long.class));
     }

--- a/test/org/mockitousage/bugs/NPEWhenMockingThrowablesTest.java
+++ b/test/org/mockitousage/bugs/NPEWhenMockingThrowablesTest.java
@@ -5,7 +5,7 @@
 
 package org.mockitousage.bugs;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 import org.mockito.Mock;
@@ -28,6 +28,6 @@ public class NPEWhenMockingThrowablesTest extends TestBase {
         try {
             mock.simpleMethod();
             fail();
-        } catch(DummyException e) {}
+        } catch(final DummyException e) {}
     }
 }

--- a/test/org/mockitousage/bugs/NPEWithCertainMatchersTest.java
+++ b/test/org/mockitousage/bugs/NPEWithCertainMatchersTest.java
@@ -4,15 +4,17 @@
  */
 package org.mockitousage.bugs;
 
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
-
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 
 public class NPEWithCertainMatchersTest extends TestBase {
 

--- a/test/org/mockitousage/bugs/ParentClassNotPublicTest.java
+++ b/test/org/mockitousage/bugs/ParentClassNotPublicTest.java
@@ -8,7 +8,9 @@ import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 import java.util.List;
+
 import org.fest.assertions.Assertions;
 import org.junit.Assume;
 import org.junit.Before;
@@ -24,17 +26,21 @@ import org.mockitoutil.TestBase;
 /**
  * See bug 212
  *
- * Mocking methods that are declared on a non-public parent is not supported.
- * We cannot really fail fast during mock creation because one might mock a method that is not declared on a parent - this would be valid.
+ * Mocking methods that are declared on a non-public parent is not supported. We
+ * cannot really fail fast during mock creation because one might mock a method
+ * that is not declared on a parent - this would be valid.
  */
 public class ParentClassNotPublicTest extends TestBase {
 
     class SuperClass {
         public boolean isValid() {
-          return false;
+            return false;
         }
-        public int arg(Object o) { return 0; }
-      }
+
+        public int arg(final Object o) {
+            return 0;
+        }
+    }
 
     public class ClassForMocking extends SuperClass {
     }
@@ -47,11 +53,11 @@ public class ParentClassNotPublicTest extends TestBase {
 
     @Test
     public void hints_that_parent_not_public_during_stubbing() throws Exception {
-        ClassForMocking clazzMock = mock(ClassForMocking.class);
+        final ClassForMocking clazzMock = mock(ClassForMocking.class);
         try {
             when(clazzMock.isValid()).thenReturn(true);
             fail();
-        } catch (MissingMethodInvocationException e) {
+        } catch (final MissingMethodInvocationException e) {
             Assertions.assertThat(e.getMessage())
                     .contains(MockitoLimitations.NON_PUBLIC_PARENT);
         }
@@ -59,13 +65,14 @@ public class ParentClassNotPublicTest extends TestBase {
 
     @Test
     public void hints_that_parent_not_public_during_stubbing_start() throws Exception {
-        ClassForMocking clazzMock = mock(ClassForMocking.class);
+        final ClassForMocking clazzMock = mock(ClassForMocking.class);
         mock(List.class).clear();
         try {
-            //Mockito thinks that we're stubbing void 'clear' method here and reports that boolean value cannot stub void method
+            // Mockito thinks that we're stubbing void 'clear' method here and
+            // reports that boolean value cannot stub void method
             when(clazzMock.isValid()).thenReturn(true);
             fail();
-        } catch (CannotStubVoidMethodWithReturnValue e) {
+        } catch (final CannotStubVoidMethodWithReturnValue e) {
             Assertions.assertThat(e.getMessage())
                     .contains(MockitoLimitations.NON_PUBLIC_PARENT);
         }
@@ -73,13 +80,14 @@ public class ParentClassNotPublicTest extends TestBase {
 
     @Test
     public void hints_that_parent_not_public_during_verify() throws Exception {
-        ClassForMocking clazzMock = mock(ClassForMocking.class);
+        final ClassForMocking clazzMock = mock(ClassForMocking.class);
         verify(clazzMock).isValid();
         try {
-            //Since Mockito did not see 'isValid()' method, we will report unfinished verification
+            // Since Mockito did not see 'isValid()' method, we will report
+            // unfinished verification
             verify(clazzMock);
             fail();
-        } catch (UnfinishedVerificationException e) {
+        } catch (final UnfinishedVerificationException e) {
             Assertions.assertThat(e.getMessage())
                     .contains(MockitoLimitations.NON_PUBLIC_PARENT);
         }
@@ -87,12 +95,13 @@ public class ParentClassNotPublicTest extends TestBase {
 
     @Test
     public void hints_that_parent_not_public_when_misplaced_matchers_detected() throws Exception {
-        ClassForMocking clazzMock = mock(ClassForMocking.class);
+        final ClassForMocking clazzMock = mock(ClassForMocking.class);
         try {
-            //Mockito does not see 'arg()' method so the anyObject() matcher is reported as misplaced
+            // Mockito does not see 'arg()' method so the anyObject() matcher is
+            // reported as misplaced
             when(clazzMock.arg(anyObject())).thenReturn(0);
             fail();
-        } catch (InvalidUseOfMatchersException e) {
+        } catch (final InvalidUseOfMatchersException e) {
             Assertions.assertThat(e.getMessage())
                     .contains(MockitoLimitations.NON_PUBLIC_PARENT);
         }

--- a/test/org/mockitousage/bugs/ParentTestMockInjectionTest.java
+++ b/test/org/mockitousage/bugs/ParentTestMockInjectionTest.java
@@ -4,6 +4,8 @@
  */
 package org.mockitousage.bugs;
 
+import static org.junit.Assert.assertNotNull;
+
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -11,14 +13,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.junit.Assert.assertNotNull;
-
 // issue 229 : @Mock fields in super test class are not injected on @InjectMocks fields
 public class ParentTestMockInjectionTest {
 
     @Test
     public void injectMocksShouldInjectMocksFromTestSuperClasses() {
-        ImplicitTest it = new ImplicitTest();
+        final ImplicitTest it = new ImplicitTest();
         MockitoAnnotations.initMocks(it);
 
         assertNotNull(it.daoFromParent);
@@ -28,13 +28,13 @@ public class ParentTestMockInjectionTest {
     }
 
     @Ignore
-    public static abstract class BaseTest {
+    public abstract static class BaseTest {
         @Mock protected DaoA daoFromParent;
     }
 
     @Ignore("JUnit test under test : don't test this!")
     public static class ImplicitTest extends BaseTest {
-        @InjectMocks private TestedSystem sut = new TestedSystem();
+        @InjectMocks private final TestedSystem sut = new TestedSystem();
 
         @Mock private DaoB daoFromSub;
 

--- a/test/org/mockitousage/bugs/ShouldAllowInlineMockCreationTest.java
+++ b/test/org/mockitousage/bugs/ShouldAllowInlineMockCreationTest.java
@@ -5,19 +5,18 @@
 
 package org.mockitousage.bugs;
 
-import org.fest.assertions.Assertions;
-import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.Spy;
-import org.mockitoutil.TestBase;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
-import static org.mockito.Mockito.*;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockitoutil.TestBase;
 
 //see issue 191
+@SuppressWarnings("rawtypes")
 public class ShouldAllowInlineMockCreationTest extends TestBase {
 
     @Mock List list;

--- a/test/org/mockitousage/bugs/ShouldMocksCompareToBeConsistentWithEqualsTest.java
+++ b/test/org/mockitousage/bugs/ShouldMocksCompareToBeConsistentWithEqualsTest.java
@@ -5,16 +5,19 @@
 
 package org.mockitousage.bugs;
 
-import org.junit.Test;
-import org.mockito.Mock;
-import org.mockitoutil.TestBase;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.Date;
-import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
-import static org.mockito.Mockito.*;
+import org.junit.Test;
+import org.mockitoutil.TestBase;
 
 //see issue 184
 public class ShouldMocksCompareToBeConsistentWithEqualsTest extends TestBase {
@@ -22,11 +25,11 @@ public class ShouldMocksCompareToBeConsistentWithEqualsTest extends TestBase {
     @Test
     public void should_compare_to_be_consistent_with_equals() {
         //given
-        Date today    = mock(Date.class);
-        Date tomorrow = mock(Date.class);
+        final Date today    = mock(Date.class);
+        final Date tomorrow = mock(Date.class);
 
         //when
-        Set<Date> set = new TreeSet<Date>();
+        final Set<Date> set = new TreeSet<Date>();
         set.add(today);
         set.add(tomorrow);
 
@@ -37,10 +40,10 @@ public class ShouldMocksCompareToBeConsistentWithEqualsTest extends TestBase {
     @Test
     public void should_compare_to_be_consistent_with_equals_when_comparing_the_same_reference() {
         //given
-        Date today    = mock(Date.class);
+        final Date today    = mock(Date.class);
 
         //when
-        Set<Date> set = new TreeSet<Date>();
+        final Set<Date> set = new TreeSet<Date>();
         set.add(today);
         set.add(today);
 
@@ -51,7 +54,7 @@ public class ShouldMocksCompareToBeConsistentWithEqualsTest extends TestBase {
     @Test
     public void should_allow_stubbing_and_verifying_compare_to() {
         //given
-        Date mock    = mock(Date.class);
+        final Date mock    = mock(Date.class);
         when(mock.compareTo(any(Date.class))).thenReturn(10);
 
         //when
@@ -65,7 +68,7 @@ public class ShouldMocksCompareToBeConsistentWithEqualsTest extends TestBase {
     @Test
     public void should_reset_not_remove_default_stubbing() {
         //given
-        Date mock    = mock(Date.class);
+        final Date mock    = mock(Date.class);
         reset(mock);
 
         //then

--- a/test/org/mockitousage/bugs/ShouldNotTryToInjectInFinalOrStaticFieldsTest.java
+++ b/test/org/mockitousage/bugs/ShouldNotTryToInjectInFinalOrStaticFieldsTest.java
@@ -5,21 +5,20 @@
 
 package org.mockitousage.bugs;
 
-import org.junit.Before;
+import static org.junit.Assert.assertNotSame;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import java.util.*;
-
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 // issue 262
 @RunWith(MockitoJUnitRunner.class)
@@ -30,10 +29,10 @@ public class ShouldNotTryToInjectInFinalOrStaticFieldsTest {
         public final Set<String> aSet = new HashSet<String>();
     }
 
-    @Spy private List<String> unrelatedList = new ArrayList<String>();
+    @Spy private final List<String> unrelatedList = new ArrayList<String>();
     @Mock private Set<String> unrelatedSet;
 
-    @InjectMocks private ExampleService exampleService = new ExampleService();
+    @InjectMocks private final ExampleService exampleService = new ExampleService();
 
     @Test
     public void dont_fail_with_CONSTANTS() throws Exception {

--- a/test/org/mockitousage/bugs/ShouldOnlyModeAllowCapturingArgumentsTest.java
+++ b/test/org/mockitousage/bugs/ShouldOnlyModeAllowCapturingArgumentsTest.java
@@ -5,7 +5,8 @@
 
 package org.mockitousage.bugs;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.verify;
 
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -22,7 +23,7 @@ public class ShouldOnlyModeAllowCapturingArgumentsTest extends TestBase {
     public void shouldAllowCapturingArguments() {
         //given
         mock.simpleMethod("o");
-        ArgumentCaptor<String> arg = ArgumentCaptor.forClass(String.class);
+        final ArgumentCaptor<String> arg = ArgumentCaptor.forClass(String.class);
         
         //when
         verify(mock, only()).simpleMethod(arg.capture());

--- a/test/org/mockitousage/bugs/SpyShouldHaveNiceNameTest.java
+++ b/test/org/mockitousage/bugs/SpyShouldHaveNiceNameTest.java
@@ -5,17 +5,18 @@
 
 package org.mockitousage.bugs;
 
+import static org.mockito.Mockito.verify;
+
+import java.util.LinkedList;
+import java.util.List;
+
 import org.fest.assertions.Assertions;
 import org.junit.Test;
 import org.mockito.Spy;
 import org.mockitoutil.TestBase;
 
-import java.util.LinkedList;
-import java.util.List;
-
-import static org.mockito.Mockito.verify;
-
 //see issue 216
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class SpyShouldHaveNiceNameTest extends TestBase {
 
     @Spy List veryCoolSpy = new LinkedList();
@@ -28,7 +29,7 @@ public class SpyShouldHaveNiceNameTest extends TestBase {
         try {
             verify(veryCoolSpy).add(2);
             fail();
-        } catch(AssertionError e) {
+        } catch(final AssertionError e) {
             Assertions.assertThat(e.getMessage()).contains("veryCoolSpy");
         }
     }

--- a/test/org/mockitousage/bugs/StubbingMocksThatAreConfiguredToReturnMocksTest.java
+++ b/test/org/mockitousage/bugs/StubbingMocksThatAreConfiguredToReturnMocksTest.java
@@ -5,24 +5,27 @@
 
 package org.mockitousage.bugs;
 
+import static org.mockito.Mockito.RETURNS_MOCKS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.junit.Test;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
-
-import static org.mockito.Mockito.*;
 
 //issue 151
 public class StubbingMocksThatAreConfiguredToReturnMocksTest extends TestBase {
 
     @Test
     public void shouldAllowStubbingMocksConfiguredWithRETURNS_MOCKS() {
-        IMethods mock = mock(IMethods.class, RETURNS_MOCKS);
+        final IMethods mock = mock(IMethods.class, RETURNS_MOCKS);
         when(mock.objectReturningMethodNoArgs()).thenReturn(null);
     }
 
     @Test
     public void shouldAllowStubbingMocksConfiguredWithRETURNS_MOCKSWithDoApi() {
-        IMethods mock = mock(IMethods.class, RETURNS_MOCKS);
+        final IMethods mock = mock(IMethods.class, RETURNS_MOCKS);
         doReturn(null).when(mock).objectReturningMethodNoArgs();
     }
 }

--- a/test/org/mockitousage/bugs/TimeoutWithAtMostOrNeverShouldBeDisabledTest.java
+++ b/test/org/mockitousage/bugs/TimeoutWithAtMostOrNeverShouldBeDisabledTest.java
@@ -5,13 +5,14 @@
 
 package org.mockitousage.bugs;
 
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.exceptions.misusing.FriendlyReminderException;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
-
-import static org.mockito.Mockito.*;
 
 //see issue 235
 @SuppressWarnings("deprecation")
@@ -24,7 +25,7 @@ public class TimeoutWithAtMostOrNeverShouldBeDisabledTest extends TestBase {
         try {
             verify(mock, timeout(30000).atMost(1)).simpleMethod();
             fail();
-        } catch (FriendlyReminderException e) {}
+        } catch (final FriendlyReminderException e) {}
     }
 
     @Test
@@ -32,6 +33,6 @@ public class TimeoutWithAtMostOrNeverShouldBeDisabledTest extends TestBase {
         try {
             verify(mock, timeout(30000).never()).simpleMethod();
             fail();
-        } catch (FriendlyReminderException e) {}
+        } catch (final FriendlyReminderException e) {}
     }
 }

--- a/test/org/mockitousage/bugs/VarargsErrorWhenCallingRealMethodTest.java
+++ b/test/org/mockitousage/bugs/VarargsErrorWhenCallingRealMethodTest.java
@@ -5,21 +5,24 @@
 
 package org.mockitousage.bugs;
 
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.junit.Test;
-import static org.mockito.Mockito.*;
 import org.mockitoutil.TestBase;
 
 public class VarargsErrorWhenCallingRealMethodTest extends TestBase {
 
     class Foo {
-        int blah(String a, String b, Object ... c) {
+        int blah(final String a, final String b, final Object ... c) {
             return 1;
         }
     }
 
     @Test
     public void shouldNotThrowAnyException() throws Exception {
-        Foo foo = mock(Foo.class);
+        final Foo foo = mock(Foo.class);
 
         when(foo.blah(anyString(), anyString())).thenCallRealMethod();
 

--- a/test/org/mockitousage/bugs/VerifyingWithAnExtraCallToADifferentMockTest.java
+++ b/test/org/mockitousage/bugs/VerifyingWithAnExtraCallToADifferentMockTest.java
@@ -5,7 +5,9 @@
 
 package org.mockitousage.bugs;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 import org.mockito.Mock;
@@ -32,6 +34,6 @@ public class VerifyingWithAnExtraCallToADifferentMockTest extends TestBase {
         try {
             verify(mockTwo, never()).simpleMethod(mock.otherMethod());
             fail();
-        } catch (NeverWantedButInvoked e) {}
+        } catch (final NeverWantedButInvoked e) {}
     }
 }

--- a/test/org/mockitousage/bugs/deepstubs/DeepStubFailingWhenGenericNestedAsRawTypeTest.java
+++ b/test/org/mockitousage/bugs/deepstubs/DeepStubFailingWhenGenericNestedAsRawTypeTest.java
@@ -1,11 +1,12 @@
 package org.mockitousage.bugs.deepstubs;
 
-import org.junit.Test;
-
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.junit.Test;
+
+@SuppressWarnings("rawtypes")
 public class DeepStubFailingWhenGenericNestedAsRawTypeTest {
 
   interface MyClass1<MC2 extends MyClass2> {
@@ -22,7 +23,7 @@ public class DeepStubFailingWhenGenericNestedAsRawTypeTest {
 
   @Test
   public void discoverDeepMockingOfGenerics() {
-    MyClass1 myMock1 = mock(MyClass1.class, RETURNS_DEEP_STUBS);
+    final MyClass1 myMock1 = mock(MyClass1.class, RETURNS_DEEP_STUBS);
     when(myMock1.getNested().getNested().returnSomething()).thenReturn("Hello World.");
   }
 }

--- a/test/org/mockitousage/bugs/varargs/VarargsAndAnyObjectPicksUpExtraInvocationsTest.java
+++ b/test/org/mockitousage/bugs/varargs/VarargsAndAnyObjectPicksUpExtraInvocationsTest.java
@@ -5,8 +5,11 @@
 
 package org.mockitousage.bugs.varargs;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import org.junit.Test;
 import org.mockito.Mock;
@@ -14,7 +17,7 @@ import org.mockitoutil.TestBase;
 
 public class VarargsAndAnyObjectPicksUpExtraInvocationsTest extends TestBase {
     public interface TableBuilder {
-        void newRow(String trAttributes, String... cells);
+        void newRow(final String trAttributes, final String... cells);
     }
 
     @Mock

--- a/test/org/mockitousage/bugs/varargs/VarargsNotPlayingWithAnyObjectTest.java
+++ b/test/org/mockitousage/bugs/varargs/VarargsNotPlayingWithAnyObjectTest.java
@@ -5,8 +5,13 @@
 
 package org.mockitousage.bugs.varargs;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 import org.mockito.Mock;
@@ -16,7 +21,7 @@ import org.mockitoutil.TestBase;
 public class VarargsNotPlayingWithAnyObjectTest extends TestBase {
 
     interface VarargMethod {
-        Object run(String... args);
+        Object run(final String... args);
     }
     
     @Mock VarargMethod mock;
@@ -43,7 +48,7 @@ public class VarargsNotPlayingWithAnyObjectTest extends TestBase {
         try {
             verify(mock).run((String[]) anyObject());
             fail();
-        } catch (AssertionError e) {}
+        } catch (final AssertionError e) {}
     }
 
     @Test

--- a/test/org/mockitousage/configuration/ClassCacheVersusClassReloadingTest.java
+++ b/test/org/mockitousage/configuration/ClassCacheVersusClassReloadingTest.java
@@ -8,7 +8,9 @@ package org.mockitousage.configuration;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
+
 import java.util.concurrent.Callable;
+
 import org.fest.assertions.Condition;
 import org.junit.Assume;
 import org.junit.Test;
@@ -17,11 +19,11 @@ import org.mockito.internal.configuration.ConfigurationAccess;
 import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockitoutil.SimplePerRealmReloadingClassLoader;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class ClassCacheVersusClassReloadingTest {
     // TODO refactor to use ClassLoaders
 
-    private SimplePerRealmReloadingClassLoader testMethodClassLoaderRealm = new SimplePerRealmReloadingClassLoader(reloadMockito());
+    private final SimplePerRealmReloadingClassLoader testMethodClassLoaderRealm = new SimplePerRealmReloadingClassLoader(reloadMockito());
 
     @Test
     public void should_throw_ClassCastException_on_second_call() throws Exception {
@@ -32,7 +34,7 @@ public class ClassCacheVersusClassReloadingTest {
         try {
             doInNewChildRealm(testMethodClassLoaderRealm, "org.mockitousage.configuration.ClassCacheVersusClassReloadingTest$DoTheMocking");
             fail("should have raised a ClassCastException when Objenesis Cache is enabled");
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             assertThat(e.getMessage())
                     .containsIgnoringCase("classloading")
                     .containsIgnoringCase("objenesis")
@@ -54,9 +56,9 @@ public class ClassCacheVersusClassReloadingTest {
     private Condition<Throwable> thatCceIsThrownFrom(final String stacktraceElementDescription) {
         return new Condition<Throwable>() {
             @Override
-            public boolean matches(Throwable throwable) {
-                StackTraceElement[] stackTrace = throwable.getStackTrace();
-                for (StackTraceElement stackTraceElement : stackTrace) {
+            public boolean matches(final Throwable throwable) {
+                final StackTraceElement[] stackTrace = throwable.getStackTrace();
+                for (final StackTraceElement stackTraceElement : stackTrace) {
                     if (stackTraceElement.toString().contains(stacktraceElementDescription)) {
                         return true;
                     }
@@ -69,19 +71,21 @@ public class ClassCacheVersusClassReloadingTest {
 
     public static class DoTheMocking implements Callable {
         public Object call() throws Exception {
-            Class clazz = this.getClass().getClassLoader().loadClass("org.mockitousage.configuration.ClassToBeMocked");
+            final Class clazz = this.getClass().getClassLoader().loadClass("org.mockitousage.configuration.ClassToBeMocked");
             return mock(clazz);
         }
     }
 
 
-    private static void doInNewChildRealm(ClassLoader parentRealm, String callableCalledInClassLoaderRealm) throws Exception {
-        new SimplePerRealmReloadingClassLoader(parentRealm, reloadScope()).doInRealm(callableCalledInClassLoaderRealm);
+    private static void doInNewChildRealm(final ClassLoader parentRealm, final String callableCalledInClassLoaderRealm) throws Exception {
+        final SimplePerRealmReloadingClassLoader simplePerRealmReloadingClassLoader = new SimplePerRealmReloadingClassLoader(parentRealm, reloadScope());
+        simplePerRealmReloadingClassLoader.doInRealm(callableCalledInClassLoaderRealm);
+        simplePerRealmReloadingClassLoader.close();
     }
 
     private static SimplePerRealmReloadingClassLoader.ReloadClassPredicate reloadScope() {
         return new SimplePerRealmReloadingClassLoader.ReloadClassPredicate() {
-            public boolean acceptReloadOf(String qualifiedName) {
+            public boolean acceptReloadOf(final String qualifiedName) {
                 return "org.mockitousage.configuration.ClassCacheVersusClassReloadingTest$DoTheMocking".equals(qualifiedName)
                     || "org.mockitousage.configuration.ClassToBeMocked".equals(qualifiedName);
             }
@@ -102,7 +106,7 @@ public class ClassCacheVersusClassReloadingTest {
 
     private static SimplePerRealmReloadingClassLoader.ReloadClassPredicate reloadMockito() {
         return new SimplePerRealmReloadingClassLoader.ReloadClassPredicate() {
-            public boolean acceptReloadOf(String qualifiedName) {
+            public boolean acceptReloadOf(final String qualifiedName) {
                 return (!qualifiedName.contains("net.bytebuddy") && qualifiedName.contains("org.mockito"));
             }
         };

--- a/test/org/mockitousage/configuration/CustomizedAnnotationForSmartMockTest.java
+++ b/test/org/mockitousage/configuration/CustomizedAnnotationForSmartMockTest.java
@@ -4,7 +4,7 @@
  */
 package org.mockitousage.configuration;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
 
 import org.junit.Test;
 import org.mockitousage.IMethods;

--- a/test/org/mockitousage/configuration/SmartMock.java
+++ b/test/org/mockitousage/configuration/SmartMock.java
@@ -4,7 +4,7 @@
  */
 package org.mockitousage.configuration;
 
-import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.ElementType.FIELD;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/test/org/mockitousage/constructor/CreatingMocksWithConstructorTest.java
+++ b/test/org/mockitousage/constructor/CreatingMocksWithConstructorTest.java
@@ -14,6 +14,7 @@ import org.mockito.mock.SerializableMode;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
+@SuppressWarnings("rawtypes")
 public class CreatingMocksWithConstructorTest extends TestBase {
 
     abstract static class AbstractMessage {

--- a/test/org/mockitousage/constructor/CreatingMocksWithConstructorTest.java
+++ b/test/org/mockitousage/constructor/CreatingMocksWithConstructorTest.java
@@ -5,7 +5,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
+
 import java.util.List;
+
 import org.junit.Test;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.mock.SerializableMode;
@@ -14,7 +16,7 @@ import org.mockitoutil.TestBase;
 
 public class CreatingMocksWithConstructorTest extends TestBase {
 
-    static abstract class AbstractMessage {
+    abstract static class AbstractMessage {
         private final String message;
         AbstractMessage() {
             this.message = "hey!";
@@ -29,31 +31,31 @@ public class CreatingMocksWithConstructorTest extends TestBase {
 
     @Test
     public void can_create_mock_with_constructor() {
-        Message mock = mock(Message.class, withSettings().useConstructor().defaultAnswer(CALLS_REAL_METHODS));
+        final Message mock = mock(Message.class, withSettings().useConstructor().defaultAnswer(CALLS_REAL_METHODS));
         //the message is a part of state of the mocked type that gets initialized in constructor
         assertEquals("hey!", mock.getMessage());
     }
 
     @Test
     public void can_mock_abstract_classes() {
-        AbstractMessage mock = mock(AbstractMessage.class, withSettings().useConstructor().defaultAnswer(CALLS_REAL_METHODS));
+        final AbstractMessage mock = mock(AbstractMessage.class, withSettings().useConstructor().defaultAnswer(CALLS_REAL_METHODS));
         assertEquals("hey!", mock.getMessage());
     }
 
     @Test
     public void can_spy_abstract_classes() {
-        AbstractMessage mock = spy(AbstractMessage.class);
+        final AbstractMessage mock = spy(AbstractMessage.class);
         assertEquals("hey!", mock.getMessage());
     }
 
     @Test
     public void can_mock_inner_classes() {
-        InnerClass mock = mock(InnerClass.class, withSettings().useConstructor().outerInstance(this).defaultAnswer(CALLS_REAL_METHODS));
+        final InnerClass mock = mock(InnerClass.class, withSettings().useConstructor().outerInstance(this).defaultAnswer(CALLS_REAL_METHODS));
         assertEquals("hey!", mock.getMessage());
     }
 
     static class HasConstructor {
-        HasConstructor(String x) {}
+        HasConstructor(final String x) {}
     }
 
     @Test
@@ -63,7 +65,7 @@ public class CreatingMocksWithConstructorTest extends TestBase {
             spy(HasConstructor.class);
             //then
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             assertEquals("Unable to create mock instance of type 'HasConstructor'", e.getMessage());
             assertContains("0-arg constructor", e.getCause().getMessage());
         }
@@ -76,7 +78,7 @@ public class CreatingMocksWithConstructorTest extends TestBase {
             mock(InnerClass.class, withSettings().useConstructor().outerInstance("foo").defaultAnswer(CALLS_REAL_METHODS));
             //then
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             assertEquals("Unable to create mock instance of type 'InnerClass'", e.getMessage());
             assertContains("Please ensure that the outer instance has correct type and that the target class has 0-arg constructor.", e.getCause().getMessage());
         }
@@ -97,12 +99,12 @@ public class CreatingMocksWithConstructorTest extends TestBase {
             mock(AbstractMessage.class, withSettings().useConstructor().serializable(SerializableMode.ACROSS_CLASSLOADERS));
             //then
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             assertEquals("Mocks instantiated with constructor cannot be combined with " + SerializableMode.ACROSS_CLASSLOADERS + " serialization mode.", e.getMessage());
         }
     }
 
-    static abstract class AbstractThing {
+    abstract static class AbstractThing {
         abstract String name();
         String fullName() {
             return "abstract " + name();
@@ -111,20 +113,20 @@ public class CreatingMocksWithConstructorTest extends TestBase {
 
     @Test
     public void abstract_method_returns_default() {
-        AbstractThing thing = spy(AbstractThing.class);
+        final AbstractThing thing = spy(AbstractThing.class);
         assertEquals("abstract null", thing.fullName());
     }
 
     @Test
     public void abstract_method_stubbed() {
-        AbstractThing thing = spy(AbstractThing.class);
+        final AbstractThing thing = spy(AbstractThing.class);
         when(thing.name()).thenReturn("me");
         assertEquals("abstract me", thing.fullName());
     }
 
     @Test
     public void calls_real_interface_method() {
-        List list = mock(List.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+        final List list = mock(List.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
         assertNull(list.get(1));
     }
 }

--- a/test/org/mockitousage/customization/BDDMockitoTest.java
+++ b/test/org/mockitousage/customization/BDDMockitoTest.java
@@ -4,6 +4,20 @@
  */
 package org.mockitousage.customization;
 
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willAnswer;
+import static org.mockito.BDDMockito.willCallRealMethod;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+import java.util.Set;
+
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mock;
@@ -16,10 +30,6 @@ import org.mockito.stubbing.Answer;
 import org.mockitousage.IMethods;
 import org.mockitousage.MethodsImpl;
 import org.mockitoutil.TestBase;
-
-import java.util.Set;
-
-import static org.mockito.BDDMockito.*;
 
 public class BDDMockitoTest extends TestBase {
     @Mock IMethods mock;
@@ -39,9 +49,10 @@ public class BDDMockitoTest extends TestBase {
         try {
             assertEquals("foo", mock.simpleMethod("foo"));
             fail();
-        } catch(SomethingWasWrong expected) {}
+        } catch(final SomethingWasWrong expected) {}
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void should_stub_with_throwable_class() throws Exception {
         given(mock.simpleMethod("foo")).willThrow(SomethingWasWrong.class);
@@ -49,13 +60,13 @@ public class BDDMockitoTest extends TestBase {
         try {
             assertEquals("foo", mock.simpleMethod("foo"));
             fail();
-        } catch(SomethingWasWrong expected) {}
+        } catch(final SomethingWasWrong expected) {}
     }
 
     @Test
     public void should_stub_with_answer() throws Exception {
         given(mock.simpleMethod(anyString())).willAnswer(new Answer<String>() {
-            public String answer(InvocationOnMock invocation) throws Throwable {
+            public String answer(final InvocationOnMock invocation) throws Throwable {
                 return (String) invocation.getArguments()[0];
             }});
 
@@ -65,7 +76,7 @@ public class BDDMockitoTest extends TestBase {
     @Test
     public void should_stub_with_will_answer_alias() throws Exception {
         given(mock.simpleMethod(anyString())).will(new Answer<String>() {
-            public String answer(InvocationOnMock invocation) throws Throwable {
+            public String answer(final InvocationOnMock invocation) throws Throwable {
                 return (String) invocation.getArguments()[0];
             }});
 
@@ -84,7 +95,7 @@ public class BDDMockitoTest extends TestBase {
 
     @Test
     public void should_stub_consecutively_with_call_real_method() throws Exception {
-        MethodsImpl mock = mock(MethodsImpl.class);
+        final MethodsImpl mock = mock(MethodsImpl.class);
         willReturn("foo").willCallRealMethod()
                 .given(mock).simpleMethod();
 
@@ -99,7 +110,7 @@ public class BDDMockitoTest extends TestBase {
         try {
             mock.voidMethod();
             fail();
-        } catch(SomethingWasWrong expected) {}
+        } catch(final SomethingWasWrong expected) {}
     }
 
     @Test
@@ -109,7 +120,7 @@ public class BDDMockitoTest extends TestBase {
         try {
             mock.voidMethod();
             fail();
-        } catch(SomethingWasWrong expected) {}
+        } catch(final SomethingWasWrong expected) {}
     }
 
     @Test
@@ -122,7 +133,7 @@ public class BDDMockitoTest extends TestBase {
         try {
             mock.voidMethod();
             fail();
-        } catch(SomethingWasWrong expected) {}
+        } catch(final SomethingWasWrong expected) {}
     }
 
     @Test
@@ -135,7 +146,7 @@ public class BDDMockitoTest extends TestBase {
         try {
             mock.voidMethod();
             fail();
-        } catch(SomethingWasWrong expected) {}
+        } catch(final SomethingWasWrong expected) {}
     }
 
     @Test
@@ -149,7 +160,7 @@ public class BDDMockitoTest extends TestBase {
     @Test
     public void should_stub_using_do_answer_style() throws Exception {
         willAnswer(new Answer<String>() {
-            public String answer(InvocationOnMock invocation) throws Throwable {
+            public String answer(final InvocationOnMock invocation) throws Throwable {
                 return (String) invocation.getArguments()[0];
             }})
                 .given(mock).simpleMethod(anyString());
@@ -160,7 +171,7 @@ public class BDDMockitoTest extends TestBase {
     @Test
     public void should_stub_by_delegating_to_real_method() throws Exception {
         //given
-        Dog dog = mock(Dog.class);
+        final Dog dog = mock(Dog.class);
         //when
         willCallRealMethod().given(dog).bark();
         //then
@@ -170,18 +181,19 @@ public class BDDMockitoTest extends TestBase {
     @Test
     public void should_stub_by_delegating_to_real_method_using_typical_stubbing_syntax() throws Exception {
         //given
-        Dog dog = mock(Dog.class);
+        final Dog dog = mock(Dog.class);
         //when
         given(dog.bark()).willCallRealMethod();
         //then
         assertEquals("woof", dog.bark());
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void should_all_stubbed_mock_reference_access() throws Exception {
-        Set expectedMock = mock(Set.class);
+        final Set expectedMock = mock(Set.class);
 
-        Set returnedMock = given(expectedMock.isEmpty()).willReturn(false).getMock();
+        final Set returnedMock = given(expectedMock.isEmpty()).willReturn(false).getMock();
 
         assertEquals(expectedMock, returnedMock);
     }
@@ -225,7 +237,7 @@ public class BDDMockitoTest extends TestBase {
         try {
             then(mock).shouldHaveZeroInteractions();
             fail("should have reported this interaction wasn't wanted");
-        } catch (NoInteractionsWanted expected) { }
+        } catch (final NoInteractionsWanted expected) { }
     }
 
     @Test
@@ -233,14 +245,14 @@ public class BDDMockitoTest extends TestBase {
         mock.booleanObjectReturningMethod();
         mock.arrayReturningMethod();
 
-        InOrder inOrder = inOrder(mock);
+        final InOrder inOrder = inOrder(mock);
         then(mock).should(inOrder).booleanObjectReturningMethod();
         then(mock).should(inOrder).arrayReturningMethod();
     }
 
     @Test
     public void should_fail_for_interactions_that_were_in_wrong_order() {
-        InOrder inOrder = inOrder(mock);
+        final InOrder inOrder = inOrder(mock);
 
         mock.arrayReturningMethod();
         mock.booleanObjectReturningMethod();
@@ -249,7 +261,7 @@ public class BDDMockitoTest extends TestBase {
         try {
             then(mock).should(inOrder).arrayReturningMethod();
             fail("should have raise in order verification failure on second verify call");
-        } catch (VerificationInOrderFailure expected) { }
+        } catch (final VerificationInOrderFailure expected) { }
     }
 
     @Test(expected = WantedButNotInvoked.class)
@@ -259,9 +271,9 @@ public class BDDMockitoTest extends TestBase {
 
     @Test
     public void should_pass_fluent_bdd_scenario() {
-        Bike bike = new Bike();
-        Person person = mock(Person.class);
-        Police police = mock(Police.class);
+        final Bike bike = new Bike();
+        final Person person = mock(Person.class);
+        final Police police = mock(Police.class);
 
         person.ride(bike);
         person.ride(bike);
@@ -272,45 +284,45 @@ public class BDDMockitoTest extends TestBase {
 
     @Test
     public void should_pass_fluent_bdd_scenario_with_ordered_verification() {
-        Bike bike = new Bike();
-        Car car = new Car();
-        Person person = mock(Person.class);
+        final Bike bike = new Bike();
+        final Car car = new Car();
+        final Person person = mock(Person.class);
 
         person.drive(car);
         person.ride(bike);
         person.ride(bike);
 
-        InOrder inOrder = inOrder(person);
+        final InOrder inOrder = inOrder(person);
         then(person).should(inOrder).drive(car);
         then(person).should(inOrder, times(2)).ride(bike);
     }
 
     @Test
     public void should_pass_fluent_bdd_scenario_with_ordered_verification_for_two_mocks() {
-        Car car = new Car();
-        Person person = mock(Person.class);
-        Police police = mock(Police.class);
+        final Car car = new Car();
+        final Person person = mock(Person.class);
+        final Police police = mock(Police.class);
 
         person.drive(car);
         person.drive(car);
         police.chase(car);
 
-        InOrder inOrder = inOrder(person, police);
+        final InOrder inOrder = inOrder(person, police);
         then(person).should(inOrder, times(2)).drive(car);
         then(police).should(inOrder).chase(car);
     }
 
     static class Person {
 
-        void ride(Bike bike) {}
-        void drive(Car car) {}
+        void ride(final Bike bike) {}
+        void drive(final Car car) {}
     }
     static class Bike { }
 
     static class Car { }
     static class Police {
 
-        void chase(Car car) {}
+        void chase(final Car car) {}
     }
 
     class Dog {
@@ -319,5 +331,6 @@ public class BDDMockitoTest extends TestBase {
         }
     }
 
+    @SuppressWarnings("serial")
     private class SomethingWasWrong extends RuntimeException { }
 }

--- a/test/org/mockitousage/debugging/InvocationListenerCallbackTest.java
+++ b/test/org/mockitousage/debugging/InvocationListenerCallbackTest.java
@@ -4,34 +4,39 @@
  */
 package org.mockitousage.debugging;
 
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.invocation.DescribedInvocation;
 import org.mockito.listeners.InvocationListener;
 import org.mockito.listeners.MethodInvocationReport;
 
-import static org.fest.assertions.Assertions.assertThat;
-import static org.junit.Assert.fail;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willReturn;
-import static org.mockito.Mockito.*;
-
 
 /**
  * Ensures that custom listeners can be registered and will be called every time
  * a method on a mock is invoked.
  */
+@SuppressWarnings("serial")
 public class InvocationListenerCallbackTest {
 
     // Cannot use a mockito-mock here: during stubbing, the listener1 will be called
     // and mockito will confuse the mocks.
-    private RememberingListener listener1 = new RememberingListener();
-    private RememberingListener listener2 = new RememberingListener();
+    private final RememberingListener listener1 = new RememberingListener();
+    private final RememberingListener listener2 = new RememberingListener();
 
     @Test
     public void should_call_single_listener_when_mock_return_normally() throws Exception {
         // given
-        Foo foo = mock(Foo.class, withSettings().invocationListeners(listener1));
+        final Foo foo = mock(Foo.class, withSettings().invocationListeners(listener1));
         willReturn("basil").given(foo).giveMeSomeString("herb");
 
         // when
@@ -44,7 +49,7 @@ public class InvocationListenerCallbackTest {
     @Test
     public void should_call_all_listener_when_mock_return_normally() throws Exception {
         // given
-        Foo foo = mock(Foo.class, withSettings().invocationListeners(listener1, listener2));
+        final Foo foo = mock(Foo.class, withSettings().invocationListeners(listener1, listener2));
         given(foo.giveMeSomeString("herb")).willReturn("rosemary");
 
         // when
@@ -59,18 +64,18 @@ public class InvocationListenerCallbackTest {
     @Test
     public void should_call_all_listener_when_mock_throws_exception() throws Exception {
         // given
-        InvocationListener listener1 = mock(InvocationListener.class, "listener1");
-        InvocationListener listener2 = mock(InvocationListener.class, "listener2");
-        Foo foo = mock(Foo.class, withSettings().invocationListeners(listener1, listener2));
+        final InvocationListener listener1 = mock(InvocationListener.class, "listener1");
+        final InvocationListener listener2 = mock(InvocationListener.class, "listener2");
+        final Foo foo = mock(Foo.class, withSettings().invocationListeners(listener1, listener2));
         doThrow(new OvenNotWorking()).when(foo).doSomething("cook");
 
         // when
         try {
             foo.doSomething("cook");
             fail("Exception expected.");
-        } catch (OvenNotWorking actualException) {
+        } catch (final OvenNotWorking actualException) {
             // then
-            InOrder orderedVerify = inOrder(listener1, listener2);
+            final InOrder orderedVerify = inOrder(listener1, listener2);
             orderedVerify.verify(listener1).reportInvocation(any(MethodInvocationReport.class));
             orderedVerify.verify(listener2).reportInvocation(any(MethodInvocationReport.class));
         }
@@ -78,7 +83,7 @@ public class InvocationListenerCallbackTest {
 
     static class OvenNotWorking extends RuntimeException { }
 
-    private void assertThatHasBeenNotified(RememberingListener listener, Object returned, String location) {
+    private void assertThatHasBeenNotified(final RememberingListener listener, final Object returned, final String location) {
         assertThat(listener.returnValue).isEqualTo(returned);
         assertThat(listener.invocation).isNotNull();
         assertThat(listener.locationOfStubbing).contains(getClass().getSimpleName());
@@ -89,7 +94,7 @@ public class InvocationListenerCallbackTest {
         Object returnValue;
         String locationOfStubbing;
 
-        public void reportInvocation(MethodInvocationReport mcr) {
+        public void reportInvocation(final MethodInvocationReport mcr) {
             this.invocation = mcr.getInvocation();
             this.returnValue = mcr.getReturnedValue();
             this.locationOfStubbing = mcr.getLocationOfStubbing();

--- a/test/org/mockitousage/debugging/PrintingInvocationsDetectsUnusedStubTest.java
+++ b/test/org/mockitousage/debugging/PrintingInvocationsDetectsUnusedStubTest.java
@@ -4,7 +4,7 @@
  */
 package org.mockitousage.debugging;
 
-import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.given;
 
 import org.junit.Test;
 import org.mockito.Mock;
@@ -22,7 +22,7 @@ public class PrintingInvocationsDetectsUnusedStubTest extends TestBase {
         mock.giveMeSomeString("arg");
 
         //when
-        String log = NewMockito.debug().printInvocations(mock, mockTwo);
+        final String log = NewMockito.debug().printInvocations(mock, mockTwo);
 
         //then
         assertContainsIgnoringCase("unused", log);

--- a/test/org/mockitousage/debugging/PrintingInvocationsWhenEverythingOkTest.java
+++ b/test/org/mockitousage/debugging/PrintingInvocationsWhenEverythingOkTest.java
@@ -4,7 +4,8 @@
  */
 package org.mockitousage.debugging;
 
-import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 import org.junit.After;
 import org.junit.Test;
@@ -30,18 +31,18 @@ public class PrintingInvocationsWhenEverythingOkTest extends TestBase {
         given(mock.giveMeSomeString("arg")).willReturn("foo");
     }
 
-    private void businessLogicWithAsking(String name) {
-        String out = mock.giveMeSomeString(name);
+    private void businessLogicWithAsking(final String name) {
+        final String out = mock.giveMeSomeString(name);
         businessLogicWithTelling(out);
     }
 
-    private void businessLogicWithTelling(String out) {
+    private void businessLogicWithTelling(final String out) {
         mockTwo.doSomething(out);
     }
 
     @After
     public void printInvocations() {
-        String log = NewMockito.debug().printInvocations(mock, mockTwo);
+        final String log = NewMockito.debug().printInvocations(mock, mockTwo);
         //asking
         assertContains("giveMeSomeString(\"arg\")", log);
         assertContains(".businessLogicWithAsking(", log);

--- a/test/org/mockitousage/debugging/PrintingInvocationsWhenStubNotUsedTest.java
+++ b/test/org/mockitousage/debugging/PrintingInvocationsWhenStubNotUsedTest.java
@@ -4,12 +4,14 @@
  */
 package org.mockitousage.debugging;
 
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
 import org.mockitoutil.TestBase;
-
-import static org.mockito.BDDMockito.*;
 
 public class PrintingInvocationsWhenStubNotUsedTest extends TestBase {
 
@@ -30,18 +32,18 @@ public class PrintingInvocationsWhenStubNotUsedTest extends TestBase {
         given(mock.giveMeSomeString("different arg")).willReturn("foo");
     }
 
-    private void businessLogicWithAsking(String name) {
-        String out = mock.giveMeSomeString(name);
+    private void businessLogicWithAsking(final String name) {
+        final String out = mock.giveMeSomeString(name);
         businessLogicWithTelling(out);
     }
 
-    private void businessLogicWithTelling(String out) {
+    private void businessLogicWithTelling(final String out) {
         mockTwo.doSomething(out);
     }
 
     @After
     public void printInvocations() {
-        String log = NewMockito.debug().printInvocations(mock, mockTwo);
+        final String log = NewMockito.debug().printInvocations(mock, mockTwo);
         //asking
         assertContains("giveMeSomeString(\"arg\")", log);
         assertContains(".businessLogicWithAsking(", log);

--- a/test/org/mockitousage/examples/use/ExampleTest.java
+++ b/test/org/mockitousage/examples/use/ExampleTest.java
@@ -4,8 +4,12 @@
  */
 
 package org.mockitousage.examples.use;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 
@@ -61,9 +65,9 @@ public class ExampleTest extends TestBase {
     
     @Test
     public void managerUpdatesNumberOfRelatedArticles() {
-        Article articleOne = new Article();
-        Article articleTwo = new Article();
-        Article articleThree = new Article();
+        final Article articleOne = new Article();
+        final Article articleTwo = new Article();
+        final Article articleThree = new Article();
         
         when(mockCalculator.countNumberOfRelatedArticles(articleOne)).thenReturn(1);
         when(mockCalculator.countNumberOfRelatedArticles(articleTwo)).thenReturn(12);
@@ -80,8 +84,8 @@ public class ExampleTest extends TestBase {
     
     @Test
     public void shouldPersistRecalculatedArticle() {
-        Article articleOne = new Article();
-        Article articleTwo = new Article();
+        final Article articleOne = new Article();
+        final Article articleTwo = new Article();
         
         when(mockCalculator.countNumberOfRelatedArticles(articleOne)).thenReturn(1);
         when(mockCalculator.countNumberOfRelatedArticles(articleTwo)).thenReturn(12);
@@ -90,7 +94,7 @@ public class ExampleTest extends TestBase {
         
         articleManager.updateRelatedArticlesCounters("Guardian");
 
-        InOrder inOrder = inOrder(mockDatabase, mockCalculator);
+        final InOrder inOrder = inOrder(mockDatabase, mockCalculator);
         
         inOrder.verify(mockCalculator).countNumberOfRelatedArticles((Article) anyObject());
         inOrder.verify(mockDatabase, atLeastOnce()).save((Article) anyObject());

--- a/test/org/mockitousage/internal/invocation/realmethod/CleanTraceRealMethodTest.java
+++ b/test/org/mockitousage/internal/invocation/realmethod/CleanTraceRealMethodTest.java
@@ -4,7 +4,7 @@
  */
 package org.mockitousage.internal.invocation.realmethod;
 
-import static org.mockitoutil.ExtraMatchers.*;
+import static org.mockitoutil.ExtraMatchers.hasMethodInStackTraceAt;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -28,8 +28,8 @@ public class CleanTraceRealMethodTest extends TestBase {
     @Test
     public void shouldRemoveMockitoInternalsFromStackTraceWhenRealMethodThrows() throws Throwable {
         //given
-        CleanTraceRealMethod realMethod = new CleanTraceRealMethod(new RealMethod() {
-            public Object invoke(Object target, Object[] arguments) throws Throwable {
+        final CleanTraceRealMethod realMethod = new CleanTraceRealMethod(new RealMethod() {
+            public Object invoke(final Object target, final Object[] arguments) throws Throwable {
                 return new Foo().throwSomething();
             }});
         
@@ -38,7 +38,7 @@ public class CleanTraceRealMethodTest extends TestBase {
             realMethod.invoke(null, null);
             fail();
         //then
-        } catch (Exception e) {
+        } catch (final Exception e) {
             assertThat(e, hasMethodInStackTraceAt(0, "throwSomething"));
             assertThat(e, hasMethodInStackTraceAt(1, "invoke"));
             assertThat(e, hasMethodInStackTraceAt(2, "shouldRemoveMockitoInternalsFromStackTraceWhenRealMethodThrows"));

--- a/test/org/mockitousage/junitrule/RuleTestWithFactoryMethodTest.java
+++ b/test/org/mockitousage/junitrule/RuleTestWithFactoryMethodTest.java
@@ -1,15 +1,14 @@
 package org.mockitousage.junitrule;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.MethodRule;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 public class RuleTestWithFactoryMethodTest {
 

--- a/test/org/mockitousage/junitrunner/JUnit44RunnerTest.java
+++ b/test/org/mockitousage/junitrunner/JUnit44RunnerTest.java
@@ -4,9 +4,10 @@
  */
 package org.mockitousage.junitrunner;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-import static org.mockitousage.junitrunner.Filters.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.verify;
+import static org.mockitousage.junitrunner.Filters.methodNameContains;
 
 import java.util.List;
 
@@ -17,11 +18,11 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnit44Runner;
 
 @RunWith(MockitoJUnit44Runner.class)
-@SuppressWarnings( { "unchecked", "deprecation" })
+@SuppressWarnings( { "unchecked", "deprecation", "rawtypes" })
 public class JUnit44RunnerTest {
 
     @InjectMocks
-    private ListDependent listDependent = new ListDependent();
+    private final ListDependent listDependent = new ListDependent();
 
     @Mock
     private List list;
@@ -38,7 +39,7 @@ public class JUnit44RunnerTest {
 
     @Test
     public void shouldFilterTestMethodsCorrectly() throws Exception{
-        MockitoJUnit44Runner runner = new MockitoJUnit44Runner(this.getClass());
+        final MockitoJUnit44Runner runner = new MockitoJUnit44Runner(this.getClass());
 
         runner.filter(methodNameContains("shouldInitMocksUsingRunner"));
 

--- a/test/org/mockitousage/junitrunner/JUnit45RunnerTest.java
+++ b/test/org/mockitousage/junitrunner/JUnit45RunnerTest.java
@@ -4,9 +4,11 @@
  */
 package org.mockitousage.junitrunner;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-import static org.mockitousage.junitrunner.Filters.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.verify;
+import static org.mockitousage.junitrunner.Filters.methodNameContains;
 
 import java.util.List;
 
@@ -17,10 +19,10 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class JUnit45RunnerTest {
 
-    @InjectMocks private ListDependent listDependent = new ListDependent();
+    @InjectMocks private final ListDependent listDependent = new ListDependent();
     @Mock private List list;
 
     @Test
@@ -37,7 +39,7 @@ public class JUnit45RunnerTest {
 
     @Test
     public void shouldFilterTestMethodsCorrectly() throws Exception{
-        MockitoJUnitRunner runner = new MockitoJUnitRunner(this.getClass());
+        final MockitoJUnitRunner runner = new MockitoJUnitRunner(this.getClass());
 
         runner.filter(methodNameContains("shouldInitMocksUsingRunner"));
 

--- a/test/org/mockitousage/junitrunner/ModellingVerboseMockitoTest.java
+++ b/test/org/mockitousage/junitrunner/ModellingVerboseMockitoTest.java
@@ -4,7 +4,8 @@
  */
 package org.mockitousage.junitrunner;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.Before;
 import org.junit.Ignore;
@@ -34,7 +35,7 @@ public class ModellingVerboseMockitoTest extends TestBase {
         when(mock.booleanObjectReturningMethod()).thenReturn(false);
 
         //TODO: stubbed with those args here -> stubbed with certain args here 
-        String ret = mock.simpleMethod(2);
+        final String ret = mock.simpleMethod(2);
 
         assertEquals("foo", ret);
         //TODO: should show message from actual failure not at the bottom but at least below 'the actual failure is ...'

--- a/test/org/mockitousage/junitrunner/VerboseMockitoRunnerTest.java
+++ b/test/org/mockitousage/junitrunner/VerboseMockitoRunnerTest.java
@@ -4,7 +4,11 @@
  */
 package org.mockitousage.junitrunner;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import junit.framework.TestCase;
+
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.JUnitCore;
@@ -15,8 +19,6 @@ import org.mockito.internal.exceptions.ExceptionIncludingMockitoWarnings;
 import org.mockito.runners.VerboseMockitoJUnitRunner;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
-
-import static org.mockito.Mockito.*;
 
 //@RunWith(ConsoleSpammingMockitoJUnitRunner.class)
 @RunWith(VerboseMockitoJUnitRunner.class)
@@ -30,7 +32,7 @@ public class VerboseMockitoRunnerTest extends TestBase {
         @Test
         @Ignore
         public void test() {
-            IMethods mock = mock(IMethods.class);
+            final IMethods mock = mock(IMethods.class);
             mock.simpleMethod(1);
             mock.otherMethod();
             
@@ -48,7 +50,7 @@ public class VerboseMockitoRunnerTest extends TestBase {
         public void testIgnored() {}
 
         public void _test() {
-            IMethods mock = mock(IMethods.class);
+            final IMethods mock = mock(IMethods.class);
             
             //some stubbing
             when(mock.simpleMethod(1)).thenReturn("foo");
@@ -56,7 +58,7 @@ public class VerboseMockitoRunnerTest extends TestBase {
             when(mock.booleanObjectReturningMethod()).thenReturn(false);
 
             //stub called with different args:
-            String ret = mock.simpleMethod(2);
+            final String ret = mock.simpleMethod(2);
 
             //assertion fails due to stub called with different args
             assertEquals("foo", ret);
@@ -71,17 +73,17 @@ public class VerboseMockitoRunnerTest extends TestBase {
     @Ignore
     public void shouldContainWarnings() throws Exception {
         //when
-        Result result = new JUnitCore().run(new ContainsWarnings());
+        final Result result = new JUnitCore().run(new ContainsWarnings());
         //then
         assertEquals(1, result.getFailures().size());
-        Throwable exception = result.getFailures().get(0).getException();
+        final Throwable exception = result.getFailures().get(0).getException();
         assertTrue(exception instanceof ExceptionIncludingMockitoWarnings);        
     }
 
     @Test
     @Ignore
     public void shouldNotContainWarnings() throws Exception {
-        Result result = new JUnitCore().run(NoWarnings.class);
+        final Result result = new JUnitCore().run(NoWarnings.class);
         assertEquals(1, result.getFailures().size());
         assertEquals("boo", result.getFailures().get(0).getException().getMessage());
     }

--- a/test/org/mockitousage/matchers/AnyXMatchersAcceptNullsTest.java
+++ b/test/org/mockitousage/matchers/AnyXMatchersAcceptNullsTest.java
@@ -4,8 +4,22 @@
  */
 package org.mockitousage.matchers;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyByte;
+import static org.mockito.Matchers.anyChar;
+import static org.mockito.Matchers.anyCollection;
+import static org.mockito.Matchers.anyDouble;
+import static org.mockito.Matchers.anyFloat;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anySet;
+import static org.mockito.Matchers.anyShort;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/test/org/mockitousage/matchers/CapturingArgumentsTest.java
+++ b/test/org/mockitousage/matchers/CapturingArgumentsTest.java
@@ -5,6 +5,16 @@
 
 package org.mockitousage.matchers;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.fest.assertions.Assertions;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -13,20 +23,14 @@ import org.mockito.exceptions.verification.WantedButNotInvoked;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
-
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class CapturingArgumentsTest extends TestBase {
 
     class Person {
 
         private final Integer age;
 
-        public Person(Integer age) {
+        public Person(final Integer age) {
             this.age = age;
         }
 
@@ -37,22 +41,22 @@ public class CapturingArgumentsTest extends TestBase {
 
     class BulkEmailService {
 
-        private EmailService service;
+        private final EmailService service;
 
-        public BulkEmailService(EmailService service) {
+        public BulkEmailService(final EmailService service) {
             this.service = service;
         }
 
-        public void email(Integer ... personId) {
-            for (Integer i : personId) {
-                Person person = new Person(i);
+        public void email(final Integer ... personId) {
+            for (final Integer i : personId) {
+                final Person person = new Person(i);
                 service.sendEmailTo(person);
             }
         }
     }
 
     interface EmailService {
-        boolean sendEmailTo(Person person);
+        boolean sendEmailTo(final Person person);
     }
 
     EmailService emailService = mock(EmailService.class);
@@ -63,7 +67,7 @@ public class CapturingArgumentsTest extends TestBase {
     @Test
     public void should_allow_assertions_on_captured_argument() {
         //given
-        ArgumentCaptor<Person> argument = new ArgumentCaptor<Person>();
+        final ArgumentCaptor<Person> argument = new ArgumentCaptor<Person>();
 
         //when
         bulkEmailService.email(12);
@@ -76,7 +80,7 @@ public class CapturingArgumentsTest extends TestBase {
     @Test
     public void should_allow_assertions_on_all_captured_arguments() {
         //given
-        ArgumentCaptor<Person> argument = ArgumentCaptor.forClass(Person.class);
+        final ArgumentCaptor<Person> argument = ArgumentCaptor.forClass(Person.class);
 
         //when
         bulkEmailService.email(11, 12);
@@ -90,7 +94,7 @@ public class CapturingArgumentsTest extends TestBase {
     @Test
     public void should_allow_assertions_on_last_argument() {
         //given
-        ArgumentCaptor<Person> argument = ArgumentCaptor.forClass(Person.class);
+        final ArgumentCaptor<Person> argument = ArgumentCaptor.forClass(Person.class);
 
         //when
         bulkEmailService.email(11, 12, 13);
@@ -103,13 +107,13 @@ public class CapturingArgumentsTest extends TestBase {
     @Test
     public void should_print_captor_matcher() {
         //given
-        ArgumentCaptor<Person> person = ArgumentCaptor.forClass(Person.class);
+        final ArgumentCaptor<Person> person = ArgumentCaptor.forClass(Person.class);
         
         try {
             //when
             verify(emailService).sendEmailTo(person.capture());
             fail();
-        } catch(WantedButNotInvoked e) {
+        } catch(final WantedButNotInvoked e) {
             //then
             assertContains("<Capturing argument>", e.getMessage());
         }
@@ -118,7 +122,7 @@ public class CapturingArgumentsTest extends TestBase {
     @Test
     public void should_allow_assertions_on_captured_null() {
         //given
-        ArgumentCaptor<Person> argument = ArgumentCaptor.forClass(Person.class);
+        final ArgumentCaptor<Person> argument = ArgumentCaptor.forClass(Person.class);
 
         //when
         emailService.sendEmailTo(null);
@@ -131,21 +135,21 @@ public class CapturingArgumentsTest extends TestBase {
     @Test
     public void should_allow_construction_of_captor_for_parameterized_type_in_a_convenient_way()  {
         //the test passes if this expression compiles
-        ArgumentCaptor<List<Person>> argument = ArgumentCaptor.forClass(List.class);
+        final ArgumentCaptor<List<Person>> argument = ArgumentCaptor.forClass(List.class);
         assertNotNull(argument);
     }
 
     @Test
     public void should_allow_construction_of_captor_for_a_more_specific_type()  {
         //the test passes if this expression compiles
-        ArgumentCaptor<List> argument = ArgumentCaptor.forClass(ArrayList.class);
+        final ArgumentCaptor<List> argument = ArgumentCaptor.forClass(ArrayList.class);
         assertNotNull(argument);
     }
     
     @Test
     public void should_allow_capturing_for_stubbing() {
         //given
-        ArgumentCaptor<Person> argument = ArgumentCaptor.forClass(Person.class);
+        final ArgumentCaptor<Person> argument = ArgumentCaptor.forClass(Person.class);
         when(emailService.sendEmailTo(argument.capture())).thenReturn(false);
         
         //when
@@ -158,7 +162,7 @@ public class CapturingArgumentsTest extends TestBase {
     @Test
     public void should_capture_when_stubbing_only_when_entire_invocation_matches() {
         //given
-        ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+        final ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
         when(mock.simpleMethod(argument.capture(), eq(2))).thenReturn("blah");
         
         //when
@@ -171,17 +175,17 @@ public class CapturingArgumentsTest extends TestBase {
     
     @Test
     public void should_say_something_smart_when_misused() {
-        ArgumentCaptor<Person> argument = ArgumentCaptor.forClass(Person.class);
+        final ArgumentCaptor<Person> argument = ArgumentCaptor.forClass(Person.class);
         try {
             argument.getValue();
             fail();
-        } catch (MockitoException expected) { }
+        } catch (final MockitoException expected) { }
     }
     
     @Test
     public void should_capture_when_full_arg_list_matches() throws Exception {
         //given
-        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
 
         //when
         mock.simpleMethod("foo", 1);
@@ -196,7 +200,7 @@ public class CapturingArgumentsTest extends TestBase {
     @Test
     public void should_capture_int_by_creating_captor_with_primitive_wrapper() {
         //given
-        ArgumentCaptor<Integer> argument = ArgumentCaptor.forClass(Integer.class);
+        final ArgumentCaptor<Integer> argument = ArgumentCaptor.forClass(Integer.class);
 
         //when
         mock.intArgumentMethod(10);
@@ -209,7 +213,7 @@ public class CapturingArgumentsTest extends TestBase {
     @Test
     public void should_capture_int_by_creating_captor_with_primitive() throws Exception {
         //given
-        ArgumentCaptor<Integer> argument = ArgumentCaptor.forClass(int.class);
+        final ArgumentCaptor<Integer> argument = ArgumentCaptor.forClass(int.class);
         
         //when
         mock.intArgumentMethod(10);
@@ -222,7 +226,7 @@ public class CapturingArgumentsTest extends TestBase {
     @Test
     public void should_capture_byte_vararg_by_creating_captor_with_primitive() throws Exception {
         // given
-        ArgumentCaptor<Byte> argumentCaptor = ArgumentCaptor.forClass(byte.class);
+        final ArgumentCaptor<Byte> argumentCaptor = ArgumentCaptor.forClass(byte.class);
 
         // when
         mock.varargsbyte((byte) 1, (byte) 2);
@@ -236,7 +240,7 @@ public class CapturingArgumentsTest extends TestBase {
     @Test
     public void should_capture_byte_vararg_by_creating_captor_with_primitive_wrapper() throws Exception {
         // given
-        ArgumentCaptor<Byte> argumentCaptor = ArgumentCaptor.forClass(Byte.class);
+        final ArgumentCaptor<Byte> argumentCaptor = ArgumentCaptor.forClass(Byte.class);
 
         // when
         mock.varargsbyte((byte) 1, (byte) 2);
@@ -250,7 +254,7 @@ public class CapturingArgumentsTest extends TestBase {
     @Test
     public void should_capture_vararg() throws Exception {
         // given
-        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+        final ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
 
         // when
         mock.mixedVarargs(42, "a", "b", "c");
@@ -263,7 +267,7 @@ public class CapturingArgumentsTest extends TestBase {
     @Test
     public void should_capture_all_vararg() throws Exception {
         // given
-        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+        final ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
 
         // when
         mock.mixedVarargs(42, "a", "b", "c");
@@ -278,7 +282,7 @@ public class CapturingArgumentsTest extends TestBase {
     @Test
     public void should_capture_one_arg_even_when_using_vararg_captor_on_nonvararg_method() throws Exception {
         // given
-        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+        final ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
 
         // when
         mock.simpleMethod("a", 2);
@@ -291,7 +295,7 @@ public class CapturingArgumentsTest extends TestBase {
     @Test
     public void captures_correctly_when_captor_used_multiple_times() throws Exception {
         // given
-        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+        final ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
 
         // when
         mock.mixedVarargs(42, "a", "b", "c");
@@ -305,7 +309,7 @@ public class CapturingArgumentsTest extends TestBase {
     @Test
     public void captures_correctly_when_captor_used_on_pure_vararg_method() throws Exception {
         // given
-        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+        final ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
 
         // when
         mock.varargs(42, "capturedValue");

--- a/test/org/mockitousage/matchers/CustomMatchersTest.java
+++ b/test/org/mockitousage/matchers/CustomMatchersTest.java
@@ -5,8 +5,17 @@
 
 package org.mockitousage.matchers;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.booleanThat;
+import static org.mockito.Matchers.byteThat;
+import static org.mockito.Matchers.charThat;
+import static org.mockito.Matchers.doubleThat;
+import static org.mockito.Matchers.floatThat;
+import static org.mockito.Matchers.intThat;
+import static org.mockito.Matchers.longThat;
+import static org.mockito.Matchers.shortThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -18,27 +27,27 @@ import org.mockitoutil.TestBase;
 public class CustomMatchersTest extends TestBase {
     
     private final class ContainsFoo extends ArgumentMatcher<String> {
-        public boolean matches(Object arg) {
+        public boolean matches(final Object arg) {
             return ((String) arg).contains("foo");
         }
     }
 
     private final class IsAnyBoolean extends ArgumentMatcher<Boolean> {
-        public boolean matches(Object arg) {
+        public boolean matches(final Object arg) {
             return true;
         }
     }
     
     private final class IsSorZ extends ArgumentMatcher<Character> {
-        public boolean matches(Object arg) {
-            Character character = (Character) arg;
+        public boolean matches(final Object arg) {
+            final Character character = (Character) arg;
             return character.equals('s') || character.equals('z');
         }
     }
 
     private final class IsZeroOrOne<T extends Number> extends ArgumentMatcher<T> {
-        public boolean matches(Object arg) {
-            Number number = (Number) arg;
+        public boolean matches(final Object arg) {
+            final Number number = (Number) arg;
             if (number.intValue() == 0 || number.intValue() == 1) {
                 return true;
             }
@@ -74,10 +83,10 @@ public class CustomMatchersTest extends TestBase {
     
     class Article {
         
-        private int pageNumber;
-        private String headline;
+        private final int pageNumber;
+        private final String headline;
         
-        public Article(int pageNumber, String headline) {
+        public Article(final int pageNumber, final String headline) {
             super();
             this.pageNumber = pageNumber;
             this.headline = headline;
@@ -127,7 +136,7 @@ public class CustomMatchersTest extends TestBase {
         try {
             verify(mock).simpleMethod(containsTest());
             fail();
-        } catch (AssertionError e) {
+        } catch (final AssertionError e) {
             assertContains("<String that contains xxx>", e.getMessage());
         }
     }
@@ -137,8 +146,8 @@ public class CustomMatchersTest extends TestBase {
     }
     
     private final class StringThatContainsXxx extends ArgumentMatcher<String> {
-        public boolean matches(Object argument) {
-            String arg = (String) argument;
+        public boolean matches(final Object argument) {
+            final String arg = (String) argument;
             return arg.contains("xxx");
         }
     }
@@ -149,11 +158,11 @@ public class CustomMatchersTest extends TestBase {
 
         try {
             verify(mock).simpleMethod((String) argThat(new ArgumentMatcher<Object>() {
-                @Override public boolean matches(Object argument) {
+                @Override public boolean matches(final Object argument) {
                     return false;
                 }}));
             fail();
-        } catch (AssertionError e) {
+        } catch (final AssertionError e) {
             assertContains("<custom argument matcher>", e.getMessage());
             assertContains("foo", e.getMessage());
         }

--- a/test/org/mockitousage/matchers/GenericMatchersTest.java
+++ b/test/org/mockitousage/matchers/GenericMatchersTest.java
@@ -5,8 +5,9 @@
 
 package org.mockitousage.matchers;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.when;
 
 import java.util.Date;
 import java.util.List;
@@ -18,8 +19,8 @@ import org.mockitoutil.TestBase;
 public class GenericMatchersTest extends TestBase {
     
     private interface Foo {
-        List<String> sort(List<String> otherList);
-        String convertDate(Date date);
+        List<String> sort(final List<String> otherList);
+        String convertDate(final Date date);
     }
     
     @Mock Foo sorter;

--- a/test/org/mockitousage/matchers/HamcrestMatchersTest.java
+++ b/test/org/mockitousage/matchers/HamcrestMatchersTest.java
@@ -5,8 +5,9 @@
 
 package org.mockitousage.matchers;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -19,11 +20,11 @@ import org.mockitoutil.TestBase;
 public class HamcrestMatchersTest extends TestBase {
     
     private final class ContainsX extends BaseMatcher<String> {
-        public boolean matches(Object o) {
+        public boolean matches(final Object o) {
             return ((String) o).contains("X");
         }
 
-        public void describeTo(Description d) {
+        public void describeTo(final Description d) {
             d.appendText("contains 'X'");
         }
     }
@@ -44,7 +45,7 @@ public class HamcrestMatchersTest extends TestBase {
         try {
             verify(mock).simpleMethod(argThat(new ContainsX()));
             fail();
-        } catch (ArgumentsAreDifferent e) {
+        } catch (final ArgumentsAreDifferent e) {
             assertContains("contains 'X'", e.getMessage());
         }
     }

--- a/test/org/mockitousage/matchers/MatchersMixedWithRawArgumentsTest.java
+++ b/test/org/mockitousage/matchers/MatchersMixedWithRawArgumentsTest.java
@@ -5,8 +5,9 @@
 
 package org.mockitousage.matchers;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.verify;
 
 import org.junit.Ignore;
 import org.junit.Test;

--- a/test/org/mockitousage/matchers/MatchersTest.java
+++ b/test/org/mockitousage/matchers/MatchersTest.java
@@ -5,9 +5,39 @@
 
 package org.mockitousage.matchers;
 
-import static org.mockito.AdditionalMatchers.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.AdditionalMatchers.and;
+import static org.mockito.AdditionalMatchers.aryEq;
+import static org.mockito.AdditionalMatchers.cmpEq;
+import static org.mockito.AdditionalMatchers.eq;
+import static org.mockito.AdditionalMatchers.find;
+import static org.mockito.AdditionalMatchers.geq;
+import static org.mockito.AdditionalMatchers.gt;
+import static org.mockito.AdditionalMatchers.leq;
+import static org.mockito.AdditionalMatchers.lt;
+import static org.mockito.AdditionalMatchers.not;
+import static org.mockito.AdditionalMatchers.or;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyByte;
+import static org.mockito.Matchers.anyChar;
+import static org.mockito.Matchers.anyDouble;
+import static org.mockito.Matchers.anyFloat;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyShort;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Matchers.isNotNull;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Matchers.matches;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Matchers.same;
+import static org.mockito.Matchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 import java.util.HashMap;
@@ -23,7 +53,7 @@ import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class MatchersTest extends TestBase {
     private IMethods mock;
 
@@ -39,7 +69,7 @@ public class MatchersTest extends TestBase {
         when(mock.oneArg(and(eq('a'), eq('a')))).thenReturn("2");
         when(mock.oneArg(and(eq((double) 1), eq((double) 1)))).thenReturn("3");
         when(mock.oneArg(and(eq((float) 1), eq((float) 1)))).thenReturn("4");
-        when(mock.oneArg(and(eq((int) 1), eq((int) 1)))).thenReturn("5");
+        when(mock.oneArg(and(eq(1), eq(1)))).thenReturn("5");
         when(mock.oneArg(and(eq((long) 1), eq((long) 1)))).thenReturn("6");
         when(mock.oneArg(and(eq((short) 1), eq((short) 1)))).thenReturn("7");
         when(mock.oneArg(and(Matchers.contains("a"), Matchers.contains("d")))).thenReturn("8");
@@ -52,7 +82,7 @@ public class MatchersTest extends TestBase {
         assertEquals("2", mock.oneArg('a'));
         assertEquals("3", mock.oneArg((double) 1));
         assertEquals("4", mock.oneArg((float) 1));
-        assertEquals("5", mock.oneArg((int) 1));
+        assertEquals("5", mock.oneArg(1));
         assertEquals("6", mock.oneArg((long) 1));
         assertEquals("7", mock.oneArg((short) 1));
 
@@ -69,7 +99,7 @@ public class MatchersTest extends TestBase {
         when(mock.oneArg(or(eq((char) 1), eq((char) 2)))).thenReturn("2");
         when(mock.oneArg(or(eq((double) 1), eq((double) 2)))).thenReturn("3");
         when(mock.oneArg(or(eq((float) 1), eq((float) 2)))).thenReturn("4");
-        when(mock.oneArg(or(eq((int) 1), eq((int) 2)))).thenReturn("5");
+        when(mock.oneArg(or(eq(1), eq(2)))).thenReturn("5");
         when(mock.oneArg(or(eq((long) 1), eq((long) 2)))).thenReturn("6");
         when(mock.oneArg(or(eq((short) 1), eq((short) 2)))).thenReturn("7");
         when(mock.oneArg(or(eq("asd"), eq("jkl")))).thenReturn("8");
@@ -82,7 +112,7 @@ public class MatchersTest extends TestBase {
         assertEquals("2", mock.oneArg((char) 1));
         assertEquals("3", mock.oneArg((double) 2));
         assertEquals("4", mock.oneArg((float) 1));
-        assertEquals("5", mock.oneArg((int) 2));
+        assertEquals("5", mock.oneArg(2));
         assertEquals("6", mock.oneArg((long) 1));
         assertEquals("7", mock.oneArg((short) 1));
 
@@ -101,7 +131,7 @@ public class MatchersTest extends TestBase {
         when(mock.oneArg(not(eq('a')))).thenReturn("2");
         when(mock.oneArg(not(eq((double) 1)))).thenReturn("3");
         when(mock.oneArg(not(eq((float) 1)))).thenReturn("4");
-        when(mock.oneArg(not(eq((int) 1)))).thenReturn("5");
+        when(mock.oneArg(not(eq(1)))).thenReturn("5");
         when(mock.oneArg(not(eq((long) 1)))).thenReturn("6");
         when(mock.oneArg(not(eq((short) 1)))).thenReturn("7");
         when(mock.oneArg(not(Matchers.contains("a")))).thenReturn("8");
@@ -114,7 +144,7 @@ public class MatchersTest extends TestBase {
         assertEquals("2", mock.oneArg('b'));
         assertEquals("3", mock.oneArg((double) 2));
         assertEquals("4", mock.oneArg((float) 2));
-        assertEquals("5", mock.oneArg((int) 2));
+        assertEquals("5", mock.oneArg(2));
         assertEquals("6", mock.oneArg((long) 2));
         assertEquals("7", mock.oneArg((short) 2));
         assertEquals("8", mock.oneArg("bcde"));
@@ -128,7 +158,7 @@ public class MatchersTest extends TestBase {
         when(mock.oneArg(leq((byte) 1))).thenReturn("1");
         when(mock.oneArg(leq((double) 1))).thenReturn("3");
         when(mock.oneArg(leq((float) 1))).thenReturn("4");
-        when(mock.oneArg(leq((int) 1))).thenReturn("5");
+        when(mock.oneArg(leq(1))).thenReturn("5");
         when(mock.oneArg(leq((long) 1))).thenReturn("6");
         when(mock.oneArg(leq((short) 1))).thenReturn("7");
         when(mock.oneArg(leq(new BigDecimal("1")))).thenReturn("8");
@@ -139,7 +169,7 @@ public class MatchersTest extends TestBase {
         assertEquals("3", mock.oneArg((double) 1));
         assertEquals("7", mock.oneArg((short) 0));
         assertEquals("4", mock.oneArg((float) -5));
-        assertEquals("5", mock.oneArg((int) -2));
+        assertEquals("5", mock.oneArg(-2));
         assertEquals("6", mock.oneArg((long) -3));
 
         assertEquals("8", mock.oneArg(new BigDecimal("0.5")));
@@ -151,7 +181,7 @@ public class MatchersTest extends TestBase {
         when(mock.oneArg(lt((byte) 1))).thenReturn("1");
         when(mock.oneArg(lt((double) 1))).thenReturn("3");
         when(mock.oneArg(lt((float) 1))).thenReturn("4");
-        when(mock.oneArg(lt((int) 1))).thenReturn("5");
+        when(mock.oneArg(lt(1))).thenReturn("5");
         when(mock.oneArg(lt((long) 1))).thenReturn("6");
         when(mock.oneArg(lt((short) 1))).thenReturn("7");
         when(mock.oneArg(lt(new BigDecimal("1")))).thenReturn("8");
@@ -162,7 +192,7 @@ public class MatchersTest extends TestBase {
         assertEquals("3", mock.oneArg((double) 0));
         assertEquals("7", mock.oneArg((short) 0));
         assertEquals("4", mock.oneArg((float) -4));
-        assertEquals("5", mock.oneArg((int) -34));
+        assertEquals("5", mock.oneArg(-34));
         assertEquals("6", mock.oneArg((long) -6));
 
         assertEquals("8", mock.oneArg(new BigDecimal("0.5")));
@@ -174,7 +204,7 @@ public class MatchersTest extends TestBase {
         when(mock.oneArg(geq((byte) 1))).thenReturn("1");
         when(mock.oneArg(geq((double) 1))).thenReturn("3");
         when(mock.oneArg(geq((float) 1))).thenReturn("4");
-        when(mock.oneArg(geq((int) 1))).thenReturn("5");
+        when(mock.oneArg(geq(1))).thenReturn("5");
         when(mock.oneArg(geq((long) 1))).thenReturn("6");
         when(mock.oneArg(geq((short) 1))).thenReturn("7");
         when(mock.oneArg(geq(new BigDecimal("1")))).thenReturn("8");
@@ -185,7 +215,7 @@ public class MatchersTest extends TestBase {
         assertEquals("3", mock.oneArg((double) 1));
         assertEquals("7", mock.oneArg((short) 2));
         assertEquals("4", mock.oneArg((float) 3));
-        assertEquals("5", mock.oneArg((int) 4));
+        assertEquals("5", mock.oneArg(4));
         assertEquals("6", mock.oneArg((long) 5));
 
         assertEquals("8", mock.oneArg(new BigDecimal("1.00")));
@@ -197,7 +227,7 @@ public class MatchersTest extends TestBase {
         when(mock.oneArg(gt((byte) 1))).thenReturn("1");
         when(mock.oneArg(gt((double) 1))).thenReturn("3");
         when(mock.oneArg(gt((float) 1))).thenReturn("4");
-        when(mock.oneArg(gt((int) 1))).thenReturn("5");
+        when(mock.oneArg(gt(1))).thenReturn("5");
         when(mock.oneArg(gt((long) 1))).thenReturn("6");
         when(mock.oneArg(gt((short) 1))).thenReturn("7");
         when(mock.oneArg(gt(new BigDecimal("1")))).thenReturn("8");
@@ -208,7 +238,7 @@ public class MatchersTest extends TestBase {
         assertEquals("3", mock.oneArg((double) 2));
         assertEquals("7", mock.oneArg((short) 2));
         assertEquals("4", mock.oneArg((float) 3));
-        assertEquals("5", mock.oneArg((int) 2));
+        assertEquals("5", mock.oneArg(2));
         assertEquals("6", mock.oneArg((long) 5));
 
         assertEquals("8", mock.oneArg(new BigDecimal("1.5")));
@@ -262,7 +292,7 @@ public class MatchersTest extends TestBase {
         assertEquals("2", mock.oneArg((char) 1));
         assertEquals("3", mock.oneArg((double) 1));
         assertEquals("4", mock.oneArg((float) 889));
-        assertEquals("5", mock.oneArg((int) 1));
+        assertEquals("5", mock.oneArg(1));
         assertEquals("6", mock.oneArg((long) 1));
         assertEquals("7", mock.oneArg((short) 1));
         assertEquals("8", mock.oneArg("Test"));
@@ -273,7 +303,7 @@ public class MatchersTest extends TestBase {
 
     @Test
     public void shouldArrayEqualsDealWithNullArray() throws Exception {
-        Object[] nullArray = null;
+        final Object[] nullArray = null;
         when(mock.oneArray(aryEq(nullArray))).thenReturn("null");
 
         assertEquals("null", mock.oneArray(nullArray));
@@ -283,7 +313,7 @@ public class MatchersTest extends TestBase {
         try {
             verify(mock).oneArray(aryEq(nullArray));
             fail();
-        } catch (WantedButNotInvoked e) {
+        } catch (final WantedButNotInvoked e) {
             assertContains("oneArray(null)", e.getMessage());
         }
     }
@@ -306,7 +336,7 @@ public class MatchersTest extends TestBase {
     
     @Test(expected=ArgumentsAreDifferent.class)
     public void arrayEqualsShouldThrowArgumentsAreDifferentExceptionForNonMatchingArguments() {        
-        List list = Mockito.mock(List.class);
+        final List list = Mockito.mock(List.class);
         
         list.add("test"); // testing fix for issue 20
         list.contains(new Object[] {"1"});
@@ -500,16 +530,16 @@ public class MatchersTest extends TestBase {
         try {
             verify(mock).oneArg(eq(1.0D, 0.1D));
             fail();
-        } catch (WantedButNotInvoked e) {
+        } catch (final WantedButNotInvoked e) {
             assertContains("eq(1.0, 0.1)", e.getMessage());
         }
     }
     
     @Test
     public void sameMatcher() {
-        Object one = new String("1243");
-        Object two = new String("1243");
-        Object three = new String("1243");
+        final Object one = new String("1243");
+        final Object two = new String("1243");
+        final Object three = new String("1243");
 
         assertNotSame(one, two);
         assertEquals(one, two);
@@ -527,7 +557,7 @@ public class MatchersTest extends TestBase {
     public void eqMatcherAndNulls() {
         mock.simpleMethod((Object) null);
 
-        verify(mock).simpleMethod((Object) eq(null));
+        verify(mock).simpleMethod(eq(null));
     }
 
     @Test

--- a/test/org/mockitousage/matchers/MoreMatchersTest.java
+++ b/test/org/mockitousage/matchers/MoreMatchersTest.java
@@ -5,16 +5,28 @@
 
 package org.mockitousage.matchers;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyCollectionOf;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.anyMapOf;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anySetOf;
+import static org.mockito.Matchers.isNotNull;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
-
-import java.util.*;
-
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class MoreMatchersTest extends TestBase {
 

--- a/test/org/mockitousage/matchers/NewMatchersTest.java
+++ b/test/org/mockitousage/matchers/NewMatchersTest.java
@@ -4,8 +4,13 @@
  */
 package org.mockitousage.matchers;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.anyCollection;
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.anySet;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.HashMap;

--- a/test/org/mockitousage/matchers/ReflectionMatchersTest.java
+++ b/test/org/mockitousage/matchers/ReflectionMatchersTest.java
@@ -5,8 +5,9 @@
 
 package org.mockitousage.matchers;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.refEq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -17,18 +18,18 @@ import org.mockitoutil.TestBase;
 public class ReflectionMatchersTest extends TestBase {
 
     class Parent {
-        private int parentField;
+        private final int parentField;
         protected String protectedParentField;
-        public Parent(int parentField, String protectedParentField) {
+        public Parent(final int parentField, final String protectedParentField) {
             this.parentField = parentField;
             this.protectedParentField = protectedParentField;
         }
     }
     
     class Child extends Parent {
-        private int childFieldOne;
-        private Object childFieldTwo;
-        public Child(int parentField, String protectedParentField, int childFieldOne, Object childFieldTwo) {
+        private final int childFieldOne;
+        private final Object childFieldTwo;
+        public Child(final int parentField, final String protectedParentField, final int childFieldOne, final Object childFieldTwo) {
             super(parentField, protectedParentField);
             this.childFieldOne = childFieldOne;
             this.childFieldTwo = childFieldTwo;
@@ -36,7 +37,7 @@ public class ReflectionMatchersTest extends TestBase {
     }
     
     interface MockMe {
-        void run(Child child);
+        void run(final Child child);
     }
     
     MockMe mock;
@@ -45,56 +46,56 @@ public class ReflectionMatchersTest extends TestBase {
     public void setup() {
         mock = mock(MockMe.class);
         
-        Child actual = new Child(1, "foo", 2, "bar");
+        final Child actual = new Child(1, "foo", 2, "bar");
         mock.run(actual);
     }
     
     @Test
     public void shouldMatchWhenFieldValuesEqual() throws Exception {
-        Child wanted = new Child(1, "foo", 2, "bar");
+        final Child wanted = new Child(1, "foo", 2, "bar");
         verify(mock).run(refEq(wanted));
     }
     
     @Test(expected=ArgumentsAreDifferent.class)
     public void shouldNotMatchWhenFieldValuesDiffer() throws Exception {
-        Child wanted = new Child(1, "foo", 2, "bar XXX");
+        final Child wanted = new Child(1, "foo", 2, "bar XXX");
         verify(mock).run(refEq(wanted));
     }
     
     @Test(expected=ArgumentsAreDifferent.class)
     public void shouldNotMatchAgain() throws Exception {
-        Child wanted = new Child(1, "foo", 999, "bar");
+        final Child wanted = new Child(1, "foo", 999, "bar");
         verify(mock).run(refEq(wanted));
     }
     
     @Test(expected=ArgumentsAreDifferent.class)
     public void shouldNotMatchYetAgain() throws Exception {
-        Child wanted = new Child(1, "XXXXX", 2, "bar");
+        final Child wanted = new Child(1, "XXXXX", 2, "bar");
         verify(mock).run(refEq(wanted));
     }
     
     @Test(expected=ArgumentsAreDifferent.class)
     public void shouldNotMatch() throws Exception {
-        Child wanted = new Child(234234, "foo", 2, "bar");
+        final Child wanted = new Child(234234, "foo", 2, "bar");
         verify(mock).run(refEq(wanted));
     }
 
     @Test
     public void shouldMatchWhenFieldValuesEqualWithOneFieldExcluded() throws Exception {
-        Child wanted = new Child(1, "foo", 2, "excluded");
+        final Child wanted = new Child(1, "foo", 2, "excluded");
         verify(mock).run(refEq(wanted, "childFieldTwo"));
     }
 
     @Test
     public void shouldMatchWhenFieldValuesEqualWithTwoFieldsExcluded() throws Exception {
-        Child wanted = new Child(234234, "foo", 2, "excluded");
+        final Child wanted = new Child(234234, "foo", 2, "excluded");
         verify(mock).run(refEq(wanted, "childFieldTwo", "parentField"));
         verify(mock).run(refEq(wanted, "parentField", "childFieldTwo"));
     }
     
     @Test(expected=ArgumentsAreDifferent.class)
     public void shouldNotMatchWithFieldsExclusion() throws Exception {
-        Child wanted = new Child(234234, "foo", 2, "excluded");
+        final Child wanted = new Child(234234, "foo", 2, "excluded");
         verify(mock).run(refEq(wanted, "childFieldTwo"));
     }    
 }

--- a/test/org/mockitousage/matchers/VerificationAndStubbingUsingMatchersTest.java
+++ b/test/org/mockitousage/matchers/VerificationAndStubbingUsingMatchersTest.java
@@ -5,8 +5,15 @@
 
 package org.mockitousage.matchers;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.stubVoid;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -44,7 +51,7 @@ public class VerificationAndStubbingUsingMatchersTest extends TestBase {
         try {
             three.simpleMethod("test three again");
             fail();
-        } catch (RuntimeException e) {}
+        } catch (final RuntimeException e) {}
     }
     
     @SuppressWarnings("deprecation")
@@ -56,7 +63,7 @@ public class VerificationAndStubbingUsingMatchersTest extends TestBase {
         try {
             one.oneArg(true);
             fail();
-        } catch (RuntimeException e) {}
+        } catch (final RuntimeException e) {}
 
         one.simpleMethod(100);
         two.simpleMethod("test Mockito");
@@ -75,6 +82,6 @@ public class VerificationAndStubbingUsingMatchersTest extends TestBase {
         try {
             verify(three).varargsObject(eq(10), eq("first arg"), startsWith("third"));
             fail();
-        } catch (WantedButNotInvoked e) {}
+        } catch (final WantedButNotInvoked e) {}
     }
 }

--- a/test/org/mockitousage/misuse/CleaningUpPotentialStubbingTest.java
+++ b/test/org/mockitousage/misuse/CleaningUpPotentialStubbingTest.java
@@ -4,7 +4,10 @@
  */
 package org.mockitousage.misuse;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -30,7 +33,7 @@ public class CleaningUpPotentialStubbingTest extends TestBase {
     @Test
     public void shouldResetOngoingStubbingOnInOrder() {
         mock.booleanReturningMethod();
-        InOrder inOrder = inOrder(mock);
+        final InOrder inOrder = inOrder(mock);
         inOrder.verify(mock).booleanReturningMethod();
         assertOngoingStubbingIsReset();
     }
@@ -48,6 +51,6 @@ public class CleaningUpPotentialStubbingTest extends TestBase {
             //I'm modelling it with null
             when(null).thenReturn("anything");
             fail();
-        } catch (MissingMethodInvocationException e) {}
+        } catch (final MissingMethodInvocationException e) {}
     }
 }

--- a/test/org/mockitousage/misuse/DescriptiveMessagesOnMisuseTest.java
+++ b/test/org/mockitousage/misuse/DescriptiveMessagesOnMisuseTest.java
@@ -5,7 +5,10 @@
 
 package org.mockitousage.misuse;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import org.junit.Test;
 import org.mockito.Mock;
@@ -28,7 +31,7 @@ public class DescriptiveMessagesOnMisuseTest extends TestBase {
     @SuppressWarnings("all")
     @Test
     public void tryDescriptiveMessagesOnMisuse() {
-        Foo foo = mock(Foo.class);
+        final Foo foo = mock(Foo.class);
         
 //        when(foo.finalMethod()).thenReturn("foo");
 //        doReturn("foo").when(foo).finalMethod();
@@ -94,6 +97,6 @@ public class DescriptiveMessagesOnMisuseTest extends TestBase {
     @SuppressWarnings("all")
     @Test(expected=MockitoException.class)
     public void shouldScreamWhenNullPassedToVerifyNoMoreInteractions() {
-        verifyNoMoreInteractions((Object[])null);
+        verifyNoMoreInteractions((Object[]) null);
     }
 }

--- a/test/org/mockitousage/misuse/DetectingFinalMethodsTest.java
+++ b/test/org/mockitousage/misuse/DetectingFinalMethodsTest.java
@@ -3,14 +3,16 @@
  * This program is made available under the terms of the MIT License.
  */
 package org.mockitousage.misuse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.exceptions.misusing.MissingMethodInvocationException;
 import org.mockito.exceptions.misusing.UnfinishedVerificationException;
 import org.mockitoutil.TestBase;
-
-import static org.mockito.Mockito.*;
 
 public class DetectingFinalMethodsTest extends TestBase {
     
@@ -29,7 +31,7 @@ public class DetectingFinalMethodsTest extends TestBase {
         try {
             verify(withFinal).foo();
             fail();
-        } catch (UnfinishedVerificationException e) {}
+        } catch (final UnfinishedVerificationException e) {}
     }
 
     @Test
@@ -39,6 +41,6 @@ public class DetectingFinalMethodsTest extends TestBase {
         try {
             when(withFinal.foo()).thenReturn(null);
             fail();
-        } catch (MissingMethodInvocationException e) {}
+        } catch (final MissingMethodInvocationException e) {}
     }
 }

--- a/test/org/mockitousage/misuse/ExplicitFrameworkValidationTest.java
+++ b/test/org/mockitousage/misuse/ExplicitFrameworkValidationTest.java
@@ -5,8 +5,9 @@
 
 package org.mockitousage.misuse;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 import org.mockito.Mock;
@@ -27,7 +28,7 @@ public class ExplicitFrameworkValidationTest extends TestBase {
         try {
             Mockito.validateMockitoUsage();
             fail();
-        } catch (UnfinishedVerificationException e) {}
+        } catch (final UnfinishedVerificationException e) {}
     }
     
     @Test
@@ -36,7 +37,7 @@ public class ExplicitFrameworkValidationTest extends TestBase {
         try {
             Mockito.validateMockitoUsage();
             fail();
-        } catch (UnfinishedStubbingException e) {}
+        } catch (final UnfinishedStubbingException e) {}
     }
     
     @Test
@@ -45,6 +46,6 @@ public class ExplicitFrameworkValidationTest extends TestBase {
         try {
             Mockito.validateMockitoUsage();
             fail();
-        } catch (InvalidUseOfMatchersException e) {}
+        } catch (final InvalidUseOfMatchersException e) {}
     }
 }

--- a/test/org/mockitousage/misuse/InvalidUsageTest.java
+++ b/test/org/mockitousage/misuse/InvalidUsageTest.java
@@ -5,6 +5,12 @@
 
 package org.mockitousage.misuse;
 
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -13,8 +19,6 @@ import org.mockito.exceptions.base.MockitoException;
 import org.mockito.exceptions.misusing.MissingMethodInvocationException;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
-
-import static org.mockito.Mockito.*;
 
 public class InvalidUsageTest extends TestBase {
 
@@ -43,7 +47,7 @@ public class InvalidUsageTest extends TestBase {
     
     @Test(expected=MockitoException.class)
     public void shouldNotAllowVerifyingInOrderUnfamilarMocks() {
-        InOrder inOrder = inOrder(mock);
+        final InOrder inOrder = inOrder(mock);
         inOrder.verify(mockTwo).simpleMethod();
     }
     
@@ -87,14 +91,14 @@ public class InvalidUsageTest extends TestBase {
     }
     
     interface ObjectLikeInterface {
-        boolean equals(Object o);
+        boolean equals(final Object o);
         String toString();
         int hashCode();
     }
     
     @Test
     public void shouldNotMockObjectMethodsOnInterface() throws Exception {
-        ObjectLikeInterface inter = mock(ObjectLikeInterface.class);
+        final ObjectLikeInterface inter = mock(ObjectLikeInterface.class);
         
         inter.equals(null);
         inter.toString();
@@ -104,7 +108,7 @@ public class InvalidUsageTest extends TestBase {
     }
     
     public void shouldNotMockObjectMethodsOnClass() throws Exception {
-        Object clazz = mock(ObjectLikeInterface.class);
+        final Object clazz = mock(ObjectLikeInterface.class);
         
         clazz.equals(null);
         clazz.toString();

--- a/test/org/mockitousage/misuse/RestrictedObjectMethodsTest.java
+++ b/test/org/mockitousage/misuse/RestrictedObjectMethodsTest.java
@@ -5,7 +5,8 @@
 
 package org.mockitousage.misuse;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
 
 import java.util.List;
 
@@ -16,7 +17,7 @@ import org.mockito.Mock;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class RestrictedObjectMethodsTest extends TestBase {
 
     @Mock List mock;
@@ -31,7 +32,7 @@ public class RestrictedObjectMethodsTest extends TestBase {
         try {
             verify(mock).toString();
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             assertContains("cannot verify", e.getMessage());
         }
     }
@@ -57,7 +58,7 @@ public class RestrictedObjectMethodsTest extends TestBase {
         //because it leads to really wierd behavior sometimes
         //it's because cglib & my code can occasionelly call those methods
         // and when user has verification started at that time there will be a mess
-        InOrder inOrder = inOrder(mock);
+        final InOrder inOrder = inOrder(mock);
         inOrder.verify(mock).equals(null);
     }       
 }

--- a/test/org/mockitousage/misuse/SpyStubbingMisuseTest.java
+++ b/test/org/mockitousage/misuse/SpyStubbingMisuseTest.java
@@ -4,25 +4,27 @@
  */
 package org.mockitousage.misuse;
 
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
 import org.junit.Test;
 import org.mockito.exceptions.misusing.WrongTypeOfReturnValue;
-
-import static org.junit.Assert.fail;
-import static org.fest.assertions.Assertions.assertThat;
-import static org.mockito.Mockito.*;
 
 public class SpyStubbingMisuseTest {
 
     @Test
     public void nestedWhenTest() {
-        Strategy mfoo = mock(Strategy.class);
-        Sampler mpoo = mock(Sampler.class);
-        Producer out = spy(new Producer(mfoo));
+        final Strategy mfoo = mock(Strategy.class);
+        final Sampler mpoo = mock(Sampler.class);
+        final Producer out = spy(new Producer(mfoo));
 
         try {
             when(out.produce()).thenReturn(mpoo);
             fail();
-        } catch (WrongTypeOfReturnValue e) {
+        } catch (final WrongTypeOfReturnValue e) {
             assertThat(e.getMessage()).contains("spy").contains("syntax").contains("doReturn|Throw");
         }
     }
@@ -37,14 +39,14 @@ public class SpyStubbingMisuseTest {
 
     public class Sampler {
         Sample sample;
-        Sampler(Strategy f) {
+        Sampler(final Strategy f) {
             sample = f.getSample();
         }
     }
 
     public class Producer {
         Strategy strategy;
-        Producer(Strategy f) {
+        Producer(final Strategy f) {
             strategy = f;
         }
         Sampler produce() {

--- a/test/org/mockitousage/packageprotected/MockingPackageProtectedTest.java
+++ b/test/org/mockitousage/packageprotected/MockingPackageProtectedTest.java
@@ -5,7 +5,7 @@
 
 package org.mockitousage.packageprotected;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 import org.junit.Test;
 import org.mockitoutil.TestBase;

--- a/test/org/mockitousage/performance/LoadsOfMocksTest.java
+++ b/test/org/mockitousage/performance/LoadsOfMocksTest.java
@@ -5,7 +5,9 @@
 
 package org.mockitousage.performance;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -15,16 +17,16 @@ import org.junit.Test;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class LoadsOfMocksTest extends TestBase {
 
     @Ignore("Use it for performance checks")
     @Test
     public void testSomething() {
-        List mocks = new LinkedList();
+        final List mocks = new LinkedList();
         for (int i = 0; i < 50000; i++) {
             System.out.println("Mock no: " + i);
-            IMethods mock = mock(IMethods.class);
+            final IMethods mock = mock(IMethods.class);
             mocks.add(mock);
             
             when(mock.simpleMethod(1)).thenReturn("one");

--- a/test/org/mockitousage/puzzlers/BridgeMethodPuzzleTest.java
+++ b/test/org/mockitousage/puzzlers/BridgeMethodPuzzleTest.java
@@ -5,8 +5,9 @@
 
 package org.mockitousage.puzzlers;
 
-import static org.mockito.Mockito.*;
-import static org.mockitoutil.ExtraMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockitoutil.ExtraMatchers.hasBridgeMethod;
 
 import org.junit.Test;
 import org.mockitoutil.TestBase;
@@ -18,35 +19,35 @@ import org.mockitoutil.TestBase;
  * method in Subclass so that erasures are the same, signatures of methods match
  * and overridding is ON.
  */
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class BridgeMethodPuzzleTest extends TestBase {
     
     private class Super<T> {
-        public String say(T t) {
+        public String say(final T t) {
             return "Super says: " + t;
         }
     }
     
     private class Sub extends Super<String> {
         @Override
-        public String say(String t)  {
+        public String say(final String t)  {
             return "Dummy says: " + t;
         }
     }
 
     Super mock;
     
-    private void setMockWithDownCast(Super mock) {
+    private void setMockWithDownCast(final Super mock) {
         this.mock = mock;
     }
     
-    private void say(String string) {
+    private void say(final String string) {
         mock.say(string);
     }
     
     @Test
     public void shouldHaveBridgeMethod() throws Exception {
-        Super s = new Sub();
+        final Super s = new Sub();
         
         assertEquals("Dummy says: Hello", s.say("Hello"));
         
@@ -58,7 +59,7 @@ public class BridgeMethodPuzzleTest extends TestBase {
     public void shouldVerifyCorrectlyWhenBridgeMethodCalled() throws Exception {
         //Super has following erasure: say(Object) which differs from Dummy.say(String)
         //mock has to detect it and do the super.say()
-        Sub s = mock(Sub.class);
+        final Sub s = mock(Sub.class);
         setMockWithDownCast(s);
         say("Hello");
         

--- a/test/org/mockitousage/puzzlers/OverloadingPuzzleTest.java
+++ b/test/org/mockitousage/puzzlers/OverloadingPuzzleTest.java
@@ -4,7 +4,8 @@
  */
 package org.mockitousage.puzzlers;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import org.junit.Test;
 import org.mockito.exceptions.verification.WantedButNotInvoked;
@@ -14,30 +15,30 @@ public class OverloadingPuzzleTest extends TestBase {
 
     private Super mock;
 
-    private void setMockWithDowncast(Super mock) {
+    private void setMockWithDowncast(final Super mock) {
         this.mock = mock;
     }
 
     private interface Super {
-        void say(Object message);
+        void say(final Object message);
     }
 
     private interface Sub extends Super {
-        void say(String message);
+        void say(final String message);
     }
 
-    private void say(Object message) {
+    private void say(final Object message) {
         mock.say(message);
     }
 
     @Test
     public void shouldUseArgumentTypeWhenOverloadingPuzzleDetected() throws Exception {
-        Sub sub = mock(Sub.class);
+        final Sub sub = mock(Sub.class);
         setMockWithDowncast(sub);
         say("Hello");
         try {
             verify(sub).say("Hello");
             fail();
-        } catch (WantedButNotInvoked e) {}
+        } catch (final WantedButNotInvoked e) {}
     }
 }

--- a/test/org/mockitousage/serialization/AcrossClassLoaderSerializationTest.java
+++ b/test/org/mockitousage/serialization/AcrossClassLoaderSerializationTest.java
@@ -9,6 +9,7 @@ import java.io.ByteArrayInputStream;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -29,12 +30,12 @@ public class AcrossClassLoaderSerializationTest {
 
     @Test
     public void check_that_mock_can_be_serialized_in_a_classloader_and_deserialized_in_another() throws Exception {
-        byte[] bytes = create_mock_and_serialize_it_in_class_loader_A();
+        final byte[] bytes = create_mock_and_serialize_it_in_class_loader_A();
 
-        Object the_deserialized_mock = read_stream_and_deserialize_it_in_class_loader_B(bytes);
+        final Object the_deserialized_mock = read_stream_and_deserialize_it_in_class_loader_B(bytes);
     }
 
-    private Object read_stream_and_deserialize_it_in_class_loader_B(byte[] bytes) throws Exception {
+    private Object read_stream_and_deserialize_it_in_class_loader_B(final byte[] bytes) throws Exception {
         return new SimplePerRealmReloadingClassLoader(this.getClass().getClassLoader(), isolating_test_classes())
                 .doInRealm(
                         "org.mockitousage.serialization.AcrossClassLoaderSerializationTest$ReadStreamAndDeserializeIt",
@@ -51,10 +52,9 @@ public class AcrossClassLoaderSerializationTest {
 
     private SimplePerRealmReloadingClassLoader.ReloadClassPredicate isolating_test_classes() {
         return new SimplePerRealmReloadingClassLoader.ReloadClassPredicate() {
-            public boolean acceptReloadOf(String qualifiedName) {
+            public boolean acceptReloadOf(final String qualifiedName) {
                 return qualifiedName.contains("org.mockitousage")
-                        || qualifiedName.contains("org.mockitoutil")
-                        ;
+                        || qualifiedName.contains("org.mockitoutil");
             }
         };
     }
@@ -63,7 +63,7 @@ public class AcrossClassLoaderSerializationTest {
     // see create_mock_and_serialize_it_in_class_loader_A
     public static class CreateMockAndSerializeIt implements Callable<byte[]> {
         public byte[] call() throws Exception {
-            AClassToBeMockedInThisTestOnlyAndInCallablesOnly mock = Mockito.mock(
+            final AClassToBeMockedInThisTestOnlyAndInCallablesOnly mock = Mockito.mock(
                     AClassToBeMockedInThisTestOnlyAndInCallablesOnly.class,
                     Mockito.withSettings().serializable(SerializableMode.ACROSS_CLASSLOADERS)
             );
@@ -76,14 +76,14 @@ public class AcrossClassLoaderSerializationTest {
 
     // see read_stream_and_deserialize_it_in_class_loader_B
     public static class ReadStreamAndDeserializeIt implements Callable<Object> {
-        private byte[] bytes;
+        private final byte[] bytes;
 
-        public ReadStreamAndDeserializeIt(byte[] bytes) {
+        public ReadStreamAndDeserializeIt(final byte[] bytes) {
             this.bytes = bytes;
         }
 
         public Object call() throws Exception {
-            ByteArrayInputStream to_unserialize = new ByteArrayInputStream(bytes);
+            final ByteArrayInputStream to_unserialize = new ByteArrayInputStream(bytes);
             return SimpleSerializationUtil.deserializeMock(
                     to_unserialize,
                     AClassToBeMockedInThisTestOnlyAndInCallablesOnly.class

--- a/test/org/mockitousage/serialization/DeepStubsSerializableTest.java
+++ b/test/org/mockitousage/serialization/DeepStubsSerializableTest.java
@@ -10,19 +10,21 @@ import static org.mockitoutil.SimpleSerializationUtil.serializeAndBack;
 import java.io.Serializable;
 import java.util.Iterator;
 import java.util.List;
+
 import org.junit.Test;
 
+@SuppressWarnings("serial")
 public class DeepStubsSerializableTest {
 
     @Test
     public void should_serialize_and_deserialize_mock_created_with_deep_stubs() throws Exception {
         // given
-        SampleClass sampleClass = mock(SampleClass.class, withSettings().defaultAnswer(RETURNS_DEEP_STUBS).serializable());
+        final SampleClass sampleClass = mock(SampleClass.class, withSettings().defaultAnswer(RETURNS_DEEP_STUBS).serializable());
         when(sampleClass.getSample().isFalse()).thenReturn(true);
         when(sampleClass.getSample().number()).thenReturn(999);
 
         // when
-        SampleClass deserializedSample = serializeAndBack(sampleClass);
+        final SampleClass deserializedSample = serializeAndBack(sampleClass);
 
         // then
         assertThat(deserializedSample.getSample().isFalse()).isEqualTo(true);
@@ -32,12 +34,12 @@ public class DeepStubsSerializableTest {
     @Test
     public void should_serialize_and_deserialize_parameterized_class_mocked_with_deep_stubs() throws Exception {
         // given
-        ListContainer deep_stubbed = mock(ListContainer.class, withSettings().defaultAnswer(RETURNS_DEEP_STUBS).serializable());
+        final ListContainer deep_stubbed = mock(ListContainer.class, withSettings().defaultAnswer(RETURNS_DEEP_STUBS).serializable());
         when(deep_stubbed.iterator().next().add("yes")).thenReturn(true);
 
         // when
-        ListContainer deserialized_deep_stub = serializeAndBack(deep_stubbed);
-        
+        final ListContainer deserialized_deep_stub = serializeAndBack(deep_stubbed);
+
         // then
         assertThat(deserialized_deep_stub.iterator().next().add("not stubbed but mock already previously resolved")).isEqualTo(false);
         assertThat(deserialized_deep_stub.iterator().next().add("yes")).isEqualTo(true);
@@ -46,42 +48,64 @@ public class DeepStubsSerializableTest {
     @Test(expected = ClassCastException.class)
     public void should_discard_generics_metadata_when_serialized_then_disabling_deep_stubs_with_generics() throws Exception {
         // given
-        ListContainer deep_stubbed = mock(ListContainer.class, withSettings().defaultAnswer(RETURNS_DEEP_STUBS).serializable());
+        final ListContainer deep_stubbed = mock(ListContainer.class, withSettings().defaultAnswer(RETURNS_DEEP_STUBS).serializable());
         when(deep_stubbed.iterator().hasNext()).thenReturn(true);
 
-        ListContainer deserialized_deep_stub = serializeAndBack(deep_stubbed);
+        final ListContainer deserialized_deep_stub = serializeAndBack(deep_stubbed);
 
         // when stubbing on a deserialized mock
         when(deserialized_deep_stub.iterator().next().get(42)).thenReturn("no");
 
-        // then revert to the default RETURNS_DEEP_STUBS and the code will raise a ClassCastException
+        // then revert to the default RETURNS_DEEP_STUBS and the code will raise
+        // a ClassCastException
     }
 
-
     static class SampleClass implements Serializable {
-        SampleClass2 getSample() { return new SampleClass2(); }
+        SampleClass2 getSample() {
+            return new SampleClass2();
+        }
     }
 
     static class SampleClass2 implements Serializable {
-        boolean isFalse() { return false; }
-        int number() { return 100; }
+        boolean isFalse() {
+            return false;
+        }
+
+        int number() {
+            return 100;
+        }
     }
 
     static class Container<E> implements Iterable<E>, Serializable {
-        private E e;
-        public Container(E e) { this.e = e; }
-        public E get() { return e; }
+        private final E e;
+
+        public Container(final E e) {
+            this.e = e;
+        }
+
+        public E get() {
+            return e;
+        }
 
         public Iterator<E> iterator() {
             return new Iterator<E>() {
-                public boolean hasNext() { return true; }
-                public E next() { return e; }
-                public void remove() { }
+                public boolean hasNext() {
+                    return true;
+                }
+
+                public E next() {
+                    return e;
+                }
+
+                public void remove() {
+                }
             };
         }
     }
 
     static class ListContainer extends Container<List<String>> {
-        public ListContainer(List<String> list) { super(list); }
+        public ListContainer(final List<String> list) {
+            super(list);
+        }
     }
 }

--- a/test/org/mockitousage/serialization/ParallelSerializationTest.java
+++ b/test/org/mockitousage/serialization/ParallelSerializationTest.java
@@ -5,32 +5,38 @@
 
 package org.mockitousage.serialization;
 
-import org.junit.Test;
-import org.mockitousage.IMethods;
-import org.mockitoutil.SimpleSerializationUtil;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
 
 import java.nio.charset.CharacterCodingException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-import java.util.concurrent.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.withSettings;
+import org.junit.Test;
+import org.mockitousage.IMethods;
+import org.mockitoutil.SimpleSerializationUtil;
 
+@SuppressWarnings("rawtypes")
 public class ParallelSerializationTest {
 
     @Test
     public void single_mock_being_serialized_in_different_classloaders_by_multiple_threads() throws ExecutionException, InterruptedException {
         // given
-        int iterations = 2;
-        int threadingFactor = 200;
+        final int iterations = 2;
+        final int threadingFactor = 200;
         final ExecutorService executorService = Executors.newFixedThreadPool(threadingFactor);
         final IMethods iMethods_that_store_invocations = mock(IMethods.class, withSettings().serializable());
 
         // when
         for (int i = 0; i <= iterations; i++) {
-            List<Future> futures = new ArrayList<Future>(threadingFactor);
+            final List<Future> futures = new ArrayList<Future>(threadingFactor);
             final CyclicBarrier barrier_that_will_wait_until_threads_are_ready = new CyclicBarrier(threadingFactor);
 
             // prepare all threads by submitting a callable
@@ -58,14 +64,14 @@ public class ParallelSerializationTest {
             }
 
             // ensure we are getting the futures
-            for (Future future : futures) {
+            for (final Future future : futures) {
                 future.get();
             }
         }
     }
 
-    private void randomCallOn(IMethods iMethods) throws CharacterCodingException {
-        int random = new Random().nextInt(10);
+    private void randomCallOn(final IMethods iMethods) throws CharacterCodingException {
+        final int random = new Random().nextInt(10);
         switch (random) {
             case 0 : iMethods.arrayReturningMethod(); break;
             case 1 : iMethods.longObjectReturningMethod(); break;

--- a/test/org/mockitousage/spies/PartialMockingWithSpiesTest.java
+++ b/test/org/mockitousage/spies/PartialMockingWithSpiesTest.java
@@ -5,7 +5,10 @@
 
 package org.mockitousage.spies;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -21,7 +24,7 @@ public class PartialMockingWithSpiesTest extends TestBase {
     }
     
     class InheritMe {
-        private String inherited = "100$";
+        private final String inherited = "100$";
         protected String getInherited() {
             return inherited;
         }
@@ -55,7 +58,7 @@ public class PartialMockingWithSpiesTest extends TestBase {
     class Name {
         private final String name;
 
-        public Name(String name) {
+        public Name(final String name) {
             this.name = name;
         }
     }
@@ -65,7 +68,7 @@ public class PartialMockingWithSpiesTest extends TestBase {
     @Test
     public void shouldCallRealMethdsEvenDelegatedToOtherSelfMethod() {
         // when
-        String name = spy.getName();
+        final String name = spy.getName();
 
         // then
         assertEquals("Default name", name);
@@ -90,7 +93,7 @@ public class PartialMockingWithSpiesTest extends TestBase {
         try {
             spy.getNameButDelegateToMethodThatThrows();
             fail();
-        } catch(Exception e) {
+        } catch(final Exception e) {
             assertEquals("appetite for destruction", e.getMessage());
         }
     }
@@ -101,7 +104,7 @@ public class PartialMockingWithSpiesTest extends TestBase {
             // when
             spy.getNameButDelegateToMethodThatThrows();
             fail();
-        } catch (Throwable t) {
+        } catch (final Throwable t) {
             // then
             assertThat(t, ExtraMatchers.hasMethodsInStackTrace(
                     "throwSomeException",
@@ -130,7 +133,7 @@ public class PartialMockingWithSpiesTest extends TestBase {
         // given
         when(spy.guessName()).thenReturn(new Name("John"));
         // when
-        String name = spy.getName();
+        final String name = spy.getName();
         // then
         assertEquals("John", name);
     }

--- a/test/org/mockitousage/spies/SpyingOnInterfacesTest.java
+++ b/test/org/mockitousage/spies/SpyingOnInterfacesTest.java
@@ -5,7 +5,8 @@
 
 package org.mockitousage.spies;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 
@@ -15,27 +16,27 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings({"unchecked"})
+@SuppressWarnings("rawtypes")
 public class SpyingOnInterfacesTest extends TestBase {
 
     @Test
     public void shouldFailFastWhenCallingRealMethodOnInterface() throws Exception {
-        List list = mock(List.class);
+        final List list = mock(List.class);
         try {
             //when
             when(list.get(0)).thenCallRealMethod();
             //then
             fail();
-        } catch (MockitoException e) {}
+        } catch (final MockitoException e) {}
     }
     
     @Test
     public void shouldFailInRuntimeWhenCallingRealMethodOnInterface() throws Exception {
         //given
-        List list = mock(List.class);
+        final List list = mock(List.class);
         when(list.get(0)).thenAnswer(
             new Answer() {
-                public Object answer(InvocationOnMock invocation) throws Throwable {
+                public Object answer(final InvocationOnMock invocation) throws Throwable {
                     return invocation.callRealMethod();
                 }
             }
@@ -45,6 +46,6 @@ public class SpyingOnInterfacesTest extends TestBase {
             list.get(0);            
             //then
             fail();
-        } catch (MockitoException e) {}
+        } catch (final MockitoException e) {}
     }
 }

--- a/test/org/mockitousage/spies/SpyingOnRealObjectsTest.java
+++ b/test/org/mockitousage/spies/SpyingOnRealObjectsTest.java
@@ -5,8 +5,15 @@
 
 package org.mockitousage.spies;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.stubVoid;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -21,7 +28,7 @@ import org.mockito.exceptions.verification.TooLittleActualInvocations;
 import org.mockito.exceptions.verification.VerificationInOrderFailure;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class SpyingOnRealObjectsTest extends TestBase {
 
     List list = new LinkedList();
@@ -80,7 +87,7 @@ public class SpyingOnRealObjectsTest extends TestBase {
         try {
             spy.clear();
             fail();
-        } catch (RuntimeException e) {}
+        } catch (final RuntimeException e) {}
             
         assertEquals(1, spy.size());
     }
@@ -103,7 +110,7 @@ public class SpyingOnRealObjectsTest extends TestBase {
         spy.add("one");
         spy.add("two");
         
-        InOrder inOrder = inOrder(spy);
+        final InOrder inOrder = inOrder(spy);
         inOrder.verify(spy).add("one");
         inOrder.verify(spy).add("two");
         
@@ -115,12 +122,12 @@ public class SpyingOnRealObjectsTest extends TestBase {
         spy.add("one");
         spy.add("two");
         
-        InOrder inOrder = inOrder(spy);
+        final InOrder inOrder = inOrder(spy);
         inOrder.verify(spy).add("two");
         try {
             inOrder.verify(spy).add("one");
             fail();
-        } catch (VerificationInOrderFailure f) {}
+        } catch (final VerificationInOrderFailure f) {}
     }
     
     @Test
@@ -140,7 +147,7 @@ public class SpyingOnRealObjectsTest extends TestBase {
         try {
             verify(spy, times(3)).add("one");
             fail();
-        } catch (TooLittleActualInvocations e) {}
+        } catch (final TooLittleActualInvocations e) {}
     }
     
     @Test
@@ -152,7 +159,7 @@ public class SpyingOnRealObjectsTest extends TestBase {
         try {
             verifyNoMoreInteractions(spy);
             fail();
-        } catch (NoInteractionsWanted e) {}
+        } catch (final NoInteractionsWanted e) {}
     }
     
     @Test
@@ -168,7 +175,7 @@ public class SpyingOnRealObjectsTest extends TestBase {
     @Test
     public void shouldAllowSpyingAnonymousClasses() {
         //when
-        Foo spy = spy(new Foo() {
+        final Foo spy = spy(new Foo() {
             public String print() {
                 return "foo";
             }
@@ -180,11 +187,11 @@ public class SpyingOnRealObjectsTest extends TestBase {
     
     @Test
     public void shouldSayNiceMessageWhenSpyingOnPrivateClass() throws Exception {
-        List real = Arrays.asList("first", "second");
+        final List real = Arrays.asList("first", "second");
         try {
             spy(real);
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             assertContains("Most likely it is a private class that is not visible by Mockito", e.getMessage());
         }
     }

--- a/test/org/mockitousage/spies/StubbingSpiesDoesNotYieldNPETest.java
+++ b/test/org/mockitousage/spies/StubbingSpiesDoesNotYieldNPETest.java
@@ -4,8 +4,12 @@
  */
 package org.mockitousage.spies;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.anyCollection;
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.anySet;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.spy;
 
 import java.util.Collection;
 import java.util.Map;
@@ -13,27 +17,27 @@ import java.util.Map;
 import org.junit.Test;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class StubbingSpiesDoesNotYieldNPETest extends TestBase {
     
     class Foo {
-        public int len(String text) {
+        public int len(final String text) {
             return text.length();
         }
         
-        public int size(Map map) {
+        public int size(final Map map) {
             return map.size();
         }
         
-        public int size(Collection collection) {
+        public int size(final Collection collection) {
             return collection.size();
         }
     }
     
     @Test
     public void shouldNotThrowNPE() throws Exception {
-        Foo foo = new Foo();
-        Foo spy = spy(foo);
+        final Foo foo = new Foo();
+        final Foo spy = spy(foo);
         
         spy.len(anyString());
         spy.size(anyMap());

--- a/test/org/mockitousage/stacktrace/ClickableStackTracesTest.java
+++ b/test/org/mockitousage/stacktrace/ClickableStackTracesTest.java
@@ -5,7 +5,8 @@
 
 package org.mockitousage.stacktrace;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import org.junit.Test;
 import org.mockito.Mock;
@@ -17,11 +18,11 @@ public class ClickableStackTracesTest extends TestBase {
     
     @Mock private IMethods mock;
 
-    private void callMethodOnMock(String param) {
+    private void callMethodOnMock(final String param) {
         mock.simpleMethod(param);
     }
 
-    private void verifyTheMock(int times, String param) {
+    private void verifyTheMock(final int times, final String param) {
         verify(mock, times(times)).simpleMethod(param);
     }
     
@@ -31,7 +32,7 @@ public class ClickableStackTracesTest extends TestBase {
         try {
             verifyTheMock(1, "not foo");
             fail();
-        } catch (ArgumentsAreDifferent e) {
+        } catch (final ArgumentsAreDifferent e) {
             assertContains("callMethodOnMock(", e.getMessage());
             assertContains("verifyTheMock(", e.getMessage());
         }

--- a/test/org/mockitousage/stacktrace/ClickableStackTracesWhenFrameworkMisusedTest.java
+++ b/test/org/mockitousage/stacktrace/ClickableStackTracesWhenFrameworkMisusedTest.java
@@ -5,8 +5,10 @@
 
 package org.mockitousage.stacktrace;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.After;
 import org.junit.Test;
@@ -36,7 +38,7 @@ public class ClickableStackTracesWhenFrameworkMisusedTest extends TestBase {
         try {
             verify(mock).simpleMethod();
             fail();
-        } catch (InvalidUseOfMatchersException e) {
+        } catch (final InvalidUseOfMatchersException e) {
             assertContains("-> at ", e.getMessage());
             assertContains("misplacedArgumentMatcherHere(", e.getMessage());
         }
@@ -53,7 +55,7 @@ public class ClickableStackTracesWhenFrameworkMisusedTest extends TestBase {
         try {
             verify(mock).simpleMethod();
             fail();
-        } catch (UnfinishedStubbingException e) {
+        } catch (final UnfinishedStubbingException e) {
             assertContains("-> at ", e.getMessage());
             assertContains("unfinishedStubbingHere(", e.getMessage());
         }
@@ -65,7 +67,7 @@ public class ClickableStackTracesWhenFrameworkMisusedTest extends TestBase {
         try {
             mock(IMethods.class);
             fail();
-        } catch (UnfinishedVerificationException e) {
+        } catch (final UnfinishedVerificationException e) {
             assertContains("unfinishedVerificationHere(", e.getMessage());
         }
     }

--- a/test/org/mockitousage/stacktrace/ModellingDescriptiveMessagesTest.java
+++ b/test/org/mockitousage/stacktrace/ModellingDescriptiveMessagesTest.java
@@ -5,8 +5,18 @@
 
 package org.mockitousage.stacktrace;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.RETURNS_SMART_NULLS;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -22,6 +32,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
+@SuppressWarnings("rawtypes")
 @Ignore
 @RunWith(MockitoJUnitRunner.class)
 public class ModellingDescriptiveMessagesTest extends TestBase {
@@ -75,7 +86,7 @@ public class ModellingDescriptiveMessagesTest extends TestBase {
     public void shouldSayWantedButNotInvokedInOrder() {
         mock.simpleMethod();
         mock.otherMethod();
-        InOrder inOrder = inOrder(mock);
+        final InOrder inOrder = inOrder(mock);
         inOrder.verify(mock).otherMethod();
         inOrder.verify(mock).simpleMethod();
     }
@@ -86,7 +97,7 @@ public class ModellingDescriptiveMessagesTest extends TestBase {
         mock.otherMethod();
         mock.otherMethod();
 
-        InOrder inOrder = inOrder(mock);
+        final InOrder inOrder = inOrder(mock);
         inOrder.verify(mock).simpleMethod();
         inOrder.verify(mock, times(3)).otherMethod();
     }
@@ -96,7 +107,7 @@ public class ModellingDescriptiveMessagesTest extends TestBase {
         mock.otherMethod();
         mock.otherMethod();
         
-        InOrder inOrder = inOrder(mock);
+        final InOrder inOrder = inOrder(mock);
         inOrder.verify(mock, times(1)).otherMethod();
     }
 
@@ -111,7 +122,7 @@ public class ModellingDescriptiveMessagesTest extends TestBase {
     public void shouldSayTooLittleInvocationsInAtLeastModeInOrder() {
         mock.simpleMethod();
 
-        InOrder inOrder = inOrder(mock);
+        final InOrder inOrder = inOrder(mock);
         inOrder.verify(mock, atLeast(2)).simpleMethod();
     }
     
@@ -133,7 +144,7 @@ public class ModellingDescriptiveMessagesTest extends TestBase {
     public void shouldSayUnstubbedMethodWasInvokedHere() {
         mock = mock(IMethods.class, RETURNS_SMART_NULLS);
         
-        IMethods m = mock.iMethodsReturningMethod();
+        final IMethods m = mock.iMethodsReturningMethod();
         
         m.simpleMethod();
     }
@@ -163,7 +174,7 @@ public class ModellingDescriptiveMessagesTest extends TestBase {
     
     @Test
     public void shouldShowExampleOfCorrectArgumentCapturing() {
-        ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+        final ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
         argument.capture();
         argument.getValue();
     }
@@ -195,7 +206,7 @@ public class ModellingDescriptiveMessagesTest extends TestBase {
 
     @Test
     public void shouldMentionSpiesWhenVoidMethodIsToldToReturnValue() {
-        List list = mock(List.class);
+        final List list = mock(List.class);
         doReturn("foo").when(list).clear();
     }
 }

--- a/test/org/mockitousage/stacktrace/PointingStackTraceToActualInvocationChunkInOrderTest.java
+++ b/test/org/mockitousage/stacktrace/PointingStackTraceToActualInvocationChunkInOrderTest.java
@@ -5,8 +5,10 @@
 
 package org.mockitousage.stacktrace;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.times;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -60,7 +62,7 @@ public class PointingStackTraceToActualInvocationChunkInOrderTest extends TestBa
         try {
             inOrder.verify(mock).simpleMethod(999);
             fail();
-        } catch (VerificationInOrderFailure e) {
+        } catch (final VerificationInOrderFailure e) {
             assertContains("secondChunk(", e.getMessage());
         }
     }
@@ -72,7 +74,7 @@ public class PointingStackTraceToActualInvocationChunkInOrderTest extends TestBa
         try {
             inOrder.verify(mockTwo).simpleMethod(999);
             fail();
-        } catch (VerificationInOrderFailure e) {
+        } catch (final VerificationInOrderFailure e) {
             assertContains("thirdChunk(", e.getMessage());
         }
     }
@@ -86,7 +88,7 @@ public class PointingStackTraceToActualInvocationChunkInOrderTest extends TestBa
         try {
             inOrder.verify(mockTwo, times(3)).simpleMethod(999);
             fail();
-        } catch (VerificationInOrderFailure e) {
+        } catch (final VerificationInOrderFailure e) {
             assertContains("thirdChunk(", e.getMessage());
         }
     }
@@ -98,7 +100,7 @@ public class PointingStackTraceToActualInvocationChunkInOrderTest extends TestBa
         try {
             inOrder.verify(mockTwo, times(0)).simpleMethod(anyInt());
             fail();
-        } catch (VerificationInOrderFailure e) {
+        } catch (final VerificationInOrderFailure e) {
             assertContains("fourthChunk(", e.getMessage());
         }
     }

--- a/test/org/mockitousage/stacktrace/PointingStackTraceToActualInvocationInOrderTest.java
+++ b/test/org/mockitousage/stacktrace/PointingStackTraceToActualInvocationInOrderTest.java
@@ -5,8 +5,10 @@
 
 package org.mockitousage.stacktrace;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.times;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -57,7 +59,7 @@ public class PointingStackTraceToActualInvocationInOrderTest extends TestBase {
         try {
             inOrder.verify(mock).simpleMethod(999);
             fail();
-        } catch (VerificationInOrderFailure e) {
+        } catch (final VerificationInOrderFailure e) {
             assertContains("fourth(", e.getMessage());
         }
     }
@@ -69,7 +71,7 @@ public class PointingStackTraceToActualInvocationInOrderTest extends TestBase {
         try {
             inOrder.verify(mockTwo).simpleMethod(999);
             fail();
-        } catch (VerificationInOrderFailure e) {
+        } catch (final VerificationInOrderFailure e) {
             assertContains("third(", e.getMessage());
         }
     }
@@ -82,7 +84,7 @@ public class PointingStackTraceToActualInvocationInOrderTest extends TestBase {
         try {
             inOrder.verify(mockTwo, times(3)).simpleMethod(999);
             fail();
-        } catch (VerificationInOrderFailure e) {
+        } catch (final VerificationInOrderFailure e) {
             assertContains("second(", e.getMessage());
         }
     }
@@ -92,7 +94,7 @@ public class PointingStackTraceToActualInvocationInOrderTest extends TestBase {
         try {
             inOrder.verify(mock, times(0)).simpleMethod(anyInt());
             fail();
-        } catch (VerificationInOrderFailure e) {
+        } catch (final VerificationInOrderFailure e) {
             assertContains("first(", e.getMessage());
         }
     }    
@@ -104,7 +106,7 @@ public class PointingStackTraceToActualInvocationInOrderTest extends TestBase {
         try {
             inOrder.verify(mockTwo, times(0)).simpleMethod(anyInt());
             fail();
-        } catch (VerificationInOrderFailure e) {
+        } catch (final VerificationInOrderFailure e) {
             assertContains("second(", e.getMessage());
         }
     }
@@ -118,7 +120,7 @@ public class PointingStackTraceToActualInvocationInOrderTest extends TestBase {
         try {
             inOrder.verify(mockTwo, times(3)).simpleMethod(anyInt());
             fail();
-        } catch (VerificationInOrderFailure e) {
+        } catch (final VerificationInOrderFailure e) {
             assertContains("fourth(", e.getMessage());
         }
     }

--- a/test/org/mockitousage/stacktrace/PointingStackTraceToActualInvocationTest.java
+++ b/test/org/mockitousage/stacktrace/PointingStackTraceToActualInvocationTest.java
@@ -5,7 +5,8 @@
 
 package org.mockitousage.stacktrace;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -50,7 +51,7 @@ public class PointingStackTraceToActualInvocationTest extends TestBase {
         try {
             verify(mock, times(0)).simpleMethod(1);
             fail();
-        } catch (NeverWantedButInvoked e) {
+        } catch (final NeverWantedButInvoked e) {
             assertContains("first(", e.getMessage());
         }
     }   
@@ -60,7 +61,7 @@ public class PointingStackTraceToActualInvocationTest extends TestBase {
         try {
             verify(mock, times(0)).simpleMethod(1);
             fail();
-        } catch (NeverWantedButInvoked e) {
+        } catch (final NeverWantedButInvoked e) {
             assertNotContains(".runners.", e.getMessage());
         }
     }   

--- a/test/org/mockitousage/stacktrace/StackTraceFilteringTest.java
+++ b/test/org/mockitousage/stacktrace/StackTraceFilteringTest.java
@@ -5,8 +5,12 @@
 
 package org.mockitousage.stacktrace;
 
-import static org.mockito.Mockito.*;
-import static org.mockitoutil.ExtraMatchers.*;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockitoutil.ExtraMatchers.hasFirstMethodInStackTrace;
 
 import org.junit.After;
 import org.junit.Before;
@@ -39,7 +43,7 @@ public class StackTraceFilteringTest extends TestBase {
         try {
             verify(mock).simpleMethod();
             fail();
-        } catch (WantedButNotInvoked e) {
+        } catch (final WantedButNotInvoked e) {
             assertThat(e, hasFirstMethodInStackTrace("shouldFilterStackTraceOnVerify"));
         }
     }
@@ -50,7 +54,7 @@ public class StackTraceFilteringTest extends TestBase {
         try {
             verifyNoMoreInteractions(mock);
             fail();
-        } catch (NoInteractionsWanted e) {
+        } catch (final NoInteractionsWanted e) {
             assertThat(e, hasFirstMethodInStackTrace("shouldFilterStackTraceOnVerifyNoMoreInteractions"));
         }
     }
@@ -61,7 +65,7 @@ public class StackTraceFilteringTest extends TestBase {
         try {
             verifyZeroInteractions(mock);
             fail();
-        } catch (NoInteractionsWanted e) {
+        } catch (final NoInteractionsWanted e) {
             assertThat(e, hasFirstMethodInStackTrace("shouldFilterStackTraceOnVerifyZeroInteractions"));
         }
     }
@@ -72,14 +76,14 @@ public class StackTraceFilteringTest extends TestBase {
         try {
             verify(mock).oneArg(true); 
             fail();
-        } catch (MockitoException expected) {
+        } catch (final MockitoException expected) {
             assertThat(expected, hasFirstMethodInStackTrace("shouldFilterStacktraceOnMockitoException"));
         }
     }
     
     @Test
     public void shouldFilterStacktraceWhenVerifyingInOrder() {
-        InOrder inOrder = inOrder(mock);
+        final InOrder inOrder = inOrder(mock);
         mock.oneArg(true);
         mock.oneArg(false);
         
@@ -87,7 +91,7 @@ public class StackTraceFilteringTest extends TestBase {
         try {
             inOrder.verify(mock).oneArg(true);
             fail();
-        } catch (VerificationInOrderFailure e) {
+        } catch (final VerificationInOrderFailure e) {
             assertThat(e, hasFirstMethodInStackTrace("shouldFilterStacktraceWhenVerifyingInOrder"));
         }
     }
@@ -97,7 +101,7 @@ public class StackTraceFilteringTest extends TestBase {
         try {
             inOrder();
             fail();
-        } catch (MockitoException expected) {
+        } catch (final MockitoException expected) {
             assertThat(expected, hasFirstMethodInStackTrace("shouldFilterStacktraceWhenInOrderThrowsMockitoException"));
         }
     }
@@ -105,10 +109,10 @@ public class StackTraceFilteringTest extends TestBase {
     @Test
     public void shouldFilterStacktraceWhenInOrderVerifies() {
         try {
-            InOrder inOrder = inOrder(mock);
+            final InOrder inOrder = inOrder(mock);
             inOrder.verify(null);
             fail();
-        } catch (MockitoException expected) {
+        } catch (final MockitoException expected) {
             assertThat(expected, hasFirstMethodInStackTrace("shouldFilterStacktraceWhenInOrderVerifies"));
         }
     }
@@ -118,7 +122,7 @@ public class StackTraceFilteringTest extends TestBase {
         try {
             when(mock.oneArg(true)).thenThrow(new Exception());
             fail();
-        } catch (MockitoException expected) {
+        } catch (final MockitoException expected) {
             assertThat(expected, hasFirstMethodInStackTrace("shouldFilterStackTraceWhenThrowingExceptionFromMockHandler"));
         }
     }
@@ -130,7 +134,7 @@ public class StackTraceFilteringTest extends TestBase {
         try {
             mock.simpleMethod();
             fail();
-        } catch (RuntimeException e) {
+        } catch (final RuntimeException e) {
             assertThat(e, hasFirstMethodInStackTrace("shouldShowProperExceptionStackTrace"));
         }
     }

--- a/test/org/mockitousage/stubbing/BasicStubbingTest.java
+++ b/test/org/mockitousage/stubbing/BasicStubbingTest.java
@@ -5,6 +5,18 @@
 
 package org.mockitousage.stubbing;
 
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.exceptions.misusing.CannotVerifyStubOnlyMock;
@@ -12,9 +24,6 @@ import org.mockito.exceptions.misusing.MissingMethodInvocationException;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
-
-import static org.mockito.Matchers.isA;
-import static org.mockito.Mockito.*;
 
 public class BasicStubbingTest extends TestBase {
 
@@ -44,12 +53,12 @@ public class BasicStubbingTest extends TestBase {
         try {
             verifyNoMoreInteractions(mock);
             fail();
-        } catch (NoInteractionsWanted e) {}
+        } catch (final NoInteractionsWanted e) {}
     }
     
     @Test
     public void should_allow_stubbing_to_string() throws Exception {
-        IMethods mockTwo = mock(IMethods.class);
+        final IMethods mockTwo = mock(IMethods.class);
         when(mockTwo.toString()).thenReturn("test");
         
         assertContains("Mock for IMethods", mock.toString());
@@ -70,7 +79,7 @@ public class BasicStubbingTest extends TestBase {
         try {
             when("").thenReturn("");
             fail(); 
-        } catch (MissingMethodInvocationException e) {}
+        } catch (final MissingMethodInvocationException e) {}
 
         //anything that can cause state validation
         verifyZeroInteractions(mock);
@@ -78,8 +87,8 @@ public class BasicStubbingTest extends TestBase {
     
     @Test
     public void should_to_string_mock_name() {
-        IMethods mock = mock(IMethods.class, "mockie");
-        IMethods mockTwo = mock(IMethods.class);
+        final IMethods mock = mock(IMethods.class, "mockie");
+        final IMethods mockTwo = mock(IMethods.class);
         
         assertContains("Mock for IMethods", "" + mockTwo);
         assertEquals("mockie", "" + mock);
@@ -98,7 +107,7 @@ public class BasicStubbingTest extends TestBase {
 
     @Test
     public void test_stub_only_not_verifiable() throws Exception {
-        IMethods localMock = mock(IMethods.class, withSettings().stubOnly());
+        final IMethods localMock = mock(IMethods.class, withSettings().stubOnly());
 
         when(localMock.objectReturningMethod(isA(Integer.class))).thenReturn(100);
         when(localMock.objectReturningMethod(200)).thenReturn(200);
@@ -110,6 +119,6 @@ public class BasicStubbingTest extends TestBase {
         try {
             verify(localMock, atLeastOnce()).objectReturningMethod(eq(200));
             fail();
-        } catch (CannotVerifyStubOnlyMock e) {}
+        } catch (final CannotVerifyStubOnlyMock e) {}
     }
 }

--- a/test/org/mockitousage/stubbing/CallingRealMethodTest.java
+++ b/test/org/mockitousage/stubbing/CallingRealMethodTest.java
@@ -4,8 +4,11 @@
  */
 package org.mockitousage.stubbing;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -19,7 +22,7 @@ public class CallingRealMethodTest extends TestBase {
     static class TestedObject {
         String value;
 
-        void setValue(String value) {
+        void setValue(final String value) {
             this.value = value;
         }
 
@@ -58,14 +61,14 @@ public class CallingRealMethodTest extends TestBase {
 
     @Test
     public void shouldCallRealMethodByDefault() {
-        TestedObject mock = mock(TestedObject.class, CALLS_REAL_METHODS);
+        final TestedObject mock = mock(TestedObject.class, CALLS_REAL_METHODS);
 
         Assert.assertEquals("HARD_CODED_RETURN_VALUE", mock.getValue());
     }
 
     @Test
     public void shouldNotCallRealMethodWhenStubbedLater() {
-        TestedObject mock = mock(TestedObject.class);
+        final TestedObject mock = mock(TestedObject.class);
 
         when(mock.getValue()).thenCallRealMethod();
         when(mock.getValue()).thenReturn("FAKE_VALUE");

--- a/test/org/mockitousage/stubbing/CloningParameterTest.java
+++ b/test/org/mockitousage/stubbing/CloningParameterTest.java
@@ -5,7 +5,9 @@
 
 package org.mockitousage.stubbing;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 
@@ -19,7 +21,7 @@ public class CloningParameterTest extends TestBase {
     public void shouldVerifyEvenIfArgumentsWereMutated() throws Exception {
 
         // given
-        EmailSender emailSender = mock(EmailSender.class, new ClonesArguments());
+        final EmailSender emailSender = mock(EmailSender.class, new ClonesArguments());
 
         // when
         businessLogic(emailSender);
@@ -28,8 +30,8 @@ public class CloningParameterTest extends TestBase {
         verify(emailSender).sendEmail(1, new Person("Wes"));
     }
 
-    private void businessLogic(EmailSender emailSender) {
-        Person person = new Person("Wes");
+    private void businessLogic(final EmailSender emailSender) {
+        final Person person = new Person("Wes");
         emailSender.sendEmail(1, person);
         person.emailSent();
     }
@@ -38,11 +40,11 @@ public class CloningParameterTest extends TestBase {
     public void shouldReturnDefaultValueWithCloningAnswer() throws Exception {
 
         // given
-        EmailSender emailSender = mock(EmailSender.class, new ClonesArguments());
+        final EmailSender emailSender = mock(EmailSender.class, new ClonesArguments());
         when(emailSender.getAllEmails(new Person("Wes"))).thenAnswer(new ClonesArguments());
 
         // when
-        List<?> emails = emailSender.getAllEmails(new Person("Wes"));
+        final List<?> emails = emailSender.getAllEmails(new Person("Wes"));
 
         // then
         assertNotNull(emails);
@@ -53,7 +55,7 @@ public class CloningParameterTest extends TestBase {
         private final String name;
         private boolean emailSent;
 
-        public Person(String name) {
+        public Person(final String name) {
             this.name = name;
         }
 
@@ -72,23 +74,30 @@ public class CloningParameterTest extends TestBase {
         }
 
         @Override
-        public boolean equals(Object obj) {
-            if (this == obj)
+        public boolean equals(final Object obj) {
+            if (this == obj) {
                 return true;
-            if (obj == null)
+            }
+            if (obj == null) {
                 return false;
-            if (getClass() != obj.getClass())
+            }
+            if (getClass() != obj.getClass()) {
                 return false;
-            Person other = (Person) obj;
-            if (!getOuterType().equals(other.getOuterType()))
+            }
+            final Person other = (Person) obj;
+            if (!getOuterType().equals(other.getOuterType())) {
                 return false;
-            if (emailSent != other.emailSent)
+            }
+            if (emailSent != other.emailSent) {
                 return false;
+            }
             if (name == null) {
-                if (other.name != null)
+                if (other.name != null) {
                     return false;
-            } else if (!name.equals(other.name))
+                }
+            } else if (!name.equals(other.name)) {
                 return false;
+            }
             return true;
         }
 
@@ -100,9 +109,9 @@ public class CloningParameterTest extends TestBase {
 
     public interface EmailSender {
 
-        void sendEmail(int i, Person person);
+        void sendEmail(final int i, final Person person);
 
-        List<?> getAllEmails(Person person);
+        List<?> getAllEmails(final Person person);
 
     }
 }

--- a/test/org/mockitousage/stubbing/DeepStubbingTest.java
+++ b/test/org/mockitousage/stubbing/DeepStubbingTest.java
@@ -17,11 +17,14 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.net.Socket;
 import java.util.Locale;
+
 import javax.net.SocketFactory;
+
 import org.fest.assertions.Assertions;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -38,7 +41,7 @@ public class DeepStubbingTest extends TestBase {
             return address;
         }
         
-        public Address getAddress(String addressName) {
+        public Address getAddress(final String addressName) {
             return address;
         }
         
@@ -54,7 +57,7 @@ public class DeepStubbingTest extends TestBase {
             return street;
         }
 
-        public Street getStreet(Locale locale) {
+        public Street getStreet(final Locale locale) {
             return street;
         }
     }
@@ -75,15 +78,15 @@ public class DeepStubbingTest extends TestBase {
     
     @Test
     public void myTest() throws Exception {
-        SocketFactory sf = mock(SocketFactory.class, RETURNS_DEEP_STUBS);
+        final SocketFactory sf = mock(SocketFactory.class, RETURNS_DEEP_STUBS);
         when(sf.createSocket(anyString(), eq(80))).thenReturn(null);
         sf.createSocket("what", 80);
     }
 
     @Test
     public void simpleCase() throws Exception {
-        OutputStream out = new ByteArrayOutputStream();
-        Socket socket = mock(Socket.class);
+        final OutputStream out = new ByteArrayOutputStream();
+        final Socket socket = mock(Socket.class);
         when(socket.getOutputStream()).thenReturn(out);
 
         assertSame(out, socket.getOutputStream());
@@ -94,9 +97,9 @@ public class DeepStubbingTest extends TestBase {
      */
     @Test
     public void oneLevelDeep() throws Exception {
-        OutputStream out = new ByteArrayOutputStream();
+        final OutputStream out = new ByteArrayOutputStream();
 
-        SocketFactory socketFactory = mock(SocketFactory.class, RETURNS_DEEP_STUBS);
+        final SocketFactory socketFactory = mock(SocketFactory.class, RETURNS_DEEP_STUBS);
         when(socketFactory.createSocket().getOutputStream()).thenReturn(out);
 
         assertSame(out, socketFactory.createSocket().getOutputStream());
@@ -107,13 +110,13 @@ public class DeepStubbingTest extends TestBase {
      */
     @Test
     public void interactions() throws Exception {
-        OutputStream out1 = new ByteArrayOutputStream();
-        OutputStream out2 = new ByteArrayOutputStream();
+        final OutputStream out1 = new ByteArrayOutputStream();
+        final OutputStream out2 = new ByteArrayOutputStream();
 
-        SocketFactory sf1 = mock(SocketFactory.class, RETURNS_DEEP_STUBS);
+        final SocketFactory sf1 = mock(SocketFactory.class, RETURNS_DEEP_STUBS);
         when(sf1.createSocket().getOutputStream()).thenReturn(out1);
 
-        SocketFactory sf2 = mock(SocketFactory.class, RETURNS_DEEP_STUBS);
+        final SocketFactory sf2 = mock(SocketFactory.class, RETURNS_DEEP_STUBS);
         when(sf2.createSocket().getOutputStream()).thenReturn(out2);
 
         assertSame(out1, sf1.createSocket().getOutputStream());
@@ -125,11 +128,11 @@ public class DeepStubbingTest extends TestBase {
      */
     @Test
     public void withArguments() throws Exception {
-        OutputStream out1 = new ByteArrayOutputStream();
-        OutputStream out2 = new ByteArrayOutputStream();
-        OutputStream out3 = new ByteArrayOutputStream();
+        final OutputStream out1 = new ByteArrayOutputStream();
+        final OutputStream out2 = new ByteArrayOutputStream();
+        final OutputStream out3 = new ByteArrayOutputStream();
 
-        SocketFactory sf = mock(SocketFactory.class, RETURNS_DEEP_STUBS);
+        final SocketFactory sf = mock(SocketFactory.class, RETURNS_DEEP_STUBS);
         when(sf.createSocket().getOutputStream()).thenReturn(out1);
         when(sf.createSocket("google.com", 80).getOutputStream()).thenReturn(out2);
         when(sf.createSocket("stackoverflow.com", 80).getOutputStream()).thenReturn(out3);
@@ -144,10 +147,10 @@ public class DeepStubbingTest extends TestBase {
      */
     @Test
     public void withAnyPatternArguments() throws Exception {
-        OutputStream out = new ByteArrayOutputStream();
+        final OutputStream out = new ByteArrayOutputStream();
 
         //TODO: should not use javax in case it changes
-        SocketFactory sf = mock(SocketFactory.class, RETURNS_DEEP_STUBS);
+        final SocketFactory sf = mock(SocketFactory.class, RETURNS_DEEP_STUBS);
         when(sf.createSocket(anyString(), anyInt()).getOutputStream()).thenReturn(out);
 
         assertSame(out, sf.createSocket("google.com", 80).getOutputStream());
@@ -159,10 +162,10 @@ public class DeepStubbingTest extends TestBase {
      */
     @Test
     public void withComplexPatternArguments() throws Exception {
-        OutputStream out1 = new ByteArrayOutputStream();
-        OutputStream out2 = new ByteArrayOutputStream();
+        final OutputStream out1 = new ByteArrayOutputStream();
+        final OutputStream out2 = new ByteArrayOutputStream();
 
-        SocketFactory sf = mock(SocketFactory.class, RETURNS_DEEP_STUBS);
+        final SocketFactory sf = mock(SocketFactory.class, RETURNS_DEEP_STUBS);
         when(sf.createSocket(anyString(), eq(80)).getOutputStream()).thenReturn(out1);
         when(sf.createSocket(anyString(), eq(8080)).getOutputStream()).thenReturn(out2);
 
@@ -177,9 +180,9 @@ public class DeepStubbingTest extends TestBase {
      */
     @Test
     public void withSimplePrimitive() throws Exception {
-        int a = 32;
+        final int a = 32;
 
-        SocketFactory sf = mock(SocketFactory.class, RETURNS_DEEP_STUBS);
+        final SocketFactory sf = mock(SocketFactory.class, RETURNS_DEEP_STUBS);
         when(sf.createSocket().getPort()).thenReturn(a);
 
         assertEquals(a, sf.createSocket().getPort());
@@ -191,9 +194,9 @@ public class DeepStubbingTest extends TestBase {
      */
     @Test
     public void withPatternPrimitive() throws Exception {
-        int a = 12, b = 23, c = 34;
+        final int a = 12, b = 23, c = 34;
 
-        SocketFactory sf = mock(SocketFactory.class, RETURNS_DEEP_STUBS);
+        final SocketFactory sf = mock(SocketFactory.class, RETURNS_DEEP_STUBS);
         when(sf.createSocket(eq("stackoverflow.com"), eq(80)).getPort()).thenReturn(a);
         when(sf.createSocket(eq("google.com"), anyInt()).getPort()).thenReturn(b);
         when(sf.createSocket(eq("stackoverflow.com"), eq(8080)).getPort()).thenReturn(c);
@@ -211,7 +214,7 @@ public class DeepStubbingTest extends TestBase {
         given(person.getAddress().getStreet().getName()).willReturn("Norymberska");
         
         //when
-        String street = person.getAddress().getStreet().getName();
+        final String street = person.getAddress().getStreet().getName();
         
         //then
         assertEquals("Norymberska", street);
@@ -277,7 +280,7 @@ public class DeepStubbingTest extends TestBase {
         person.getAddress("the docks").getStreet(Locale.ITALIAN).getName();
         person.getAddress("the docks").getStreet(Locale.CHINESE).getName();
 
-        InOrder inOrder = inOrder(
+        final InOrder inOrder = inOrder(
                 person.getAddress("the docks").getStreet(),
                 person.getAddress("the docks").getStreet(Locale.CHINESE),
                 person.getAddress("the docks").getStreet(Locale.ITALIAN)
@@ -302,7 +305,7 @@ public class DeepStubbingTest extends TestBase {
         try {
             verify(person.getAddress("the docks"), times(1)).getStreet();
             fail();
-        } catch (TooManyActualInvocations e) {
+        } catch (final TooManyActualInvocations e) {
             Assertions.assertThat(e.getMessage())
                     .contains("Wanted 1 time")
                     .contains("But was 3 times");
@@ -312,7 +315,7 @@ public class DeepStubbingTest extends TestBase {
     @Test
     public void shouldFailGracefullyWhenClassIsFinal() throws Exception {
         //when        
-        FinalClass value = new FinalClass();
+        final FinalClass value = new FinalClass();
         given(person.getFinalClass()).willReturn(value);
         
         //then

--- a/test/org/mockitousage/stubbing/DeprecatedStubbingTest.java
+++ b/test/org/mockitousage/stubbing/DeprecatedStubbingTest.java
@@ -5,8 +5,12 @@
 
 package org.mockitousage.stubbing;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.stub;
+import static org.mockito.Mockito.stubVoid;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -44,12 +48,12 @@ public class DeprecatedStubbingTest extends TestBase {
         try {
             verifyNoMoreInteractions(mock);
             fail();
-        } catch (NoInteractionsWanted e) {}
+        } catch (final NoInteractionsWanted e) {}
     }
     
     @Test
     public void shouldAllowStubbingToString() throws Exception {
-        IMethods mockTwo = mock(IMethods.class);
+        final IMethods mockTwo = mock(IMethods.class);
         stub(mockTwo.toString()).toReturn("test");
         
         assertContains("Mock for IMethods", mock.toString());

--- a/test/org/mockitousage/stubbing/ReturningDefaultValuesTest.java
+++ b/test/org/mockitousage/stubbing/ReturningDefaultValuesTest.java
@@ -15,7 +15,7 @@ import org.mockito.Mockito;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class ReturningDefaultValuesTest extends TestBase {
 
     @Mock private IMethods mock;
@@ -47,7 +47,7 @@ public class ReturningDefaultValuesTest extends TestBase {
     
     @Test 
     public void shouldReturnEmptyCollections() {
-        CollectionsServer mock = Mockito.mock(CollectionsServer.class);
+        final CollectionsServer mock = Mockito.mock(CollectionsServer.class);
         
         assertTrue(mock.list().isEmpty());
         assertTrue(mock.linkedList().isEmpty());
@@ -57,9 +57,9 @@ public class ReturningDefaultValuesTest extends TestBase {
     
     @Test 
     public void shouldReturnMutableEmptyCollection() {
-        CollectionsServer mock = Mockito.mock(CollectionsServer.class);
+        final CollectionsServer mock = Mockito.mock(CollectionsServer.class);
         
-        List list = mock.list();
+        final List list = mock.list();
         list.add("test");
        
         assertTrue(mock.list().isEmpty());

--- a/test/org/mockitousage/stubbing/SmartNullsStubbingTest.java
+++ b/test/org/mockitousage/stubbing/SmartNullsStubbingTest.java
@@ -5,7 +5,9 @@
 
 package org.mockitousage.stubbing;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.RETURNS_SMART_NULLS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -24,17 +26,17 @@ public class SmartNullsStubbingTest extends TestBase {
         mock = mock(IMethods.class, Mockito.RETURNS_SMART_NULLS);
     }
     
-    public IMethods unstubbedMethodInvokedHere(IMethods mock) {
+    public IMethods unstubbedMethodInvokedHere(final IMethods mock) {
         return mock.iMethodsReturningMethod();
     }
 
     @Test
     public void shouldSmartNPEPointToUnstubbedCall() throws Exception {
-        IMethods methods = unstubbedMethodInvokedHere(mock); 
+        final IMethods methods = unstubbedMethodInvokedHere(mock); 
         try {
             methods.simpleMethod();
             fail();
-        } catch (SmartNullPointerException e) {
+        } catch (final SmartNullPointerException e) {
             assertContains("unstubbedMethodInvokedHere(", e.getMessage());
         }
     }
@@ -52,7 +54,7 @@ public class SmartNullsStubbingTest extends TestBase {
             return null;
         }
 
-        Bar getBarWithParams(int x, String y) {
+        Bar getBarWithParams(final int x, final String y) {
             return null;
         }
 
@@ -61,28 +63,28 @@ public class SmartNullsStubbingTest extends TestBase {
 
     @Test
     public void shouldThrowSmartNPEWhenMethodReturnsClass() throws Exception {
-        Foo mock = mock(Foo.class, RETURNS_SMART_NULLS);
-        Foo foo = mock.getSomeClass();
+        final Foo mock = mock(Foo.class, RETURNS_SMART_NULLS);
+        final Foo foo = mock.getSomeClass();
         try {
             foo.boo();
             fail();
-        } catch (SmartNullPointerException e) {}
+        } catch (final SmartNullPointerException e) {}
     }
 
     @Test
     public void shouldThrowSmartNPEWhenMethodReturnsInterface() throws Exception {
-        Foo mock = mock(Foo.class, RETURNS_SMART_NULLS);
-        Bar bar = mock.getSomeInterface();
+        final Foo mock = mock(Foo.class, RETURNS_SMART_NULLS);
+        final Bar bar = mock.getSomeInterface();
         try {
             bar.boo();
             fail();
-        } catch (SmartNullPointerException e) {}
+        } catch (final SmartNullPointerException e) {}
     }
 
 
     @Test
     public void shouldReturnOrdinaryEmptyValuesForOrdinaryTypes() throws Exception {
-        IMethods mock = mock(IMethods.class, RETURNS_SMART_NULLS);
+        final IMethods mock = mock(IMethods.class, RETURNS_SMART_NULLS);
 
         assertEquals("", mock.stringReturningMethod());
         assertEquals(0, mock.intReturningMethod());
@@ -92,42 +94,42 @@ public class SmartNullsStubbingTest extends TestBase {
 
     @Test
     public void shouldNotThrowSmartNullPointerOnToString() {
-        Object smartNull = mock.objectReturningMethod();
+        final Object smartNull = mock.objectReturningMethod();
         try {
             verify(mock).simpleMethod(smartNull);
             fail();
-        } catch (WantedButNotInvoked e) {}
+        } catch (final WantedButNotInvoked e) {}
     }
 
     @Test
     public void shouldNotThrowSmartNullPointerOnObjectMethods() {
-        Object smartNull = mock.objectReturningMethod();
+        final Object smartNull = mock.objectReturningMethod();
         smartNull.toString();
     }
 
     @Test
     public void shouldShowParameters() {
-        Foo foo = mock(Foo.class, RETURNS_SMART_NULLS);
-        Bar smartNull = foo.getBarWithParams(10, "yes sir");
+        final Foo foo = mock(Foo.class, RETURNS_SMART_NULLS);
+        final Bar smartNull = foo.getBarWithParams(10, "yes sir");
 
         try {
             smartNull.boo();
             fail();
-        } catch (Exception e) {
+        } catch (final Exception e) {
             assertContains("yes sir", e.getMessage());
         }
     }
 
     @Test
     public void shouldShowParametersWhenParamsAreHuge() {
-        Foo foo = mock(Foo.class, RETURNS_SMART_NULLS);
-        String longStr = "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.";
-        Bar smartNull = foo.getBarWithParams(10, longStr);
+        final Foo foo = mock(Foo.class, RETURNS_SMART_NULLS);
+        final String longStr = "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.";
+        final Bar smartNull = foo.getBarWithParams(10, longStr);
 
         try {
             smartNull.boo();
             fail();
-        } catch (Exception e) {
+        } catch (final Exception e) {
             assertContains("Lorem Ipsum", e.getMessage());
         }
     }

--- a/test/org/mockitousage/stubbing/StubbingConsecutiveAnswersTest.java
+++ b/test/org/mockitousage/stubbing/StubbingConsecutiveAnswersTest.java
@@ -5,7 +5,8 @@
 
 package org.mockitousage.stubbing;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.stubVoid;
+import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 import org.mockito.Mock;
@@ -35,7 +36,7 @@ public class StubbingConsecutiveAnswersTest extends TestBase {
     @SuppressWarnings("all")
     @Test
     public void shouldReturnConsecutiveValuesForTwoNulls() throws Exception {
-        when(mock.simpleMethod()).thenReturn(null, (String[])null);
+        when(mock.simpleMethod()).thenReturn(null, (String[]) null);
         
         assertNull(mock.simpleMethod());        
         assertNull(mock.simpleMethod());        
@@ -69,16 +70,16 @@ public class StubbingConsecutiveAnswersTest extends TestBase {
         try {
             mock.simpleMethod();
             fail();
-        } catch (NullPointerException e) {}
+        } catch (final NullPointerException e) {}
         try {
             mock.simpleMethod();
             fail();
-        } catch (RuntimeException e) {}
+        } catch (final RuntimeException e) {}
         assertEquals("three", mock.simpleMethod());
         try {
             mock.simpleMethod();
             fail();
-        } catch (IllegalArgumentException e) {}
+        } catch (final IllegalArgumentException e) {}
     }
     
     @Test
@@ -91,22 +92,22 @@ public class StubbingConsecutiveAnswersTest extends TestBase {
         try {
             mock.simpleMethod();
             fail();
-        } catch (RuntimeException e) {}
+        } catch (final RuntimeException e) {}
         
         try {
             mock.simpleMethod();
             fail();
-        } catch (IllegalArgumentException e) {}
+        } catch (final IllegalArgumentException e) {}
         
         try {
             mock.simpleMethod();
             fail();
-        } catch (NullPointerException e) {}
+        } catch (final NullPointerException e) {}
         
         try {
             mock.simpleMethod();
             fail();
-        } catch (NullPointerException e) {}
+        } catch (final NullPointerException e) {}
     }
 
     @Test
@@ -117,22 +118,22 @@ public class StubbingConsecutiveAnswersTest extends TestBase {
         try {
             mock.simpleMethod();
             fail();
-        } catch (RuntimeException e) {}
+        } catch (final RuntimeException e) {}
         
         try {
             mock.simpleMethod();
             fail();
-        } catch (IllegalArgumentException e) {}
+        } catch (final IllegalArgumentException e) {}
         
         try {
             mock.simpleMethod();
             fail();
-        } catch (NullPointerException e) {}
+        } catch (final NullPointerException e) {}
         
         try {
             mock.simpleMethod();
             fail();
-        } catch (NullPointerException e) {}
+        } catch (final NullPointerException e) {}
     }
     
     @Test
@@ -146,14 +147,14 @@ public class StubbingConsecutiveAnswersTest extends TestBase {
         try {
             mock.simpleMethod();
             fail();
-        } catch (IllegalArgumentException e) {}
+        } catch (final IllegalArgumentException e) {}
         
         assertEquals("one", mock.simpleMethod());
         
         try {
             mock.simpleMethod();
             fail();
-        } catch (NullPointerException e) {}
+        } catch (final NullPointerException e) {}
         
         assertEquals(null, mock.simpleMethod());
         assertEquals(null, mock.simpleMethod());
@@ -177,19 +178,19 @@ public class StubbingConsecutiveAnswersTest extends TestBase {
         try {
             mock.voidMethod();
             fail();
-        } catch (IllegalArgumentException e) {}
+        } catch (final IllegalArgumentException e) {}
         
         mock.voidMethod();
         
         try {
             mock.voidMethod();
             fail();
-        } catch (NullPointerException e) {}
+        } catch (final NullPointerException e) {}
         
         try {
             mock.voidMethod();
             fail();
-        } catch (NullPointerException e) {}        
+        } catch (final NullPointerException e) {}        
     }
     
     @Test
@@ -205,7 +206,7 @@ public class StubbingConsecutiveAnswersTest extends TestBase {
         try {
             mock.voidMethod();
             fail();
-        } catch (NullPointerException e) {}
+        } catch (final NullPointerException e) {}
         
         mock.voidMethod();
         mock.voidMethod();

--- a/test/org/mockitousage/stubbing/StubbingUsingDoReturnTest.java
+++ b/test/org/mockitousage/stubbing/StubbingUsingDoReturnTest.java
@@ -5,6 +5,19 @@
 
 package org.mockitousage.stubbing;
 
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.io.IOException;
+
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -15,12 +28,6 @@ import org.mockito.stubbing.Answer;
 import org.mockitousage.IMethods;
 import org.mockitousage.MethodsImpl;
 import org.mockitoutil.TestBase;
-
-import java.io.IOException;
-
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
 
 @SuppressWarnings("serial")
 public class StubbingUsingDoReturnTest extends TestBase {
@@ -57,7 +64,7 @@ public class StubbingUsingDoReturnTest extends TestBase {
         try {
             mock.voidMethod();
             fail();
-        } catch (FooRuntimeException e) {}
+        } catch (final FooRuntimeException e) {}
     }
     
     @Test
@@ -67,7 +74,7 @@ public class StubbingUsingDoReturnTest extends TestBase {
         try {
             mock.throwsIOException(0);
             fail();
-        } catch (IOException e) {}
+        } catch (final IOException e) {}
     }
     
     class FooCheckedException extends Exception {}
@@ -77,7 +84,7 @@ public class StubbingUsingDoReturnTest extends TestBase {
         try {
             doThrow(new FooCheckedException()).when(mock).throwsIOException(0);
             fail();
-        } catch (Exception e) {
+        } catch (final Exception e) {
             assertContains("Checked exception is invalid", e.getMessage());
         }
     }
@@ -87,7 +94,7 @@ public class StubbingUsingDoReturnTest extends TestBase {
         try {
             doReturn("foo").when(mock).voidMethod();
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             assertContains("void method", e.getMessage());
             assertContains("cannot", e.getMessage());
         }
@@ -98,7 +105,7 @@ public class StubbingUsingDoReturnTest extends TestBase {
         try {
             doReturn("foo").when("foo").toString();
             fail();
-        } catch (Exception e) {
+        } catch (final Exception e) {
             assertContains("Argument passed to when() is not a mock", e.getMessage());
         }
     }
@@ -108,7 +115,7 @@ public class StubbingUsingDoReturnTest extends TestBase {
         try {
             doReturn("foo").when((Object) null).toString();
             fail();
-        } catch (Exception e) {
+        } catch (final Exception e) {
             assertContains("Argument passed to when() is null", e.getMessage());
         }
     }    
@@ -124,7 +131,7 @@ public class StubbingUsingDoReturnTest extends TestBase {
         try {
             mock.simpleMethod();
             fail();
-        } catch (RuntimeException e) {}
+        } catch (final RuntimeException e) {}
         
         assertEquals("bar", mock.simpleMethod());
         assertEquals("bar", mock.simpleMethod());
@@ -132,7 +139,7 @@ public class StubbingUsingDoReturnTest extends TestBase {
 
     @Test
     public void shouldAllowDoCallRealMethodInChainedStubbing() throws Exception {
-        MethodsImpl methods = mock(MethodsImpl.class);
+        final MethodsImpl methods = mock(MethodsImpl.class);
         doReturn("A").doCallRealMethod()
                 .when(methods).simpleMethod();
 
@@ -160,17 +167,17 @@ public class StubbingUsingDoReturnTest extends TestBase {
         try {
             mock.voidMethod();
             fail();
-        } catch (RuntimeException e) {}
+        } catch (final RuntimeException e) {}
         try {
             mock.voidMethod();
             fail();
-        } catch (RuntimeException e) {}
+        } catch (final RuntimeException e) {}
     }
     
     @Test
     public void shouldStubWithGenericAnswer() {
         doAnswer(new Answer<Object>() {
-            public Object answer(InvocationOnMock invocation) throws Throwable {
+            public Object answer(final InvocationOnMock invocation) throws Throwable {
                 return "foo";
             }
         })
@@ -184,7 +191,7 @@ public class StubbingUsingDoReturnTest extends TestBase {
         try {
             doNothing().when(mock).simpleMethod();
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             assertContains("Only void methods can doNothing()", e.getMessage());
         }
     }
@@ -196,7 +203,7 @@ public class StubbingUsingDoReturnTest extends TestBase {
         try {
             verifyNoMoreInteractions(mock);
             fail();
-        } catch (NoInteractionsWanted e) {}
+        } catch (final NoInteractionsWanted e) {}
     }
     
     @Test
@@ -220,7 +227,7 @@ public class StubbingUsingDoReturnTest extends TestBase {
         try {
             doReturn("foo").when(mock).booleanObjectReturningMethod();
             fail();
-        } catch (Exception e) {
+        } catch (final Exception e) {
             assertContains("String cannot be returned by booleanObjectReturningMethod()" +
                     "\n" +
                     "booleanObjectReturningMethod() should return Boolean",
@@ -233,7 +240,7 @@ public class StubbingUsingDoReturnTest extends TestBase {
         try {
             doReturn(null).when(mock).intReturningMethod();
             fail();
-        } catch (Exception e) {
+        } catch (final Exception e) {
             assertContains("null cannot be returned by intReturningMethod", e.getMessage());
         }
     }

--- a/test/org/mockitousage/stubbing/StubbingWithCustomAnswerTest.java
+++ b/test/org/mockitousage/stubbing/StubbingWithCustomAnswerTest.java
@@ -4,6 +4,14 @@
  */
 package org.mockitousage.stubbing;
 
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.stubVoid;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.util.Set;
+
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
@@ -11,15 +19,7 @@ import org.mockito.stubbing.Answer;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import java.lang.reflect.Method;
-import java.util.Set;
-
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.stubVoid;
-import static org.mockito.Mockito.when;
-
-@SuppressWarnings({"unchecked", "deprecation"})
+@SuppressWarnings({"rawtypes", "deprecation"})
 public class StubbingWithCustomAnswerTest extends TestBase {
     @Mock
     private IMethods mock;
@@ -27,8 +27,8 @@ public class StubbingWithCustomAnswerTest extends TestBase {
     @Test
     public void shouldAnswer() throws Exception {
         when(mock.simpleMethod(anyString())).thenAnswer(new Answer<String>() {
-            public String answer(InvocationOnMock invocation) throws Throwable {
-                String arg = (String) invocation.getArguments()[0];
+            public String answer(final InvocationOnMock invocation) throws Throwable {
+                final String arg = (String) invocation.getArguments()[0];
 
                 return invocation.getMethod().getName() + "-" + arg;
             }
@@ -39,8 +39,8 @@ public class StubbingWithCustomAnswerTest extends TestBase {
 
     @Test
     public void shouldAnswerWithThenAnswerAlias() throws Exception {
-        RecordCall recordCall = new RecordCall();
-        Set mockedSet = when(mock(Set.class).isEmpty()).then(recordCall).getMock();
+        final RecordCall recordCall = new RecordCall();
+        final Set mockedSet = when(mock(Set.class).isEmpty()).then(recordCall).getMock();
 
         mockedSet.isEmpty();
 
@@ -51,13 +51,13 @@ public class StubbingWithCustomAnswerTest extends TestBase {
     public void shouldAnswerConsecutively() throws Exception {
         when(mock.simpleMethod())
                 .thenAnswer(new Answer<String>() {
-                    public String answer(InvocationOnMock invocation) throws Throwable {
+                    public String answer(final InvocationOnMock invocation) throws Throwable {
                         return invocation.getMethod().getName();
                     }
                 })
                 .thenReturn("Hello")
                 .thenAnswer(new Answer<String>() {
-                    public String answer(InvocationOnMock invocation) throws Throwable {
+                    public String answer(final InvocationOnMock invocation) throws Throwable {
                         return invocation.getMethod().getName() + "-1";
                     }
                 });
@@ -70,7 +70,7 @@ public class StubbingWithCustomAnswerTest extends TestBase {
 
     @Test
     public void shoudAnswerVoidMethod() throws Exception {
-        RecordCall recordCall = new RecordCall();
+        final RecordCall recordCall = new RecordCall();
 
         stubVoid(mock).toAnswer(recordCall).on().voidMethod();
 
@@ -80,8 +80,8 @@ public class StubbingWithCustomAnswerTest extends TestBase {
 
     @Test
     public void shouldAnswerVoidMethodConsecutively() throws Exception {
-        RecordCall call1 = new RecordCall();
-        RecordCall call2 = new RecordCall();
+        final RecordCall call1 = new RecordCall();
+        final RecordCall call2 = new RecordCall();
 
         stubVoid(mock).toAnswer(call1)
                 .toThrow(new UnsupportedOperationException())
@@ -95,7 +95,7 @@ public class StubbingWithCustomAnswerTest extends TestBase {
         try {
             mock.voidMethod();
             fail();
-        } catch (UnsupportedOperationException e) {
+        } catch (final UnsupportedOperationException e) {
         }
 
         mock.voidMethod();
@@ -105,7 +105,7 @@ public class StubbingWithCustomAnswerTest extends TestBase {
     @Test
     public void shouldMakeSureTheInterfaceDoesNotChange() throws Exception {
         when(mock.simpleMethod(anyString())).thenAnswer(new Answer<String>() {
-            public String answer(InvocationOnMock invocation) throws Throwable {
+            public String answer(final InvocationOnMock invocation) throws Throwable {
                 assertTrue(invocation.getArguments().getClass().isArray());
                 assertEquals(Method.class, invocation.getMethod().getClass());
 
@@ -123,7 +123,7 @@ public class StubbingWithCustomAnswerTest extends TestBase {
             return called;
         }
 
-        public Object answer(InvocationOnMock invocation) throws Throwable {
+        public Object answer(final InvocationOnMock invocation) throws Throwable {
             called = true;
             return null;
         }

--- a/test/org/mockitousage/stubbing/StubbingWithDelegateTest.java
+++ b/test/org/mockitousage/stubbing/StubbingWithDelegateTest.java
@@ -4,15 +4,17 @@
  */
 package org.mockitousage.stubbing;
 
+import static junit.framework.Assert.assertEquals;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static junit.framework.Assert.assertEquals;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.exceptions.base.MockitoException;
@@ -24,12 +26,12 @@ public class StubbingWithDelegateTest {
     public class FakeList<T> {
         private T value;
 
-        public T get(int i) {
+        public T get(final int i) {
             return value;
         }
 
-        public T set(int i, T value) {
-            T oldValue = value;
+        public T set(final int i, final T value) {
+            final T oldValue = value;
             this.value = value;
             return oldValue;
         }
@@ -38,7 +40,7 @@ public class StubbingWithDelegateTest {
             return 10;
         }
 
-        public ArrayList<T> subList(int fromIndex, int toIndex) {
+        public ArrayList<T> subList(final int fromIndex, final int toIndex) {
             return new ArrayList<T>();
         }
     }
@@ -48,17 +50,17 @@ public class StubbingWithDelegateTest {
             return 10;
         }
 
-        public Collection<T> subList(int fromIndex, int toIndex) {
+        public Collection<T> subList(final int fromIndex, final int toIndex) {
             return new ArrayList<T>();
         }
     }
 
     @Test
     public void when_not_stubbed_delegate_should_be_called() {
-        List<String> delegatedList = new ArrayList<String>();
+        final List<String> delegatedList = new ArrayList<String>();
         delegatedList.add("un");
 
-        List<String> mock = mock(List.class, delegatesTo(delegatedList));
+        final List<String> mock = mock(List.class, delegatesTo(delegatedList));
 
         mock.add("two");
 
@@ -67,9 +69,9 @@ public class StubbingWithDelegateTest {
 
     @Test
     public void when_stubbed_the_delegate_should_not_be_called() {
-        List<String> delegatedList = new ArrayList<String>();
+        final List<String> delegatedList = new ArrayList<String>();
         delegatedList.add("un");
-        List<String> mock = mock(List.class, delegatesTo(delegatedList));
+        final List<String> mock = mock(List.class, delegatesTo(delegatedList));
 
         doReturn(10).when(mock).size();
 
@@ -81,9 +83,9 @@ public class StubbingWithDelegateTest {
 
     @Test
     public void delegate_should_not_be_called_when_stubbed2() {
-        List<String> delegatedList = new ArrayList<String>();
+        final List<String> delegatedList = new ArrayList<String>();
         delegatedList.add("un");
-        List<String> mockedList = mock(List.class, delegatesTo(delegatedList));
+        final List<String> mockedList = mock(List.class, delegatesTo(delegatedList));
 
         doReturn(false).when(mockedList).add(Mockito.anyString());
 
@@ -95,19 +97,20 @@ public class StubbingWithDelegateTest {
 
     @Test
     public void null_wrapper_dont_throw_exception_from_org_mockito_package() throws Exception {
-        IMethods methods = mock(IMethods.class, delegatesTo(new MethodsImpl()));
+        final IMethods methods = mock(IMethods.class, delegatesTo(new MethodsImpl()));
 
         try {
-            byte b = methods.byteObjectReturningMethod(); // real method returns null
+            @SuppressWarnings("unused")
+            final byte b = methods.byteObjectReturningMethod(); // real method returns null
             fail();
-        } catch (Exception e) {
+        } catch (final Exception e) {
             assertThat(e.toString()).doesNotContain("org.mockito");
         }
     }
 
     @Test
     public void instance_of_different_class_can_be_called() {
-        List<String> mock = mock(List.class, delegatesTo(new FakeList<String>()));
+        final List<String> mock = mock(List.class, delegatesTo(new FakeList<String>()));
 
         mock.set(1, "1");
         assertThat(mock.get(1).equals("1"));
@@ -115,44 +118,44 @@ public class StubbingWithDelegateTest {
 
     @Test
     public void method_with_subtype_return_can_be_called() {
-        List<String> mock = mock(List.class, delegatesTo(new FakeList<String>()));
+        final List<String> mock = mock(List.class, delegatesTo(new FakeList<String>()));
 
-        List<String> subList = mock.subList(0, 0);
+        final List<String> subList = mock.subList(0, 0);
         assertThat(subList.isEmpty());
     }
 
     @Test
     public void calling_missing_method_should_throw_exception() {
-        List<String> mock = mock(List.class, delegatesTo(new FakeList<String>()));
+        final List<String> mock = mock(List.class, delegatesTo(new FakeList<String>()));
 
         try {
             mock.isEmpty();
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             assertThat(e.toString()).contains("Methods called on mock must exist");
         }
     }
 
     @Test
     public void calling_method_with_wrong_primitive_return_should_throw_exception() {
-        List<String> mock = mock(List.class, delegatesTo(new FakeListWithWrongMethods<String>()));
+        final List<String> mock = mock(List.class, delegatesTo(new FakeListWithWrongMethods<String>()));
 
         try {
             mock.size();
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             assertThat(e.toString()).contains("Methods called on delegated instance must have compatible return type");
         }
     }
 
     @Test
     public void calling_method_with_wrong_reference_return_should_throw_exception() {
-        List<String> mock = mock(List.class, delegatesTo(new FakeListWithWrongMethods<String>()));
+        final List<String> mock = mock(List.class, delegatesTo(new FakeListWithWrongMethods<String>()));
 
         try {
             mock.subList(0, 0);
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             assertThat(e.toString()).contains("Methods called on delegated instance must have compatible return type");
         }
     }
@@ -160,7 +163,7 @@ public class StubbingWithDelegateTest {
     @Test
     public void exception_should_be_propagated_from_delegate() throws Exception {
         final RuntimeException failure = new RuntimeException("angry-method");
-        IMethods methods = mock(IMethods.class, delegatesTo(new MethodsImpl() {
+        final IMethods methods = mock(IMethods.class, delegatesTo(new MethodsImpl() {
             @Override
             public String simpleMethod() {
                 throw failure;
@@ -170,7 +173,7 @@ public class StubbingWithDelegateTest {
         try {
             methods.simpleMethod(); // delegate throws an exception
             fail();
-        } catch (RuntimeException e) {
+        } catch (final RuntimeException e) {
             assertThat(e).isEqualTo(failure);
         }
     }

--- a/test/org/mockitousage/stubbing/StubbingWithExtraAnswersTest.java
+++ b/test/org/mockitousage/stubbing/StubbingWithExtraAnswersTest.java
@@ -5,8 +5,8 @@
 
 package org.mockitousage.stubbing;
 
-import static java.util.Arrays.*;
-import static org.mockito.Mockito.*;
+import static java.util.Arrays.asList;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 
@@ -17,6 +17,7 @@ import org.mockito.stubbing.answers.ReturnsElementsOf;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
+
 public class StubbingWithExtraAnswersTest extends TestBase {
 
     @Mock private IMethods mock;
@@ -24,7 +25,7 @@ public class StubbingWithExtraAnswersTest extends TestBase {
     @Test
     public void shouldWorkAsStandardMockito() throws Exception {
         //when
-        List<Integer> list = asList(1, 2, 3);
+        final List<Integer> list = asList(1, 2, 3);
         when(mock.objectReturningMethodNoArgs()).thenAnswer(new ReturnsElementsOf(list));
         
         //then
@@ -39,7 +40,7 @@ public class StubbingWithExtraAnswersTest extends TestBase {
     @Test
     public void shouldReturnNullIfNecessary() throws Exception {
         //when
-        List<Integer> list = asList(1, null);
+        final List<Integer> list = asList(1, null);
         when(mock.objectReturningMethodNoArgs()).thenAnswer(new ReturnsElementsOf(list));
         
         //then
@@ -55,6 +56,6 @@ public class StubbingWithExtraAnswersTest extends TestBase {
             new ReturnsElementsOf(null);
             //then
             fail();
-        } catch (MockitoException e) {}
+        } catch (final MockitoException e) {}
     }
 }

--- a/test/org/mockitousage/stubbing/StubbingWithThrowablesTest.java
+++ b/test/org/mockitousage/stubbing/StubbingWithThrowablesTest.java
@@ -5,13 +5,12 @@
 
 package org.mockitousage.stubbing;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
-import org.mockito.exceptions.base.MockitoException;
-import org.mockito.exceptions.verification.NoInteractionsWanted;
-import org.mockito.exceptions.verification.WantedButNotInvoked;
-import org.mockitoutil.TestBase;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.stubVoid;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -19,7 +18,13 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 
-import static org.mockito.Mockito.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.exceptions.base.MockitoException;
+import org.mockito.exceptions.verification.NoInteractionsWanted;
+import org.mockito.exceptions.verification.WantedButNotInvoked;
+import org.mockitoutil.TestBase;
 
 @SuppressWarnings({"serial", "unchecked", "all", "deprecation"})
 public class StubbingWithThrowablesTest extends TestBase {
@@ -35,26 +40,26 @@ public class StubbingWithThrowablesTest extends TestBase {
     
     @Test
     public void shouldStubWithThrowable() throws Exception {
-        IllegalArgumentException expected = new IllegalArgumentException("thrown by mock");
+        final IllegalArgumentException expected = new IllegalArgumentException("thrown by mock");
         when(mock.add("throw")).thenThrow(expected);
         
         try {
             mock.add("throw");
             fail();
-        } catch (IllegalArgumentException e) {
+        } catch (final IllegalArgumentException e) {
             assertEquals(expected, e);
         }
     }
     
     @Test
     public void shouldSetThrowableToVoidMethod() throws Exception {
-        IllegalArgumentException expected = new IllegalArgumentException("thrown by mock");
+        final IllegalArgumentException expected = new IllegalArgumentException("thrown by mock");
         
         stubVoid(mock).toThrow(expected).on().clear();
         try {
             mock.clear();
             fail();
-        } catch (Exception e) {
+        } catch (final Exception e) {
             assertEquals(expected, e);
         }
     } 
@@ -67,7 +72,7 @@ public class StubbingWithThrowablesTest extends TestBase {
         try {
             mock.clear();
             fail();
-        } catch (ExceptionTwo e) {}
+        } catch (final ExceptionTwo e) {}
     }
     
     @Test
@@ -77,34 +82,34 @@ public class StubbingWithThrowablesTest extends TestBase {
         try {
             when(mock.get(1)).thenThrow(new ExceptionTwo());
             fail();
-        } catch (ExceptionOne e) {}
+        } catch (final ExceptionOne e) {}
     }   
     
     @Test
     public void shouldAllowSettingCheckedException() throws Exception {
-        Reader reader = mock(Reader.class);
-        IOException ioException = new IOException();
+        final Reader reader = mock(Reader.class);
+        final IOException ioException = new IOException();
         
         when(reader.read()).thenThrow(ioException);
         
         try {
             reader.read();
             fail();
-        } catch (Exception e) {
+        } catch (final Exception e) {
             assertEquals(ioException, e);
         }
     }
     
     @Test
     public void shouldAllowSettingError() throws Exception {
-        Error error = new Error();
+        final Error error = new Error();
         
         when(mock.add("quake")).thenThrow(error);
         
         try {
             mock.add("quake");
             fail();
-        } catch (Error e) {
+        } catch (final Error e) {
             assertEquals(error, e);
         }
     }
@@ -155,22 +160,22 @@ public class StubbingWithThrowablesTest extends TestBase {
         try {
             mockTwo.clear();
             fail();
-        } catch (ExceptionThree e) {}
+        } catch (final ExceptionThree e) {}
         try {
             mockTwo.containsValue("ExceptionFour");
             fail();
-        } catch (ExceptionFour e) {}
+        } catch (final ExceptionFour e) {}
         
         assertNull(mock.getFirst());
         assertEquals("last", mock.getLast());
         try {
             mock.add("ExceptionOne");
             fail();
-        } catch (ExceptionOne e) {}
+        } catch (final ExceptionOne e) {}
         try {
             mock.clear();
             fail();
-        } catch (ExceptionTwo e) {}
+        } catch (final ExceptionTwo e) {}
     }
     
     @Test
@@ -181,12 +186,12 @@ public class StubbingWithThrowablesTest extends TestBase {
         try {
             mock.size();
             fail();
-        } catch (RuntimeException e) {}
+        } catch (final RuntimeException e) {}
         
         try {
             mock.clone();
             fail();
-        } catch (RuntimeException e) {}
+        } catch (final RuntimeException e) {}
         
         verify(mock).size();
         verify(mock).clone();
@@ -205,17 +210,17 @@ public class StubbingWithThrowablesTest extends TestBase {
         try {
             verify(mock).size();
             fail();
-        } catch (WantedButNotInvoked e) {}
+        } catch (final WantedButNotInvoked e) {}
         
         try {
             verify(mock).clone();
             fail();
-        } catch (WantedButNotInvoked e) {}
+        } catch (final WantedButNotInvoked e) {}
         
         try {
             verifyNoMoreInteractions(mock);
             fail();
-        } catch (NoInteractionsWanted e) {}
+        } catch (final NoInteractionsWanted e) {}
     }
     
     private class ExceptionOne extends RuntimeException {}

--- a/test/org/mockitousage/verification/AtLeastXVerificationTest.java
+++ b/test/org/mockitousage/verification/AtLeastXVerificationTest.java
@@ -5,16 +5,19 @@
 
 package org.mockitousage.verification;
 
-import org.junit.Test;
 import static org.mockito.Matchers.anyString;
-import org.mockito.Mock;
-import static org.mockito.Mockito.*;
-import org.mockito.exceptions.base.MockitoAssertionError;
-import org.mockitoutil.TestBase;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import java.util.List;
 
-@SuppressWarnings("unchecked")
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.exceptions.base.MockitoAssertionError;
+import org.mockitoutil.TestBase;
+
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class AtLeastXVerificationTest extends TestBase {
 
     @Mock private List mock;
@@ -38,7 +41,7 @@ public class AtLeastXVerificationTest extends TestBase {
         try {
             verify(mock, atLeast(2)).add(anyString());
             fail();
-        } catch (MockitoAssertionError e) {}
+        } catch (final MockitoAssertionError e) {}
     }
     
     @Test

--- a/test/org/mockitousage/verification/AtMostXVerificationTest.java
+++ b/test/org/mockitousage/verification/AtMostXVerificationTest.java
@@ -5,8 +5,11 @@
 
 package org.mockitousage.verification;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.atMost;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import java.util.List;
 
@@ -18,7 +21,7 @@ import org.mockito.exceptions.base.MockitoException;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class AtMostXVerificationTest extends TestBase {
 
     @Mock private List mock;
@@ -34,7 +37,7 @@ public class AtMostXVerificationTest extends TestBase {
         try {
             verify(mock, atMost(1)).clear();
             fail();
-        } catch (MockitoAssertionError e) {}
+        } catch (final MockitoAssertionError e) {}
     }
     
     @Test
@@ -45,7 +48,7 @@ public class AtMostXVerificationTest extends TestBase {
         try {
             verify(mock, atMost(0)).add(anyString());
             fail();
-        } catch (MockitoAssertionError e) {}
+        } catch (final MockitoAssertionError e) {}
     }
     
     @Test
@@ -53,7 +56,7 @@ public class AtMostXVerificationTest extends TestBase {
         try {
             verify(mock, atMost(-1)).clear();
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             assertEquals("Negative value is not allowed here", e.getMessage());
         }
     }
@@ -66,7 +69,7 @@ public class AtMostXVerificationTest extends TestBase {
         try {
             verify(mock, atMost(1)).clear();
             fail();
-        } catch (MockitoAssertionError e) {
+        } catch (final MockitoAssertionError e) {
             assertEquals("\nWanted at most 1 time but was 2", e.getMessage());
         }
     }
@@ -74,12 +77,12 @@ public class AtMostXVerificationTest extends TestBase {
     @Test
     public void shouldNotAllowInOrderMode() throws Exception {
         mock.clear();
-        InOrder inOrder = inOrder(mock);
+        final InOrder inOrder = inOrder(mock);
         
         try {
             inOrder.verify(mock, atMost(1)).clear();
             fail();
-        } catch (MockitoException e) {
+        } catch (final MockitoException e) {
             assertEquals("AtMost is not implemented to work with InOrder", e.getMessage());
         }
     }
@@ -103,7 +106,7 @@ public class AtMostXVerificationTest extends TestBase {
         try {
             verifyNoMoreInteractions(mock);
             fail();
-        } catch(NoInteractionsWanted e) {
+        } catch(final NoInteractionsWanted e) {
             assertContains("undesiredInteraction(", e.getMessage());
         }
     }

--- a/test/org/mockitousage/verification/BasicVerificationInOrderTest.java
+++ b/test/org/mockitousage/verification/BasicVerificationInOrderTest.java
@@ -5,7 +5,12 @@
 
 package org.mockitousage.verification;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -80,7 +85,7 @@ public class BasicVerificationInOrderTest extends TestBase {
         try {
             inOrder.verify(mockOne).simpleMethod(1);
             fail();
-        } catch (VerificationInOrderFailure e) {
+        } catch (final VerificationInOrderFailure e) {
         }
     }
 
@@ -94,7 +99,7 @@ public class BasicVerificationInOrderTest extends TestBase {
         try {
             inOrder.verify(mockOne).simpleMethod(4);
             fail();
-        } catch (VerificationInOrderFailure e) {
+        } catch (final VerificationInOrderFailure e) {
         }
     }
 
@@ -114,7 +119,7 @@ public class BasicVerificationInOrderTest extends TestBase {
         try {
             inOrder.verify(mockTwo, times(4)).simpleMethod(2);
             fail();
-        } catch (VerificationInOrderFailure e) {
+        } catch (final VerificationInOrderFailure e) {
         }
     }
 
@@ -124,7 +129,7 @@ public class BasicVerificationInOrderTest extends TestBase {
         try {
             inOrder.verify(mockTwo, times(0)).simpleMethod(2);
             fail();
-        } catch (VerificationInOrderFailure e) {
+        } catch (final VerificationInOrderFailure e) {
         }
     }
 
@@ -137,7 +142,7 @@ public class BasicVerificationInOrderTest extends TestBase {
         try {
             inOrder.verify(mockOne, times(0)).simpleMethod(4);
             fail();
-        } catch (VerificationInOrderFailure e) {
+        } catch (final VerificationInOrderFailure e) {
         }
     }
 
@@ -150,7 +155,7 @@ public class BasicVerificationInOrderTest extends TestBase {
         try {
             inOrder.verify(mockOne, times(2)).simpleMethod(4);
             fail();
-        } catch (VerificationInOrderFailure e) {
+        } catch (final VerificationInOrderFailure e) {
         }
     }
 
@@ -172,7 +177,7 @@ public class BasicVerificationInOrderTest extends TestBase {
         try {
             inOrder.verify(mockTwo, times(2)).simpleMethod(-999);
             fail();
-        } catch (VerificationInOrderFailure e) {
+        } catch (final VerificationInOrderFailure e) {
         }
     }
 
@@ -182,7 +187,7 @@ public class BasicVerificationInOrderTest extends TestBase {
         try {
             inOrder.verify(mockTwo, times(2)).oneArg(true);
             fail();
-        } catch (VerificationInOrderFailure e) {
+        } catch (final VerificationInOrderFailure e) {
         }
     }
 
@@ -195,7 +200,7 @@ public class BasicVerificationInOrderTest extends TestBase {
         try {
             inOrder.verify(mockOne).simpleMethod(-666);
             fail();
-        } catch (VerificationInOrderFailure e) {
+        } catch (final VerificationInOrderFailure e) {
         }
     }
 
@@ -208,7 +213,7 @@ public class BasicVerificationInOrderTest extends TestBase {
         try {
             inOrder.verify(mockOne).oneArg(false);
             fail();
-        } catch (VerificationInOrderFailure e) {
+        } catch (final VerificationInOrderFailure e) {
         }
     }
 
@@ -220,7 +225,7 @@ public class BasicVerificationInOrderTest extends TestBase {
         try {
             inOrder.verify(mockOne).simpleMethod(1);
             fail();
-        } catch (VerificationInOrderFailure e) {
+        } catch (final VerificationInOrderFailure e) {
         }
     }
 
@@ -230,7 +235,7 @@ public class BasicVerificationInOrderTest extends TestBase {
         try {
             inOrder.verify(mockOne).simpleMethod(1);
             fail();
-        } catch (VerificationInOrderFailure e) {
+        } catch (final VerificationInOrderFailure e) {
         }
     }
 
@@ -240,7 +245,7 @@ public class BasicVerificationInOrderTest extends TestBase {
         try {
             inOrder.verify(mockOne).simpleMethod(1);
             fail();
-        } catch (VerificationInOrderFailure e) {
+        } catch (final VerificationInOrderFailure e) {
         }
     }
 
@@ -254,7 +259,7 @@ public class BasicVerificationInOrderTest extends TestBase {
         try {
             verifyNoMoreInteractions(mockOne, mockTwo, mockThree);
             fail();
-        } catch (NoInteractionsWanted e) {
+        } catch (final NoInteractionsWanted e) {
         }
     }
 
@@ -266,6 +271,6 @@ public class BasicVerificationInOrderTest extends TestBase {
     @SuppressWarnings("all")
     @Test(expected = MockitoException.class)
     public void shouldScreamWhenNullPassed() {
-        inOrder((Object[])null);
+        inOrder((Object[]) null);
     }
 }

--- a/test/org/mockitousage/verification/BasicVerificationTest.java
+++ b/test/org/mockitousage/verification/BasicVerificationTest.java
@@ -5,7 +5,11 @@
 
 package org.mockitousage.verification;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 
@@ -17,7 +21,7 @@ import org.mockito.exceptions.verification.WantedButNotInvoked;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class BasicVerificationTest extends TestBase {
 
     @Mock private List mock;
@@ -48,7 +52,7 @@ public class BasicVerificationTest extends TestBase {
         try {
             verify(mock).add("bar");
             fail();
-        } catch (AssertionError expected) {}
+        } catch (final AssertionError expected) {}
     }
 
     @Test
@@ -63,7 +67,7 @@ public class BasicVerificationTest extends TestBase {
         try {
             verify(mockTwo, atLeastOnce()).add("foo");
             fail();
-        } catch (WantedButNotInvoked e) {}
+        } catch (final WantedButNotInvoked e) {}
     }
 
     @Test
@@ -78,7 +82,7 @@ public class BasicVerificationTest extends TestBase {
         try {
             verifyNoMoreInteractions(mock);
             fail();
-        } catch (NoInteractionsWanted e) {}
+        } catch (final NoInteractionsWanted e) {}
     }
     
     @Test
@@ -92,7 +96,7 @@ public class BasicVerificationTest extends TestBase {
         try {
             verify(mock).clear();
             fail();
-        } catch (TooManyActualInvocations e) {}
+        } catch (final TooManyActualInvocations e) {}
     }
 
     @Test
@@ -107,12 +111,12 @@ public class BasicVerificationTest extends TestBase {
 
     @Test
     public void shouldDetectWhenOverloadedMethodCalled() throws Exception {
-        IMethods mockThree = mock(IMethods.class);
+        final IMethods mockThree = mock(IMethods.class);
         
-        mockThree.varargs((Object[]) new Object[] {});
+        mockThree.varargs(new Object[] {});
         try {
-            verify(mockThree).varargs((String[]) new String[] {});
+            verify(mockThree).varargs(new String[] {});
             fail();
-        } catch(WantedButNotInvoked e) {}
+        } catch(final WantedButNotInvoked e) {}
     }
 }

--- a/test/org/mockitousage/verification/DescriptiveMessagesOnVerificationInOrderErrorsTest.java
+++ b/test/org/mockitousage/verification/DescriptiveMessagesOnVerificationInOrderErrorsTest.java
@@ -5,8 +5,10 @@
 
 package org.mockitousage.verification;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.times;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -47,8 +49,8 @@ public class DescriptiveMessagesOnVerificationInOrderErrorsTest extends TestBase
         try {
             inOrder.verify(one, atLeastOnce()).simpleMethod(11);
             fail();
-        } catch (VerificationInOrderFailure e) {
-            String expected = 
+        } catch (final VerificationInOrderFailure e) {
+            final String expected = 
                     "\n" +
                     "Verification in order failure" +
                     "\n" +
@@ -60,7 +62,7 @@ public class DescriptiveMessagesOnVerificationInOrderErrorsTest extends TestBase
             
             assertContains(expected, e.getMessage());
             
-            String expectedCause = 
+            final String expectedCause = 
                 "\n" +
                 "Wanted anywhere AFTER following interaction:" +
                 "\n" +
@@ -77,8 +79,8 @@ public class DescriptiveMessagesOnVerificationInOrderErrorsTest extends TestBase
         try {
             inOrder.verify(one).differentMethod();
             fail();
-        } catch (WantedButNotInvoked e) {
-            String expected = 
+        } catch (final WantedButNotInvoked e) {
+            final String expected = 
                     "\n" +
                     "Wanted but not invoked:" +
                     "\n" +
@@ -95,7 +97,7 @@ public class DescriptiveMessagesOnVerificationInOrderErrorsTest extends TestBase
         try {
             inOrder.verify(one).simpleMethod(999);
             fail();
-        } catch (org.mockito.exceptions.verification.junit.ArgumentsAreDifferent e) {           
+        } catch (final org.mockito.exceptions.verification.junit.ArgumentsAreDifferent e) {           
             assertContains("has different arguments", e.getMessage());
         }
     }
@@ -107,7 +109,7 @@ public class DescriptiveMessagesOnVerificationInOrderErrorsTest extends TestBase
         try {
             inOrder.verify(one).simpleMethod(999);
             fail();
-        } catch (VerificationInOrderFailure e) {
+        } catch (final VerificationInOrderFailure e) {
             assertContains("Wanted but not invoked", e.getMessage());
         }
     } 
@@ -121,9 +123,9 @@ public class DescriptiveMessagesOnVerificationInOrderErrorsTest extends TestBase
         try {
             inOrder.verify(three).simpleMethod(999);
             fail();
-        } catch (VerificationInOrderFailure e) {
-            String actualMessage = e.getMessage();
-            String expectedMessage = 
+        } catch (final VerificationInOrderFailure e) {
+            final String actualMessage = e.getMessage();
+            final String expectedMessage = 
                     "\n" +
                     "Verification in order failure" +
                     "\n" +
@@ -141,9 +143,9 @@ public class DescriptiveMessagesOnVerificationInOrderErrorsTest extends TestBase
         try {
             inOrder.verify(two, times(1)).simpleMethod(2);
             fail();
-        } catch (VerificationInOrderFailure e) {
-            String actualMessage = e.getMessage();
-            String expectedMessage = 
+        } catch (final VerificationInOrderFailure e) {
+            final String actualMessage = e.getMessage();
+            final String expectedMessage = 
                     "\n" +
                     "Verification in order failure:" +
                     "\n" +
@@ -154,7 +156,7 @@ public class DescriptiveMessagesOnVerificationInOrderErrorsTest extends TestBase
                     "-> at"; 
             assertContains(expectedMessage, actualMessage);      
 
-            String expectedCause =
+            final String expectedCause =
                 "\n" +
                 "But was 2 times. Undesired invocation:" +
                 "\n" +
@@ -174,9 +176,9 @@ public class DescriptiveMessagesOnVerificationInOrderErrorsTest extends TestBase
         try {
             inOrder.verify(two, times(2)).simpleMethod(2);
             fail();
-        } catch (VerificationInOrderFailure e) {
-            String actualMessage = e.getMessage();
-            String expectedMessage = 
+        } catch (final VerificationInOrderFailure e) {
+            final String actualMessage = e.getMessage();
+            final String expectedMessage = 
                     "\n" +
                     "Verification in order failure:" +
                     "\n" +
@@ -187,7 +189,7 @@ public class DescriptiveMessagesOnVerificationInOrderErrorsTest extends TestBase
                     "-> at";
             assertContains(expectedMessage, actualMessage);
             
-            String expectedCause = 
+            final String expectedCause = 
                 "\n" +
                 "But was 1 time:" +
                 "\n" +

--- a/test/org/mockitousage/verification/DescriptiveMessagesWhenTimesXVerificationFailsTest.java
+++ b/test/org/mockitousage/verification/DescriptiveMessagesWhenTimesXVerificationFailsTest.java
@@ -5,7 +5,7 @@
 
 package org.mockitousage.verification;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
 
 import java.util.LinkedList;
 
@@ -16,7 +16,7 @@ import org.mockito.exceptions.verification.TooLittleActualInvocations;
 import org.mockito.exceptions.verification.TooManyActualInvocations;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class DescriptiveMessagesWhenTimesXVerificationFailsTest extends TestBase {
 
     @Mock private LinkedList mock;
@@ -31,7 +31,7 @@ public class DescriptiveMessagesWhenTimesXVerificationFailsTest extends TestBase
         try {
             Mockito.verify(mock, times(100)).clear();
             fail();
-        } catch (TooLittleActualInvocations e) {
+        } catch (final TooLittleActualInvocations e) {
             assertContains("mock.clear();", e.getMessage());
             assertContains("Wanted 100 times", e.getMessage());
             assertContains("was 3", e.getMessage());
@@ -49,7 +49,7 @@ public class DescriptiveMessagesWhenTimesXVerificationFailsTest extends TestBase
         try {
             Mockito.verify(mock, times(1)).clear();
             fail();
-        } catch (TooManyActualInvocations e) {
+        } catch (final TooManyActualInvocations e) {
             assertContains("mock.clear();", e.getMessage());
             assertContains("Wanted 1 time", e.getMessage());
             assertContains("was 4", e.getMessage());

--- a/test/org/mockitousage/verification/ExactNumberOfTimesVerificationTest.java
+++ b/test/org/mockitousage/verification/ExactNumberOfTimesVerificationTest.java
@@ -5,7 +5,12 @@
 
 package org.mockitousage.verification;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.LinkedList;
 
@@ -19,7 +24,7 @@ import org.mockito.exceptions.verification.VerificationInOrderFailure;
 import org.mockito.exceptions.verification.WantedButNotInvoked;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class ExactNumberOfTimesVerificationTest extends TestBase {
 
     private LinkedList mock;
@@ -38,7 +43,7 @@ public class ExactNumberOfTimesVerificationTest extends TestBase {
         try {
             verify(mock, times(100)).clear();
             fail();
-        } catch (TooLittleActualInvocations e) {
+        } catch (final TooLittleActualInvocations e) {
             assertContains("Wanted 100 times", e.getMessage());
             assertContains("was 2", e.getMessage());
         }
@@ -53,7 +58,7 @@ public class ExactNumberOfTimesVerificationTest extends TestBase {
         try {
             verify(mock, times(1)).clear();
             fail();
-        } catch (TooManyActualInvocations e) {
+        } catch (final TooManyActualInvocations e) {
             assertContains("Wanted 1 time", e.getMessage());
             assertContains("was 2 times", e.getMessage());
         }
@@ -65,7 +70,7 @@ public class ExactNumberOfTimesVerificationTest extends TestBase {
         try {
             verify(mock, times(15)).clear();
             fail();
-        } catch (WantedButNotInvoked e) {}
+        } catch (final WantedButNotInvoked e) {}
     }
 
     @Test
@@ -75,7 +80,7 @@ public class ExactNumberOfTimesVerificationTest extends TestBase {
         try {
             verify(mock, times(0)).clear();
             fail();
-        } catch (NeverWantedButInvoked e) {
+        } catch (final NeverWantedButInvoked e) {
             assertContains("Never wanted here", e.getMessage());
         }
     }
@@ -107,7 +112,7 @@ public class ExactNumberOfTimesVerificationTest extends TestBase {
         try {
             verify(mock, never()).add("one");
             fail();
-        } catch (NeverWantedButInvoked e) {}
+        } catch (final NeverWantedButInvoked e) {}
     }
     
     @Test
@@ -115,7 +120,7 @@ public class ExactNumberOfTimesVerificationTest extends TestBase {
         mock.add("one");
         mock.add("two");
 
-        InOrder inOrder = inOrder(mock);
+        final InOrder inOrder = inOrder(mock);
         
         inOrder.verify(mock, never()).add("xxx");
         inOrder.verify(mock).add("one");
@@ -124,6 +129,6 @@ public class ExactNumberOfTimesVerificationTest extends TestBase {
         try {
             inOrder.verify(mock, never()).add("two");
             fail();
-        } catch (VerificationInOrderFailure e) {}
+        } catch (final VerificationInOrderFailure e) {}
     }
 }

--- a/test/org/mockitousage/verification/FindingRedundantInvocationsInOrderTest.java
+++ b/test/org/mockitousage/verification/FindingRedundantInvocationsInOrderTest.java
@@ -5,7 +5,8 @@
 
 package org.mockitousage.verification;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
 
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -23,7 +24,7 @@ public class FindingRedundantInvocationsInOrderTest extends TestBase {
     @Test
     public void shouldWorkFineIfNoInvocatins() throws Exception {
         //when
-        InOrder inOrder = inOrder(mock);
+        final InOrder inOrder = inOrder(mock);
         
         //then
         inOrder.verifyNoMoreInteractions();        
@@ -35,11 +36,11 @@ public class FindingRedundantInvocationsInOrderTest extends TestBase {
         mock.simpleMethod();
         
         //then
-        InOrder inOrder = inOrder(mock);
+        final InOrder inOrder = inOrder(mock);
         try {
             inOrder.verifyNoMoreInteractions();
             fail();
-        } catch(VerificationInOrderFailure e) {
+        } catch(final VerificationInOrderFailure e) {
             assertContains("No interactions wanted", e.getMessage());
         }
     }
@@ -52,7 +53,7 @@ public class FindingRedundantInvocationsInOrderTest extends TestBase {
         mock.otherMethod();
         
         //then
-        InOrder inOrder = inOrder(mock);
+        final InOrder inOrder = inOrder(mock);
         inOrder.verify(mock).simpleMethod(10);
         inOrder.verify(mock).otherMethod();
         inOrder.verifyNoMoreInteractions();        
@@ -66,7 +67,7 @@ public class FindingRedundantInvocationsInOrderTest extends TestBase {
         mock.otherMethod();
         
         //then
-        InOrder inOrder = inOrder(mock, mock2);
+        final InOrder inOrder = inOrder(mock, mock2);
         inOrder.verify(mock2).simpleMethod();
         inOrder.verify(mock).otherMethod();
         inOrder.verifyNoMoreInteractions();        
@@ -80,12 +81,12 @@ public class FindingRedundantInvocationsInOrderTest extends TestBase {
         mock.otherMethod();
         
         //then
-        InOrder inOrder = inOrder(mock);
+        final InOrder inOrder = inOrder(mock);
         inOrder.verify(mock).simpleMethod(10);
         try {
             inOrder.verifyNoMoreInteractions();
             fail();
-        } catch(VerificationInOrderFailure e) {}
+        } catch(final VerificationInOrderFailure e) {}
     }
     
     @Test
@@ -96,24 +97,24 @@ public class FindingRedundantInvocationsInOrderTest extends TestBase {
         mock.otherMethod();
         
         //then
-        InOrder inOrder = inOrder(mock, mock2);
+        final InOrder inOrder = inOrder(mock, mock2);
         inOrder.verify(mock2).simpleMethod();
         try {
             inOrder.verifyNoMoreInteractions();
             fail();
-        } catch(VerificationInOrderFailure e) {}
+        } catch(final VerificationInOrderFailure e) {}
     }
     
     @Test
     public void shouldValidateState() throws Exception {
         //when
-        InOrder inOrder = inOrder(mock);
+        final InOrder inOrder = inOrder(mock);
         verify(mock); // mess up state
         
         //then
         try {
             inOrder.verifyNoMoreInteractions();
             fail();
-        } catch(UnfinishedVerificationException e) {}
+        } catch(final UnfinishedVerificationException e) {}
     }
 }

--- a/test/org/mockitousage/verification/NoMoreInteractionsVerificationTest.java
+++ b/test/org/mockitousage/verification/NoMoreInteractionsVerificationTest.java
@@ -5,7 +5,12 @@
 
 package org.mockitousage.verification;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -65,7 +70,7 @@ public class NoMoreInteractionsVerificationTest extends TestBase {
         try {
             verifyZeroInteractions(mock);
             fail();
-        } catch (NoInteractionsWanted e) {}
+        } catch (final NoInteractionsWanted e) {}
     }
     
     @Test
@@ -75,7 +80,7 @@ public class NoMoreInteractionsVerificationTest extends TestBase {
         try {
             verifyNoMoreInteractions(mock);
             fail();
-        } catch (NoInteractionsWanted e) {}
+        } catch (final NoInteractionsWanted e) {}
     }
     
     @Test
@@ -88,7 +93,7 @@ public class NoMoreInteractionsVerificationTest extends TestBase {
         try {
             verifyNoMoreInteractions(mock);
             fail();
-        } catch (NoInteractionsWanted e) {
+        } catch (final NoInteractionsWanted e) {
             assertContains("list of all invocations", e.getMessage());
         }
     }
@@ -100,15 +105,15 @@ public class NoMoreInteractionsVerificationTest extends TestBase {
         try {
             verifyNoMoreInteractions(mock);
             fail();
-        } catch (NoInteractionsWanted e) {
+        } catch (final NoInteractionsWanted e) {
             assertNotContains("list of all invocations", e.getMessage());
         }
     }    
     
     @Test
     public void shouldVerifyOneMockButFailOnOther() throws Exception {
-        List list = mock(List.class);
-        Map map = mock(Map.class);
+        final List list = mock(List.class);
+        final Map map = mock(Map.class);
 
         list.add("one");
         list.add("one");
@@ -121,12 +126,12 @@ public class NoMoreInteractionsVerificationTest extends TestBase {
         try {
             verifyZeroInteractions(map);
             fail();
-        } catch (NoInteractionsWanted e) {}
+        } catch (final NoInteractionsWanted e) {}
     }
     
     @SuppressWarnings("all")
     @Test(expected=MockitoException.class)
     public void verifyNoMoreInteractionsShouldScreamWhenNullPassed() throws Exception {
-        verifyNoMoreInteractions((Object[])null);
+        verifyNoMoreInteractions((Object[]) null);
     }
 }

--- a/test/org/mockitousage/verification/NoMoreInteractionsVerificationTest.java
+++ b/test/org/mockitousage/verification/NoMoreInteractionsVerificationTest.java
@@ -22,7 +22,7 @@ import org.mockito.exceptions.base.MockitoException;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class NoMoreInteractionsVerificationTest extends TestBase {
 
     private LinkedList mock;

--- a/test/org/mockitousage/verification/OrdinaryVerificationPrintsAllInteractionsTest.java
+++ b/test/org/mockitousage/verification/OrdinaryVerificationPrintsAllInteractionsTest.java
@@ -5,7 +5,7 @@
 
 package org.mockitousage.verification;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
 
 import org.junit.Test;
 import org.mockito.Mock;
@@ -26,7 +26,7 @@ public class OrdinaryVerificationPrintsAllInteractionsTest extends TestBase {
         try {
             verify(mock).simpleMethod();
             fail();
-        } catch (WantedButNotInvoked e) {
+        } catch (final WantedButNotInvoked e) {
             assertContains("However, there were other interactions with this mock", e.getMessage());
             assertContains("firstInteraction(", e.getMessage());
             assertContains("secondInteraction(", e.getMessage());
@@ -41,7 +41,7 @@ public class OrdinaryVerificationPrintsAllInteractionsTest extends TestBase {
         try {
             verify(mock).simpleMethod();
             fail();
-        } catch (WantedButNotInvoked e) {
+        } catch (final WantedButNotInvoked e) {
             assertContains("firstInteraction(", e.getMessage());
             assertNotContains("differentMockInteraction(", e.getMessage());
         }
@@ -52,7 +52,7 @@ public class OrdinaryVerificationPrintsAllInteractionsTest extends TestBase {
         try {
             verify(mock).simpleMethod();
             fail();
-        } catch (WantedButNotInvoked e) {
+        } catch (final WantedButNotInvoked e) {
             assertContains("there were zero interactions with this mock.", e.getMessage());
         }
     }

--- a/test/org/mockitousage/verification/PrintingVerboseTypesWithArgumentsTest.java
+++ b/test/org/mockitousage/verification/PrintingVerboseTypesWithArgumentsTest.java
@@ -5,8 +5,10 @@
 
 package org.mockitousage.verification;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import org.junit.Test;
 import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
@@ -16,24 +18,24 @@ import org.mockitoutil.TestBase;
 public class PrintingVerboseTypesWithArgumentsTest extends TestBase {
 
     class Boo {
-        public void withLong(long x) {
+        public void withLong(final long x) {
         }
         
-        public void withLongAndInt(long x, int y) {
+        public void withLongAndInt(final long x, final int y) {
         }
     }
     
     @Test
     public void shouldNotReportArgumentTypesWhenToStringIsTheSame() throws Exception {
         //given
-        Boo boo = mock(Boo.class);
+        final Boo boo = mock(Boo.class);
         boo.withLong(100);
         
         try {
             //when
             verify(boo).withLong(eq(100));
             fail();
-        } catch (ArgumentsAreDifferent e) {
+        } catch (final ArgumentsAreDifferent e) {
             //then
             assertContains("withLong((Integer) 100);", e.getMessage());
             assertContains("withLong((Long) 100);", e.getMessage());
@@ -43,14 +45,14 @@ public class PrintingVerboseTypesWithArgumentsTest extends TestBase {
     @Test
     public void shouldShowTheTypeOfOnlyTheArgumentThatDoesntMatch() throws Exception {
         //given
-        Boo boo = mock(Boo.class);
+        final Boo boo = mock(Boo.class);
         boo.withLongAndInt(100, 200);
         
         try {
             //when
             verify(boo).withLongAndInt(eq(100), eq(200));
             fail();
-        } catch (ArgumentsAreDifferent e) {
+        } catch (final ArgumentsAreDifferent e) {
             //then
             assertContains("withLongAndInt((Integer) 100, 200)", e.getMessage());
             assertContains("withLongAndInt((Long) 100, 200)", e.getMessage());
@@ -60,14 +62,14 @@ public class PrintingVerboseTypesWithArgumentsTest extends TestBase {
     @Test
     public void shouldShowTheTypeOfTheMismatchingArgumentWhenOutputDescriptionsForInvocationsAreDifferent() throws Exception {
         //given
-        Boo boo = mock(Boo.class);
+        final Boo boo = mock(Boo.class);
         boo.withLongAndInt(100, 200);
         
         try {
             //when
             verify(boo).withLongAndInt(eq(100), any(Integer.class));
             fail();
-        } catch (ArgumentsAreDifferent e) {
+        } catch (final ArgumentsAreDifferent e) {
             //then
             assertContains("withLongAndInt((Long) 100, 200)", e.getMessage());
             assertContains("withLongAndInt((Integer) 100, <any>", e.getMessage());
@@ -77,14 +79,14 @@ public class PrintingVerboseTypesWithArgumentsTest extends TestBase {
     @Test
     public void shouldNotShowTypesWhenArgumentValueIsDifferent() throws Exception {
         //given
-        Boo boo = mock(Boo.class);
+        final Boo boo = mock(Boo.class);
         boo.withLongAndInt(100, 200);
         
         try {
             //when
             verify(boo).withLongAndInt(eq(100L), eq(230));
             fail();
-        } catch (ArgumentsAreDifferent e) {
+        } catch (final ArgumentsAreDifferent e) {
             //then
             assertContains("withLongAndInt(100, 200)", e.getMessage());
             assertContains("withLongAndInt(100, 230)", e.getMessage());
@@ -95,11 +97,11 @@ public class PrintingVerboseTypesWithArgumentsTest extends TestBase {
         
         private final int x;
 
-        public Foo(int x) {
+        public Foo(final int x) {
             this.x = x;
         }
         
-        public boolean equals(Object obj) {
+        public boolean equals(final Object obj) {
             return x == ((Foo) obj).x;
         }
         
@@ -115,14 +117,14 @@ public class PrintingVerboseTypesWithArgumentsTest extends TestBase {
     @Test
     public void shouldNotShowTypesWhenTypesAreTheSameEvenIfToStringGivesTheSameResult() throws Exception {
         //given
-        IMethods mock = mock(IMethods.class);
+        final IMethods mock = mock(IMethods.class);
         mock.simpleMethod(new Foo(10));
         
         try {
             //when
             verify(mock).simpleMethod(new Foo(20));
             fail();
-        } catch (ArgumentsAreDifferent e) {
+        } catch (final ArgumentsAreDifferent e) {
             //then
             assertContains("simpleMethod(foo)", e.getMessage());
         }

--- a/test/org/mockitousage/verification/RelaxedVerificationInOrderTest.java
+++ b/test/org/mockitousage/verification/RelaxedVerificationInOrderTest.java
@@ -5,7 +5,12 @@
 
 package org.mockitousage.verification;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -69,7 +74,7 @@ public class RelaxedVerificationInOrderTest extends TestBase {
         try {
             verifyNoMoreInteractions(mockTwo);
             fail();
-        } catch (NoInteractionsWanted e) {}
+        } catch (final NoInteractionsWanted e) {}
     }
     
     @Test
@@ -87,7 +92,7 @@ public class RelaxedVerificationInOrderTest extends TestBase {
         try {
             verifyNoMoreInteractions(mockTwo);
             fail();
-        } catch(NoInteractionsWanted e) {}
+        } catch(final NoInteractionsWanted e) {}
     }  
     
     @Test
@@ -104,7 +109,7 @@ public class RelaxedVerificationInOrderTest extends TestBase {
         try {
             inOrder.verify(mockThree).simpleMethod(3);
             fail();
-        } catch (VerificationInOrderFailure e) {}
+        } catch (final VerificationInOrderFailure e) {}
     }
     
     @Test
@@ -113,7 +118,7 @@ public class RelaxedVerificationInOrderTest extends TestBase {
         try {
             verifyNoMoreInteractions(mockTwo);
             fail();
-        } catch (NoInteractionsWanted e) {}
+        } catch (final NoInteractionsWanted e) {}
     }
     
     @Test(expected=VerificationInOrderFailure.class)
@@ -194,7 +199,7 @@ public class RelaxedVerificationInOrderTest extends TestBase {
         try {
             verify(mockOne, times(0)).simpleMethod(1);
             fail();
-        } catch (NeverWantedButInvoked e) {}
+        } catch (final NeverWantedButInvoked e) {}
     }
     
     @Test
@@ -203,7 +208,7 @@ public class RelaxedVerificationInOrderTest extends TestBase {
         try {
             inOrder.verify(mockThree, times(0)).simpleMethod(3);
             fail();
-        } catch (VerificationInOrderFailure e) {}
+        } catch (final VerificationInOrderFailure e) {}
     }
     
     @Test(expected=VerificationInOrderFailure.class)
@@ -234,7 +239,7 @@ public class RelaxedVerificationInOrderTest extends TestBase {
         try {
             inOrder.verify(mockTwo, atLeastOnce()).simpleMethod(2);
             fail();
-        } catch (VerificationInOrderFailure e) {}
+        } catch (final VerificationInOrderFailure e) {}
     }
     
     @Test
@@ -243,7 +248,7 @@ public class RelaxedVerificationInOrderTest extends TestBase {
         try {
             inOrder.verify(mockOne).simpleMethod(1);
             fail();
-        } catch (VerificationInOrderFailure e) {}
+        } catch (final VerificationInOrderFailure e) {}
     }
     
     @Test
@@ -252,6 +257,6 @@ public class RelaxedVerificationInOrderTest extends TestBase {
         try {
             inOrder.verify(mockOne).simpleMethod(999);
             fail();
-        } catch (VerificationInOrderFailure e) {}
+        } catch (final VerificationInOrderFailure e) {}
     }
 }

--- a/test/org/mockitousage/verification/SelectedMocksInOrderVerificationTest.java
+++ b/test/org/mockitousage/verification/SelectedMocksInOrderVerificationTest.java
@@ -5,7 +5,11 @@
 
 package org.mockitousage.verification;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -37,7 +41,7 @@ public class SelectedMocksInOrderVerificationTest extends TestBase {
     
     @Test
     public void shouldVerifyAllInvocationsInOrder() {
-        InOrder inOrder = inOrder(mockOne, mockTwo, mockThree);
+        final InOrder inOrder = inOrder(mockOne, mockTwo, mockThree);
         inOrder.verify(mockOne).simpleMethod(1);
         inOrder.verify(mockTwo, times(2)).simpleMethod(2);
         inOrder.verify(mockThree).simpleMethod(3);
@@ -48,7 +52,7 @@ public class SelectedMocksInOrderVerificationTest extends TestBase {
     
     @Test
     public void shouldVerifyInOrderMockTwoAndThree() {
-        InOrder inOrder = inOrder(mockTwo, mockThree);
+        final InOrder inOrder = inOrder(mockTwo, mockThree);
         
         inOrder.verify(mockTwo, times(2)).simpleMethod(2);
         inOrder.verify(mockThree).simpleMethod(3);
@@ -58,7 +62,7 @@ public class SelectedMocksInOrderVerificationTest extends TestBase {
     
     @Test
     public void shouldVerifyInOrderMockOneAndThree() {
-        InOrder inOrder = inOrder(mockOne, mockThree);
+        final InOrder inOrder = inOrder(mockOne, mockThree);
         
         inOrder.verify(mockOne).simpleMethod(1);
         inOrder.verify(mockThree).simpleMethod(3);
@@ -68,7 +72,7 @@ public class SelectedMocksInOrderVerificationTest extends TestBase {
     
     @Test
     public void shouldVerifyMockOneInOrder() {
-        InOrder inOrder = inOrder(mockOne);
+        final InOrder inOrder = inOrder(mockOne);
         
         inOrder.verify(mockOne).simpleMethod(1);
         inOrder.verify(mockOne).simpleMethod(4);
@@ -78,29 +82,29 @@ public class SelectedMocksInOrderVerificationTest extends TestBase {
     
     @Test
     public void shouldFailVerificationForMockOne() {
-        InOrder inOrder = inOrder(mockOne);
+        final InOrder inOrder = inOrder(mockOne);
         
         inOrder.verify(mockOne).simpleMethod(1);
         try {
             inOrder.verify(mockOne).differentMethod();
             fail();
-        } catch (VerificationInOrderFailure e) {}
+        } catch (final VerificationInOrderFailure e) {}
     } 
     
     @Test
     public void shouldFailVerificationForMockOneBecauseOfWrongOrder() {
-        InOrder inOrder = inOrder(mockOne);
+        final InOrder inOrder = inOrder(mockOne);
         
         inOrder.verify(mockOne).simpleMethod(4);
         try {
             inOrder.verify(mockOne).simpleMethod(1);
             fail();
-        } catch (VerificationInOrderFailure e) {}
+        } catch (final VerificationInOrderFailure e) {}
     } 
 
     @Test
     public void shouldVerifyMockTwoWhenThreeTimesUsed() {
-        InOrder inOrder = inOrder(mockTwo);
+        final InOrder inOrder = inOrder(mockTwo);
         
         inOrder.verify(mockTwo, times(3)).simpleMethod(2);
         
@@ -109,7 +113,7 @@ public class SelectedMocksInOrderVerificationTest extends TestBase {
     
     @Test
     public void shouldVerifyMockTwo() {
-        InOrder inOrder = inOrder(mockTwo);
+        final InOrder inOrder = inOrder(mockTwo);
         
         inOrder.verify(mockTwo, atLeastOnce()).simpleMethod(2);
         
@@ -118,47 +122,47 @@ public class SelectedMocksInOrderVerificationTest extends TestBase {
     
     @Test
     public void shouldFailVerificationForMockTwo() {
-        InOrder inOrder = inOrder(mockTwo);
+        final InOrder inOrder = inOrder(mockTwo);
 
         try {
             inOrder.verify(mockTwo).simpleMethod(2);
             fail();
-        } catch (VerificationInOrderFailure e) {}
+        } catch (final VerificationInOrderFailure e) {}
     }
     
     @Test
     public void shouldThrowNoMoreInvocationsForMockTwo() {
-        InOrder inOrder = inOrder(mockTwo);
+        final InOrder inOrder = inOrder(mockTwo);
 
         try {
             inOrder.verify(mockTwo, times(2)).simpleMethod(2);
             fail();
-        } catch (VerificationInOrderFailure e) {}
+        } catch (final VerificationInOrderFailure e) {}
     }
     
     @Test
     public void shouldThrowTooLittleInvocationsForMockTwo() {
-        InOrder inOrder = inOrder(mockTwo);
+        final InOrder inOrder = inOrder(mockTwo);
 
         try {
             inOrder.verify(mockTwo, times(4)).simpleMethod(2);
             fail();
-        } catch (VerificationInOrderFailure e) {}
+        } catch (final VerificationInOrderFailure e) {}
     }
     
     @Test
     public void shouldThrowTooManyInvocationsForMockTwo() {
-        InOrder inOrder = inOrder(mockTwo);
+        final InOrder inOrder = inOrder(mockTwo);
 
         try {
             inOrder.verify(mockTwo, times(2)).simpleMethod(2);
             fail();
-        } catch (VerificationInOrderFailure e) {}
+        } catch (final VerificationInOrderFailure e) {}
     }
     
     @Test
     public void shouldAllowThreeTimesOnMockTwo() {
-        InOrder inOrder = inOrder(mockTwo);
+        final InOrder inOrder = inOrder(mockTwo);
 
         inOrder.verify(mockTwo, times(3)).simpleMethod(2);
         verifyNoMoreInteractions(mockTwo);
@@ -166,7 +170,7 @@ public class SelectedMocksInOrderVerificationTest extends TestBase {
     
     @Test
     public void shouldVerifyMockTwoCompletely() {
-        InOrder inOrder = inOrder(mockTwo, mockThree);
+        final InOrder inOrder = inOrder(mockTwo, mockThree);
 
         inOrder.verify(mockTwo, times(2)).simpleMethod(2);
         inOrder.verify(mockThree).simpleMethod(3);
@@ -176,12 +180,12 @@ public class SelectedMocksInOrderVerificationTest extends TestBase {
     
     @Test
     public void shouldAllowTwoTimesOnMockTwo() {
-        InOrder inOrder = inOrder(mockTwo, mockThree);
+        final InOrder inOrder = inOrder(mockTwo, mockThree);
 
         inOrder.verify(mockTwo, times(2)).simpleMethod(2);
         try {
             verifyNoMoreInteractions(mockTwo);
             fail();
-        } catch (NoInteractionsWanted e) {}
+        } catch (final NoInteractionsWanted e) {}
     }
 }

--- a/test/org/mockitousage/verification/VerificationExcludingStubsTest.java
+++ b/test/org/mockitousage/verification/VerificationExcludingStubsTest.java
@@ -5,6 +5,12 @@
 
 package org.mockitousage.verification;
 
+import static org.mockito.Mockito.ignoreStubs;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mock;
@@ -13,9 +19,6 @@ import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static org.mockito.Mockito.*;
-
-@SuppressWarnings("unchecked")
 public class VerificationExcludingStubsTest extends TestBase {
 
     @Mock IMethods mock;
@@ -26,14 +29,14 @@ public class VerificationExcludingStubsTest extends TestBase {
         when(mock.simpleMethod()).thenReturn("foo");
 
         //when
-        String stubbed = mock.simpleMethod(); //irrelevant call because it is stubbing
+        final String stubbed = mock.simpleMethod(); //irrelevant call because it is stubbing
         mock.objectArgMethod(stubbed);
 
         //then
         verify(mock).objectArgMethod("foo");
 
         //verifyNoMoreInteractions fails:
-        try { verifyNoMoreInteractions(mock); fail(); } catch (NoInteractionsWanted e) {};
+        try { verifyNoMoreInteractions(mock); fail(); } catch (final NoInteractionsWanted e) {};
         
         //but it works when stubs are ignored:
         ignoreStubs(mock);
@@ -51,7 +54,7 @@ public class VerificationExcludingStubsTest extends TestBase {
         mock.simpleMethod(); //calling the stub
 
         //then
-        InOrder inOrder = inOrder(ignoreStubs(mock));
+        final InOrder inOrder = inOrder(ignoreStubs(mock));
         inOrder.verify(mock).objectArgMethod("1");
         inOrder.verify(mock).objectArgMethod("2");
         inOrder.verifyNoMoreInteractions();

--- a/test/org/mockitousage/verification/VerificationExcludingStubsTest.java
+++ b/test/org/mockitousage/verification/VerificationExcludingStubsTest.java
@@ -21,39 +21,45 @@ import org.mockitoutil.TestBase;
 
 public class VerificationExcludingStubsTest extends TestBase {
 
-    @Mock IMethods mock;
+    @Mock
+    IMethods mock;
 
     @Test
     public void shouldAllowToExcludeStubsForVerification() throws Exception {
-        //given
+        // given
         when(mock.simpleMethod()).thenReturn("foo");
 
-        //when
-        final String stubbed = mock.simpleMethod(); //irrelevant call because it is stubbing
+        // when
+        final String stubbed = mock.simpleMethod(); // irrelevant call because
+                                                    // it is stubbing
         mock.objectArgMethod(stubbed);
 
-        //then
+        // then
         verify(mock).objectArgMethod("foo");
 
-        //verifyNoMoreInteractions fails:
-        try { verifyNoMoreInteractions(mock); fail(); } catch (final NoInteractionsWanted e) {};
-        
-        //but it works when stubs are ignored:
+        // verifyNoMoreInteractions fails:
+        try {
+            verifyNoMoreInteractions(mock);
+            fail();
+        } catch (final NoInteractionsWanted e) {
+        }
+
+        // but it works when stubs are ignored:
         ignoreStubs(mock);
         verifyNoMoreInteractions(mock);
     }
 
     @Test
     public void shouldExcludeFromVerificationInOrder() throws Exception {
-        //given
+        // given
         when(mock.simpleMethod()).thenReturn("foo");
 
-        //when
+        // when
         mock.objectArgMethod("1");
         mock.objectArgMethod("2");
-        mock.simpleMethod(); //calling the stub
+        mock.simpleMethod(); // calling the stub
 
-        //then
+        // then
         final InOrder inOrder = inOrder(ignoreStubs(mock));
         inOrder.verify(mock).objectArgMethod("1");
         inOrder.verify(mock).objectArgMethod("2");

--- a/test/org/mockitousage/verification/VerificationInOrderMixedWithOrdiraryVerificationTest.java
+++ b/test/org/mockitousage/verification/VerificationInOrderMixedWithOrdiraryVerificationTest.java
@@ -5,7 +5,12 @@
 
 package org.mockitousage.verification;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -82,7 +87,7 @@ public class VerificationInOrderMixedWithOrdiraryVerificationTest extends TestBa
         try {
             verifyNoMoreInteractions(mockOne, mockTwo, mockThree);
             fail();
-        } catch (NoInteractionsWanted e) {}
+        } catch (final NoInteractionsWanted e) {}
     }
     
     @Test
@@ -94,7 +99,7 @@ public class VerificationInOrderMixedWithOrdiraryVerificationTest extends TestBa
         try {
             verifyNoMoreInteractions(mockOne, mockTwo, mockThree);
             fail();
-        } catch (NoInteractionsWanted e) {}
+        } catch (final NoInteractionsWanted e) {}
     }
     
     @Test
@@ -115,7 +120,7 @@ public class VerificationInOrderMixedWithOrdiraryVerificationTest extends TestBa
         try {
             inOrder.verify(mockOne, atLeastOnce()).simpleMethod(1);
             fail();
-        } catch (VerificationInOrderFailure e) {}
+        } catch (final VerificationInOrderFailure e) {}
     }
     
     @Test(expected=MockitoException.class)
@@ -127,8 +132,8 @@ public class VerificationInOrderMixedWithOrdiraryVerificationTest extends TestBa
     public void shouldUseEqualsToVerifyMethodArguments() {
         mockOne = mock(IMethods.class);
         
-        String textOne = "test";
-        String textTwo = new String(textOne);
+        final String textOne = "test";
+        final String textTwo = new String(textOne);
         
         assertEquals(textOne, textTwo);
         assertNotSame(textOne, textTwo);
@@ -146,8 +151,8 @@ public class VerificationInOrderMixedWithOrdiraryVerificationTest extends TestBa
     public void shouldUseEqualsToVerifyMethodVarargs() {
         mockOne = mock(IMethods.class);
         
-        String textOne = "test";
-        String textTwo = new String(textOne);
+        final String textOne = "test";
+        final String textTwo = new String(textOne);
         
         assertEquals(textOne, textTwo);
         assertNotSame(textOne, textTwo);

--- a/test/org/mockitousage/verification/VerificationInOrderTest.java
+++ b/test/org/mockitousage/verification/VerificationInOrderTest.java
@@ -5,8 +5,12 @@
 
 package org.mockitousage.verification;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -47,7 +51,7 @@ public class VerificationInOrderTest extends TestBase {
         try {
             inOrder.verify(mockOne).simpleMethod(1);
             fail();
-        } catch (VerificationInOrderFailure e) {}
+        } catch (final VerificationInOrderFailure e) {}
     } 
     
     @Test
@@ -58,7 +62,7 @@ public class VerificationInOrderTest extends TestBase {
         try {
             inOrder.verify(mockOne, atLeastOnce()).differentMethod();
             fail();
-        } catch (WantedButNotInvoked e) {
+        } catch (final WantedButNotInvoked e) {
             assertContains("differentMethod()", e.getMessage());
         }
     }
@@ -77,7 +81,7 @@ public class VerificationInOrderTest extends TestBase {
         try {
             inOrder.verify(mockOne, atLeastOnce()).simpleMethod();
             fail();
-        } catch (VerificationInOrderFailure e) {}
+        } catch (final VerificationInOrderFailure e) {}
     }
     
     @Test
@@ -96,6 +100,6 @@ public class VerificationInOrderTest extends TestBase {
         try {
             inOrder.verify(mockOne, times(3)).simpleMethod(anyInt());
             fail();
-        } catch (VerificationInOrderFailure e) {}
+        } catch (final VerificationInOrderFailure e) {}
     }
 }

--- a/test/org/mockitousage/verification/VerificationInOrderWithCallsTest.java
+++ b/test/org/mockitousage/verification/VerificationInOrderWithCallsTest.java
@@ -4,6 +4,13 @@
  */
 package org.mockitousage.verification;
 
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.calls;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -14,8 +21,6 @@ import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockito.exceptions.verification.VerificationInOrderFailure;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
-
-import static org.mockito.Mockito.*;
 
 public class VerificationInOrderWithCallsTest extends TestBase {
 
@@ -28,7 +33,7 @@ public class VerificationInOrderWithCallsTest extends TestBase {
     public void shouldFailWhenMethodNotCalled(){
         // Given
         mockOne.oneArg( 1 );
-        InOrder verifier = inOrder( mockOne );
+        final InOrder verifier = inOrder( mockOne );
         verifier.verify( mockOne, calls(1)).oneArg( 1 );
 
         exceptionRule.expect( VerificationInOrderFailure.class );
@@ -48,7 +53,7 @@ public class VerificationInOrderWithCallsTest extends TestBase {
         mockOne.oneArg( 1 );
         mockOne.oneArg( 2 );
 
-        InOrder verifier = inOrder( mockOne );
+        final InOrder verifier = inOrder( mockOne );
         verifier.verify( mockOne, calls(1)).oneArg( 1 );
 
         exceptionRule.expect( VerificationInOrderFailure.class );
@@ -69,7 +74,7 @@ public class VerificationInOrderWithCallsTest extends TestBase {
         mockOne.oneArg( 1 );
         mockOne.oneArg( 2 );
 
-        InOrder verifier = inOrder( mockOne );
+        final InOrder verifier = inOrder( mockOne );
         verifier.verify( mockOne, calls(1)).oneArg( 2 );
 
         exceptionRule.expect( VerificationInOrderFailure.class );
@@ -89,7 +94,7 @@ public class VerificationInOrderWithCallsTest extends TestBase {
         mockOne.oneArg( 1 );
         mockOne.voidMethod();
 
-        InOrder verifier = inOrder( mockOne );
+        final InOrder verifier = inOrder( mockOne );
         verifier.verify( mockOne, calls(1)).voidMethod();
 
         exceptionRule.expect( VerificationInOrderFailure.class );
@@ -109,7 +114,7 @@ public class VerificationInOrderWithCallsTest extends TestBase {
         mockOne.voidMethod();
         mockTwo.voidMethod();
 
-        InOrder verifier = inOrder( mockOne, mockTwo );
+        final InOrder verifier = inOrder( mockOne, mockTwo );
         verifier.verify( mockTwo, calls(1)).voidMethod();
 
         exceptionRule.expect( VerificationInOrderFailure.class );
@@ -132,7 +137,7 @@ public class VerificationInOrderWithCallsTest extends TestBase {
         mockOne.oneArg( 2 );
         mockOne.oneArg( 1 );
 
-        InOrder verifier = inOrder( mockOne );
+        final InOrder verifier = inOrder( mockOne );
 
         // When
         verifier.verify( mockOne, calls(1)).oneArg( 1 );
@@ -152,7 +157,7 @@ public class VerificationInOrderWithCallsTest extends TestBase {
         mockOne.voidMethod();
         mockOne.oneArg( 1 );
 
-        InOrder verifier = inOrder( mockOne );
+        final InOrder verifier = inOrder( mockOne );
 
         // When
         verifier.verify( mockOne, calls(1)).oneArg( 1 );
@@ -172,7 +177,7 @@ public class VerificationInOrderWithCallsTest extends TestBase {
         mockTwo.voidMethod();
         mockOne.voidMethod();
 
-        InOrder verifier = inOrder( mockOne, mockTwo );
+        final InOrder verifier = inOrder( mockOne, mockTwo );
 
         // When
         verifier.verify( mockOne, calls(1)).voidMethod();
@@ -195,7 +200,7 @@ public class VerificationInOrderWithCallsTest extends TestBase {
         mockOne.oneArg( 1 );
         mockOne.oneArg( 2 );
 
-        InOrder verifier = inOrder( mockOne );
+        final InOrder verifier = inOrder( mockOne );
 
         // When
         verifier.verify( mockOne, calls(1)).oneArg( 1 );
@@ -214,7 +219,7 @@ public class VerificationInOrderWithCallsTest extends TestBase {
         mockOne.oneArg( 2 );
         mockOne.oneArg( 1 );
 
-        InOrder verifier = inOrder( mockOne );
+        final InOrder verifier = inOrder( mockOne );
         verifier.verify( mockOne, calls(1)).oneArg( 1 );
         verifier.verify( mockOne, calls(1)).oneArg( 2 );
         verifier.verify( mockOne, calls(1)).oneArg( 1 );
@@ -234,7 +239,7 @@ public class VerificationInOrderWithCallsTest extends TestBase {
         mockOne.oneArg( 2 );
         mockOne.oneArg( 2 );
 
-        InOrder verifier = inOrder( mockOne );
+        final InOrder verifier = inOrder( mockOne );
         verifier.verify( mockOne, calls(1)).oneArg( 1 );
         verifier.verify( mockOne, calls(1)).oneArg( 2 );
 
@@ -256,7 +261,7 @@ public class VerificationInOrderWithCallsTest extends TestBase {
         mockOne.oneArg( 1 );
         mockOne.voidMethod();
 
-        InOrder verifier = inOrder( mockOne );
+        final InOrder verifier = inOrder( mockOne );
 
         // When
         verifier.verify( mockOne, calls(1)).oneArg( 1 );
@@ -275,7 +280,7 @@ public class VerificationInOrderWithCallsTest extends TestBase {
         mockOne.voidMethod();
         mockOne.oneArg( 1 );
 
-        InOrder verifier = inOrder( mockOne );
+        final InOrder verifier = inOrder( mockOne );
         verifier.verify( mockOne, calls(1)).oneArg( 1 );
         verifier.verify( mockOne, calls(1)).voidMethod();
         verifier.verify( mockOne, calls(1)).oneArg( 1 );
@@ -295,7 +300,7 @@ public class VerificationInOrderWithCallsTest extends TestBase {
         mockOne.voidMethod();
         mockOne.voidMethod();
 
-        InOrder verifier = inOrder( mockOne );
+        final InOrder verifier = inOrder( mockOne );
         verifier.verify( mockOne, calls(1)).oneArg( 1 );
         verifier.verify( mockOne, calls(1)).voidMethod();
 
@@ -317,7 +322,7 @@ public class VerificationInOrderWithCallsTest extends TestBase {
         mockOne.voidMethod();
         mockTwo.voidMethod();
 
-        InOrder verifier = inOrder( mockOne, mockTwo );
+        final InOrder verifier = inOrder( mockOne, mockTwo );
 
         // When
         verifier.verify( mockOne, calls(1)).voidMethod();
@@ -336,7 +341,7 @@ public class VerificationInOrderWithCallsTest extends TestBase {
         mockTwo.voidMethod();
         mockOne.voidMethod();
 
-        InOrder verifier = inOrder( mockOne, mockTwo );
+        final InOrder verifier = inOrder( mockOne, mockTwo );
         verifier.verify( mockOne, calls(1)).voidMethod();
         verifier.verify( mockTwo, calls(1)).voidMethod();
         verifier.verify( mockOne, calls(1)).voidMethod();
@@ -356,7 +361,7 @@ public class VerificationInOrderWithCallsTest extends TestBase {
         mockTwo.voidMethod();
         mockTwo.voidMethod();
 
-        InOrder verifier = inOrder( mockOne, mockTwo );
+        final InOrder verifier = inOrder( mockOne, mockTwo );
         verifier.verify( mockOne, calls(1)).voidMethod();
         verifier.verify( mockTwo, calls(1)).voidMethod();
 
@@ -377,7 +382,7 @@ public class VerificationInOrderWithCallsTest extends TestBase {
         mockOne.oneArg( 2 );
         mockOne.oneArg( 1 );
 
-        InOrder verifier = inOrder( mockOne );
+        final InOrder verifier = inOrder( mockOne );
 
         // When
         verifier.verify( mockOne, times(1)).oneArg( 1 );
@@ -394,7 +399,7 @@ public class VerificationInOrderWithCallsTest extends TestBase {
         mockOne.oneArg( 2 );
         mockOne.oneArg( 2 );
 
-        InOrder verifier = inOrder( mockOne );
+        final InOrder verifier = inOrder( mockOne );
 
         // When
         verifier.verify( mockOne, atLeast(1)).oneArg( 1 );
@@ -411,7 +416,7 @@ public class VerificationInOrderWithCallsTest extends TestBase {
         mockOne.oneArg( 2 );
         mockOne.oneArg( 1 );
 
-        InOrder verifier = inOrder( mockOne );
+        final InOrder verifier = inOrder( mockOne );
 
         // When
         verifier.verify( mockOne, calls(1)).oneArg( 1 );
@@ -429,7 +434,7 @@ public class VerificationInOrderWithCallsTest extends TestBase {
         mockOne.oneArg( 2 );
         mockOne.oneArg( 1 );
 
-        InOrder verifier = inOrder( mockOne );
+        final InOrder verifier = inOrder( mockOne );
 
         // When
         verifier.verify( mockOne, calls(1)).oneArg( 1 );
@@ -446,7 +451,7 @@ public class VerificationInOrderWithCallsTest extends TestBase {
         mockOne.oneArg( 1 );
         mockOne.oneArg( 1 );
 
-        InOrder verifier = inOrder( mockOne );
+        final InOrder verifier = inOrder( mockOne );
 
         // When
         verifier.verify( mockOne, calls(1)).oneArg( 1 );
@@ -459,7 +464,7 @@ public class VerificationInOrderWithCallsTest extends TestBase {
     @Test
     public void shouldFailToCreateCallsWithZeroArgument(){
         // Given
-        InOrder verifier = inOrder( mockOne );
+        final InOrder verifier = inOrder( mockOne );
         exceptionRule.expect( MockitoException.class );
         exceptionRule.expectMessage( "Negative and zero values are not allowed here" );
 
@@ -472,7 +477,7 @@ public class VerificationInOrderWithCallsTest extends TestBase {
     @Test
     public void shouldFailToCreateCallsWithNegativeArgument(){
         // Given
-        InOrder verifier = inOrder( mockOne );
+        final InOrder verifier = inOrder( mockOne );
         exceptionRule.expect( MockitoException.class );
         exceptionRule.expectMessage( "Negative and zero values are not allowed here" );
 

--- a/test/org/mockitousage/verification/VerificationOnMultipleMocksUsingMatchersTest.java
+++ b/test/org/mockitousage/verification/VerificationOnMultipleMocksUsingMatchersTest.java
@@ -5,8 +5,14 @@
 
 package org.mockitousage.verification;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 import java.util.HashMap;
 import java.util.List;
@@ -17,13 +23,13 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class VerificationOnMultipleMocksUsingMatchersTest extends TestBase {
 
     @Test
     public void shouldVerifyUsingMatchers() throws Exception {
-        List list = Mockito.mock(List.class);
-        HashMap map = Mockito.mock(HashMap.class);
+        final List list = Mockito.mock(List.class);
+        final HashMap map = Mockito.mock(HashMap.class);
         
         list.add("test");
         list.add(1, "test two");
@@ -42,9 +48,9 @@ public class VerificationOnMultipleMocksUsingMatchersTest extends TestBase {
     
     @Test
     public void shouldVerifyMultipleMocks() throws Exception {
-        List list = mock(List.class);
-        Map map = mock(Map.class);
-        Set set = mock(Set.class);
+        final List list = mock(List.class);
+        final Map map = mock(Map.class);
+        final Set set = mock(Set.class);
 
         list.add("one");
         list.add("one");

--- a/test/org/mockitousage/verification/VerificationUsingMatchersTest.java
+++ b/test/org/mockitousage/verification/VerificationUsingMatchersTest.java
@@ -5,9 +5,14 @@
 
 package org.mockitousage.verification;
 
-import static org.mockito.AdditionalMatchers.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.AdditionalMatchers.and;
+import static org.mockito.AdditionalMatchers.geq;
+import static org.mockito.AdditionalMatchers.leq;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -37,9 +42,9 @@ public class VerificationUsingMatchersTest extends TestBase {
 
     @Test
     public void shouldVerifyUsingSameMatcher() {
-        Object one = new String("1243");
-        Object two = new String("1243");
-        Object three = new String("1243");
+        final Object one = new String("1243");
+        final Object two = new String("1243");
+        final Object three = new String("1243");
 
         assertNotSame(one, two);
         assertEquals(one, two);
@@ -54,7 +59,7 @@ public class VerificationUsingMatchersTest extends TestBase {
         try {
             verify(mock).oneArg(same(three));
             fail();
-        } catch (WantedButNotInvoked e) {}
+        } catch (final WantedButNotInvoked e) {}
     }  
     
     @Test
@@ -64,21 +69,21 @@ public class VerificationUsingMatchersTest extends TestBase {
         try {
             verify(mock).threeArgumentMethod(and(geq(7), leq(10)), isA(String.class), Matchers.contains("123"));
             fail();
-        } catch (ArgumentsAreDifferent e) {}
+        } catch (final ArgumentsAreDifferent e) {}
 
         mock.threeArgumentMethod(8, new Object(), "01234");
         
         try {
             verify(mock).threeArgumentMethod(and(geq(7), leq(10)), isA(String.class), Matchers.contains("123"));
             fail();
-        } catch (ArgumentsAreDifferent e) {}
+        } catch (final ArgumentsAreDifferent e) {}
         
         mock.threeArgumentMethod(8, "", "no match");
 
         try {
             verify(mock).threeArgumentMethod(and(geq(7), leq(10)), isA(String.class), Matchers.contains("123"));
             fail();
-        } catch (ArgumentsAreDifferent e) {}
+        } catch (final ArgumentsAreDifferent e) {}
         
         mock.threeArgumentMethod(8, "", "123");
         

--- a/test/org/mockitoutil/ClassLoaders.java
+++ b/test/org/mockitoutil/ClassLoaders.java
@@ -24,396 +24,397 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public abstract class ClassLoaders {
-	protected ClassLoader parent = currentClassLoader();
+    protected ClassLoader parent = currentClassLoader();
 
-	protected ClassLoaders() {
-	}
+    protected ClassLoaders() {
+    }
 
-	public static IsolatedURLClassLoaderBuilder isolatedClassLoader() {
-		return new IsolatedURLClassLoaderBuilder();
-	}
+    public static IsolatedURLClassLoaderBuilder isolatedClassLoader() {
+        return new IsolatedURLClassLoaderBuilder();
+    }
 
-	public static ExcludingURLClassLoaderBuilder excludingClassLoader() {
-		return new ExcludingURLClassLoaderBuilder();
-	}
+    public static ExcludingURLClassLoaderBuilder excludingClassLoader() {
+        return new ExcludingURLClassLoaderBuilder();
+    }
 
-	public static InMemoryClassLoaderBuilder inMemoryClassLoader() {
-		return new InMemoryClassLoaderBuilder();
-	}
+    public static InMemoryClassLoaderBuilder inMemoryClassLoader() {
+        return new InMemoryClassLoaderBuilder();
+    }
 
-	public static ReachableClassesFinder in(
-			final ClassLoader classLoader_without_jUnit) {
-		return new ReachableClassesFinder(classLoader_without_jUnit);
-	}
+    public static ReachableClassesFinder in(
+            final ClassLoader classLoader_without_jUnit) {
+        return new ReachableClassesFinder(classLoader_without_jUnit);
+    }
 
-	public static ClassLoader jdkClassLoader() {
-		return String.class.getClassLoader();
-	}
+    public static ClassLoader jdkClassLoader() {
+        return String.class.getClassLoader();
+    }
 
-	public static ClassLoader systemClassLoader() {
-		return ClassLoader.getSystemClassLoader();
-	}
+    public static ClassLoader systemClassLoader() {
+        return ClassLoader.getSystemClassLoader();
+    }
 
-	public static ClassLoader currentClassLoader() {
-		return ClassLoaders.class.getClassLoader();
-	}
+    public static ClassLoader currentClassLoader() {
+        return ClassLoaders.class.getClassLoader();
+    }
 
-	public abstract ClassLoader build();
+    public abstract ClassLoader build();
 
-	public static class IsolatedURLClassLoaderBuilder extends ClassLoaders {
-		private final ArrayList<String> privateCopyPrefixes = new ArrayList<String>();
-		private final ArrayList<URL> codeSourceUrls = new ArrayList<URL>();
+    public static class IsolatedURLClassLoaderBuilder extends ClassLoaders {
+        private final ArrayList<String> privateCopyPrefixes = new ArrayList<String>();
+        private final ArrayList<URL> codeSourceUrls = new ArrayList<URL>();
 
-		public IsolatedURLClassLoaderBuilder withPrivateCopyOf(
-				final String... privatePrefixes) {
-			privateCopyPrefixes.addAll(asList(privatePrefixes));
-			return this;
-		}
+        public IsolatedURLClassLoaderBuilder withPrivateCopyOf(
+                final String... privatePrefixes) {
+            privateCopyPrefixes.addAll(asList(privatePrefixes));
+            return this;
+        }
 
-		public IsolatedURLClassLoaderBuilder withCodeSourceUrls(final String... urls) {
-			codeSourceUrls.addAll(pathsToURLs(urls));
-			return this;
-		}
+        public IsolatedURLClassLoaderBuilder withCodeSourceUrls(final String... urls) {
+            codeSourceUrls.addAll(pathsToURLs(urls));
+            return this;
+        }
 
-		public IsolatedURLClassLoaderBuilder withCodeSourceUrlOf(
-				final Class<?>... classes) {
-			for (final Class<?> clazz : classes) {
-				codeSourceUrls.add(obtainClassPathOf(clazz.getName()));
-			}
-			return this;
-		}
+        public IsolatedURLClassLoaderBuilder withCodeSourceUrlOf(
+                final Class<?>... classes) {
+            for (final Class<?> clazz : classes) {
+                codeSourceUrls.add(obtainClassPathOf(clazz.getName()));
+            }
+            return this;
+        }
 
-		public IsolatedURLClassLoaderBuilder withCurrentCodeSourceUrls() {
-			codeSourceUrls.add(obtainClassPathOf(ClassLoaders.class.getName()));
-			return this;
-		}
+        public IsolatedURLClassLoaderBuilder withCurrentCodeSourceUrls() {
+            codeSourceUrls.add(obtainClassPathOf(ClassLoaders.class.getName()));
+            return this;
+        }
 
         public ClassLoader build() {
-			return new LocalIsolatedURLClassLoader(jdkClassLoader(),
-					codeSourceUrls.toArray(new URL[codeSourceUrls.size()]),
-					privateCopyPrefixes);
-		}
-	}
+            return new LocalIsolatedURLClassLoader(jdkClassLoader(),
+                    codeSourceUrls.toArray(new URL[codeSourceUrls.size()]),
+                    privateCopyPrefixes);
+        }
+    }
 
-	static class LocalIsolatedURLClassLoader extends URLClassLoader {
-		private final ArrayList<String> privateCopyPrefixes;
+    static class LocalIsolatedURLClassLoader extends URLClassLoader {
+        private final ArrayList<String> privateCopyPrefixes;
 
-		public LocalIsolatedURLClassLoader(final ClassLoader classLoader, final URL[] urls,
-				final ArrayList<String> privateCopyPrefixes) {
-			super(urls, classLoader);
-			this.privateCopyPrefixes = privateCopyPrefixes;
-		}
+        public LocalIsolatedURLClassLoader(final ClassLoader classLoader, final URL[] urls,
+                final ArrayList<String> privateCopyPrefixes) {
+            super(urls, classLoader);
+            this.privateCopyPrefixes = privateCopyPrefixes;
+        }
 
-		@Override
-		public Class<?> findClass(final String name) throws ClassNotFoundException {
-			if (classShouldBePrivate(name))
-				return super.findClass(name);
-			throw new ClassNotFoundException(
-					"Can only load classes with prefix : "
-							+ privateCopyPrefixes);
-		}
+        @Override
+        public Class<?> findClass(final String name) throws ClassNotFoundException {
+            if (classShouldBePrivate(name)) {
+                return super.findClass(name);
+            }
+            throw new ClassNotFoundException(
+                    "Can only load classes with prefix : "
+                            + privateCopyPrefixes);
+        }
 
-		private boolean classShouldBePrivate(final String name) {
-			for (final String prefix : privateCopyPrefixes) {
-				if (name.startsWith(prefix)) {
+        private boolean classShouldBePrivate(final String name) {
+            for (final String prefix : privateCopyPrefixes) {
+                if (name.startsWith(prefix)) {
                     return true;
                 }
-			}
-			return false;
-		}
-	}
+            }
+            return false;
+        }
+    }
 
-	public static class ExcludingURLClassLoaderBuilder extends ClassLoaders {
-		private final ArrayList<String> privateCopyPrefixes = new ArrayList<String>();
-		private final ArrayList<URL> codeSourceUrls = new ArrayList<URL>();
+    public static class ExcludingURLClassLoaderBuilder extends ClassLoaders {
+        private final ArrayList<String> privateCopyPrefixes = new ArrayList<String>();
+        private final ArrayList<URL> codeSourceUrls = new ArrayList<URL>();
 
-		public ExcludingURLClassLoaderBuilder without(final String... privatePrefixes) {
-			privateCopyPrefixes.addAll(asList(privatePrefixes));
-			return this;
-		}
+        public ExcludingURLClassLoaderBuilder without(final String... privatePrefixes) {
+            privateCopyPrefixes.addAll(asList(privatePrefixes));
+            return this;
+        }
 
-		public ExcludingURLClassLoaderBuilder withCodeSourceUrls(final String... urls) {
-			codeSourceUrls.addAll(pathsToURLs(urls));
-			return this;
-		}
+        public ExcludingURLClassLoaderBuilder withCodeSourceUrls(final String... urls) {
+            codeSourceUrls.addAll(pathsToURLs(urls));
+            return this;
+        }
 
-		public ExcludingURLClassLoaderBuilder withCodeSourceUrlOf(
-				final Class<?>... classes) {
-			for (final Class<?> clazz : classes) {
-				codeSourceUrls.add(obtainClassPathOf(clazz.getName()));
-			}
-			return this;
-		}
+        public ExcludingURLClassLoaderBuilder withCodeSourceUrlOf(
+                final Class<?>... classes) {
+            for (final Class<?> clazz : classes) {
+                codeSourceUrls.add(obtainClassPathOf(clazz.getName()));
+            }
+            return this;
+        }
 
-		public ExcludingURLClassLoaderBuilder withCurrentCodeSourceUrls() {
-			codeSourceUrls.add(obtainClassPathOf(ClassLoaders.class.getName()));
-			return this;
-		}
+        public ExcludingURLClassLoaderBuilder withCurrentCodeSourceUrls() {
+            codeSourceUrls.add(obtainClassPathOf(ClassLoaders.class.getName()));
+            return this;
+        }
 
-		@Override
+        @Override
         public ClassLoader build() {
-			return new LocalExcludingURLClassLoader(jdkClassLoader(),
-					codeSourceUrls.toArray(new URL[codeSourceUrls.size()]),
-					privateCopyPrefixes);
-		}
-	}
+            return new LocalExcludingURLClassLoader(jdkClassLoader(),
+                    codeSourceUrls.toArray(new URL[codeSourceUrls.size()]),
+                    privateCopyPrefixes);
+        }
+    }
 
-	static class LocalExcludingURLClassLoader extends URLClassLoader {
-		private final ArrayList<String> privateCopyPrefixes;
+    static class LocalExcludingURLClassLoader extends URLClassLoader {
+        private final ArrayList<String> privateCopyPrefixes;
 
-		public LocalExcludingURLClassLoader(final ClassLoader classLoader,
-				final URL[] urls, final ArrayList<String> privateCopyPrefixes) {
-			super(urls, classLoader);
-			this.privateCopyPrefixes = privateCopyPrefixes;
-		}
+        public LocalExcludingURLClassLoader(final ClassLoader classLoader,
+                final URL[] urls, final ArrayList<String> privateCopyPrefixes) {
+            super(urls, classLoader);
+            this.privateCopyPrefixes = privateCopyPrefixes;
+        }
 
-		@Override
-		public Class<?> findClass(final String name) throws ClassNotFoundException {
-			if (classShouldBePrivate(name)) {
-				throw new ClassNotFoundException("classes with prefix : "
-						+ privateCopyPrefixes + " are excluded");
-			}
-			return super.findClass(name);
-		}
+        @Override
+        public Class<?> findClass(final String name) throws ClassNotFoundException {
+            if (classShouldBePrivate(name)) {
+                throw new ClassNotFoundException("classes with prefix : "
+                        + privateCopyPrefixes + " are excluded");
+            }
+            return super.findClass(name);
+        }
 
-		private boolean classShouldBePrivate(final String name) {
-			for (final String prefix : privateCopyPrefixes) {
-				if (name.startsWith(prefix)) {
-					return true;
-				}
-			}
-			return false;
-		}
-	}
+        private boolean classShouldBePrivate(final String name) {
+            for (final String prefix : privateCopyPrefixes) {
+                if (name.startsWith(prefix)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
 
-	public static class InMemoryClassLoaderBuilder extends ClassLoaders {
-		private final Map<String, byte[]> inMemoryClassObjects = new HashMap<String, byte[]>();
+    public static class InMemoryClassLoaderBuilder extends ClassLoaders {
+        private final Map<String, byte[]> inMemoryClassObjects = new HashMap<String, byte[]>();
 
-		public InMemoryClassLoaderBuilder withParent(final ClassLoader parent) {
-			this.parent = parent;
-			return this;
-		}
+        public InMemoryClassLoaderBuilder withParent(final ClassLoader parent) {
+            this.parent = parent;
+            return this;
+        }
 
-		public InMemoryClassLoaderBuilder withClassDefinition(final String name,
-				final byte[] classDefinition) {
-			inMemoryClassObjects.put(name, classDefinition);
-			return this;
-		}
+        public InMemoryClassLoaderBuilder withClassDefinition(final String name,
+                final byte[] classDefinition) {
+            inMemoryClassObjects.put(name, classDefinition);
+            return this;
+        }
 
-		@Override
+        @Override
         public ClassLoader build() {
-			return new InMemoryClassLoader(parent, inMemoryClassObjects);
-		}
-	}
+            return new InMemoryClassLoader(parent, inMemoryClassObjects);
+        }
+    }
 
-	static class InMemoryClassLoader extends ClassLoader {
-		public static final String SCHEME = "mem";
-		private Map<String, byte[]> inMemoryClassObjects = new HashMap<String, byte[]>();
+    static class InMemoryClassLoader extends ClassLoader {
+        public static final String SCHEME = "mem";
+        private Map<String, byte[]> inMemoryClassObjects = new HashMap<String, byte[]>();
 
-		public InMemoryClassLoader(final ClassLoader parent,
-				final Map<String, byte[]> inMemoryClassObjects) {
-			super(parent);
-			this.inMemoryClassObjects = inMemoryClassObjects;
-		}
+        public InMemoryClassLoader(final ClassLoader parent,
+                final Map<String, byte[]> inMemoryClassObjects) {
+            super(parent);
+            this.inMemoryClassObjects = inMemoryClassObjects;
+        }
 
-		@Override
+        @Override
         protected Class findClass(final String name) throws ClassNotFoundException {
-			final byte[] classDefinition = inMemoryClassObjects.get(name);
-			if (classDefinition != null) {
-				return defineClass(name, classDefinition, 0,
-						classDefinition.length);
-			}
-			throw new ClassNotFoundException(name);
-		}
+            final byte[] classDefinition = inMemoryClassObjects.get(name);
+            if (classDefinition != null) {
+                return defineClass(name, classDefinition, 0,
+                        classDefinition.length);
+            }
+            throw new ClassNotFoundException(name);
+        }
 
-		@Override
-		public Enumeration<URL> getResources(final String ignored) throws IOException {
-			return inMemoryOnly();
-		}
+        @Override
+        public Enumeration<URL> getResources(final String ignored) throws IOException {
+            return inMemoryOnly();
+        }
 
-		private Enumeration<URL> inMemoryOnly() {
-			final Set<String> names = inMemoryClassObjects.keySet();
-			return new Enumeration<URL>() {
-				private final MemHandler memHandler = new MemHandler(
-						InMemoryClassLoader.this);
-				private final Iterator<String> it = names.iterator();
+        private Enumeration<URL> inMemoryOnly() {
+            final Set<String> names = inMemoryClassObjects.keySet();
+            return new Enumeration<URL>() {
+                private final MemHandler memHandler = new MemHandler(
+                        InMemoryClassLoader.this);
+                private final Iterator<String> it = names.iterator();
 
                 public boolean hasMoreElements() {
-					return it.hasNext();
-				}
+                    return it.hasNext();
+                }
 
                 public URL nextElement() {
-					try {
-						return new URL(null, SCHEME + ":" + it.next(),
-								memHandler);
-					} catch (final MalformedURLException rethrown) {
-						throw new IllegalStateException(rethrown);
-					}
-				}
-			};
-		}
-	}
+                    try {
+                        return new URL(null, SCHEME + ":" + it.next(),
+                                memHandler);
+                    } catch (final MalformedURLException rethrown) {
+                        throw new IllegalStateException(rethrown);
+                    }
+                }
+            };
+        }
+    }
 
-	public static class MemHandler extends URLStreamHandler {
-		private final InMemoryClassLoader inMemoryClassLoader;
+    public static class MemHandler extends URLStreamHandler {
+        private final InMemoryClassLoader inMemoryClassLoader;
 
-		public MemHandler(final InMemoryClassLoader inMemoryClassLoader) {
-			this.inMemoryClassLoader = inMemoryClassLoader;
-		}
+        public MemHandler(final InMemoryClassLoader inMemoryClassLoader) {
+            this.inMemoryClassLoader = inMemoryClassLoader;
+        }
 
-		@Override
-		protected URLConnection openConnection(final URL url) throws IOException {
-			return new MemURLConnection(url, inMemoryClassLoader);
-		}
+        @Override
+        protected URLConnection openConnection(final URL url) throws IOException {
+            return new MemURLConnection(url, inMemoryClassLoader);
+        }
 
-		private static class MemURLConnection extends URLConnection {
-			private final InMemoryClassLoader inMemoryClassLoader;
-			private final String qualifiedName;
+        private static class MemURLConnection extends URLConnection {
+            private final InMemoryClassLoader inMemoryClassLoader;
+            private final String qualifiedName;
 
-			public MemURLConnection(final URL url,
-					final InMemoryClassLoader inMemoryClassLoader) {
-				super(url);
-				this.inMemoryClassLoader = inMemoryClassLoader;
-				qualifiedName = url.getPath();
-			}
+            public MemURLConnection(final URL url,
+                    final InMemoryClassLoader inMemoryClassLoader) {
+                super(url);
+                this.inMemoryClassLoader = inMemoryClassLoader;
+                qualifiedName = url.getPath();
+            }
 
-			@Override
-			public void connect() throws IOException {
-			}
+            @Override
+            public void connect() throws IOException {
+            }
 
-			@Override
-			public InputStream getInputStream() throws IOException {
-				return new ByteArrayInputStream(
-						inMemoryClassLoader.inMemoryClassObjects
-								.get(qualifiedName));
-			}
-		}
-	}
+            @Override
+            public InputStream getInputStream() throws IOException {
+                return new ByteArrayInputStream(
+                        inMemoryClassLoader.inMemoryClassObjects
+                                .get(qualifiedName));
+            }
+        }
+    }
 
-	protected URL obtainClassPathOf(final String className) {
-		final String path = className.replace('.', '/') + ".class";
-		final String url = ClassLoaders.class.getClassLoader().getResource(path)
-				.toExternalForm();
+    protected URL obtainClassPathOf(final String className) {
+        final String path = className.replace('.', '/') + ".class";
+        final String url = ClassLoaders.class.getClassLoader().getResource(path)
+                .toExternalForm();
 
-		try {
-			return new URL(url.substring(0, url.length() - path.length()));
-		} catch (final MalformedURLException e) {
-			throw new RuntimeException(
-					"Classloader couldn't obtain a proper classpath URL", e);
-		}
-	}
+        try {
+            return new URL(url.substring(0, url.length() - path.length()));
+        } catch (final MalformedURLException e) {
+            throw new RuntimeException(
+                    "Classloader couldn't obtain a proper classpath URL", e);
+        }
+    }
 
-	protected List<URL> pathsToURLs(final String... codeSourceUrls) {
-		return pathsToURLs(Arrays.asList(codeSourceUrls));
-	}
+    protected List<URL> pathsToURLs(final String... codeSourceUrls) {
+        return pathsToURLs(Arrays.asList(codeSourceUrls));
+    }
 
-	private List<URL> pathsToURLs(final List<String> codeSourceUrls) {
-		final ArrayList<URL> urls = new ArrayList<URL>(codeSourceUrls.size());
-		for (final String codeSourceUrl : codeSourceUrls) {
-			final URL url = pathToUrl(codeSourceUrl);
-			urls.add(url);
-		}
-		return urls;
-	}
+    private List<URL> pathsToURLs(final List<String> codeSourceUrls) {
+        final ArrayList<URL> urls = new ArrayList<URL>(codeSourceUrls.size());
+        for (final String codeSourceUrl : codeSourceUrls) {
+            final URL url = pathToUrl(codeSourceUrl);
+            urls.add(url);
+        }
+        return urls;
+    }
 
-	private URL pathToUrl(final String path) {
-		try {
-			return new File(path).getAbsoluteFile().toURI().toURL();
-		} catch (final MalformedURLException e) {
-			throw new IllegalArgumentException("Path is malformed", e);
-		}
-	}
+    private URL pathToUrl(final String path) {
+        try {
+            return new File(path).getAbsoluteFile().toURI().toURL();
+        } catch (final MalformedURLException e) {
+            throw new IllegalArgumentException("Path is malformed", e);
+        }
+    }
 
-	public static class ReachableClassesFinder {
-		private final ClassLoader classLoader;
-		private final Set<String> qualifiedNameSubstring = new HashSet<String>();
+    public static class ReachableClassesFinder {
+        private final ClassLoader classLoader;
+        private final Set<String> qualifiedNameSubstring = new HashSet<String>();
 
-		public ReachableClassesFinder(final ClassLoader classLoader) {
-			this.classLoader = classLoader;
-		}
+        public ReachableClassesFinder(final ClassLoader classLoader) {
+            this.classLoader = classLoader;
+        }
 
-		public ReachableClassesFinder omit(final String... qualifiedNameSubstring) {
-			this.qualifiedNameSubstring.addAll(Arrays
-					.asList(qualifiedNameSubstring));
-			return this;
-		}
+        public ReachableClassesFinder omit(final String... qualifiedNameSubstring) {
+            this.qualifiedNameSubstring.addAll(Arrays
+                    .asList(qualifiedNameSubstring));
+            return this;
+        }
 
-		public Set<String> listOwnedClasses() throws IOException,
-				URISyntaxException {
-			final Enumeration<URL> roots = classLoader.getResources("");
+        public Set<String> listOwnedClasses() throws IOException,
+                URISyntaxException {
+            final Enumeration<URL> roots = classLoader.getResources("");
 
-			final Set<String> classes = new HashSet<String>();
-			while (roots.hasMoreElements()) {
-				final URI uri = roots.nextElement().toURI();
+            final Set<String> classes = new HashSet<String>();
+            while (roots.hasMoreElements()) {
+                final URI uri = roots.nextElement().toURI();
 
-				if (uri.getScheme().equalsIgnoreCase("file")) {
-					addFromFileBasedClassLoader(classes, uri);
-				} else if (uri.getScheme().equalsIgnoreCase(
-						InMemoryClassLoader.SCHEME)) {
-					addFromInMemoryBasedClassLoader(classes, uri);
-				} else {
-					throw new IllegalArgumentException(
-							String.format(
-									"Given ClassLoader '%s' don't have reachable by File or vi ClassLoaders.inMemory",
-									classLoader));
-				}
-			}
-			return classes;
-		}
+                if (uri.getScheme().equalsIgnoreCase("file")) {
+                    addFromFileBasedClassLoader(classes, uri);
+                } else if (uri.getScheme().equalsIgnoreCase(
+                        InMemoryClassLoader.SCHEME)) {
+                    addFromInMemoryBasedClassLoader(classes, uri);
+                } else {
+                    throw new IllegalArgumentException(
+                            String.format(
+                                    "Given ClassLoader '%s' don't have reachable by File or vi ClassLoaders.inMemory",
+                                    classLoader));
+                }
+            }
+            return classes;
+        }
 
-		private void addFromFileBasedClassLoader(final Set<String> classes, final URI uri) {
-			final File root = new File(uri);
-			classes.addAll(findClassQualifiedNames(root, root,
-					qualifiedNameSubstring));
-		}
+        private void addFromFileBasedClassLoader(final Set<String> classes, final URI uri) {
+            final File root = new File(uri);
+            classes.addAll(findClassQualifiedNames(root, root,
+                    qualifiedNameSubstring));
+        }
 
-		private void addFromInMemoryBasedClassLoader(final Set<String> classes,
-				final URI uri) {
-			final String qualifiedName = uri.getSchemeSpecificPart();
-			if (excludes(qualifiedName, qualifiedNameSubstring)) {
-				classes.add(qualifiedName);
-			}
-		}
+        private void addFromInMemoryBasedClassLoader(final Set<String> classes,
+                final URI uri) {
+            final String qualifiedName = uri.getSchemeSpecificPart();
+            if (excludes(qualifiedName, qualifiedNameSubstring)) {
+                classes.add(qualifiedName);
+            }
+        }
 
-		private Set<String> findClassQualifiedNames(final File root, final File file,
-				final Set<String> packageFilters) {
-			if (file.isDirectory()) {
-				final File[] files = file.listFiles();
-				final Set<String> classes = new HashSet<String>();
-				for (final File children : files) {
-					classes.addAll(findClassQualifiedNames(root, children,
-							packageFilters));
-				}
-				return classes;
-			} else {
-				if (file.getName().endsWith(".class")) {
-					final String qualifiedName = classNameFor(root, file);
-					if (excludes(qualifiedName, packageFilters)) {
-						return Collections.singleton(qualifiedName);
-					}
-				}
-			}
-			return Collections.emptySet();
-		}
+        private Set<String> findClassQualifiedNames(final File root, final File file,
+                final Set<String> packageFilters) {
+            if (file.isDirectory()) {
+                final File[] files = file.listFiles();
+                final Set<String> classes = new HashSet<String>();
+                for (final File children : files) {
+                    classes.addAll(findClassQualifiedNames(root, children,
+                            packageFilters));
+                }
+                return classes;
+            } else {
+                if (file.getName().endsWith(".class")) {
+                    final String qualifiedName = classNameFor(root, file);
+                    if (excludes(qualifiedName, packageFilters)) {
+                        return Collections.singleton(qualifiedName);
+                    }
+                }
+            }
+            return Collections.emptySet();
+        }
 
-		private boolean excludes(final String qualifiedName,
-				final Set<String> packageFilters) {
-			for (final String filter : packageFilters) {
-				if (qualifiedName.contains(filter)) {
-					return false;
-				}
-			}
-			return true;
-		}
+        private boolean excludes(final String qualifiedName,
+                final Set<String> packageFilters) {
+            for (final String filter : packageFilters) {
+                if (qualifiedName.contains(filter)) {
+                    return false;
+                }
+            }
+            return true;
+        }
 
-		private String classNameFor(final File root, final File file) {
-			final String temp = file.getAbsolutePath()
-					.substring(root.getAbsolutePath().length() + 1)
-					.replace(File.separatorChar, '.');
-			return temp.subSequence(0, temp.indexOf(".class")).toString();
-		}
+        private String classNameFor(final File root, final File file) {
+            final String temp = file.getAbsolutePath()
+                    .substring(root.getAbsolutePath().length() + 1)
+                    .replace(File.separatorChar, '.');
+            return temp.subSequence(0, temp.indexOf(".class")).toString();
+        }
 
-	}
+    }
 }

--- a/test/org/mockitoutil/ClassLoaders.java
+++ b/test/org/mockitoutil/ClassLoaders.java
@@ -1,5 +1,7 @@
 package org.mockitoutil;
 
+import static java.util.Arrays.asList;
+
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -11,357 +13,407 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
-import static java.util.Arrays.asList;
-
+@SuppressWarnings("unchecked")
 public abstract class ClassLoaders {
-    protected ClassLoader parent = currentClassLoader();
+	protected ClassLoader parent = currentClassLoader();
 
-    protected ClassLoaders() {}
+	protected ClassLoaders() {
+	}
 
-    public static IsolatedURLClassLoaderBuilder isolatedClassLoader() {
-        return new IsolatedURLClassLoaderBuilder();
-    }
+	public static IsolatedURLClassLoaderBuilder isolatedClassLoader() {
+		return new IsolatedURLClassLoaderBuilder();
+	}
 
-    public static ExcludingURLClassLoaderBuilder excludingClassLoader() {
-        return new ExcludingURLClassLoaderBuilder();
-    }
+	public static ExcludingURLClassLoaderBuilder excludingClassLoader() {
+		return new ExcludingURLClassLoaderBuilder();
+	}
 
-    public static InMemoryClassLoaderBuilder inMemoryClassLoader() {
-        return new InMemoryClassLoaderBuilder();
-    }
+	public static InMemoryClassLoaderBuilder inMemoryClassLoader() {
+		return new InMemoryClassLoaderBuilder();
+	}
 
-    public static ReachableClassesFinder in(ClassLoader classLoader_without_jUnit) {
-        return new ReachableClassesFinder(classLoader_without_jUnit);
-    }
+	public static ReachableClassesFinder in(
+			final ClassLoader classLoader_without_jUnit) {
+		return new ReachableClassesFinder(classLoader_without_jUnit);
+	}
 
-    public static ClassLoader jdkClassLoader() {
-        return String.class.getClassLoader();
-    }
+	public static ClassLoader jdkClassLoader() {
+		return String.class.getClassLoader();
+	}
 
-    public static ClassLoader systemClassLoader() {
-        return ClassLoader.getSystemClassLoader();
-    }
+	public static ClassLoader systemClassLoader() {
+		return ClassLoader.getSystemClassLoader();
+	}
 
-    public static ClassLoader currentClassLoader() {
-        return ClassLoaders.class.getClassLoader();
-    }
+	public static ClassLoader currentClassLoader() {
+		return ClassLoaders.class.getClassLoader();
+	}
 
-    public abstract ClassLoader build();
+	public abstract ClassLoader build();
 
-    public static class IsolatedURLClassLoaderBuilder extends ClassLoaders {
-        private final ArrayList<String> privateCopyPrefixes = new ArrayList<String>();
-        private final ArrayList<URL> codeSourceUrls = new ArrayList<URL>();
+	public static class IsolatedURLClassLoaderBuilder extends ClassLoaders {
+		private final ArrayList<String> privateCopyPrefixes = new ArrayList<String>();
+		private final ArrayList<URL> codeSourceUrls = new ArrayList<URL>();
 
-        public IsolatedURLClassLoaderBuilder withPrivateCopyOf(String... privatePrefixes) {
-            privateCopyPrefixes.addAll(asList(privatePrefixes));
-            return this;
-        }
+		public IsolatedURLClassLoaderBuilder withPrivateCopyOf(
+				final String... privatePrefixes) {
+			privateCopyPrefixes.addAll(asList(privatePrefixes));
+			return this;
+		}
 
-        public IsolatedURLClassLoaderBuilder withCodeSourceUrls(String... urls) {
-            codeSourceUrls.addAll(pathsToURLs(urls));
-            return this;
-        }
+		public IsolatedURLClassLoaderBuilder withCodeSourceUrls(final String... urls) {
+			codeSourceUrls.addAll(pathsToURLs(urls));
+			return this;
+		}
 
-        public IsolatedURLClassLoaderBuilder withCodeSourceUrlOf(Class<?>... classes) {
-            for (Class<?> clazz : classes) {
-                codeSourceUrls.add(obtainClassPathOf(clazz.getName()));
-            }
-            return this;
-        }
+		public IsolatedURLClassLoaderBuilder withCodeSourceUrlOf(
+				final Class<?>... classes) {
+			for (final Class<?> clazz : classes) {
+				codeSourceUrls.add(obtainClassPathOf(clazz.getName()));
+			}
+			return this;
+		}
 
-        public IsolatedURLClassLoaderBuilder withCurrentCodeSourceUrls() {
-            codeSourceUrls.add(obtainClassPathOf(ClassLoaders.class.getName()));
-            return this;
-        }
-
-        public ClassLoader build() {
-            return new LocalIsolatedURLClassLoader(
-                    jdkClassLoader(),
-                    codeSourceUrls.toArray(new URL[codeSourceUrls.size()]),
-                    privateCopyPrefixes
-            );
-        }
-    }
-
-    static class LocalIsolatedURLClassLoader extends URLClassLoader {
-        private final ArrayList<String> privateCopyPrefixes;
-
-        public LocalIsolatedURLClassLoader(ClassLoader classLoader, URL[] urls, ArrayList<String> privateCopyPrefixes) {
-            super(urls, classLoader);
-            this.privateCopyPrefixes = privateCopyPrefixes;
-        }
-
-        @Override
-        public Class<?> findClass(String name) throws ClassNotFoundException {
-            if(classShouldBePrivate(name)) return super.findClass(name);
-            throw new ClassNotFoundException("Can only load classes with prefix : " + privateCopyPrefixes);
-        }
-
-        private boolean classShouldBePrivate(String name) {
-            for (String prefix : privateCopyPrefixes) {
-                if (name.startsWith(prefix)) return true;
-            }
-            return false;
-        }
-    }
-
-    public static class ExcludingURLClassLoaderBuilder extends ClassLoaders {
-        private final ArrayList<String> privateCopyPrefixes = new ArrayList<String>();
-        private final ArrayList<URL> codeSourceUrls = new ArrayList<URL>();
-
-        public ExcludingURLClassLoaderBuilder without(String... privatePrefixes) {
-            privateCopyPrefixes.addAll(asList(privatePrefixes));
-            return this;
-        }
-
-        public ExcludingURLClassLoaderBuilder withCodeSourceUrls(String... urls) {
-            codeSourceUrls.addAll(pathsToURLs(urls));
-            return this;
-        }
-
-        public ExcludingURLClassLoaderBuilder withCodeSourceUrlOf(Class<?>... classes) {
-            for (Class<?> clazz : classes) {
-                codeSourceUrls.add(obtainClassPathOf(clazz.getName()));
-            }
-            return this;
-        }
-
-        public ExcludingURLClassLoaderBuilder withCurrentCodeSourceUrls() {
-            codeSourceUrls.add(obtainClassPathOf(ClassLoaders.class.getName()));
-            return this;
-        }
+		public IsolatedURLClassLoaderBuilder withCurrentCodeSourceUrls() {
+			codeSourceUrls.add(obtainClassPathOf(ClassLoaders.class.getName()));
+			return this;
+		}
 
         public ClassLoader build() {
-            return new LocalExcludingURLClassLoader(
-                    jdkClassLoader(),
-                    codeSourceUrls.toArray(new URL[codeSourceUrls.size()]),
-                    privateCopyPrefixes
-            );
-        }
-    }
+			return new LocalIsolatedURLClassLoader(jdkClassLoader(),
+					codeSourceUrls.toArray(new URL[codeSourceUrls.size()]),
+					privateCopyPrefixes);
+		}
+	}
 
-    static class LocalExcludingURLClassLoader extends URLClassLoader {
-        private final ArrayList<String> privateCopyPrefixes;
+	static class LocalIsolatedURLClassLoader extends URLClassLoader {
+		private final ArrayList<String> privateCopyPrefixes;
 
-        public LocalExcludingURLClassLoader(ClassLoader classLoader, URL[] urls, ArrayList<String> privateCopyPrefixes) {
-            super(urls, classLoader);
-            this.privateCopyPrefixes = privateCopyPrefixes;
-        }
+		public LocalIsolatedURLClassLoader(final ClassLoader classLoader, final URL[] urls,
+				final ArrayList<String> privateCopyPrefixes) {
+			super(urls, classLoader);
+			this.privateCopyPrefixes = privateCopyPrefixes;
+		}
 
-        @Override
-        public Class<?> findClass(String name) throws ClassNotFoundException {
-            if(classShouldBePrivate(name)) throw new ClassNotFoundException("classes with prefix : " + privateCopyPrefixes + " are excluded");
-            return super.findClass(name);
-        }
+		@Override
+		public Class<?> findClass(final String name) throws ClassNotFoundException {
+			if (classShouldBePrivate(name))
+				return super.findClass(name);
+			throw new ClassNotFoundException(
+					"Can only load classes with prefix : "
+							+ privateCopyPrefixes);
+		}
 
-        private boolean classShouldBePrivate(String name) {
-            for (String prefix : privateCopyPrefixes) {
-                if (name.startsWith(prefix)) return true;
-            }
-            return false;
-        }
-    }
+		private boolean classShouldBePrivate(final String name) {
+			for (final String prefix : privateCopyPrefixes) {
+				if (name.startsWith(prefix)) {
+                    return true;
+                }
+			}
+			return false;
+		}
+	}
 
-    public static class InMemoryClassLoaderBuilder extends ClassLoaders {
-        private Map<String , byte[]> inMemoryClassObjects = new HashMap<String , byte[]>();
+	public static class ExcludingURLClassLoaderBuilder extends ClassLoaders {
+		private final ArrayList<String> privateCopyPrefixes = new ArrayList<String>();
+		private final ArrayList<URL> codeSourceUrls = new ArrayList<URL>();
 
-        public InMemoryClassLoaderBuilder withParent(ClassLoader parent) {
-            this.parent = parent;
-            return this;
-        }
+		public ExcludingURLClassLoaderBuilder without(final String... privatePrefixes) {
+			privateCopyPrefixes.addAll(asList(privatePrefixes));
+			return this;
+		}
 
-        public InMemoryClassLoaderBuilder withClassDefinition(String name, byte[] classDefinition) {
-            inMemoryClassObjects.put(name, classDefinition);
-            return this;
-        }
+		public ExcludingURLClassLoaderBuilder withCodeSourceUrls(final String... urls) {
+			codeSourceUrls.addAll(pathsToURLs(urls));
+			return this;
+		}
 
+		public ExcludingURLClassLoaderBuilder withCodeSourceUrlOf(
+				final Class<?>... classes) {
+			for (final Class<?> clazz : classes) {
+				codeSourceUrls.add(obtainClassPathOf(clazz.getName()));
+			}
+			return this;
+		}
+
+		public ExcludingURLClassLoaderBuilder withCurrentCodeSourceUrls() {
+			codeSourceUrls.add(obtainClassPathOf(ClassLoaders.class.getName()));
+			return this;
+		}
+
+		@Override
         public ClassLoader build() {
-            return new InMemoryClassLoader(parent, inMemoryClassObjects);
-        }
-    }
+			return new LocalExcludingURLClassLoader(jdkClassLoader(),
+					codeSourceUrls.toArray(new URL[codeSourceUrls.size()]),
+					privateCopyPrefixes);
+		}
+	}
 
-    static class InMemoryClassLoader extends ClassLoader {
-        public static final String SCHEME = "mem";
-        private Map<String , byte[]> inMemoryClassObjects = new HashMap<String , byte[]>();
+	static class LocalExcludingURLClassLoader extends URLClassLoader {
+		private final ArrayList<String> privateCopyPrefixes;
 
-        public InMemoryClassLoader(ClassLoader parent, Map<String, byte[]> inMemoryClassObjects) {
-            super(parent);
-            this.inMemoryClassObjects = inMemoryClassObjects;
-        }
+		public LocalExcludingURLClassLoader(final ClassLoader classLoader,
+				final URL[] urls, final ArrayList<String> privateCopyPrefixes) {
+			super(urls, classLoader);
+			this.privateCopyPrefixes = privateCopyPrefixes;
+		}
 
-        protected Class findClass(String name) throws ClassNotFoundException {
-            byte[] classDefinition = inMemoryClassObjects.get(name);
-            if (classDefinition != null) {
-                return defineClass(name, classDefinition, 0, classDefinition.length);
-            }
-            throw new ClassNotFoundException(name);
-        }
+		@Override
+		public Class<?> findClass(final String name) throws ClassNotFoundException {
+			if (classShouldBePrivate(name)) {
+				throw new ClassNotFoundException("classes with prefix : "
+						+ privateCopyPrefixes + " are excluded");
+			}
+			return super.findClass(name);
+		}
 
-        @Override
-        public Enumeration<URL> getResources(String ignored) throws IOException {
-            return inMemoryOnly();
-        }
+		private boolean classShouldBePrivate(final String name) {
+			for (final String prefix : privateCopyPrefixes) {
+				if (name.startsWith(prefix)) {
+					return true;
+				}
+			}
+			return false;
+		}
+	}
 
-        private Enumeration<URL> inMemoryOnly() {
-            final Set<String> names = inMemoryClassObjects.keySet();
-            return new Enumeration<URL>() {
-                private final MemHandler memHandler = new MemHandler(InMemoryClassLoader.this);
-                private final Iterator<String> it = names.iterator();
+	public static class InMemoryClassLoaderBuilder extends ClassLoaders {
+		private final Map<String, byte[]> inMemoryClassObjects = new HashMap<String, byte[]>();
+
+		public InMemoryClassLoaderBuilder withParent(final ClassLoader parent) {
+			this.parent = parent;
+			return this;
+		}
+
+		public InMemoryClassLoaderBuilder withClassDefinition(final String name,
+				final byte[] classDefinition) {
+			inMemoryClassObjects.put(name, classDefinition);
+			return this;
+		}
+
+		@Override
+        public ClassLoader build() {
+			return new InMemoryClassLoader(parent, inMemoryClassObjects);
+		}
+	}
+
+	static class InMemoryClassLoader extends ClassLoader {
+		public static final String SCHEME = "mem";
+		private Map<String, byte[]> inMemoryClassObjects = new HashMap<String, byte[]>();
+
+		public InMemoryClassLoader(final ClassLoader parent,
+				final Map<String, byte[]> inMemoryClassObjects) {
+			super(parent);
+			this.inMemoryClassObjects = inMemoryClassObjects;
+		}
+
+		@Override
+        protected Class findClass(final String name) throws ClassNotFoundException {
+			final byte[] classDefinition = inMemoryClassObjects.get(name);
+			if (classDefinition != null) {
+				return defineClass(name, classDefinition, 0,
+						classDefinition.length);
+			}
+			throw new ClassNotFoundException(name);
+		}
+
+		@Override
+		public Enumeration<URL> getResources(final String ignored) throws IOException {
+			return inMemoryOnly();
+		}
+
+		private Enumeration<URL> inMemoryOnly() {
+			final Set<String> names = inMemoryClassObjects.keySet();
+			return new Enumeration<URL>() {
+				private final MemHandler memHandler = new MemHandler(
+						InMemoryClassLoader.this);
+				private final Iterator<String> it = names.iterator();
 
                 public boolean hasMoreElements() {
-                    return it.hasNext();
-                }
+					return it.hasNext();
+				}
 
                 public URL nextElement() {
-                    try {
-                        return new URL(null, SCHEME + ":" + it.next(), memHandler);
-                    } catch (MalformedURLException rethrown) {
-                        throw new IllegalStateException(rethrown);
-                    }
-                }
-            };
-        }
-    }
+					try {
+						return new URL(null, SCHEME + ":" + it.next(),
+								memHandler);
+					} catch (final MalformedURLException rethrown) {
+						throw new IllegalStateException(rethrown);
+					}
+				}
+			};
+		}
+	}
 
-    public static class MemHandler extends URLStreamHandler {
-        private InMemoryClassLoader inMemoryClassLoader;
+	public static class MemHandler extends URLStreamHandler {
+		private final InMemoryClassLoader inMemoryClassLoader;
 
-        public MemHandler(InMemoryClassLoader inMemoryClassLoader) {
-            this.inMemoryClassLoader = inMemoryClassLoader;
-        }
+		public MemHandler(final InMemoryClassLoader inMemoryClassLoader) {
+			this.inMemoryClassLoader = inMemoryClassLoader;
+		}
 
-        @Override
-        protected URLConnection openConnection(URL url) throws IOException {
-            return new MemURLConnection(url, inMemoryClassLoader);
-        }
+		@Override
+		protected URLConnection openConnection(final URL url) throws IOException {
+			return new MemURLConnection(url, inMemoryClassLoader);
+		}
 
-        private static class MemURLConnection extends URLConnection {
-            private final InMemoryClassLoader inMemoryClassLoader;
-            private String qualifiedName;
-            public MemURLConnection(URL url, InMemoryClassLoader inMemoryClassLoader) {
-                super(url);
-                this.inMemoryClassLoader = inMemoryClassLoader;
-                qualifiedName = url.getPath();
-            }
-            @Override
-            public void connect() throws IOException { }
+		private static class MemURLConnection extends URLConnection {
+			private final InMemoryClassLoader inMemoryClassLoader;
+			private final String qualifiedName;
 
-            @Override
-            public InputStream getInputStream() throws IOException {
-                return new ByteArrayInputStream(inMemoryClassLoader.inMemoryClassObjects.get(qualifiedName));
-            }
-        }
-    }
+			public MemURLConnection(final URL url,
+					final InMemoryClassLoader inMemoryClassLoader) {
+				super(url);
+				this.inMemoryClassLoader = inMemoryClassLoader;
+				qualifiedName = url.getPath();
+			}
 
-    protected URL obtainClassPathOf(String className) {
-        String path = className.replace('.', '/') + ".class";
-        String url = ClassLoaders.class.getClassLoader().getResource(path).toExternalForm();
+			@Override
+			public void connect() throws IOException {
+			}
 
-        try {
-            return new URL(url.substring(0, url.length() - path.length()));
-        } catch (MalformedURLException e) {
-            throw new RuntimeException("Classloader couldn't obtain a proper classpath URL", e);
-        }
-    }
+			@Override
+			public InputStream getInputStream() throws IOException {
+				return new ByteArrayInputStream(
+						inMemoryClassLoader.inMemoryClassObjects
+								.get(qualifiedName));
+			}
+		}
+	}
 
-    protected List<URL> pathsToURLs(String... codeSourceUrls) {
-        return pathsToURLs(Arrays.asList(codeSourceUrls));
-    }
+	protected URL obtainClassPathOf(final String className) {
+		final String path = className.replace('.', '/') + ".class";
+		final String url = ClassLoaders.class.getClassLoader().getResource(path)
+				.toExternalForm();
 
-    private List<URL> pathsToURLs(List<String> codeSourceUrls) {
-        ArrayList<URL> urls = new ArrayList<URL>(codeSourceUrls.size());
-        for (String codeSourceUrl : codeSourceUrls) {
-            URL url = pathToUrl(codeSourceUrl);
-            urls.add(url);
-        }
-        return urls;
-    }
+		try {
+			return new URL(url.substring(0, url.length() - path.length()));
+		} catch (final MalformedURLException e) {
+			throw new RuntimeException(
+					"Classloader couldn't obtain a proper classpath URL", e);
+		}
+	}
 
-    private URL pathToUrl(String path) {
-        try {
-            return new File(path).getAbsoluteFile().toURI().toURL();
-        } catch (MalformedURLException e) {
-            throw new IllegalArgumentException("Path is malformed", e);
-        }
-    }
+	protected List<URL> pathsToURLs(final String... codeSourceUrls) {
+		return pathsToURLs(Arrays.asList(codeSourceUrls));
+	}
 
-    public static class ReachableClassesFinder {
-        private ClassLoader classLoader;
-        private Set<String> qualifiedNameSubstring = new HashSet<String>();
+	private List<URL> pathsToURLs(final List<String> codeSourceUrls) {
+		final ArrayList<URL> urls = new ArrayList<URL>(codeSourceUrls.size());
+		for (final String codeSourceUrl : codeSourceUrls) {
+			final URL url = pathToUrl(codeSourceUrl);
+			urls.add(url);
+		}
+		return urls;
+	}
 
-        public ReachableClassesFinder(ClassLoader classLoader) {
-            this.classLoader = classLoader;
-        }
+	private URL pathToUrl(final String path) {
+		try {
+			return new File(path).getAbsoluteFile().toURI().toURL();
+		} catch (final MalformedURLException e) {
+			throw new IllegalArgumentException("Path is malformed", e);
+		}
+	}
 
-        public ReachableClassesFinder omit(String... qualifiedNameSubstring) {
-            this.qualifiedNameSubstring.addAll(Arrays.asList(qualifiedNameSubstring));
-            return this;
-        }
+	public static class ReachableClassesFinder {
+		private final ClassLoader classLoader;
+		private final Set<String> qualifiedNameSubstring = new HashSet<String>();
 
-        public Set<String> listOwnedClasses() throws IOException, URISyntaxException {
-            Enumeration<URL> roots = classLoader.getResources("");
+		public ReachableClassesFinder(final ClassLoader classLoader) {
+			this.classLoader = classLoader;
+		}
 
-            Set<String> classes = new HashSet<String>();
-            while(roots.hasMoreElements()) {
-                URI uri = roots.nextElement().toURI();
+		public ReachableClassesFinder omit(final String... qualifiedNameSubstring) {
+			this.qualifiedNameSubstring.addAll(Arrays
+					.asList(qualifiedNameSubstring));
+			return this;
+		}
 
-                if (uri.getScheme().equalsIgnoreCase("file")) {
-                    addFromFileBasedClassLoader(classes, uri);
-                } else if(uri.getScheme().equalsIgnoreCase(InMemoryClassLoader.SCHEME)) {
-                    addFromInMemoryBasedClassLoader(classes, uri);
-                } else {
-                    throw new IllegalArgumentException(String.format("Given ClassLoader '%s' don't have reachable by File or vi ClassLoaders.inMemory", classLoader));
-                }
-            }
-            return classes;
-        }
+		public Set<String> listOwnedClasses() throws IOException,
+				URISyntaxException {
+			final Enumeration<URL> roots = classLoader.getResources("");
 
-        private void addFromFileBasedClassLoader(Set<String> classes, URI uri) {
-            File root = new File(uri);
-            classes.addAll(findClassQualifiedNames(root, root, qualifiedNameSubstring));
-        }
+			final Set<String> classes = new HashSet<String>();
+			while (roots.hasMoreElements()) {
+				final URI uri = roots.nextElement().toURI();
 
-        private void addFromInMemoryBasedClassLoader(Set<String> classes, URI uri) {
-            String qualifiedName = uri.getSchemeSpecificPart();
-            if(excludes(qualifiedName, qualifiedNameSubstring)) {
-                classes.add(qualifiedName);
-            }
-        }
+				if (uri.getScheme().equalsIgnoreCase("file")) {
+					addFromFileBasedClassLoader(classes, uri);
+				} else if (uri.getScheme().equalsIgnoreCase(
+						InMemoryClassLoader.SCHEME)) {
+					addFromInMemoryBasedClassLoader(classes, uri);
+				} else {
+					throw new IllegalArgumentException(
+							String.format(
+									"Given ClassLoader '%s' don't have reachable by File or vi ClassLoaders.inMemory",
+									classLoader));
+				}
+			}
+			return classes;
+		}
 
+		private void addFromFileBasedClassLoader(final Set<String> classes, final URI uri) {
+			final File root = new File(uri);
+			classes.addAll(findClassQualifiedNames(root, root,
+					qualifiedNameSubstring));
+		}
 
-        private Set<String> findClassQualifiedNames(File root, File file, Set<String> packageFilters) {
-            if(file.isDirectory()) {
-                File[] files = file.listFiles();
-                Set<String> classes = new HashSet<String>();
-                for (File children : files) {
-                    classes.addAll(findClassQualifiedNames(root, children, packageFilters));
-                }
-                return classes;
-            } else {
-                if (file.getName().endsWith(".class")) {
-                    String qualifiedName = classNameFor(root, file);
-                    if (excludes(qualifiedName, packageFilters)) {
-                        return Collections.singleton(qualifiedName);
-                    }
-                }
-            }
-            return Collections.emptySet();
-        }
+		private void addFromInMemoryBasedClassLoader(final Set<String> classes,
+				final URI uri) {
+			final String qualifiedName = uri.getSchemeSpecificPart();
+			if (excludes(qualifiedName, qualifiedNameSubstring)) {
+				classes.add(qualifiedName);
+			}
+		}
 
-        private boolean excludes(String qualifiedName, Set<String> packageFilters) {
-            for (String filter : packageFilters) {
-                if(qualifiedName.contains(filter)) return false;
-            }
-            return true;
-        }
+		private Set<String> findClassQualifiedNames(final File root, final File file,
+				final Set<String> packageFilters) {
+			if (file.isDirectory()) {
+				final File[] files = file.listFiles();
+				final Set<String> classes = new HashSet<String>();
+				for (final File children : files) {
+					classes.addAll(findClassQualifiedNames(root, children,
+							packageFilters));
+				}
+				return classes;
+			} else {
+				if (file.getName().endsWith(".class")) {
+					final String qualifiedName = classNameFor(root, file);
+					if (excludes(qualifiedName, packageFilters)) {
+						return Collections.singleton(qualifiedName);
+					}
+				}
+			}
+			return Collections.emptySet();
+		}
 
-        private String classNameFor(File root, File file) {
-            String temp = file.getAbsolutePath().substring(root.getAbsolutePath().length() + 1).
-                    replace(File.separatorChar, '.');
-            return temp.subSequence(0, temp.indexOf(".class")).toString();
-        }
+		private boolean excludes(final String qualifiedName,
+				final Set<String> packageFilters) {
+			for (final String filter : packageFilters) {
+				if (qualifiedName.contains(filter)) {
+					return false;
+				}
+			}
+			return true;
+		}
 
-    }
+		private String classNameFor(final File root, final File file) {
+			final String temp = file.getAbsolutePath()
+					.substring(root.getAbsolutePath().length() + 1)
+					.replace(File.separatorChar, '.');
+			return temp.subSequence(0, temp.indexOf(".class")).toString();
+		}
+
+	}
 }

--- a/test/org/mockitoutil/ExtraMatchers.java
+++ b/test/org/mockitoutil/ExtraMatchers.java
@@ -5,7 +5,9 @@
 
 package org.mockitoutil;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -16,7 +18,7 @@ import java.util.List;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matcher;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class ExtraMatchers {
 
     public static <T> Assertor<Throwable> hasFirstMethodInStackTrace(final String method) {
@@ -25,8 +27,8 @@ public class ExtraMatchers {
     
     public static <T> Assertor<Throwable> hasOnlyThoseClassesInStackTrace(final String ... classes) {
         return new Assertor<Throwable>() {
-            public void assertValue(Throwable traceElements) {
-                StackTraceElement[] trace = traceElements.getStackTrace();
+            public void assertValue(final Throwable traceElements) {
+                final StackTraceElement[] trace = traceElements.getStackTrace();
                 
                 assertEquals("Number of classes does not match." +
                         "\nExpected: " + Arrays.toString(classes) + 
@@ -42,7 +44,7 @@ public class ExtraMatchers {
     
     public static <T> Assertor<StackTraceElement[]> hasOnlyThoseClasses(final String ... classes) {
         return new Assertor<StackTraceElement[]>() {
-            public void assertValue(StackTraceElement[] traceElements) {
+            public void assertValue(final StackTraceElement[] traceElements) {
                 assertEquals("Number of classes does not match." +
                         "\nExpected: " + Arrays.toString(classes) + 
                         "\nGot: " + Arrays.toString(traceElements),
@@ -60,7 +62,7 @@ public class ExtraMatchers {
 
             private String actualMethodAtIndex;
 
-            public void assertValue(Throwable throwable) {
+            public void assertValue(final Throwable throwable) {
                 actualMethodAtIndex = throwable.getStackTrace()[stackTraceIndex].getMethodName();
                 assertTrue(
                     "Method at index: " + stackTraceIndex + 
@@ -76,7 +78,7 @@ public class ExtraMatchers {
     public static <T> Assertor<Object> hasBridgeMethod(final String methodName) {
         return new Assertor<Object>() {
 
-            public void assertValue(Object o) {
+            public void assertValue(final Object o) {
                 Class clazz = null;
                 if (o instanceof Class) {
                     clazz = (Class) o;
@@ -84,7 +86,7 @@ public class ExtraMatchers {
                     clazz = o.getClass();
                 }
                 
-                for (Method m : clazz.getMethods()) {
+                for (final Method m : clazz.getMethods()) {
                     if (m.isBridge() && m.getName().equals(methodName)) {
                         return;
                     }
@@ -98,10 +100,10 @@ public class ExtraMatchers {
     public static <T> Assertor<Collection> hasExactlyInOrder(final T ... elements) {
         return new Assertor<Collection>() {
 
-            public void assertValue(Collection value) {
+            public void assertValue(final Collection value) {
                 assertEquals(elements.length, value.size());
                 
-                boolean containsSublist = Collections.indexOfSubList((List<?>) value, Arrays.asList(elements)) != -1;
+                final boolean containsSublist = Collections.indexOfSubList((List<?>) value, Arrays.asList(elements)) != -1;
                 assertTrue(
                         "Elements:" +
                         "\n" + 
@@ -117,10 +119,10 @@ public class ExtraMatchers {
     public static <T> Assertor<Collection> contains(final Matcher<T> ... elements) {
         return new Assertor<Collection>() {
             
-            public void assertValue(Collection value) {
+            public void assertValue(final Collection value) {
                 int matched = 0;
-                for (Matcher<T> m : elements) {
-                    for (Object el : value) {
+                for (final Matcher<T> m : elements) {
+                    for (final Object el : value) {
                         if (m.matches(el)) {
                             matched++;
                             continue;
@@ -133,14 +135,14 @@ public class ExtraMatchers {
         };
     }
     
-    public static org.hamcrest.Matcher<java.lang.Object> clazz(java.lang.Class<?> type) {
+    public static org.hamcrest.Matcher<java.lang.Object> clazz(final java.lang.Class<?> type) {
         return CoreMatchers.is(type);
     }
 
     public static Assertor hasMethodsInStackTrace(final String ... methods) {
         return new Assertor<Throwable>() {
-            public void assertValue(Throwable value) {
-                StackTraceElement[] trace = value.getStackTrace();
+            public void assertValue(final Throwable value) {
+                final StackTraceElement[] trace = value.getStackTrace();
                 for (int i = 0; i < methods.length; i++) {
                     assertEquals("Expected methods[" + i + "] to be in the stack trace.", methods[i], trace[i].getMethodName());
                 }

--- a/test/org/mockitoutil/SimplePerRealmReloadingClassLoader.java
+++ b/test/org/mockitoutil/SimplePerRealmReloadingClassLoader.java
@@ -14,7 +14,7 @@ import java.util.concurrent.Callable;
  */
 public class SimplePerRealmReloadingClassLoader extends URLClassLoader {
 
-    private final Map<String,Class> classHashMap = new HashMap<String, Class>();
+    private final Map<String, Class> classHashMap = new HashMap<String, Class>();
     private ReloadClassPredicate reloadClassPredicate;
 
     public SimplePerRealmReloadingClassLoader(ReloadClassPredicate reloadClassPredicate) {

--- a/test/org/mockitoutil/SimplePerRealmReloadingClassLoader.java
+++ b/test/org/mockitoutil/SimplePerRealmReloadingClassLoader.java
@@ -12,17 +12,18 @@ import java.util.concurrent.Callable;
  *
  * Each class can be reloaded in the realm if the LoadClassPredicate says so.
  */
+@SuppressWarnings("rawtypes")
 public class SimplePerRealmReloadingClassLoader extends URLClassLoader {
 
     private final Map<String, Class> classHashMap = new HashMap<String, Class>();
-    private ReloadClassPredicate reloadClassPredicate;
+    private final ReloadClassPredicate reloadClassPredicate;
 
-    public SimplePerRealmReloadingClassLoader(ReloadClassPredicate reloadClassPredicate) {
+    public SimplePerRealmReloadingClassLoader(final ReloadClassPredicate reloadClassPredicate) {
         super(getPossibleClassPathsUrls());
         this.reloadClassPredicate = reloadClassPredicate;
     }
 
-    public SimplePerRealmReloadingClassLoader(ClassLoader parentClassLoader, ReloadClassPredicate reloadClassPredicate) {
+    public SimplePerRealmReloadingClassLoader(final ClassLoader parentClassLoader, final ReloadClassPredicate reloadClassPredicate) {
         super(getPossibleClassPathsUrls(), parentClassLoader);
         this.reloadClassPredicate = reloadClassPredicate;
     }
@@ -36,17 +37,17 @@ public class SimplePerRealmReloadingClassLoader extends URLClassLoader {
     }
 
     private static URL obtainClassPath() {
-        String className = SimplePerRealmReloadingClassLoader.class.getName();
+        final String className = SimplePerRealmReloadingClassLoader.class.getName();
         return obtainClassPath(className);
     }
 
-    private static URL obtainClassPath(String className) {
-        String path = className.replace('.', '/') + ".class";
-        String url = SimplePerRealmReloadingClassLoader.class.getClassLoader().getResource(path).toExternalForm();
+    private static URL obtainClassPath(final String className) {
+        final String path = className.replace('.', '/') + ".class";
+        final String url = SimplePerRealmReloadingClassLoader.class.getClassLoader().getResource(path).toExternalForm();
 
         try {
             return new URL(url.substring(0, url.length() - path.length()));
-        } catch (MalformedURLException e) {
+        } catch (final MalformedURLException e) {
             throw new RuntimeException("Classloader couldn't obtain a proper classpath URL", e);
         }
     }
@@ -54,12 +55,12 @@ public class SimplePerRealmReloadingClassLoader extends URLClassLoader {
 
 
     @Override
-    public Class<?> loadClass(String qualifiedClassName) throws ClassNotFoundException {
+    public Class<?> loadClass(final String qualifiedClassName) throws ClassNotFoundException {
         if(reloadClassPredicate.acceptReloadOf(qualifiedClassName)) {
             // return customLoadClass(qualifiedClassName);
 //            Class<?> loadedClass = findLoadedClass(qualifiedClassName);
             if(!classHashMap.containsKey(qualifiedClassName)) {
-                Class<?> foundClass = findClass(qualifiedClassName);
+                final Class<?> foundClass = findClass(qualifiedClassName);
                 saveFoundClass(qualifiedClassName, foundClass);
                 return foundClass;
             }
@@ -69,23 +70,23 @@ public class SimplePerRealmReloadingClassLoader extends URLClassLoader {
         return useParentClassLoaderFor(qualifiedClassName);
     }
 
-    private void saveFoundClass(String qualifiedClassName, Class<?> foundClass) {
+    private void saveFoundClass(final String qualifiedClassName, final Class<?> foundClass) {
         classHashMap.put(qualifiedClassName, foundClass);
     }
 
 
-    private Class<?> useParentClassLoaderFor(String qualifiedName) throws ClassNotFoundException {
+    private Class<?> useParentClassLoaderFor(final String qualifiedName) throws ClassNotFoundException {
         return super.loadClass(qualifiedName);
     }
 
 
-    public Object doInRealm(String callableCalledInClassLoaderRealm) throws Exception {
-        ClassLoader current = Thread.currentThread().getContextClassLoader();
+    public Object doInRealm(final String callableCalledInClassLoaderRealm) throws Exception {
+        final ClassLoader current = Thread.currentThread().getContextClassLoader();
         try {
             Thread.currentThread().setContextClassLoader(this);
-            Object instance = this.loadClass(callableCalledInClassLoaderRealm).getConstructor().newInstance();
+            final Object instance = this.loadClass(callableCalledInClassLoaderRealm).getConstructor().newInstance();
             if (instance instanceof Callable) {
-                Callable<?> callableInRealm = (Callable<?>) instance;
+                final Callable<?> callableInRealm = (Callable<?>) instance;
                 return callableInRealm.call();
             }
         } finally {
@@ -95,13 +96,13 @@ public class SimplePerRealmReloadingClassLoader extends URLClassLoader {
     }
 
 
-    public Object doInRealm(String callableCalledInClassLoaderRealm, Class[] argTypes, Object[] args) throws Exception {
-        ClassLoader current = Thread.currentThread().getContextClassLoader();
+    public Object doInRealm(final String callableCalledInClassLoaderRealm, final Class[] argTypes, final Object[] args) throws Exception {
+        final ClassLoader current = Thread.currentThread().getContextClassLoader();
         try {
             Thread.currentThread().setContextClassLoader(this);
-            Object instance = this.loadClass(callableCalledInClassLoaderRealm).getConstructor(argTypes).newInstance(args);
+            final Object instance = this.loadClass(callableCalledInClassLoaderRealm).getConstructor(argTypes).newInstance(args);
             if (instance instanceof Callable) {
-                Callable<?> callableInRealm = (Callable<?>) instance;
+                final Callable<?> callableInRealm = (Callable<?>) instance;
                 return callableInRealm.call();
             }
         } finally {
@@ -113,6 +114,6 @@ public class SimplePerRealmReloadingClassLoader extends URLClassLoader {
 
 
     public interface ReloadClassPredicate {
-        boolean acceptReloadOf(String qualifiedName);
+        boolean acceptReloadOf(final String qualifiedName);
     }
 }

--- a/test/org/mockitoutil/SimpleSerializationUtil.java
+++ b/test/org/mockitoutil/SimpleSerializationUtil.java
@@ -1,7 +1,5 @@
 package org.mockitoutil;
 
-import junit.framework.Assert;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -9,28 +7,31 @@ import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
+import junit.framework.Assert;
+
 public abstract class SimpleSerializationUtil {
 
     //TODO use widely
-    public static <T> T serializeAndBack(T obj) throws Exception {
-        ByteArrayOutputStream os = serializeMock(obj);
+    @SuppressWarnings("unchecked")
+    public static <T> T serializeAndBack(final T obj) throws Exception {
+        final ByteArrayOutputStream os = serializeMock(obj);
         return (T) deserializeMock(os, Object.class);
     }
 
-    public static <T> T deserializeMock(ByteArrayOutputStream serialized, Class<T> type) throws IOException,
+    public static <T> T deserializeMock(final ByteArrayOutputStream serialized, final Class<T> type) throws IOException,
             ClassNotFoundException {
-        InputStream unserialize = new ByteArrayInputStream(serialized.toByteArray());
+        final InputStream unserialize = new ByteArrayInputStream(serialized.toByteArray());
         return deserializeMock(unserialize, type);
     }
 
-    public static <T> T deserializeMock(InputStream unserialize, Class<T> type) throws IOException, ClassNotFoundException {
-        Object readObject = new ObjectInputStream(unserialize).readObject();
+    public static <T> T deserializeMock(final InputStream unserialize, final Class<T> type) throws IOException, ClassNotFoundException {
+        final Object readObject = new ObjectInputStream(unserialize).readObject();
         Assert.assertNotNull(readObject);
         return type.cast(readObject);
     }
 
-    public static ByteArrayOutputStream serializeMock(Object mock) throws IOException {
-        ByteArrayOutputStream serialized = new ByteArrayOutputStream();
+    public static ByteArrayOutputStream serializeMock(final Object mock) throws IOException {
+        final ByteArrayOutputStream serialized = new ByteArrayOutputStream();
         new ObjectOutputStream(serialized).writeObject(mock);
         return serialized;
     }

--- a/test/org/mockitoutil/TestBase.java
+++ b/test/org/mockitoutil/TestBase.java
@@ -5,7 +5,15 @@
 
 package org.mockitoutil;
 
+import static org.mockito.Mockito.mock;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Collection;
+
 import junit.framework.Assert;
+
 import org.fest.assertions.Assertions;
 import org.fest.assertions.Condition;
 import org.hamcrest.Matcher;
@@ -23,25 +31,18 @@ import org.mockito.internal.invocation.realmethod.RealMethod;
 import org.mockito.internal.util.MockUtil;
 import org.mockito.invocation.Invocation;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.PrintStream;
-import java.util.Collection;
-
-import static org.mockito.Mockito.mock;
-
 /**
  * the easiest way to make sure that tests clean up invalid state is to require
  * valid state for all tests.
  */
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class TestBase extends Assert {
 
     @After
     public void cleanUpConfigInAnyCase() {
         ConfigurationAccess.getConfig().overrideCleansStackTrace(false);
         ConfigurationAccess.getConfig().overrideDefaultAnswer(null);
-        StateMaster state = new StateMaster();
+        final StateMaster state = new StateMaster();
         //catch any invalid state left over after test case run
         //this way we can catch early if some Mockito operations leave weird state afterwards
         state.validate();
@@ -67,21 +68,21 @@ public class TestBase extends Assert {
     }
 
     //I'm really tired of matchers, enter the assertor!
-    protected static <T> void assertThat(T o, Assertor<T> a) {
+    protected static <T> void assertThat(final T o, final Assertor<T> a) {
         a.assertValue(o);
     }
     
-    protected static <T> void assertThat(T actual, Matcher<T> m) {
+    protected static <T> void assertThat(final T actual, final Matcher<T> m) {
         org.junit.Assert.assertThat(actual, m);
     }
     
-    protected static <T> void assertThat(String message, T actual, Matcher<T> m) {
+    protected static <T> void assertThat(final String message, final T actual, final Matcher<T> m) {
         org.junit.Assert.assertThat(message, actual, m);
     }
     
     public static <T> Assertor<String> endsWith(final String substring) {
         return new Assertor<String>() {
-            public void assertValue(String value) {
+            public void assertValue(final String value) {
                 assertTrue("This substring: \n" + substring + 
                         "\nshould be at the end of:\n" + value
                         , value.endsWith(substring));
@@ -89,11 +90,11 @@ public class TestBase extends Assert {
         };
     }
     
-    public static void assertNotEquals(Object expected, Object got) {
+    public static void assertNotEquals(final Object expected, final Object got) {
         assertFalse(expected.equals(got));
     }
 
-    public static void assertContains(String sub, String string) {
+    public static void assertContains(final String sub, final String string) {
         assertTrue("\n" +
                 "This substring:[" +
                 sub +
@@ -104,7 +105,7 @@ public class TestBase extends Assert {
                 , string.contains(sub));
     }
 
-    public static void assertContainsIgnoringCase(String sub, String string) {
+    public static void assertContainsIgnoringCase(final String sub, final String string) {
         assertTrue("\n" +
                 "This substring:" +
                 sub +
@@ -115,14 +116,14 @@ public class TestBase extends Assert {
                 , containsIgnoringCase(string, sub));
     }
 
-    private static boolean containsIgnoringCase(String string, String sub) {
-        int subLength = sub.length();
+    private static boolean containsIgnoringCase(final String string, final String sub) {
+        final int subLength = sub.length();
         if (string.length() < subLength) {
             return false;
         }
         int i = 0;
         while(i+subLength <= string.length()) {
-            boolean temp = string.substring(i, i+subLength).equalsIgnoreCase(sub);
+            final boolean temp = string.substring(i, i+subLength).equalsIgnoreCase(sub);
             if (temp) {
                 return true;
             }
@@ -131,7 +132,7 @@ public class TestBase extends Assert {
         return false;
     }
 
-    public static void assertNotContains(String sub, String string) {
+    public static void assertNotContains(final String sub, final String string) {
         assertFalse("\n" +
                 "This substring:" +
                 sub +
@@ -142,8 +143,8 @@ public class TestBase extends Assert {
                 , string.contains(sub));
     }
     
-    protected static Invocation invocationOf(Class<?> type, String methodName, Object ... args) throws NoSuchMethodException {
-        Class[] types = new Class[args.length];
+    protected static Invocation invocationOf(final Class<?> type, final String methodName, final Object ... args) throws NoSuchMethodException {
+        final Class[] types = new Class[args.length];
         for (int i = 0; i < args.length; i++) {
             types[i] = args[i].getClass();
         }
@@ -151,24 +152,24 @@ public class TestBase extends Assert {
                 types)), args, 1, null);
     }
 
-    protected static Invocation invocationOf(Class<?> type, String methodName, RealMethod realMethod) throws NoSuchMethodException {
+    protected static Invocation invocationOf(final Class<?> type, final String methodName, final RealMethod realMethod) throws NoSuchMethodException {
         return new InvocationImpl(new Object(), new SerializableMethod(type.getMethod(methodName,
                 new Class[0])), new Object[0], 1, realMethod);
     }
 
-    protected static String describe(SelfDescribing m) {
+    protected static String describe(final SelfDescribing m) {
         return StringDescription.toString(m);
     }
 
-    protected boolean isMock(Object o) {
+    protected boolean isMock(final Object o) {
         return new MockUtil().isMock(o);
     }
 
     protected void assertContainsType(final Collection<?> list, final Class<?> clazz) {
         Assertions.assertThat(list).satisfies(new Condition<Collection<?>>() {
             @Override
-            public boolean matches(Collection<?> objects) {
-                for (Object object : objects) {
+            public boolean matches(final Collection<?> objects) {
+                for (final Object object : objects) {
                     if (clazz.isAssignableFrom(object.getClass())) {
                         return true;
                     }
@@ -178,12 +179,12 @@ public class TestBase extends Assert {
         });
     }
 
-    protected String getStackTrace(Throwable e) {
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
+    protected String getStackTrace(final Throwable e) {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
         e.printStackTrace(new PrintStream(out));
         try {
             out.close();
-        } catch (IOException ex) {}
+        } catch (final IOException ex) {}
         return out.toString();
     }
 }


### PR DESCRIPTION
Originally the repository contained over 1100 warnings, this has been reduced to 47.

Most of the fixes are simple suppression warning fixes/additions or imports. I also auto-added (<3 Eclipse save-actions) the final modifiers to speed up the compiler. Therefore the test suite should run a bit faster now.

The number of files changes is insanely high and I used (and fixed) the Checkstyle configuration in the repository. I hope this is still the desired configuration.