### PR TITLE
Fixes #220 constructor invoking methods raise NPE

### DIFF
--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -35,8 +35,8 @@ task mockitoJavadoc(type: Javadoc) {
         <script type="text/javascript">
           var usingOldIE = \$.browser.msie && parseInt(\$.browser.version) < 9;
           if(!usingOldIE) {
-              \$("head").append("<link rel=\\"shortcut icon\\" href=\\"@{docRoot}/favicon.ico?v=cafebabe\\">")
-              \$("head", window.parent.document).append("<link rel=\\"shortcut icon\\" href=\\"@{docRoot}/favicon.ico?v=cafebabe\\">")
+              \$("head").append("<link rel=\\"shortcut icon\\" href=\\"{@docRoot}/favicon.ico?v=cafebabe\\">")
+              \$("head", window.parent.document).append("<link rel=\\"shortcut icon\\" href=\\"{@docRoot}/favicon.ico?v=cafebabe\\">")
               hljs.initHighlightingOnLoad();
               injectProjectVersionForJavadocJDK6("Mockito ${project.version} API",
                                                  "em#mockito-version-header-javadoc7-header",

--- a/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMaker.java
+++ b/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMaker.java
@@ -1,14 +1,16 @@
 package org.mockito.internal.creation.bytebuddy;
 
-import static org.mockito.internal.util.StringJoiner.join;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.InternalMockHandler;
+import org.mockito.internal.creation.bytebuddy.MockMethodInterceptor.MockAccess;
 import org.mockito.internal.creation.instance.Instantiator;
 import org.mockito.internal.creation.instance.InstantiatorProvider;
 import org.mockito.invocation.MockHandler;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.mock.SerializableMode;
 import org.mockito.plugins.MockMaker;
+
+import static org.mockito.internal.util.StringJoiner.join;
 
 public class ByteBuddyMockMaker implements MockMaker {
 
@@ -25,7 +27,7 @@ public class ByteBuddyMockMaker implements MockMaker {
         T mockInstance = null;
         try {
             mockInstance = instantiator.newInstance(mockedProxyType);
-            MockMethodInterceptor.MockAccess mockAccess = (MockMethodInterceptor.MockAccess) mockInstance;
+            MockAccess mockAccess = (MockAccess) mockInstance;
             mockAccess.setMockitoInterceptor(new MockMethodInterceptor(asInternalMockHandler(handler), settings));
 
             return ensureMockIsAssignableToMockedType(settings, mockInstance);
@@ -75,14 +77,14 @@ public class ByteBuddyMockMaker implements MockMaker {
     }
 
     public MockHandler getHandler(Object mock) {
-        if (!(mock instanceof MockMethodInterceptor.MockAccess)) {
+        if (!(mock instanceof MockAccess)) {
             return null;
         }
-        return ((MockMethodInterceptor.MockAccess) mock).getMockitoInterceptor().getMockHandler();
+        return ((MockAccess) mock).getMockitoInterceptor().getMockHandler();
     }
 
     public void resetMock(Object mock, MockHandler newHandler, MockCreationSettings settings) {
-        ((MockMethodInterceptor.MockAccess) mock).setMockitoInterceptor(
+        ((MockAccess) mock).setMockitoInterceptor(
                 new MockMethodInterceptor(asInternalMockHandler(newHandler), settings)
         );
     }

--- a/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/MockBytecodeGenerator.java
+++ b/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/MockBytecodeGenerator.java
@@ -5,9 +5,17 @@ import net.bytebuddy.ClassFileVersion;
 import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import net.bytebuddy.dynamic.scaffold.subclass.ConstructorStrategy;
+import net.bytebuddy.implementation.FieldAccessor;
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.implementation.MethodDelegation;
 import net.bytebuddy.implementation.attribute.MethodAttributeAppender;
 import net.bytebuddy.implementation.attribute.TypeAttributeAppender;
+import net.bytebuddy.implementation.bind.annotation.FieldProxy;
 import org.mockito.internal.creation.bytebuddy.ByteBuddyCrossClassLoaderSerializationSupport.CrossClassLoaderSerializableMock;
+import org.mockito.internal.creation.bytebuddy.MockMethodInterceptor.InterceptionDispatcher;
+import org.mockito.internal.creation.bytebuddy.MockMethodInterceptor.InterceptionDispatcher.FieldGetter;
+import org.mockito.internal.creation.bytebuddy.MockMethodInterceptor.InterceptionDispatcher.FieldSetter;
+import org.mockito.internal.creation.bytebuddy.MockMethodInterceptor.MockAccess;
 import org.mockito.internal.creation.util.SearchingClassLoader;
 
 import java.util.Random;
@@ -15,21 +23,22 @@ import java.util.Random;
 import static net.bytebuddy.description.modifier.FieldManifestation.FINAL;
 import static net.bytebuddy.description.modifier.Ownership.STATIC;
 import static net.bytebuddy.description.modifier.Visibility.PRIVATE;
-import static net.bytebuddy.implementation.FieldAccessor.ofBeanProperty;
 import static net.bytebuddy.implementation.MethodDelegation.to;
-import static net.bytebuddy.implementation.MethodDelegation.toInstanceField;
 import static net.bytebuddy.matcher.ElementMatchers.*;
 
 class MockBytecodeGenerator {
     private final ByteBuddy byteBuddy;
     private final Random random;
+    private final Implementation delegation;
 
     public MockBytecodeGenerator() {
         byteBuddy = new ByteBuddy(ClassFileVersion.JAVA_V5)
-//                .withIgnoredMethods(isBridge())
                 .withDefaultMethodAttributeAppender(MethodAttributeAppender.ForInstrumentedMethod.INSTANCE)
                 .withAttribute(TypeAttributeAppender.ForSuperType.INSTANCE);
 
+        delegation = MethodDelegation.to(InterceptionDispatcher.class)
+                                     .appendParameterBinder(FieldProxy.Binder.install(FieldGetter.class,
+                                                                                      FieldSetter.class));
         random = new Random();
     }
 
@@ -38,9 +47,9 @@ class MockBytecodeGenerator {
                 byteBuddy.subclass(features.mockedType, ConstructorStrategy.Default.IMITATE_SUPER_TYPE)
                          .name(nameFor(features.mockedType))
                          .implement(features.interfaces.toArray(new Class<?>[features.interfaces.size()]))
-                         .method(any()).intercept(toInstanceField(MockMethodInterceptor.class, "mockitoInterceptor")
-                                                          .filter(isDeclaredBy(MockMethodInterceptor.class)))
-                         .implement(MockMethodInterceptor.MockAccess.class).intercept(ofBeanProperty())
+                         .method(any()).intercept(delegation)
+                         .defineField("mockitoInterceptor", MockMethodInterceptor.class, PRIVATE)
+                         .implement(MockAccess.class).intercept(FieldAccessor.ofBeanProperty())
                          .method(isHashCode()).intercept(to(MockMethodInterceptor.ForHashCode.class))
                          .method(isEquals()).intercept(to(MockMethodInterceptor.ForEquals.class))
                          .defineField("serialVersionUID", long.class, STATIC, PRIVATE, FINAL).value(42L);
@@ -48,16 +57,17 @@ class MockBytecodeGenerator {
             builder = builder.implement(CrossClassLoaderSerializableMock.class)
                              .intercept(to(MockMethodInterceptor.ForWriteReplace.class));
         }
+        return builder.make()
+                      .load(SearchingClassLoader.combineLoadersOf(allMockedTypes(features)), ClassLoadingStrategy.Default.INJECTION)
+                      .getLoaded();
+    }
+
+    private <T> Class<?>[] allMockedTypes(MockFeatures<T> features) {
         Class<?>[] allMockedTypes = new Class<?>[features.interfaces.size() + 1];
         allMockedTypes[0] = features.mockedType;
-//            System.arraycopy(interfaces.toArray(), 0, allMockedTypes, 1, interfaces.size());
-        int index = 1;
-        for (Class<?> type : features.interfaces) {
-            allMockedTypes[index++] = type;
-        }
-        return builder.make()
-                      .load(SearchingClassLoader.combineLoadersOf(allMockedTypes), ClassLoadingStrategy.Default.INJECTION)
-                      .getLoaded();
+        System.arraycopy(features.interfaces.toArray(), 0,
+                         (Object[]) allMockedTypes, 1, features.interfaces.size());
+        return allMockedTypes;
     }
 
     // TODO inspect naming strategy (for OSGI, signed package, java.* (and bootstrap classes), etc...)

--- a/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/MockMethodInterceptor.java
+++ b/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/MockMethodInterceptor.java
@@ -1,9 +1,6 @@
 package org.mockito.internal.creation.bytebuddy;
 
-import java.io.ObjectStreamException;
-import java.io.Serializable;
-import java.lang.reflect.Method;
-import java.util.concurrent.Callable;
+import net.bytebuddy.implementation.bind.annotation.*;
 import org.mockito.internal.InternalMockHandler;
 import org.mockito.internal.creation.DelegatingMethod;
 import org.mockito.internal.invocation.MockitoMethod;
@@ -11,14 +8,11 @@ import org.mockito.internal.invocation.SerializableMethod;
 import org.mockito.internal.progress.SequenceNumber;
 import org.mockito.invocation.MockHandler;
 import org.mockito.mock.MockCreationSettings;
-import net.bytebuddy.implementation.bind.annotation.AllArguments;
-import net.bytebuddy.implementation.bind.annotation.Argument;
-import net.bytebuddy.implementation.bind.annotation.BindingPriority;
-import net.bytebuddy.implementation.bind.annotation.DefaultCall;
-import net.bytebuddy.implementation.bind.annotation.Origin;
-import net.bytebuddy.implementation.bind.annotation.RuntimeType;
-import net.bytebuddy.implementation.bind.annotation.SuperCall;
-import net.bytebuddy.implementation.bind.annotation.This;
+
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.util.concurrent.Callable;
 
 public class MockMethodInterceptor implements Serializable {
 
@@ -122,8 +116,53 @@ public class MockMethodInterceptor implements Serializable {
         }
     }
 
-    public static interface MockAccess {
+    public interface MockAccess {
         MockMethodInterceptor getMockitoInterceptor();
         void setMockitoInterceptor(MockMethodInterceptor mockMethodInterceptor);
+    }
+
+    public static class InterceptionDispatcher {
+        public interface FieldGetter<T> {
+            T getValue();
+        }
+        public interface FieldSetter<T> {
+            void setValue(T value);
+        }
+
+        @RuntimeType
+        @BindingPriority(BindingPriority.DEFAULT * 2)
+        public static Object interceptSuperCallable(@This Object mock,
+                                                    @FieldProxy("mockitoInterceptor") FieldGetter<MockMethodInterceptor> fieldGetter,
+                                                    @Origin Method invokedMethod,
+                                                    @AllArguments Object[] arguments,
+                                                    @SuperCall(serializableProxy = true) Callable<?> superCall) throws Throwable {
+            MockMethodInterceptor interceptor = fieldGetter.getValue();
+            if (interceptor == null) {
+                return null;
+            }
+            return interceptor.doIntercept(
+                    mock,
+                    invokedMethod,
+                    arguments,
+                    new InterceptedInvocation.SuperMethod.FromCallable(superCall)
+            );
+        }
+
+        @RuntimeType
+        public static Object interceptAbstract(@This Object mock,
+                                               @FieldProxy("mockitoInterceptor") FieldGetter<MockMethodInterceptor> fieldGetter,
+                                               @Origin(cache = true) Method invokedMethod,
+                                               @AllArguments Object[] arguments) throws Throwable {
+            MockMethodInterceptor interceptor = fieldGetter.getValue();
+            if (interceptor == null) {
+                return null;
+            }
+            return interceptor.doIntercept(
+                    mock,
+                    invokedMethod,
+                    arguments,
+                    InterceptedInvocation.SuperMethod.IsIllegal.INSTANCE
+            );
+        }
     }
 }

--- a/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/MockMethodInterceptor.java
+++ b/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/MockMethodInterceptor.java
@@ -121,7 +121,7 @@ public class MockMethodInterceptor implements Serializable {
         void setMockitoInterceptor(MockMethodInterceptor mockMethodInterceptor);
     }
 
-    public static class InterceptionDispatcher {
+    public static class DispatcherDefaultingToRealMethod {
         public interface FieldGetter<T> {
             T getValue();
         }
@@ -138,7 +138,7 @@ public class MockMethodInterceptor implements Serializable {
                                                     @SuperCall(serializableProxy = true) Callable<?> superCall) throws Throwable {
             MockMethodInterceptor interceptor = fieldGetter.getValue();
             if (interceptor == null) {
-                return null;
+                return superCall.call();
             }
             return interceptor.doIntercept(
                     mock,

--- a/test/org/mockitousage/bugs/ConstructorInvokingMethodShouldNotRaiseExceptionTest.java
+++ b/test/org/mockitousage/bugs/ConstructorInvokingMethodShouldNotRaiseExceptionTest.java
@@ -1,21 +1,46 @@
 package org.mockitousage.bugs;
 
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 
+@RunWith(Enclosed.class)
 public class ConstructorInvokingMethodShouldNotRaiseExceptionTest {
-    @Spy HasConstructorInvokingMethod hasConstructorInvokingMethod;
 
-    @Test
-    public void should_be_able_to_create_spy() throws Exception {
-        MockitoAnnotations.initMocks(this);
+    public static class WithDumbMethod {
+        @Spy
+        HasConstructorInvokingMethod hasConstructorInvokingMethod;
+
+        @Test
+        public void should_be_able_to_create_spy() throws Exception {
+            MockitoAnnotations.initMocks(this);
+        }
+
+        private static class HasConstructorInvokingMethod {
+            public HasConstructorInvokingMethod() { someMethod(); }
+
+            void someMethod() { }
+        }
     }
 
-    private static class HasConstructorInvokingMethod {
-        public HasConstructorInvokingMethod() {
-            someMethod();
+    public static class UsingMethodResult {
+        @Spy
+        HasConstructorInvokingMethod hasConstructorInvokingMethod;
+
+        @Test
+        public void should_be_able_to_create_spy() throws Exception {
+            MockitoAnnotations.initMocks(this);
         }
-        void someMethod() { }
+
+        private static class HasConstructorInvokingMethod {
+            private final boolean doesIt;
+            public HasConstructorInvokingMethod() {
+                doesIt = someMethod().contains("yup");
+            }
+
+            String someMethod() { return "tada!"; }
+        }
     }
 }

--- a/test/org/mockitousage/bugs/ConstructorInvokingMethodShouldNotRaiseExceptionTest.java
+++ b/test/org/mockitousage/bugs/ConstructorInvokingMethodShouldNotRaiseExceptionTest.java
@@ -1,0 +1,21 @@
+package org.mockitousage.bugs;
+
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+public class ConstructorInvokingMethodShouldNotRaiseExceptionTest {
+    @Spy HasConstructorInvokingMethod hasConstructorInvokingMethod;
+
+    @Test
+    public void should_be_able_to_create_spy() throws Exception {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    private static class HasConstructorInvokingMethod {
+        public HasConstructorInvokingMethod() {
+            someMethod();
+        }
+        void someMethod() { }
+    }
+}


### PR DESCRIPTION
In some recent version of mockito `@Spy` annotation will use the constructor rather than objenesis, that mean that constructor carry actual work. But since the interceptor set after instantiation, this raised an NPE with ByteBuddy. It wasn't an issue with CGLIB but it probably didn't event intercept such calls (unconfirmed at this point).

This PR aims to fix that by calling real code, if interceptor is not set, which can only happen if `ConstructorInstanciator` is used

Thanks to @raphw for his tip on this regard as well : https://github.com/raphw/byte-buddy/issues/32#issuecomment-113269844