### PR TITLE
Moves responsibility of isTypeMockable to MockMaker

### DIFF
--- a/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMaker.java
+++ b/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMaker.java
@@ -95,8 +95,24 @@ public class ByteBuddyMockMaker implements MockMaker {
     }
 
     @Override
-    public boolean isTypeMockable(Class<?> type) {
-        return !type.isPrimitive() && !Modifier.isFinal(type.getModifiers());
+    public TypeMockability isTypeMockable(final Class<?> type) {
+        return new TypeMockability() {
+            @Override
+            public boolean mockable() {
+                return !type.isPrimitive() && !Modifier.isFinal(type.getModifiers());
+            }
+
+            @Override
+            public String nonMockableReason() {
+                if(type.isPrimitive()) {
+                    return "primitive type";
+                }
+                if(Modifier.isFinal(type.getModifiers())) {
+                    return "final or anonymous class";
+                }
+                return join("not handled type");
+            }
+        };
     }
 
     private static InternalMockHandler asInternalMockHandler(MockHandler handler) {
@@ -109,4 +125,5 @@ public class ByteBuddyMockMaker implements MockMaker {
         }
         return (InternalMockHandler) handler;
     }
+
 }

--- a/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMaker.java
+++ b/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMaker.java
@@ -10,6 +10,8 @@ import org.mockito.mock.MockCreationSettings;
 import org.mockito.mock.SerializableMode;
 import org.mockito.plugins.MockMaker;
 
+import java.lang.reflect.Modifier;
+
 import static org.mockito.internal.util.StringJoiner.join;
 
 public class ByteBuddyMockMaker implements MockMaker {
@@ -20,6 +22,7 @@ public class ByteBuddyMockMaker implements MockMaker {
         cachingMockBytecodeGenerator = new CachingMockBytecodeGenerator();
     }
 
+    @Override
     public <T> T createMock(MockCreationSettings<T> settings, MockHandler handler) {
         Class<T> mockedProxyType = createProxyClass(mockWithFeaturesFrom(settings));
 
@@ -63,7 +66,7 @@ public class ByteBuddyMockMaker implements MockMaker {
     private <T> T ensureMockIsAssignableToMockedType(MockCreationSettings<T> settings, T mock) {
         // Force explicit cast to mocked type here, instead of
         // relying on the JVM to implicitly cast on the client call site.
-        // This allows us to catch the ClassCastException earlier
+        // This allows us to catch earlier the ClassCastException earlier
         Class<T> typeToMock = settings.getTypeToMock();
         return typeToMock.cast(mock);
     }
@@ -76,6 +79,7 @@ public class ByteBuddyMockMaker implements MockMaker {
         return instance == null ? "null" : describeClass(instance.getClass());
     }
 
+    @Override
     public MockHandler getHandler(Object mock) {
         if (!(mock instanceof MockAccess)) {
             return null;
@@ -83,10 +87,16 @@ public class ByteBuddyMockMaker implements MockMaker {
         return ((MockAccess) mock).getMockitoInterceptor().getMockHandler();
     }
 
+    @Override
     public void resetMock(Object mock, MockHandler newHandler, MockCreationSettings settings) {
         ((MockAccess) mock).setMockitoInterceptor(
                 new MockMethodInterceptor(asInternalMockHandler(newHandler), settings)
         );
+    }
+
+    @Override
+    public boolean isTypeMockable(Class<?> type) {
+        return !type.isPrimitive() && !Modifier.isFinal(type.getModifiers());
     }
 
     private static InternalMockHandler asInternalMockHandler(MockHandler handler) {

--- a/mockmaker/cglib/main/java/org/mockito/internal/creation/cglib/CglibMockMaker.java
+++ b/mockmaker/cglib/main/java/org/mockito/internal/creation/cglib/CglibMockMaker.java
@@ -56,7 +56,23 @@ public class CglibMockMaker implements MockMaker {
     }
 
     @Override
-    public boolean isTypeMockable(Class<?> type) {
-        return !type.isPrimitive() && !Modifier.isFinal(type.getModifiers());
+    public TypeMockability isTypeMockable(final Class<?> type) {
+        return new TypeMockability() {
+            @Override
+            public boolean mockable() {
+                return !type.isPrimitive() && !Modifier.isFinal(type.getModifiers());
+            }
+
+            @Override
+            public String nonMockableReason() {
+                if(type.isPrimitive()) {
+                    return "primitive type";
+                }
+                if(Modifier.isFinal(type.getModifiers())) {
+                    return "final or anonymous class";
+                }
+                return join("not handled type");
+            }
+        };
     }
 }

--- a/mockmaker/cglib/main/java/org/mockito/internal/creation/cglib/CglibMockMaker.java
+++ b/mockmaker/cglib/main/java/org/mockito/internal/creation/cglib/CglibMockMaker.java
@@ -13,11 +13,15 @@ import org.mockito.invocation.MockHandler;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.plugins.MockMaker;
 
+import java.lang.reflect.Modifier;
+
+
 /**
  * A MockMaker that uses cglib to generate mocks on a JVM.
  */
 public class CglibMockMaker implements MockMaker {
 
+    @Override
     public <T> T createMock(MockCreationSettings<T> settings, MockHandler handler) {
         InternalMockHandler mockitoHandler = cast(handler);
         new AcrossJVMSerializationFeature().enableSerializationAcrossJVM(settings);
@@ -33,10 +37,12 @@ public class CglibMockMaker implements MockMaker {
         return (InternalMockHandler) handler;
     }
 
+    @Override
     public void resetMock(Object mock, MockHandler newHandler, MockCreationSettings settings) {
         ((Factory) mock).setCallback(0, new MethodInterceptorFilter(cast(newHandler), settings));
     }
 
+    @Override
     public MockHandler getHandler(Object mock) {
         if (!(mock instanceof Factory)) {
             return null;
@@ -47,5 +53,10 @@ public class CglibMockMaker implements MockMaker {
             return null;
         }
         return ((MethodInterceptorFilter) callback).getHandler();
+    }
+
+    @Override
+    public boolean isTypeMockable(Class<?> type) {
+        return !type.isPrimitive() && !Modifier.isFinal(type.getModifiers());
     }
 }

--- a/src/org/mockito/exceptions/Reporter.java
+++ b/src/org/mockito/exceptions/Reporter.java
@@ -442,13 +442,11 @@ public class Reporter {
         ));
     }
 
-    public void cannotMockFinalClass(Class<?> clazz) {
+    public void cannotMockClass(Class<?> clazz, String reason) {
         throw new MockitoException(join(
                 "Cannot mock/spy " + clazz.toString(),
-                "Mockito cannot mock/spy following:",
-                "  - final classes",
-                "  - anonymous classes",
-                "  - primitive types"
+                "Mockito cannot mock/spy because :",
+                " - " + reason
         ));
     }
 

--- a/src/org/mockito/internal/MockitoCore.java
+++ b/src/org/mockito/internal/MockitoCore.java
@@ -4,9 +4,6 @@
  */
 package org.mockito.internal;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.mockito.InOrder;
 import org.mockito.MockSettings;
 import org.mockito.MockingDetails;
@@ -37,6 +34,9 @@ import org.mockito.stubbing.Stubber;
 import org.mockito.stubbing.VoidMethodStubbable;
 import org.mockito.verification.VerificationMode;
 
+import java.util.Arrays;
+import java.util.List;
+
 @SuppressWarnings("unchecked")
 public class MockitoCore {
 
@@ -45,7 +45,7 @@ public class MockitoCore {
     private final MockingProgress mockingProgress = new ThreadSafeMockingProgress();
 
     public boolean isTypeMockable(Class<?> typeToMock) {
-        return mockUtil.isTypeMockable(typeToMock);
+        return mockUtil.typeMockabilityOf(typeToMock).mockable();
     }
 
     public <T> T mock(Class<T> typeToMock, MockSettings settings) {

--- a/src/org/mockito/internal/util/MockCreationValidator.java
+++ b/src/org/mockito/internal/util/MockCreationValidator.java
@@ -7,6 +7,7 @@ package org.mockito.internal.util;
 import org.mockito.exceptions.Reporter;
 import org.mockito.internal.util.reflection.Constructors;
 import org.mockito.mock.SerializableMode;
+import org.mockito.plugins.MockMaker.TypeMockability;
 
 import java.io.Serializable;
 import java.util.Collection;
@@ -17,8 +18,9 @@ public class MockCreationValidator {
     private final MockUtil mockUtil = new MockUtil();
 
     public void validateType(Class classToMock) {
-        if (!mockUtil.isTypeMockable(classToMock)) {
-            new Reporter().cannotMockFinalClass(classToMock);
+        TypeMockability typeMockability = mockUtil.typeMockabilityOf(classToMock);
+        if (!typeMockability.mockable()) {
+            new Reporter().cannotMockClass(classToMock, typeMockability.nonMockableReason());
         }
     }
 

--- a/src/org/mockito/internal/util/MockUtil.java
+++ b/src/org/mockito/internal/util/MockUtil.java
@@ -16,15 +16,13 @@ import org.mockito.mock.MockCreationSettings;
 import org.mockito.mock.MockName;
 import org.mockito.plugins.MockMaker;
 
-import java.lang.reflect.Modifier;
-
 @SuppressWarnings("unchecked")
 public class MockUtil {
 
     private static final MockMaker mockMaker = Plugins.getMockMaker();
 
     public boolean isTypeMockable(Class<?> type) {
-      return !type.isPrimitive() && !Modifier.isFinal(type.getModifiers());
+      return mockMaker.isTypeMockable(type);
     }
 
     public <T> T createMock(MockCreationSettings<T> settings) {

--- a/src/org/mockito/internal/util/MockUtil.java
+++ b/src/org/mockito/internal/util/MockUtil.java
@@ -15,13 +15,14 @@ import org.mockito.invocation.MockHandler;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.mock.MockName;
 import org.mockito.plugins.MockMaker;
+import org.mockito.plugins.MockMaker.TypeMockability;
 
 @SuppressWarnings("unchecked")
 public class MockUtil {
 
     private static final MockMaker mockMaker = Plugins.getMockMaker();
 
-    public boolean isTypeMockable(Class<?> type) {
+    public TypeMockability typeMockabilityOf(Class<?> type) {
       return mockMaker.isTypeMockable(type);
     }
 

--- a/src/org/mockito/internal/util/reflection/FieldInitializer.java
+++ b/src/org/mockito/internal/util/reflection/FieldInitializer.java
@@ -228,7 +228,7 @@ public class FieldInitializer {
             private int countMockableParams(Constructor<?> constructor) {
                 int constructorMockableParamsSize = 0;
                 for (Class<?> aClass : constructor.getParameterTypes()) {
-                    if(mockUtil.isTypeMockable(aClass)){
+                    if(mockUtil.typeMockabilityOf(aClass).mockable()){
                         constructorMockableParamsSize++;
                     }
                 }

--- a/src/org/mockito/plugins/MockMaker.java
+++ b/src/org/mockito/plugins/MockMaker.java
@@ -4,6 +4,7 @@
  */
 package org.mockito.plugins;
 
+import org.mockito.Incubating;
 import org.mockito.invocation.MockHandler;
 import org.mockito.mock.MockCreationSettings;
 
@@ -110,5 +111,12 @@ public interface MockMaker {
      * @param type The type that may be mocked.
      * @return <code>true</code> if mockable, <code>false</code> otherwise.
      */
-    boolean isTypeMockable(Class<?> type);
+    @Incubating
+    TypeMockability isTypeMockable(Class<?> type);
+
+    @Incubating
+    interface TypeMockability {
+        boolean mockable();
+        String nonMockableReason();
+    }
 }

--- a/src/org/mockito/plugins/MockMaker.java
+++ b/src/org/mockito/plugins/MockMaker.java
@@ -55,7 +55,7 @@ public interface MockMaker {
      *     </li>
      * </ul>
      *
-     * @param settings - mock creation settings like type to mock, extra interfaces and so on.
+     * @param settings Mock creation settings like type to mock, extra interfaces and so on.
      * @param handler See {@link org.mockito.invocation.MockHandler}.
      *                <b>Do not</b> provide your own implementation at this time. Make sure your implementation of
      *                {@link #getHandler(Object)} will return this instance.
@@ -74,7 +74,7 @@ public interface MockMaker {
      * Use the instance provided to you by Mockito at {@link #createMock} or {@link #resetMock}.
      *
      * @param mock The mock instance.
-     * @return may return null - it means that there is no handler attached to provided object.
+     * @return The mock handler, but may return null - it means that there is no handler attached to provided object.
      *   This means the passed object is not really a Mockito mock.
      * @since 1.9.5
      */
@@ -99,4 +99,16 @@ public interface MockMaker {
             MockHandler newHandler,
             MockCreationSettings settings
     );
+
+    /**
+     * Indicates if the given type can be mocked by this mockmaker.
+     *
+     * <p>Mockmaker may have different capabilities in term of mocking, typically
+     * Mockito 1.x's internal mockmaker cannot mock final types. Other implementations, may
+     * have different limitations.</p>
+     *
+     * @param type The type that may be mocked.
+     * @return <code>true</code> if mockable, <code>false</code> otherwise.
+     */
+    boolean isTypeMockable(Class<?> type);
 }

--- a/subprojects/extTest/src/test/java/org/mockitousage/plugins/switcher/MyMockMaker.java
+++ b/subprojects/extTest/src/test/java/org/mockitousage/plugins/switcher/MyMockMaker.java
@@ -22,4 +22,9 @@ public class MyMockMaker extends ByteBuddyMockMaker {
     public void resetMock(Object mock, MockHandler newHandler, MockCreationSettings settings) {
         super.resetMock(mock, newHandler, settings);
     }
+
+    @Override
+    public boolean isTypeMockable(Class<?> type) {
+        return super.isTypeMockable(type);
+    }
 }

--- a/subprojects/extTest/src/test/java/org/mockitousage/plugins/switcher/MyMockMaker.java
+++ b/subprojects/extTest/src/test/java/org/mockitousage/plugins/switcher/MyMockMaker.java
@@ -24,7 +24,7 @@ public class MyMockMaker extends ByteBuddyMockMaker {
     }
 
     @Override
-    public boolean isTypeMockable(Class<?> type) {
+    public TypeMockability isTypeMockable(Class<?> type) {
         return super.isTypeMockable(type);
     }
 }

--- a/test/org/mockito/internal/util/MockCreationValidatorTest.java
+++ b/test/org/mockito/internal/util/MockCreationValidatorTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.fail;
 @SuppressWarnings("unchecked")
 public class MockCreationValidatorTest {
 
-    final class FinalClass {}
     MockCreationValidator validator = new MockCreationValidator();
 
     @Test
@@ -70,5 +69,14 @@ public class MockCreationValidatorTest {
         boolean serializable = true;
         validator.validateSerializable(Observer.class, serializable);
         validator.validateSerializable(Integer.class, serializable);
+    }
+
+    @Test
+    public void should_fail_when_type_not_mockable() throws Exception {
+        try {
+            validator.validateType(long.class);
+        } catch (MockitoException ex) {
+            assertThat(ex.getMessage()).contains("primitive");
+        }
     }
 }

--- a/test/org/mockito/internal/util/MockUtilTest.java
+++ b/test/org/mockito/internal/util/MockUtilTest.java
@@ -5,15 +5,17 @@
 
 package org.mockito.internal.util;
 
-import static org.mockito.Mockito.withSettings;
-import java.util.ArrayList;
-import java.util.List;
 import org.fest.assertions.Assertions;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.exceptions.misusing.NotAMockException;
 import org.mockitoutil.TestBase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.withSettings;
 
 @SuppressWarnings("unchecked")
 public class MockUtilTest extends TestBase {
@@ -80,11 +82,11 @@ public class MockUtilTest extends TestBase {
     interface SomeInterface {}
 
     @Test
-    public void should_konw_if_type_is_mockable() throws Exception {
-        assertFalse(mockUtil.isTypeMockable(FinalClass.class));
-        assertFalse(mockUtil.isTypeMockable(int.class));
+    public void should_know_if_type_is_mockable() throws Exception {
+        assertFalse(mockUtil.typeMockabilityOf(FinalClass.class).mockable());
+        assertFalse(mockUtil.typeMockabilityOf(int.class).mockable());
 
-        assertTrue(mockUtil.isTypeMockable(SomeClass.class));
-        assertTrue(mockUtil.isTypeMockable(SomeInterface.class));
+        assertTrue(mockUtil.typeMockabilityOf(SomeClass.class).mockable());
+        assertTrue(mockUtil.typeMockabilityOf(SomeInterface.class).mockable());
     }
 }

--- a/test/org/mockitousage/annotation/MockInjectionUsingConstructorTest.java
+++ b/test/org/mockitousage/annotation/MockInjectionUsingConstructorTest.java
@@ -25,7 +25,10 @@ import java.util.List;
 import java.util.Set;
 
 import static org.fest.assertions.Assertions.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -61,6 +64,7 @@ public class MockInjectionUsingConstructorTest {
     @Test
     public void constructor_is_called_for_each_test_in_test_class() throws Exception {
         // given
+        junit_test_with_3_tests_methods.constructor_instantiation = 0;
         JUnitCore jUnitCore = new JUnitCore();
         jUnitCore.addListener(new TextListener(System.out));
 

--- a/test/org/mockitoutil/ClassLoaders.java
+++ b/test/org/mockitoutil/ClassLoaders.java
@@ -32,8 +32,8 @@ public abstract class ClassLoaders {
         return new InMemoryClassLoaderBuilder();
     }
 
-    public static ReachableClassesFinder in(ClassLoader classLoader_without_jUnit) {
-        return new ReachableClassesFinder(classLoader_without_jUnit);
+    public static ReachableClassesFinder in(ClassLoader classLoader) {
+        return new ReachableClassesFinder(classLoader);
     }
 
     public static ClassLoader jdkClassLoader() {


### PR DESCRIPTION
Mock makers may have different capabilities. Historically CGLIB and Mockito were deeply related, later Mockmaker was created to allow Android developers to use dexmaker to create mocks. But logic that decided if a type could be mocked still reside in the mockito base, while it should be the responsibility of the mockmaker.

Also for example one could create his own mockmaker that forbid to mock type if some annotation is present. 