### PR TITLE
Rework stubbing api with consecutive vararg to avoid JDK7+ warnings

### DIFF
--- a/src/main/java/org/mockito/BDDMockito.java
+++ b/src/main/java/org/mockito/BDDMockito.java
@@ -323,6 +323,12 @@ public class BDDMockito extends Mockito {
         BDDStubber willAnswer(Answer answer);
 
         /**
+         * See original {@link Stubber#doAnswer(Answer)}
+         * @since 1.8.0
+         */
+        BDDStubber will(Answer answer);
+
+        /**
          * See original {@link Stubber#doNothing()}
          * @since 1.8.0
          */
@@ -393,6 +399,10 @@ public class BDDMockito extends Mockito {
             return new BDDStubberImpl(mockitoStubber.doAnswer(answer));
         }
 
+        public BDDStubber will(Answer answer) {
+            return new BDDStubberImpl(mockitoStubber.doAnswer(answer));
+        }
+
         public BDDStubber willNothing() {
             return new BDDStubberImpl(mockitoStubber.doNothing());
         }
@@ -451,6 +461,14 @@ public class BDDMockito extends Mockito {
      * @since 1.8.0
      */
     public static BDDStubber willAnswer(Answer answer) {
+        return new BDDStubberImpl(Mockito.doAnswer(answer));
+    }
+
+    /**
+     * see original {@link Mockito#doAnswer(Answer)}
+     * @since 2.0.0
+     */
+    public static BDDStubber will(Answer answer) {
         return new BDDStubberImpl(Mockito.doAnswer(answer));
     }
 

--- a/src/main/java/org/mockito/BDDMockito.java
+++ b/src/main/java/org/mockito/BDDMockito.java
@@ -107,6 +107,7 @@ public class BDDMockito extends Mockito {
          * See original {@link OngoingStubbing#thenReturn(Object, Object[])}
          * @since 1.8.0
          */
+        @SuppressWarnings({"unchecked", "varargs"})
         BDDMyOngoingStubbing<T> willReturn(T value, T... values);
 
         /**
@@ -116,10 +117,18 @@ public class BDDMockito extends Mockito {
         BDDMyOngoingStubbing<T> willThrow(Throwable... throwables);
 
         /**
-         * See original {@link OngoingStubbing#thenThrow(Class[])}
-         * @since 1.9.0
+         * See original {@link OngoingStubbing#thenThrow(Class)}
+         * @since 2.0.0
          */
-        BDDMyOngoingStubbing<T> willThrow(Class<? extends Throwable>... throwableClasses);
+        BDDMyOngoingStubbing<T> willThrow(Class<? extends Throwable> throwableType);
+
+        /**
+         * See original {@link OngoingStubbing#thenThrow(Class, Class[])}
+         * @since 2.0.0
+         */
+        // Additional method helps users of JDK7+ to hide heap pollution / unchecked generics array creation
+        @SuppressWarnings ({"unchecked", "varargs"})
+        BDDMyOngoingStubbing<T> willThrow(Class<? extends Throwable> throwableType, Class<? extends Throwable>... throwableTypes);
 
         /**
          * See original {@link OngoingStubbing#thenCallRealMethod()}
@@ -166,8 +175,12 @@ public class BDDMockito extends Mockito {
             return new BDDOngoingStubbingImpl<T>(mockitoOngoingStubbing.thenThrow(throwables));
         }
 
-        public BDDMyOngoingStubbing<T> willThrow(Class<? extends Throwable>... throwableClasses) {
-            return new BDDOngoingStubbingImpl<T>(mockitoOngoingStubbing.thenThrow(throwableClasses));
+        public BDDMyOngoingStubbing<T> willThrow(Class<? extends Throwable> throwableType) {
+            return new BDDOngoingStubbingImpl<T>(mockitoOngoingStubbing.thenThrow(throwableType));
+        }
+
+        public BDDMyOngoingStubbing<T> willThrow(Class<? extends Throwable> throwableType, Class<? extends Throwable>... throwableTypes) {
+            return new BDDOngoingStubbingImpl<T>(mockitoOngoingStubbing.thenThrow(throwableType, throwableTypes));
         }
 
         public BDDMyOngoingStubbing<T> willCallRealMethod() {
@@ -317,21 +330,35 @@ public class BDDMockito extends Mockito {
 
         /**
          * See original {@link Stubber#doReturn(Object)}
-         * @since 1.8.0
+         * @since 2.0.0
          */
         BDDStubber willReturn(Object toBeReturned);
 
         /**
-         * See original {@link Stubber#doThrow(Throwable)}
+         * See original {@link Stubber#doReturn(Object)}
+         * @since 2.0.0
+         */
+        @SuppressWarnings({"unchecked", "varargs"})
+        BDDStubber willReturn(Object toBeReturned, Object... nextToBeReturned);
+
+        /**
+         * See original {@link Stubber#doThrow(Throwable...)}
          * @since 1.8.0
          */
-        BDDStubber willThrow(Throwable toBeThrown);
+        BDDStubber willThrow(Throwable... toBeThrown);
 
         /**
          * See original {@link Stubber#doThrow(Class)}
-         * @since 1.9.0
+         * @since 2.0.0
          */
         BDDStubber willThrow(Class<? extends Throwable> toBeThrown);
+
+        /**
+         * See original {@link Stubber#doThrow(Class, Class[])}
+         * @since 2.0.0
+         */
+        @SuppressWarnings ({"unchecked", "varargs"})
+        BDDStubber willThrow(Class<? extends Throwable> toBeThrown, Class<? extends Throwable>... nextToBeThrown);
 
         /**
          * See original {@link Stubber#doCallRealMethod()}
@@ -374,12 +401,20 @@ public class BDDMockito extends Mockito {
             return new BDDStubberImpl(mockitoStubber.doReturn(toBeReturned));
         }
 
-        public BDDStubber willThrow(Throwable toBeThrown) {
+        public BDDStubber willReturn(Object toBeReturned, Object... nextToBeReturned) {
+            return new BDDStubberImpl(mockitoStubber.doReturn(toBeReturned).doReturn(nextToBeReturned));
+        }
+
+        public BDDStubber willThrow(Throwable... toBeThrown) {
             return new BDDStubberImpl(mockitoStubber.doThrow(toBeThrown));
         }
 
         public BDDStubber willThrow(Class<? extends Throwable> toBeThrown) {
             return new BDDStubberImpl(mockitoStubber.doThrow(toBeThrown));
+        }
+
+        public BDDStubber willThrow(Class<? extends Throwable> toBeThrown, Class<? extends Throwable>... nextToBeThrown) {
+            return new BDDStubberImpl(mockitoStubber.doThrow(toBeThrown, nextToBeThrown));
         }
 
         public BDDStubber willCallRealMethod() {
@@ -388,19 +423,27 @@ public class BDDMockito extends Mockito {
     }
 
     /**
-     * see original {@link Mockito#doThrow(Throwable)}
-     * @since 1.8.0
+     * see original {@link Mockito#doThrow(Throwable[])}
+     * @since 2.0.0
      */
-    public static BDDStubber willThrow(Throwable toBeThrown) {
+    public static BDDStubber willThrow(Throwable... toBeThrown) {
         return new BDDStubberImpl(Mockito.doThrow(toBeThrown));
     }
 
     /**
-     * see original {@link Mockito#doThrow(Throwable)}
+     * see original {@link Mockito#doThrow(Class)}
      * @since 1.9.0
      */
     public static BDDStubber willThrow(Class<? extends Throwable> toBeThrown) {
         return new BDDStubberImpl(Mockito.doThrow(toBeThrown));
+    }
+
+    /**
+     * see original {@link Mockito#doThrow(Class)}
+     * @since 1.9.0
+     */
+    public static BDDStubber willThrow(Class<? extends Throwable> toBeThrown, Class<? extends Throwable>... throwableTypes) {
+        return new BDDStubberImpl(Mockito.doThrow(toBeThrown, throwableTypes));
     }
 
     /**
@@ -425,6 +468,15 @@ public class BDDMockito extends Mockito {
      */
     public static BDDStubber willReturn(Object toBeReturned) {
         return new BDDStubberImpl(Mockito.doReturn(toBeReturned));
+    }
+
+    /**
+     * see original {@link Mockito#doReturn(Object, Object...)}
+     * @since 2.0.0
+     */
+    @SuppressWarnings({"unchecked", "varargs"})
+    public static BDDStubber willReturn(Object toBeReturned, Object... toBeReturnedNext) {
+        return new BDDStubberImpl(Mockito.doReturn(toBeReturned, toBeReturnedNext));
     }
 
     /**

--- a/src/main/java/org/mockito/exceptions/Reporter.java
+++ b/src/main/java/org/mockito/exceptions/Reporter.java
@@ -823,6 +823,12 @@ public class Reporter {
                 ""));
     }
 
+    public void notAnException() {
+        throw new MockitoException(join(
+                "Exception type cannot be null.",
+                "This may happen with doThrow(Class)|thenThrow(Class) family of methods if passing null parameter."));
+    }
+
     private MockName safelyGetMockName(Object mock) {
         return new MockUtil().getMockName(mock);
     }

--- a/src/main/java/org/mockito/internal/MockitoCore.java
+++ b/src/main/java/org/mockito/internal/MockitoCore.java
@@ -27,11 +27,7 @@ import org.mockito.internal.verification.api.VerificationDataInOrder;
 import org.mockito.internal.verification.api.VerificationDataInOrderImpl;
 import org.mockito.invocation.Invocation;
 import org.mockito.mock.MockCreationSettings;
-import org.mockito.stubbing.Answer;
-import org.mockito.stubbing.DeprecatedOngoingStubbing;
-import org.mockito.stubbing.OngoingStubbing;
-import org.mockito.stubbing.Stubber;
-import org.mockito.stubbing.VoidMethodStubbable;
+import org.mockito.stubbing.*;
 import org.mockito.verification.VerificationMode;
 
 import java.util.Arrays;
@@ -144,10 +140,10 @@ public class MockitoCore {
         return new InOrderImpl(Arrays.asList(mocks));
     }
     
-    public Stubber doAnswer(Answer answer) {
+    public Stubber stubber() {
         mockingProgress.stubbingStarted();
         mockingProgress.resetOngoingStubbing();
-        return new StubberImpl().doAnswer(answer);
+        return new StubberImpl();
     }
     
     public <T> VoidMethodStubbable<T> stubVoid(T mock) {

--- a/src/main/java/org/mockito/internal/stubbing/BaseStubbing.java
+++ b/src/main/java/org/mockito/internal/stubbing/BaseStubbing.java
@@ -13,13 +13,13 @@ import org.mockito.stubbing.OngoingStubbing;
 
 public abstract class BaseStubbing<T> implements OngoingStubbing<T>, DeprecatedOngoingStubbing<T> {
 
-    //TODO why we need this method? The other thenReturn covers it.
     public OngoingStubbing<T> thenReturn(T value) {
         return thenAnswer(new Returns(value));
     }
 
+    @SuppressWarnings({"unchecked","vararg"})
     public OngoingStubbing<T> thenReturn(T value, T... values) {
-        OngoingStubbing<T> stubbing = thenReturn(value);            
+        OngoingStubbing<T> stubbing = thenReturn(value);
         if (values == null) {
             //TODO below does not seem right
             return stubbing.thenReturn(null);
@@ -36,7 +36,7 @@ public abstract class BaseStubbing<T> implements OngoingStubbing<T>, DeprecatedO
 
     public OngoingStubbing<T> thenThrow(Throwable... throwables) {
         if (throwables == null) {
-            thenThrow((Throwable) null);
+            return thenThrow((Throwable) null);
         }
         OngoingStubbing<T> stubbing = null;
         for (Throwable t: throwables) {
@@ -49,21 +49,18 @@ public abstract class BaseStubbing<T> implements OngoingStubbing<T>, DeprecatedO
         return stubbing;
     }        
 
-    private OngoingStubbing<T> thenThrow(Class<? extends Throwable> throwableClass) {
-        return thenAnswer(new ThrowsExceptionClass(throwableClass));
+    public OngoingStubbing<T> thenThrow(Class<? extends Throwable> throwableType) {
+        return thenAnswer(new ThrowsExceptionClass(throwableType));
     }
 
-    public OngoingStubbing<T> thenThrow(Class<? extends Throwable>... throwableClasses) {
-        if (throwableClasses == null) {
+    @SuppressWarnings ({"unchecked", "varargs"})
+    public OngoingStubbing<T> thenThrow(Class<? extends Throwable> toBeThrown, Class<? extends Throwable>... nextToBeThrown) {
+        if (nextToBeThrown == null) {
             thenThrow((Throwable) null);
         }
-        OngoingStubbing<T> stubbing = null;
-        for (Class<? extends Throwable> t: throwableClasses) {
-            if (stubbing == null) {
-                stubbing = thenThrow(t);
-            } else {
-                stubbing = stubbing.thenThrow(t);
-            }
+        OngoingStubbing<T> stubbing = thenThrow(toBeThrown);
+        for (Class<? extends Throwable> t: nextToBeThrown) {
+            stubbing = stubbing.thenThrow(t);
         }
         return stubbing;
     }

--- a/src/main/java/org/mockito/internal/stubbing/StubberImpl.java
+++ b/src/main/java/org/mockito/internal/stubbing/StubberImpl.java
@@ -35,17 +35,50 @@ public class StubberImpl implements Stubber {
     }
 
     public Stubber doReturn(Object toBeReturned) {
-        answers.add(new Returns(toBeReturned));
+        return doReturnValues(toBeReturned);
+    }
+
+    public Stubber doReturn(Object toBeReturned, Object... nextToBeReturned) {
+        return doReturnValues(toBeReturned).doReturnValues(nextToBeReturned);
+    }
+
+    private StubberImpl doReturnValues(Object... toBeReturned) {
+        if(toBeReturned == null) {
+            answers.add(new Returns(null));
+            return this;
+        }
+        for (Object r : toBeReturned) {
+            answers.add(new Returns(r));
+        }
         return this;
     }
 
-    public Stubber doThrow(Throwable toBeThrown) {
-        answers.add(new ThrowsException(toBeThrown));
+    @Override
+    public Stubber doThrow(Throwable... toBeThrown) {
+        if(toBeThrown == null) {
+            answers.add(new ThrowsException(null));
+            return this;
+        }
+        for (Throwable throwable : toBeThrown) {
+            answers.add(new ThrowsException(throwable));
+        }
         return this;
     }
 
+    @Override
     public Stubber doThrow(Class<? extends Throwable> toBeThrown) {
-        answers.add(new ThrowsExceptionClass(toBeThrown));
+        return doThrowClasses(toBeThrown);
+    }
+
+    @Override
+    public Stubber doThrow(Class<? extends Throwable> toBeThrown, Class<? extends Throwable>... nextToBeThrown) {
+        return doThrowClasses(toBeThrown).doThrowClasses(nextToBeThrown);
+    }
+
+    private StubberImpl doThrowClasses(Class<? extends Throwable>... toBeThrown) {
+        for (Class<? extends Throwable> throwable: toBeThrown) {
+            answers.add(new ThrowsExceptionClass(throwable));
+        }
         return this;
     }
 

--- a/src/main/java/org/mockito/internal/stubbing/answers/ThrowsExceptionClass.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/ThrowsExceptionClass.java
@@ -5,6 +5,7 @@
 
 package org.mockito.internal.stubbing.answers;
 
+import org.mockito.exceptions.Reporter;
 import org.mockito.internal.exceptions.stacktrace.ConditionalStackTraceFilter;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -18,7 +19,14 @@ public class ThrowsExceptionClass implements Answer<Object>, Serializable {
     private final ConditionalStackTraceFilter filter = new ConditionalStackTraceFilter();
 
     public ThrowsExceptionClass(Class<? extends Throwable> throwableClass) {
-        this.throwableClass = throwableClass;
+        this.throwableClass = checkNonNullThrowable(throwableClass);
+    }
+
+    private Class<? extends Throwable> checkNonNullThrowable(Class<? extends Throwable> throwableClass) {
+        if(throwableClass == null || !Throwable.class.isAssignableFrom(throwableClass)) {
+            new Reporter().notAnException();
+        }
+        return throwableClass;
     }
 
     public Object answer(InvocationOnMock invocation) throws Throwable {

--- a/src/main/java/org/mockito/internal/util/reflection/Fields.java
+++ b/src/main/java/org/mockito/internal/util/reflection/Fields.java
@@ -61,6 +61,7 @@ public abstract class Fields {
      * @param annotations Annotation types to check.
      * @return The filter.
      */
+    @SuppressWarnings({"unchecked", "vararg"})
     public static Filter<InstanceField> annotatedBy(final Class<? extends Annotation>... annotations) {
         return new Filter<InstanceField>() {
             public boolean isOut(InstanceField instanceField) {

--- a/src/main/java/org/mockito/stubbing/OngoingStubbing.java
+++ b/src/main/java/org/mockito/stubbing/OngoingStubbing.java
@@ -63,6 +63,8 @@ public interface OngoingStubbing<T> extends IOngoingStubbing {
      *
      * @return iOngoingStubbing object that allows stubbing consecutive calls
      */
+    // Additional method helps users of JDK7+ to hide heap pollution / unchecked generics array creation warnings (on call site)
+    @SuppressWarnings ({"unchecked", "varargs"})
     OngoingStubbing<T> thenReturn(T value, T... values);
 
     /**
@@ -77,7 +79,7 @@ public interface OngoingStubbing<T> extends IOngoingStubbing {
      * You can specify throwables to be thrown for consecutive calls. 
      * In that case the last throwable determines the behavior of further consecutive calls.
      * <p>
-     * if throwable is null then exception will be thrown.
+     * If throwable is null then exception will be thrown.
      * <p>
      * See examples in javadoc for {@link Mockito#when}
      *
@@ -88,6 +90,27 @@ public interface OngoingStubbing<T> extends IOngoingStubbing {
     OngoingStubbing<T> thenThrow(Throwable... throwables);
 
     /**
+     * Sets a Throwable type to be thrown when the method is called. E.g:
+     * <pre class="code"><code class="java">
+     * when(mock.someMethod()).thenThrow(RuntimeException.class);
+     * </code></pre>
+     *
+     * <p>
+     * If the throwable class is a checked exception then it has to
+     * match one of the checked exceptions of the stubbed method signature.
+     * <p>
+     * If throwable is null then exception will be thrown.
+     * <p>
+     * See examples in javadoc for {@link Mockito#when}
+     *
+     * @param throwableType to be thrown on method invocation
+     *
+     * @return iOngoingStubbing object that allows stubbing consecutive calls
+     * @since 2.0.0
+     */
+    OngoingStubbing<T> thenThrow(Class<? extends Throwable> throwableType);
+
+    /**
      * Sets Throwable classes to be thrown when the method is called. E.g:
      * <pre class="code"><code class="java">
      * when(mock.someMethod()).thenThrow(RuntimeException.class);
@@ -96,22 +119,29 @@ public interface OngoingStubbing<T> extends IOngoingStubbing {
      * <p>
      * Each throwable class will be instantiated for each method invocation.
      * <p>
-     * If throwableClasses contain a checked exception then it has to
+     * If <code>throwableTypes</code> contain a checked exception then it has to
      * match one of the checked exceptions of method signature.
      * <p>
-     * You can specify throwableClasses to be thrown for consecutive calls.
+     * You can specify <code>throwableTypes</code> to be thrown for consecutive calls.
      * In that case the last throwable determines the behavior of further consecutive calls.
      * <p>
-     * if throwable is null then exception will be thrown.
+     * If throwable is null then exception will be thrown.
      * <p>
      * See examples in javadoc for {@link Mockito#when}
      *
-     * @param throwableClasses to be thrown on method invocation
+     *
+     * <p>Note since JDK 7, invoking this method will raise a compiler warning "possible heap pollution",
+     * this API is safe to use. If you don't want to see this warning it is possible to chain {@link #thenThrow(Class)}
+     *
+     * @param toBeThrown to be thrown on method invocation
+     * @param nextToBeThrown next to be thrown on method invocation
      *
      * @return iOngoingStubbing object that allows stubbing consecutive calls
-     * @since 1.9.0
+     * @since 2.0.0
      */
-    OngoingStubbing<T> thenThrow(Class<? extends Throwable>... throwableClasses);
+    // Additional method helps users of JDK7+ to hide heap pollution / unchecked generics array creation warnings (on call site)
+    @SuppressWarnings ({"unchecked", "varargs"})
+    OngoingStubbing<T> thenThrow(Class<? extends Throwable> toBeThrown, Class<? extends Throwable>... nextToBeThrown);
 
     /**     
      * Sets the real implementation to be called when the method is called on a mock object.

--- a/src/main/java/org/mockito/stubbing/Stubber.java
+++ b/src/main/java/org/mockito/stubbing/Stubber.java
@@ -27,7 +27,7 @@ import org.mockito.Mockito;
  * 
  * Read more about those methods:
  * <p>
- * {@link Mockito#doThrow(Throwable)}
+ * {@link Mockito#doThrow(Throwable[])}
  * <p>
  * {@link Mockito#doAnswer(Answer)}
  * <p>
@@ -55,7 +55,7 @@ public interface Stubber {
      * 
      * Read more about those methods:
      * <p>
-     * {@link Mockito#doThrow(Throwable)}
+     * {@link Mockito#doThrow(Throwable[])}
      * <p>
      * {@link Mockito#doAnswer(Answer)}
      * <p>
@@ -64,7 +64,7 @@ public interface Stubber {
      * {@link Mockito#doReturn(Object)}
      * <p>
      * 
-     *  See examples in javadoc for {@link Mockito}
+     * See examples in javadoc for {@link Mockito}
      * 
      * @param mock The mock
      * @return select method for stubbing
@@ -72,39 +72,60 @@ public interface Stubber {
     <T> T when(T mock);
 
     /**
-     * Use it for stubbing consecutive calls in {@link Mockito#doThrow(Throwable)} style:
+     * Use it for stubbing consecutive calls in {@link Mockito#doThrow(Throwable[])} style:
      * <pre class="code"><code class="java">
      *   doThrow(new RuntimeException("one")).
      *   doThrow(new RuntimeException("two"))
-     *   .when(mock).someVoidMethod();
+     *       .when(mock).someVoidMethod();
      * </code></pre>
-     * See javadoc for {@link Mockito#doThrow(Throwable)}
+     * See javadoc for {@link Mockito#doThrow(Throwable[])}
      * 
      * @param toBeThrown to be thrown when the stubbed method is called
      * @return stubber - to select a method for stubbing
      */
-    Stubber doThrow(Throwable toBeThrown);
+    Stubber doThrow(Throwable... toBeThrown);
 
     /**
      * Use it for stubbing consecutive calls in {@link Mockito#doThrow(Class)} style:
      * <pre class="code"><code class="java">
      *   doThrow(RuntimeException.class).
      *   doThrow(IllegalArgumentException.class)
-     *   .when(mock).someVoidMethod();
+     *       .when(mock).someVoidMethod();
      * </code></pre>
      * See javadoc for {@link Mockito#doThrow(Class)}
      *
      * @param toBeThrown exception class to be thrown when the stubbed method is called
      * @return stubber - to select a method for stubbing
+     *
+     * @since 2.0.0
      */
     Stubber doThrow(Class<? extends Throwable> toBeThrown);
+
+    /**
+     * Use it for stubbing consecutive calls in {@link Mockito#doThrow(Class)} style:
+     * <pre class="code"><code class="java">
+     *   doThrow(RuntimeException.class).
+     *   doThrow(IllegalArgumentException.class)
+     *       .when(mock).someVoidMethod();
+     * </code></pre>
+     * See javadoc for {@link Mockito#doThrow(Class)}
+     *
+     * @param toBeThrown exception class to be thrown when the stubbed method is called
+     * @param nextToBeThrown exception class next to be thrown when the stubbed method is called
+     * @return stubber - to select a method for stubbing
+     *
+     * @since 2.0.0
+     */
+    // Additional method helps users of JDK7+ to hide heap pollution / unchecked generics array creation
+    @SuppressWarnings ({"unchecked", "varargs"})
+    Stubber doThrow(Class<? extends Throwable> toBeThrown, Class<? extends Throwable>... nextToBeThrown);
 
     /**
      * Use it for stubbing consecutive calls in {@link Mockito#doAnswer(Answer)} style:
      * <pre class="code"><code class="java">
      *   doAnswer(answerOne).
      *   doAnswer(answerTwo)
-     *   .when(mock).someVoidMethod();
+     *       .when(mock).someVoidMethod();
      * </code></pre>
      * See javadoc for {@link Mockito#doAnswer(Answer)}
      * 
@@ -118,7 +139,7 @@ public interface Stubber {
      * <pre class="code"><code class="java">
      *   doNothing().
      *   doThrow(new RuntimeException("two"))
-     *   .when(mock).someVoidMethod();
+     *       .when(mock).someVoidMethod();
      * </code></pre>
      * See javadoc for {@link Mockito#doNothing()}
      * 
@@ -135,6 +156,18 @@ public interface Stubber {
      * @return stubber - to select a method for stubbing
      */
     Stubber doReturn(Object toBeReturned);
+
+    /**
+     * Use it for stubbing consecutive calls in {@link Mockito#doReturn(Object)} style.
+     * <p>
+     * See javadoc for {@link Mockito#doReturn(Object, Object...)}
+     *
+     * @param toBeReturned to be returned when the stubbed method is called
+     * @param nextToBeReturned to be returned in consecutive calls when the stubbed method is called
+     * @return stubber - to select a method for stubbing
+     */
+    @SuppressWarnings({"unchecked", "varargs"})
+    Stubber doReturn(Object toBeReturned, Object... nextToBeReturned);
 
     /**
      * Use it for stubbing consecutive calls in {@link Mockito#doCallRealMethod()} style.

--- a/src/test/java/org/mockitousage/CompilationWarningsTest.java
+++ b/src/test/java/org/mockitousage/CompilationWarningsTest.java
@@ -1,0 +1,111 @@
+package org.mockitousage;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import static org.mockito.BDDMockito.doAnswer;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+
+public class CompilationWarningsTest {
+
+    @Before
+    public void pay_attention_to_compilation_warnings_and_JDK_version() { }
+
+    @Test
+    public void no_warnings_for_most_common_api() throws Exception {
+        doReturn(null).when(mock(IMethods.class)).objectReturningMethodNoArgs();
+        doReturn("a", 12).when(mock(IMethods.class)).objectReturningMethodNoArgs();
+        doReturn(1000).when(mock(IMethods.class)).objectReturningMethodNoArgs();
+        doThrow(new NullPointerException()).when(mock(IMethods.class)).objectReturningMethodNoArgs();
+        doThrow(new NullPointerException(), new IllegalArgumentException()).when(mock(IMethods.class)).objectReturningMethodNoArgs();
+        doThrow(NullPointerException.class).when(mock(IMethods.class)).objectReturningMethodNoArgs();
+
+        doAnswer(ignore()).doReturn(null).when(mock(IMethods.class)).objectReturningMethodNoArgs();
+        doAnswer(ignore()).doReturn("a", 12).when(mock(IMethods.class)).objectReturningMethodNoArgs();
+        doAnswer(ignore()).doReturn(1000).when(mock(IMethods.class)).objectReturningMethodNoArgs();
+        doAnswer(ignore()).doThrow(new NullPointerException()).when(mock(IMethods.class)).objectReturningMethodNoArgs();
+        doAnswer(ignore()).doThrow(new NullPointerException(), new IllegalArgumentException()).when(mock(IMethods.class)).objectReturningMethodNoArgs();
+        doAnswer(ignore()).doThrow(NullPointerException.class).when(mock(IMethods.class)).objectReturningMethodNoArgs();
+
+        when(mock(IMethods.class).objectReturningMethodNoArgs()).thenReturn(null);
+        when(mock(IMethods.class).objectReturningMethodNoArgs()).thenReturn("a", 12L);
+        when(mock(IMethods.class).objectReturningMethodNoArgs()).thenReturn(1000);
+        when(mock(IMethods.class).objectReturningMethodNoArgs()).thenThrow(new NullPointerException());
+        when(mock(IMethods.class).objectReturningMethodNoArgs()).thenThrow(new NullPointerException(), new IllegalArgumentException());
+        when(mock(IMethods.class).objectReturningMethodNoArgs()).thenThrow(NullPointerException.class);
+
+        when(mock(IMethods.class).objectReturningMethodNoArgs()).then(ignore()).thenReturn(null);
+        when(mock(IMethods.class).objectReturningMethodNoArgs()).then(ignore()).thenReturn("a", 12L);
+        when(mock(IMethods.class).objectReturningMethodNoArgs()).then(ignore()).thenReturn(1000);
+        when(mock(IMethods.class).objectReturningMethodNoArgs()).then(ignore()).thenThrow(new NullPointerException());
+        when(mock(IMethods.class).objectReturningMethodNoArgs()).then(ignore()).thenThrow(new NullPointerException(), new IllegalArgumentException());
+        when(mock(IMethods.class).objectReturningMethodNoArgs()).then(ignore()).thenThrow(NullPointerException.class);
+
+        willReturn(null).given(mock(IMethods.class)).objectReturningMethodNoArgs();
+        willReturn("a", 12).given(mock(IMethods.class)).objectReturningMethodNoArgs();
+        willReturn(1000).given(mock(IMethods.class)).objectReturningMethodNoArgs();
+        willThrow(new NullPointerException()).given(mock(IMethods.class)).objectReturningMethodNoArgs();
+        willThrow(new NullPointerException(), new IllegalArgumentException()).given(mock(IMethods.class)).objectReturningMethodNoArgs();
+        willThrow(NullPointerException.class).given(mock(IMethods.class)).objectReturningMethodNoArgs();
+
+        willAnswer(ignore()).willReturn(null).given(mock(IMethods.class)).objectReturningMethodNoArgs();
+        willAnswer(ignore()).willReturn("a", 12).given(mock(IMethods.class)).objectReturningMethodNoArgs();
+        willAnswer(ignore()).willReturn(1000).given(mock(IMethods.class)).objectReturningMethodNoArgs();
+        willAnswer(ignore()).willThrow(new NullPointerException()).given(mock(IMethods.class)).objectReturningMethodNoArgs();
+        willAnswer(ignore()).willThrow(new NullPointerException(), new IllegalArgumentException()).given(mock(IMethods.class)).objectReturningMethodNoArgs();
+        willAnswer(ignore()).willThrow(NullPointerException.class).given(mock(IMethods.class)).objectReturningMethodNoArgs();
+
+        given(mock(IMethods.class).objectReturningMethodNoArgs()).willReturn(null);
+        given(mock(IMethods.class).objectReturningMethodNoArgs()).willReturn("a", 12L);
+        given(mock(IMethods.class).objectReturningMethodNoArgs()).willReturn(1000);
+        given(mock(IMethods.class).objectReturningMethodNoArgs()).willThrow(new NullPointerException());
+        given(mock(IMethods.class).objectReturningMethodNoArgs()).willThrow(new NullPointerException(), new IllegalArgumentException());
+        given(mock(IMethods.class).objectReturningMethodNoArgs()).willThrow(NullPointerException.class);
+
+        given(mock(IMethods.class).objectReturningMethodNoArgs()).will(ignore()).willReturn(null);
+        given(mock(IMethods.class).objectReturningMethodNoArgs()).will(ignore()).willReturn("a", 12L);
+        given(mock(IMethods.class).objectReturningMethodNoArgs()).will(ignore()).willReturn(1000);
+        given(mock(IMethods.class).objectReturningMethodNoArgs()).will(ignore()).willThrow(new NullPointerException());
+        given(mock(IMethods.class).objectReturningMethodNoArgs()).will(ignore()).willThrow(new NullPointerException(), new IllegalArgumentException());
+        given(mock(IMethods.class).objectReturningMethodNoArgs()).will(ignore()).willThrow(NullPointerException.class);
+    }
+
+    @Test
+    public void heap_pollution_JDK7plus_warning_avoided_BUT_now_unchecked_generic_array_creation_warnings_ON_JDK5plus_environment() throws Exception {
+        doThrow(NullPointerException.class, IllegalArgumentException.class).when(mock(IMethods.class)).objectReturningMethodNoArgs();
+        when(mock(IMethods.class).objectReturningMethodNoArgs()).thenThrow(NullPointerException.class, IllegalArgumentException.class);
+        doAnswer(ignore()).doThrow(NullPointerException.class, IllegalArgumentException.class).when(mock(IMethods.class)).objectReturningMethodNoArgs();
+
+        willThrow(NullPointerException.class, IllegalArgumentException.class).given(mock(IMethods.class)).objectReturningMethodNoArgs();
+        given(mock(IMethods.class).objectReturningMethodNoArgs()).willThrow(NullPointerException.class, IllegalArgumentException.class);
+        willAnswer(ignore()).willThrow(NullPointerException.class, IllegalArgumentException.class).given(mock(IMethods.class)).objectReturningMethodNoArgs();
+    }
+
+    @Test
+    public void unchecked_confusing_null_argument_warnings() throws Exception {
+        doReturn(null, null).when(mock(IMethods.class)).objectReturningMethodNoArgs();
+        doAnswer(ignore()).doReturn(null, null).when(mock(IMethods.class)).objectReturningMethodNoArgs();
+        when(mock(IMethods.class).objectReturningMethodNoArgs()).thenReturn(null, null);
+        when(mock(IMethods.class).objectReturningMethodNoArgs()).then(ignore()).thenReturn(null, null);
+        willReturn(null, null).given(mock(IMethods.class)).objectReturningMethodNoArgs();
+        given(mock(IMethods.class).objectReturningMethodNoArgs()).willReturn(null, null);
+        willAnswer(ignore()).willReturn(null, null).given(mock(IMethods.class)).objectReturningMethodNoArgs();
+        given(mock(IMethods.class).objectReturningMethodNoArgs()).will(ignore()).willReturn(null, null);
+    }
+
+    private static Answer<?> ignore() {
+        return new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                return null;
+            }
+        };
+    }
+}

--- a/src/test/java/org/mockitousage/customization/BDDMockitoTest.java
+++ b/src/test/java/org/mockitousage/customization/BDDMockitoTest.java
@@ -4,6 +4,7 @@
  */
 package org.mockitousage.customization;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mock;
@@ -28,8 +29,8 @@ public class BDDMockitoTest extends TestBase {
     public void should_stub() throws Exception {
         given(mock.simpleMethod("foo")).willReturn("bar");
 
-        assertEquals("bar", mock.simpleMethod("foo"));
-        assertEquals(null, mock.simpleMethod("whatever"));
+        Assertions.assertThat(mock.simpleMethod("foo")).isEqualTo("bar");
+        Assertions.assertThat(mock.simpleMethod("whatever")).isEqualTo(null);
     }
 
     @Test
@@ -37,7 +38,7 @@ public class BDDMockitoTest extends TestBase {
         given(mock.simpleMethod("foo")).willThrow(new SomethingWasWrong());
 
         try {
-            assertEquals("foo", mock.simpleMethod("foo"));
+            Assertions.assertThat(mock.simpleMethod("foo")).isEqualTo("foo");
             fail();
         } catch(SomethingWasWrong expected) {}
     }
@@ -47,7 +48,18 @@ public class BDDMockitoTest extends TestBase {
         given(mock.simpleMethod("foo")).willThrow(SomethingWasWrong.class);
 
         try {
-            assertEquals("foo", mock.simpleMethod("foo"));
+            Assertions.assertThat(mock.simpleMethod("foo")).isEqualTo("foo");
+            fail();
+        } catch(SomethingWasWrong expected) {}
+    }
+
+    @Test
+    public void should_stub_with_throwable_classes() throws Exception {
+        // unavoidable 'unchecked generic array creation' warning (from JDK7 onward)
+        given(mock.simpleMethod("foo")).willThrow(SomethingWasWrong.class, AnotherThingWasWrong.class);
+
+        try {
+            Assertions.assertThat(mock.simpleMethod("foo")).isEqualTo("foo");
             fail();
         } catch(SomethingWasWrong expected) {}
     }
@@ -59,7 +71,7 @@ public class BDDMockitoTest extends TestBase {
                 return (String) invocation.getArguments()[0];
             }});
 
-        assertEquals("foo", mock.simpleMethod("foo"));
+        Assertions.assertThat(mock.simpleMethod("foo")).isEqualTo("foo");
     }
 
     @Test
@@ -67,9 +79,10 @@ public class BDDMockitoTest extends TestBase {
         given(mock.simpleMethod(anyString())).will(new Answer<String>() {
             public String answer(InvocationOnMock invocation) throws Throwable {
                 return (String) invocation.getArguments()[0];
-            }});
+            }
+        });
 
-        assertEquals("foo", mock.simpleMethod("foo"));
+        Assertions.assertThat(mock.simpleMethod("foo")).isEqualTo("foo");
     }
 
     @Test
@@ -78,8 +91,19 @@ public class BDDMockitoTest extends TestBase {
                 .willReturn("foo")
                 .willReturn("bar");
 
-        assertEquals("foo", mock.simpleMethod("whatever"));
-        assertEquals("bar", mock.simpleMethod("whatever"));
+        Assertions.assertThat(mock.simpleMethod("whatever")).isEqualTo("foo");
+        Assertions.assertThat(mock.simpleMethod("whatever")).isEqualTo("bar");
+    }
+
+    @Test
+    public void should_return_consecutively() throws Exception {
+        given(mock.objectReturningMethodNoArgs())
+                .willReturn("foo", "bar", 12L, new byte[0]);
+
+        Assertions.assertThat(mock.objectReturningMethodNoArgs()).isEqualTo("foo");
+        Assertions.assertThat(mock.objectReturningMethodNoArgs()).isEqualTo("bar");
+        Assertions.assertThat(mock.objectReturningMethodNoArgs()).isEqualTo(12L);
+        Assertions.assertThat(mock.objectReturningMethodNoArgs()).isEqualTo(new byte[0]);
     }
 
     @Test
@@ -88,8 +112,8 @@ public class BDDMockitoTest extends TestBase {
         willReturn("foo").willCallRealMethod()
                 .given(mock).simpleMethod();
 
-       assertEquals("foo", mock.simpleMethod());
-       assertEquals(null, mock.simpleMethod());
+       Assertions.assertThat(mock.simpleMethod()).isEqualTo("foo");
+       Assertions.assertThat(mock.simpleMethod()).isEqualTo(null);
     }
 
     @Test
@@ -105,6 +129,16 @@ public class BDDMockitoTest extends TestBase {
     @Test
     public void should_stub_void_with_exception_class() throws Exception {
         willThrow(SomethingWasWrong.class).given(mock).voidMethod();
+
+        try {
+            mock.voidMethod();
+            fail();
+        } catch(SomethingWasWrong expected) {}
+    }
+
+    @Test
+    public void should_stub_void_with_exception_classes() throws Exception {
+        willThrow(SomethingWasWrong.class, AnotherThingWasWrong.class).given(mock).voidMethod();
 
         try {
             mock.voidMethod();
@@ -142,8 +176,8 @@ public class BDDMockitoTest extends TestBase {
     public void should_stub_using_do_return_style() throws Exception {
         willReturn("foo").given(mock).simpleMethod("bar");
 
-        assertEquals(null, mock.simpleMethod("boooo"));
-        assertEquals("foo", mock.simpleMethod("bar"));
+        Assertions.assertThat(mock.simpleMethod("boooo")).isEqualTo(null);
+        Assertions.assertThat(mock.simpleMethod("bar")).isEqualTo("foo");
     }
 
     @Test
@@ -151,10 +185,11 @@ public class BDDMockitoTest extends TestBase {
         willAnswer(new Answer<String>() {
             public String answer(InvocationOnMock invocation) throws Throwable {
                 return (String) invocation.getArguments()[0];
-            }})
+            }
+        })
                 .given(mock).simpleMethod(anyString());
 
-        assertEquals("foo", mock.simpleMethod("foo"));
+        Assertions.assertThat(mock.simpleMethod("foo")).isEqualTo("foo");
     }
 
     @Test
@@ -164,7 +199,7 @@ public class BDDMockitoTest extends TestBase {
         //when
         willCallRealMethod().given(dog).bark();
         //then
-        assertEquals("woof", dog.bark());
+        Assertions.assertThat(dog.bark()).isEqualTo("woof");
     }
 
     @Test
@@ -174,7 +209,7 @@ public class BDDMockitoTest extends TestBase {
         //when
         given(dog.bark()).willCallRealMethod();
         //then
-        assertEquals("woof", dog.bark());
+        Assertions.assertThat(dog.bark()).isEqualTo("woof");
     }
 
     @Test
@@ -183,7 +218,7 @@ public class BDDMockitoTest extends TestBase {
 
         Set returnedMock = given(expectedMock.isEmpty()).willReturn(false).getMock();
 
-        assertEquals(expectedMock, returnedMock);
+        Assertions.assertThat(returnedMock).isEqualTo(expectedMock);
     }
 
     @Test(expected = NotAMockException.class)
@@ -320,4 +355,5 @@ public class BDDMockitoTest extends TestBase {
     }
 
     private class SomethingWasWrong extends RuntimeException { }
+    private class AnotherThingWasWrong extends RuntimeException { }
 }

--- a/src/test/java/org/mockitousage/stubbing/StubbingConsecutiveAnswersTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingConsecutiveAnswersTest.java
@@ -5,47 +5,28 @@
 
 package org.mockitousage.stubbing;
 
-import static org.mockito.Mockito.*;
-
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
+import static org.mockito.Mockito.stubVoid;
+import static org.mockito.Mockito.when;
+
 @SuppressWarnings("deprecation")
 public class StubbingConsecutiveAnswersTest extends TestBase {
 
-    @Mock private IMethods mock;
-   
-    @Test
-    public void shouldReturnConsecutiveValues() throws Exception {
-        when(mock.simpleMethod())
-            .thenReturn("one")
-            .thenReturn("two")
-            .thenReturn("three");
-        
-        assertEquals("one", mock.simpleMethod());
-        assertEquals("two", mock.simpleMethod());
-        assertEquals("three", mock.simpleMethod());
-        assertEquals("three", mock.simpleMethod());
-        assertEquals("three", mock.simpleMethod());
-    }
-
-    @SuppressWarnings("all")
-    @Test
-    public void shouldReturnConsecutiveValuesForTwoNulls() throws Exception {
-        when(mock.simpleMethod()).thenReturn(null, (String[])null);
-        
-        assertNull(mock.simpleMethod());        
-        assertNull(mock.simpleMethod());        
-    }
+    @Mock
+    private IMethods mock;
 
     @Test
-    public void shouldReturnConsecutiveValuesSetByShortenThenReturnMethod() throws Exception {        
+    public void should_return_consecutive_values() throws Exception {
         when(mock.simpleMethod())
-            .thenReturn("one", "two", "three");
-        
+                .thenReturn("one")
+                .thenReturn("two")
+                .thenReturn("three");
+
         assertEquals("one", mock.simpleMethod());
         assertEquals("two", mock.simpleMethod());
         assertEquals("three", mock.simpleMethod());
@@ -54,14 +35,31 @@ public class StubbingConsecutiveAnswersTest extends TestBase {
     }
 
     @Test
-    public void shouldReturnConsecutiveValueAndThrowExceptionssSetByShortenReturnMethods()
-            throws Exception {
-        when(mock.simpleMethod())
-            .thenReturn("zero")
-            .thenReturn("one", "two")
-            .thenThrow(new NullPointerException(), new RuntimeException())
-            .thenReturn("three")
-            .thenThrow(new IllegalArgumentException());
+    public void should_return_consecutive_values_for_two_nulls() throws Exception {
+        when(mock.simpleMethod()).thenReturn(null, null);
+
+        assertNull(mock.simpleMethod());
+        assertNull(mock.simpleMethod());
+    }
+
+    @Test
+    public void should_return_consecutive_values_set_by_shorten_then_return_method() throws Exception {
+        when(mock.simpleMethod()).thenReturn("one", "two", "three");
+
+        assertEquals("one", mock.simpleMethod());
+        assertEquals("two", mock.simpleMethod());
+        assertEquals("three", mock.simpleMethod());
+        assertEquals("three", mock.simpleMethod());
+        assertEquals("three", mock.simpleMethod());
+    }
+
+    @Test
+    public void should_return_consecutive_value_and_throw_exceptions_set_by_shorten_return_methods() {
+        when(mock.simpleMethod()).thenReturn("zero")
+                                 .thenReturn("one", "two")
+                                 .thenThrow(new NullPointerException(), new RuntimeException())
+                                 .thenReturn("three")
+                                 .thenThrow(new IllegalArgumentException());
 
         assertEquals("zero", mock.simpleMethod());
         assertEquals("one", mock.simpleMethod());
@@ -69,153 +67,195 @@ public class StubbingConsecutiveAnswersTest extends TestBase {
         try {
             mock.simpleMethod();
             fail();
-        } catch (NullPointerException e) {}
+        } catch (NullPointerException expected) { }
         try {
             mock.simpleMethod();
             fail();
-        } catch (RuntimeException e) {}
+        } catch (RuntimeException expected) { }
         assertEquals("three", mock.simpleMethod());
         try {
             mock.simpleMethod();
             fail();
-        } catch (IllegalArgumentException e) {}
+        } catch (IllegalArgumentException expected) { }
     }
-    
+
     @Test
-    public void shouldThrowConsecutively() throws Exception {
-        when(mock.simpleMethod())
-            .thenThrow(new RuntimeException())
-            .thenThrow(new IllegalArgumentException())
-            .thenThrow(new NullPointerException());
+    public void should_throw_consecutively() throws Exception {
+        when(mock.simpleMethod()).thenThrow(new RuntimeException())
+                                 .thenThrow(new IllegalArgumentException())
+                                 .thenThrow(new NullPointerException());
 
         try {
             mock.simpleMethod();
             fail();
-        } catch (RuntimeException e) {}
-        
-        try {
-            mock.simpleMethod();
-            fail();
-        } catch (IllegalArgumentException e) {}
-        
-        try {
-            mock.simpleMethod();
-            fail();
-        } catch (NullPointerException e) {}
-        
-        try {
-            mock.simpleMethod();
-            fail();
-        } catch (NullPointerException e) {}
-    }
-
-    @Test
-    public void shouldThrowConsecutivelySetByShortenThenThrowMethod() throws Exception {
-        when(mock.simpleMethod())
-            .thenThrow(new RuntimeException(), new IllegalArgumentException(), new NullPointerException());
+        } catch (RuntimeException expected) { }
 
         try {
             mock.simpleMethod();
             fail();
-        } catch (RuntimeException e) {}
-        
+        } catch (IllegalArgumentException expected) { }
+
         try {
             mock.simpleMethod();
             fail();
-        } catch (IllegalArgumentException e) {}
-        
+        } catch (NullPointerException expected) { }
+
         try {
             mock.simpleMethod();
             fail();
-        } catch (NullPointerException e) {}
-        
-        try {
-            mock.simpleMethod();
-            fail();
-        } catch (NullPointerException e) {}
+        } catch (NullPointerException expected) { }
     }
-    
+
     @Test
-    public void shouldMixConsecutiveReturnsWithExcepions() throws Exception {
-        when(mock.simpleMethod())
-            .thenThrow(new IllegalArgumentException())
-            .thenReturn("one")
-            .thenThrow(new NullPointerException())
-            .thenReturn(null);
-        
+    public void should_throw_consecutively_set_by_shorten_then_throw_method() throws Exception {
+        when(mock.simpleMethod()).thenThrow(new RuntimeException(),
+                                            new IllegalArgumentException(),
+                                            new NullPointerException());
+
         try {
             mock.simpleMethod();
             fail();
-        } catch (IllegalArgumentException e) {}
-        
+        } catch (RuntimeException expected) { }
+
+        try {
+            mock.simpleMethod();
+            fail();
+        } catch (IllegalArgumentException expected) { }
+
+        try {
+            mock.simpleMethod();
+            fail();
+        } catch (NullPointerException expected) { }
+
+        try {
+            mock.simpleMethod();
+            fail();
+        } catch (NullPointerException expected) { }
+    }
+
+    @Test
+    public void should_throw_classes() throws Exception {
+        // Unavoidable JDK7+ 'unchecked generic array creation' warning
+        when(mock.simpleMethod()).thenThrow(IllegalArgumentException.class);
+
+        try {
+            mock.simpleMethod();
+            fail();
+        } catch (IllegalArgumentException expected) { }
+
+        try {
+            mock.simpleMethod();
+            fail();
+        } catch (IllegalArgumentException expected) { }
+    }
+
+    @Test
+    public void should_throw_consecutively_classes_set_by_shorten_then_throw_method() throws Exception {
+        // Unavoidable JDK7+ 'unchecked generic array creation' warning
+        when(mock.simpleMethod()).thenThrow(RuntimeException.class,
+                                            IllegalArgumentException.class,
+                                            NullPointerException.class);
+
+        try {
+            mock.simpleMethod();
+            fail();
+        } catch (RuntimeException expected) { }
+
+        try {
+            mock.simpleMethod();
+            fail();
+        } catch (IllegalArgumentException expected) { }
+
+        try {
+            mock.simpleMethod();
+            fail();
+        } catch (NullPointerException expected) { }
+
+        try {
+            mock.simpleMethod();
+            fail();
+        } catch (NullPointerException expected) { }
+    }
+
+    @Test
+    public void should_mix_consecutive_returns_with_excepions() throws Exception {
+        when(mock.simpleMethod())
+                .thenThrow(new IllegalArgumentException())
+                .thenReturn("one")
+                .thenThrow(new NullPointerException())
+                .thenReturn(null);
+
+        try {
+            mock.simpleMethod();
+            fail();
+        } catch (IllegalArgumentException expected) { }
+
         assertEquals("one", mock.simpleMethod());
-        
+
         try {
             mock.simpleMethod();
             fail();
-        } catch (NullPointerException e) {}
-        
+        } catch (NullPointerException expected) { }
+
         assertEquals(null, mock.simpleMethod());
         assertEquals(null, mock.simpleMethod());
     }
-    
-    @Test(expected=MockitoException.class)
-    public void shouldValidateConsecutiveException() throws Exception {
+
+    @Test(expected = MockitoException.class)
+    public void should_validate_consecutive_exception() throws Exception {
         when(mock.simpleMethod())
-            .thenReturn("one")
-            .thenThrow(new Exception());
+                .thenReturn("one")
+                .thenThrow(new Exception());
     }
-    
+
     @Test
-    public void shouldStubVoidMethodAndContinueThrowing() throws Exception {
+    public void should_stub_void_method_and_continue_throwing() throws Exception {
         stubVoid(mock)
-            .toThrow(new IllegalArgumentException())
-            .toReturn()
-            .toThrow(new NullPointerException())
-            .on().voidMethod();
-        
+                .toThrow(new IllegalArgumentException())
+                .toReturn()
+                .toThrow(new NullPointerException())
+                .on().voidMethod();
+
         try {
             mock.voidMethod();
             fail();
-        } catch (IllegalArgumentException e) {}
-        
+        } catch (IllegalArgumentException expected) { }
+
         mock.voidMethod();
-        
+
         try {
             mock.voidMethod();
             fail();
-        } catch (NullPointerException e) {}
-        
+        } catch (NullPointerException expected) { }
+
         try {
             mock.voidMethod();
             fail();
-        } catch (NullPointerException e) {}        
+        } catch (NullPointerException expected) { }
     }
-    
+
     @Test
-    public void shouldStubVoidMethod() throws Exception {
-        stubVoid(mock)
-            .toReturn()
-            .toThrow(new NullPointerException())
-            .toReturn()
-            .on().voidMethod();
-        
+    public void should_stub_void_method() throws Exception {
+        stubVoid(mock).toReturn()
+                      .toThrow(new NullPointerException())
+                      .toReturn()
+                      .on().voidMethod();
+
         mock.voidMethod();
-        
+
         try {
             mock.voidMethod();
             fail();
-        } catch (NullPointerException e) {}
-        
+        } catch (NullPointerException expected) { }
+
         mock.voidMethod();
         mock.voidMethod();
     }
-    
-    @Test(expected=MockitoException.class)
-    public void shouldValidateConsecutiveExceptionForVoidMethod() throws Exception {
-        stubVoid(mock)
-            .toReturn()
-            .toThrow(new Exception())
-            .on().voidMethod();
+
+    @Test(expected = MockitoException.class)
+    public void should_validate_consecutive_exception_for_void_method() throws Exception {
+        stubVoid(mock).toReturn()
+                      .toThrow(new Exception())
+                      .on().voidMethod();
     }
 }

--- a/src/test/java/org/mockitousage/stubbing/StubbingWithThrowablesTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingWithThrowablesTest.java
@@ -7,7 +7,6 @@ package org.mockitousage.stubbing;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockito.exceptions.verification.WantedButNotInvoked;
@@ -109,21 +108,26 @@ public class StubbingWithThrowablesTest extends TestBase {
         }
     }
 
+    @Test(expected = MockitoException.class)
+    public void shouldNotAllowNullExceptionType() {
+        when(mock.add(null)).thenThrow((Exception) null);
+    }
 
-    @Test(expected = IllegalArgumentException.class)
+
+    @Test(expected = NaughtyException.class)
     public void shouldInstantiateExceptionClassOnInteraction() {
-        when(mock.add(null)).thenThrow(IllegalArgumentException.class);
+        when(mock.add(null)).thenThrow(NaughtyException.class);
 
         mock.add(null);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NaughtyException.class)
     public void shouldInstantiateExceptionClassWithOngoingStubbingOnInteraction() {
-        Mockito.doThrow(IllegalArgumentException.class).when(mock).add(null);
+        doThrow(NaughtyException.class).when(mock).add(null);
 
         mock.add(null);
     }
-    
+
     @Test(expected=MockitoException.class)
     public void shouldNotAllowSettingInvalidCheckedException() throws Exception {
         when(mock.add("monkey island")).thenThrow(new Exception());
@@ -138,7 +142,7 @@ public class StubbingWithThrowablesTest extends TestBase {
     public void shouldNotAllowSettingNullThrowableArray() throws Exception {
         when(mock.add("monkey island")).thenThrow((Throwable[]) null);
     }
-    
+
     @Test
     public void shouldMixThrowablesAndReturnsOnDifferentMocks() throws Exception {
         when(mock.add("ExceptionOne")).thenThrow(new ExceptionOne());

--- a/subprojects/testng/src/main/java/org/mockito/testng/MockitoBeforeTestNGMethod.java
+++ b/subprojects/testng/src/main/java/org/mockito/testng/MockitoBeforeTestNGMethod.java
@@ -43,6 +43,7 @@ public class MockitoBeforeTestNGMethod {
         markAsInitialized(testResult.getInstance());
     }
 
+    @SuppressWarnings("unchecked")
     private void initializeCaptors(Object instance) {
         List<InstanceField> instanceFields = Fields.allDeclaredFieldsOf(instance).filter(annotatedBy(Captor.class)).instanceFields();
         for (InstanceField instanceField : instanceFields) {


### PR DESCRIPTION
The motivation behind this rework, is that developers using JDK7+ see compiler warnings on some varargs methods.

While these warning are false alarms, users may not feel the same way. These compiler warnings cannot be entirely avoided ; annotations like `@SafeVarargs` don't work on interfaces, and `@SuppressWarning({"unchecked", "varargs"})` have a limited impact on user code.

**As these annotations have limited impact, and most people use a single argument anyway, I propose to to introduce API that takes a single argument. While an overload can takes more arguments**

If we don't do that i.e. if we keep the same API with compiler warnings it may encourages users to add `@SuppressWarning({"unchecked", "varargs"})` in their test code, thus potentially hiding bugs in their code base.