### PR TITLE
Upgraded to Byte Buddy 0.6.11 and took improved features in use.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ tasks.withType(JavaCompile) {
 
 //TODO we should remove all dependencies to checked-in jars
 dependencies {
-    compile 'net.bytebuddy:byte-buddy:0.6.10'
+    compile 'net.bytebuddy:byte-buddy:0.6.11'
 
     provided "junit:junit:4.10"
     compile "org.hamcrest:hamcrest-core:1.1", "org.objenesis:objenesis:2.1"

--- a/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyCrossClassLoaderSerializationSupport.java
+++ b/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyCrossClassLoaderSerializationSupport.java
@@ -166,7 +166,7 @@ class ByteBuddyCrossClassLoaderSerializationSupport implements Serializable {
         private static final long serialVersionUID = -7600267929109286514L;
         private final byte[] serializedMock;
         private final Class typeToMock;
-        private final Set<Class> extraInterfaces;
+        private final Set<Class<?>> extraInterfaces;
 
         /**
          * Creates the wrapper that be used in the serialization stream.
@@ -246,9 +246,9 @@ class ByteBuddyCrossClassLoaderSerializationSupport implements Serializable {
      */
     public static class MockitoMockObjectInputStream extends ObjectInputStream {
         private final Class typeToMock;
-        private final Set<Class> extraInterfaces;
+        private final Set<Class<?>> extraInterfaces;
 
-        public MockitoMockObjectInputStream(InputStream in, Class typeToMock, Set<Class> extraInterfaces) throws IOException {
+        public MockitoMockObjectInputStream(InputStream in, Class typeToMock, Set<Class<?>> extraInterfaces) throws IOException {
             super(in);
             this.typeToMock = typeToMock;
             this.extraInterfaces = extraInterfaces;

--- a/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/CachingMockBytecodeGenerator.java
+++ b/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/CachingMockBytecodeGenerator.java
@@ -99,7 +99,7 @@ class CachingMockBytecodeGenerator {
             private final String mockedType;
             private final Set<String> types = new HashSet<String>();
 
-            private MockKey(Class<T> mockedType, Set<Class> interfaces) {
+            private MockKey(Class<T> mockedType, Set<Class<?>> interfaces) {
                 this.mockedType = mockedType.getName();
                 for (Class anInterface : interfaces) {
                     types.add(anInterface.getName());
@@ -127,7 +127,7 @@ class CachingMockBytecodeGenerator {
                 return result;
             }
 
-            public static <T> MockKey of(Class<T> mockedType, Set<Class> interfaces) {
+            public static <T> MockKey of(Class<T> mockedType, Set<Class<?>> interfaces) {
                 return new MockKey<T>(mockedType, interfaces);
             }
         }

--- a/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/MockBytecodeGenerator.java
+++ b/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/MockBytecodeGenerator.java
@@ -6,15 +6,11 @@ import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import net.bytebuddy.dynamic.scaffold.subclass.ConstructorStrategy;
 import net.bytebuddy.implementation.FieldAccessor;
-import net.bytebuddy.implementation.Implementation;
 import net.bytebuddy.implementation.MethodDelegation;
 import net.bytebuddy.implementation.attribute.MethodAttributeAppender;
 import net.bytebuddy.implementation.attribute.TypeAttributeAppender;
-import net.bytebuddy.implementation.bind.annotation.FieldProxy;
 import org.mockito.internal.creation.bytebuddy.ByteBuddyCrossClassLoaderSerializationSupport.CrossClassLoaderSerializableMock;
 import org.mockito.internal.creation.bytebuddy.MockMethodInterceptor.DispatcherDefaultingToRealMethod;
-import org.mockito.internal.creation.bytebuddy.MockMethodInterceptor.DispatcherDefaultingToRealMethod.FieldGetter;
-import org.mockito.internal.creation.bytebuddy.MockMethodInterceptor.DispatcherDefaultingToRealMethod.FieldSetter;
 import org.mockito.internal.creation.bytebuddy.MockMethodInterceptor.MockAccess;
 import org.mockito.internal.creation.util.SearchingClassLoader;
 
@@ -24,24 +20,16 @@ import static net.bytebuddy.description.modifier.FieldManifestation.FINAL;
 import static net.bytebuddy.description.modifier.Ownership.STATIC;
 import static net.bytebuddy.description.modifier.Visibility.PRIVATE;
 import static net.bytebuddy.implementation.MethodDelegation.to;
-import static net.bytebuddy.matcher.ElementMatchers.any;
-import static net.bytebuddy.matcher.ElementMatchers.isEquals;
-import static net.bytebuddy.matcher.ElementMatchers.isHashCode;
+import static net.bytebuddy.matcher.ElementMatchers.*;
 
 class MockBytecodeGenerator {
     private final ByteBuddy byteBuddy;
     private final Random random;
-    private final Implementation toDispatcher;
 
     public MockBytecodeGenerator() {
         byteBuddy = new ByteBuddy(ClassFileVersion.JAVA_V5)
                 .withDefaultMethodAttributeAppender(MethodAttributeAppender.ForInstrumentedMethod.INSTANCE)
                 .withAttribute(TypeAttributeAppender.ForSuperType.INSTANCE);
-
-        // Necessary for ConstructorInstantiator
-        toDispatcher = MethodDelegation.to(DispatcherDefaultingToRealMethod.class)
-                                       .appendParameterBinder(FieldProxy.Binder.install(FieldGetter.class,
-                                                                                        FieldSetter.class));
         random = new Random();
     }
 
@@ -50,7 +38,7 @@ class MockBytecodeGenerator {
                 byteBuddy.subclass(features.mockedType, ConstructorStrategy.Default.IMITATE_SUPER_TYPE)
                          .name(nameFor(features.mockedType))
                          .implement(features.interfaces.toArray(new Class<?>[features.interfaces.size()]))
-                         .method(any()).intercept(toDispatcher)
+                         .method(any()).intercept(MethodDelegation.to(DispatcherDefaultingToRealMethod.class))
                          .defineField("mockitoInterceptor", MockMethodInterceptor.class, PRIVATE)
                          .implement(MockAccess.class).intercept(FieldAccessor.ofBeanProperty())
                          .method(isHashCode()).intercept(to(MockMethodInterceptor.ForHashCode.class))

--- a/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/MockBytecodeGenerator.java
+++ b/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/MockBytecodeGenerator.java
@@ -27,7 +27,7 @@ class MockBytecodeGenerator {
     private final Random random;
 
     public MockBytecodeGenerator() {
-        byteBuddy = new ByteBuddy(ClassFileVersion.JAVA_V5)
+        byteBuddy = new ByteBuddy()
                 .withDefaultMethodAttributeAppender(MethodAttributeAppender.ForInstrumentedMethod.INSTANCE)
                 .withAttribute(TypeAttributeAppender.ForSuperType.INSTANCE);
         random = new Random();

--- a/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/MockFeatures.java
+++ b/mockmaker/bytebuddy/main/java/org/mockito/internal/creation/bytebuddy/MockFeatures.java
@@ -5,16 +5,16 @@ import java.util.Set;
 
 class MockFeatures<T> {
     final Class<T> mockedType;
-    final Set<Class> interfaces;
+    final Set<Class<?>> interfaces;
     final boolean crossClassLoaderSerializable;
 
-    private MockFeatures(Class<T> mockedType, Set<Class> interfaces, boolean crossClassLoaderSerializable) {
+    private MockFeatures(Class<T> mockedType, Set<Class<?>> interfaces, boolean crossClassLoaderSerializable) {
         this.mockedType = mockedType;
         this.interfaces = Collections.unmodifiableSet(interfaces);
         this.crossClassLoaderSerializable = crossClassLoaderSerializable;
     }
 
-    public static <T> MockFeatures<T> withMockFeatures(Class<T> mockedType, Set<Class> interfaces, boolean crossClassLoaderSerializable) {
+    public static <T> MockFeatures<T> withMockFeatures(Class<T> mockedType, Set<Class<?>> interfaces, boolean crossClassLoaderSerializable) {
         return new MockFeatures<T>(mockedType, interfaces, crossClassLoaderSerializable);
     }
 }

--- a/mockmaker/bytebuddy/test/java/org/mockito/internal/creation/bytebuddy/CachingMockBytecodeGeneratorTest.java
+++ b/mockmaker/bytebuddy/test/java/org/mockito/internal/creation/bytebuddy/CachingMockBytecodeGeneratorTest.java
@@ -30,7 +30,7 @@ public class CachingMockBytecodeGeneratorTest {
         CachingMockBytecodeGenerator cachingMockBytecodeGenerator = new CachingMockBytecodeGenerator();
         Class<?> the_mock_type = cachingMockBytecodeGenerator.get(withMockFeatures(
                         classloader_with_life_shorter_than_cache.loadClass("foo.Bar"),
-                        Collections.<Class>emptySet(),
+                        Collections.<Class<?>>emptySet(),
                         false
                 ));
 

--- a/osgi.gradle
+++ b/osgi.gradle
@@ -21,7 +21,7 @@ afterEvaluate {
 
             instruction 'Import-Package',
                     '!org.mockito.asm.signature',
-                    'net.bytebuddy.*;version=0.2.1',
+                    'net.bytebuddy.*;version=0.6.11',
                     'junit.*;resolution:=optional',
                     'org.junit.*;resolution:=optional',
                     'org.apache.tools.ant.*;resolution:=optional',

--- a/src/org/mockito/internal/creation/MockSettingsImpl.java
+++ b/src/org/mockito/internal/creation/MockSettingsImpl.java
@@ -39,12 +39,12 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
         return this;
     }
 
-    public MockSettings extraInterfaces(Class... extraInterfaces) {
+    public MockSettings extraInterfaces(Class<?>... extraInterfaces) {
         if (extraInterfaces == null || extraInterfaces.length == 0) {
             new Reporter().extraInterfacesRequiresAtLeastOneInterface();
         }
 
-        for (Class i : extraInterfaces) {
+        for (Class<?> i : extraInterfaces) {
             if (i == null) {
                 new Reporter().extraInterfacesDoesNotAcceptNullParameters();
             } else if (!i.isInterface()) {
@@ -59,7 +59,7 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
         return mockName;
     }
 
-    public Set<Class> getExtraInterfaces() {
+    public Set<Class<?>> getExtraInterfaces() {
         return extraInterfaces;
     }
 
@@ -182,8 +182,8 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
         return settings;
     }
 
-    private static Set<Class> prepareExtraInterfaces(CreationSettings settings) {
-        Set<Class> interfaces = new HashSet<Class>(settings.getExtraInterfaces());
+    private static Set<Class<?>> prepareExtraInterfaces(CreationSettings settings) {
+        Set<Class<?>> interfaces = new HashSet<Class<?>>(settings.getExtraInterfaces());
         if(settings.isSerializable()) {
             interfaces.add(Serializable.class);
         }

--- a/src/org/mockito/internal/creation/settings/CreationSettings.java
+++ b/src/org/mockito/internal/creation/settings/CreationSettings.java
@@ -23,7 +23,7 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
     private static final long serialVersionUID = -6789800638070123629L;
 
     protected Class<T> typeToMock;
-    protected Set<Class> extraInterfaces = new LinkedHashSet<Class>();
+    protected Set<Class<?>> extraInterfaces = new LinkedHashSet<Class<?>>();
     protected String name;
     protected Object spiedInstance;
     protected Answer<Object> defaultAnswer;
@@ -60,11 +60,11 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
         return this;
     }
 
-    public Set<Class> getExtraInterfaces() {
+    public Set<Class<?>> getExtraInterfaces() {
         return extraInterfaces;
     }
 
-    public CreationSettings<T> setExtraInterfaces(Set<Class> extraInterfaces) {
+    public CreationSettings<T> setExtraInterfaces(Set<Class<?>> extraInterfaces) {
         this.extraInterfaces = extraInterfaces;
         return this;
     }

--- a/src/org/mockito/internal/util/MockCreationValidator.java
+++ b/src/org/mockito/internal/util/MockCreationValidator.java
@@ -17,14 +17,14 @@ public class MockCreationValidator {
 
     private final MockUtil mockUtil = new MockUtil();
 
-    public void validateType(Class classToMock) {
+    public void validateType(Class<?> classToMock) {
         TypeMockability typeMockability = mockUtil.typeMockabilityOf(classToMock);
         if (!typeMockability.mockable()) {
             new Reporter().cannotMockClass(classToMock, typeMockability.nonMockableReason());
         }
     }
 
-    public void validateExtraInterfaces(Class classToMock, Collection<Class> extraInterfaces) {
+    public void validateExtraInterfaces(Class<?> classToMock, Collection<Class<?>> extraInterfaces) {
         if (extraInterfaces == null) {
             return;
         }
@@ -36,7 +36,7 @@ public class MockCreationValidator {
         }
     }
 
-    public void validateMockedType(Class classToMock, Object spiedInstance) {
+    public void validateMockedType(Class<?> classToMock, Object spiedInstance) {
         if (classToMock == null || spiedInstance == null) {
             return;
         }
@@ -45,7 +45,7 @@ public class MockCreationValidator {
         }
     }
 
-    public void validateDelegatedInstance(Class classToMock, Object delegatedInstance) {
+    public void validateDelegatedInstance(Class<?> classToMock, Object delegatedInstance) {
         if (classToMock == null || delegatedInstance == null) {
             return;
         }
@@ -54,7 +54,7 @@ public class MockCreationValidator {
         }
     }
 
-    public void validateSerializable(Class classToMock, boolean serializable) {
+    public void validateSerializable(Class<?> classToMock, boolean serializable) {
         // We can't catch all the errors with this piece of code
         // Having a **superclass that do not implements Serializable** might fail as well when serialized
         // Though it might prevent issues when mockito is mocking a class without superclass.

--- a/src/org/mockito/mock/MockCreationSettings.java
+++ b/src/org/mockito/mock/MockCreationSettings.java
@@ -25,7 +25,7 @@ public interface MockCreationSettings<T> {
     /**
      * the extra interfaces the mock object should implement.
      */
-    Set<Class> getExtraInterfaces();
+    Set<Class<?>> getExtraInterfaces();
 
     /**
      * the name of this mock, as printed on verification errors; see {@link org.mockito.MockSettings#name}.


### PR DESCRIPTION
Over the recent versions, several new features were added to Byte Buddy:

1. An interceptor is now automatically detecting if a default interface method can be invoked if no super method exists.
2. `@Origin` annotated methods are now automatically cached.
3. A field value can be read without generating a proxy using the `@FieldValue` annotation in order to avoid the overhead of the accessor.
4. Replaced Mockito's `SearchingClassLoader` with Byte Buddy's `MultipleParentClassLoader` to avoid the overhead of multiple class loader creation as class loaders are rather heavy objects for a VM.
5. Removed duplicated interception methods.
6. Added `@StubValue` to return correct default value for intercepted constructors.
7. Generified several `Class` values in order to make the project compile against Byte Buddy's `Class<?>` values.
8. Updated *out of sync* OSGi manifest.

Also: Why does Mockito explicitly set the Java version for generated classes to version 5? If not specified explicitly, Mockito discovers the JVM version and generates the newest possible version". This way, Byte Buddy can support Java 8 default methods on demand.