### PR TITLE
Fixes #244 StackOverflowError in MockitoSerializationIssue.java

### DIFF
--- a/src/org/mockito/exceptions/base/MockitoSerializationIssue.java
+++ b/src/org/mockito/exceptions/base/MockitoSerializationIssue.java
@@ -30,12 +30,6 @@ public class MockitoSerializationIssue extends ObjectStreamException {
         filterStackTrace();
     }
 
-    @Override
-    public StackTraceElement[] getStackTrace() {
-        filterStackTrace();
-        return super.getStackTrace();
-    }
-
     private void filterStackTrace() {
         unfilteredStackTrace = super.getStackTrace();
 

--- a/test/org/mockito/exceptions/base/MockitoSerializationIssueTest.java
+++ b/test/org/mockito/exceptions/base/MockitoSerializationIssueTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito.exceptions.base;
+
+import org.junit.Test;
+import org.mockito.internal.configuration.ConfigurationAccess;
+import org.mockitoutil.TestBase;
+
+import java.util.Arrays;
+
+public class MockitoSerializationIssueTest extends TestBase {
+
+    @Test
+    public void shouldFilterOutTestClassFromStacktraceWhenCleanFlagIsTrue() {
+        // given
+        ConfigurationAccess.getConfig().overrideCleansStackTrace(true);
+
+        // when
+        MockitoSerializationIssue issue = new MockitoSerializationIssue("msg", new Exception("cause"));
+
+        // then
+        assertContains("MockitoSerializationIssueTest", Arrays.toString(issue.getUnfilteredStackTrace()));
+        assertNotContains("MockitoSerializationIssueTest", Arrays.toString(issue.getStackTrace()));
+    }
+
+    @Test
+    public void shouldKeepExecutingClassInStacktraceWhenCleanFlagIsFalse() {
+        // given
+        ConfigurationAccess.getConfig().overrideCleansStackTrace(false);
+
+        // when
+        MockitoSerializationIssue issue = new MockitoSerializationIssue("msg", new Exception("cause"));
+
+        // then
+        assertContains("MockitoSerializationIssueTest", Arrays.toString(issue.getUnfilteredStackTrace()));
+        assertContains("MockitoSerializationIssueTest", Arrays.toString(issue.getStackTrace()));
+    }
+}


### PR DESCRIPTION
Fixes #244 It looked to me that the getStackTrace() method in MockitoSerializationIssue.java was unneeded. Deleting it solves the problem with Stackoverflow. 