### PR TITLE
Upgraded to Byte Buddy 0.6.12. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ test {
 }
 
 dependencies {
-    compile 'net.bytebuddy:byte-buddy:0.6.11'
+    compile 'net.bytebuddy:byte-buddy:0.6.12'
 
     provided "junit:junit:4.10", "org.hamcrest:hamcrest-core:1.3"
     compile "org.objenesis:objenesis:2.1"


### PR DESCRIPTION
Fixes https://github.com/mockito/mockito/issues/253

- Adapted minor API changes. 
- Added modifier resolver that removes the synchronization flag from intercepted methods.