### PR TITLE
Fixes #260: Typo in documentation

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -1051,7 +1051,7 @@ import org.mockito.junit.*;
  * such as <code>&#064;{@link Mock}</code>, <code>&#064;{@link Spy}</code>, <code>&#064;{@link InjectMocks}</code>, etc.
  *
  * <ul>
- *     <li>Annotating the JUnit test class with a <code>&#064;{@link org.junit.runner.RunWith}(&#064;{@link MockitoJUnitRunner}.class)</code></li>
+ *     <li>Annotating the JUnit test class with a <code>&#064;{@link org.junit.runner.RunWith}({@link MockitoJUnitRunner}.class)</code></li>
  *     <li>Invoking <code>{@link MockitoAnnotations#initMocks(Object)}</code> in the <code>&#064;{@link org.junit.Before}</code> method</li>
  * </ul>
  *


### PR DESCRIPTION
Very minor typo in documentation: https://github.com/mockito/mockito/issues/260

There's an extra "at" (@) in the documentation.

Before it reads:
"Annotating the JUnit test class with a @RunWith(@MockitoJUnitRunner.class)"

After it reads:
"Annotating the JUnit test class with a @RunWith(MockitoJUnitRunner.class)"

![image](https://cloud.githubusercontent.com/assets/338917/8634099/6c7f5264-27b8-11e5-93d9-98b725c9f749.png)