### PR TITLE
Providing functionality for setting the annotation engine for a test …

### DIFF
--- a/src/main/java/org/mockito/MockitoPlugin.java
+++ b/src/main/java/org/mockito/MockitoPlugin.java
@@ -1,0 +1,77 @@
+package org.mockito;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.mockito.configuration.AnnotationEngine;
+import org.mockito.internal.configuration.InjectingAnnotationEngine;
+
+/**
+ * Sets the annotation engine for the TestClass being run
+ *
+ * <ul>
+ * <li>Allows a customized annotation engine to be used instead of the default engine i.e. {@link org.mockito.internal.configuration.InjectingAnnotationEngine}</li>
+ * <li>Provides the possibilities to use different injection strategies for each test class instead of having a single strategy</li>
+ * <li>Provides an alternative to the approach of providing a {@link org.mockito.configuration.MockitoConfiguration} implementation</li>
+ * <li>Provides the possibility to use alternative/additional annotations for the fields being injected, such as marking a field to be injected with real instances rather than mocks</li>
+ * </ul>
+ *
+ * <pre class="code"><code class="java">
+ *   &#064;MockitoPlugin(annotationEngine = MyAnnotationEngine.class)
+ *   public class ArticleManagerTest extends SampleBaseTestCase {
+ *
+ *       &#064;Mock private ArticleCalculator calculator;
+ *       &#064;Mock private  articleMonitor;
+ *
+ *       private ArticleManager manager;
+ *   }
+ *
+ *   public class SampleBaseTestCase {
+ *
+ *       &#064;Before public void initMocks() {
+ *           MockitoAnnotations.initMocks(this);
+ *       }
+ *   }
+ *   
+ *   public class MyAnnotationEngine implements AnnotationEngine {
+ *       void process(Class<?> clazz, Object testInstance) {
+ *           ... processing of logic to do the injection ...
+ *       }
+ *
+ *   }
+ * </code></pre>
+ *
+ * <p>
+ * The annotation engine needs to extend the interface {@link org.mockito.configuration.AnnotationEngine} and implement the 
+ * <strong><code>void process(Class<?> clazz, Object testInstance)</code></strong> method and a provide default constructor.
+ * </p>
+ *
+ * <p>
+ * <strong><code>MockitoAnnotations.initMocks(this)</code></strong> method has to be called to initialize annotated objects.
+ * In above example, <code>initMocks()</code> is called in &#064;Before (JUnit4) method of test's base class.
+ * For JUnit3 <code>initMocks()</code> can go to <code>setup()</code> method of a base class.
+ * <strong>Instead</strong> you can also put initMocks() in your JUnit runner (&#064;RunWith) or use the built-in
+ * {@link org.mockito.runners.MockitoJUnitRunner}.
+ * </p>
+ * 
+ * <p>
+ * Please note that the annotation engine will not work well in combination with using MockitoConfiguration, 
+ * as the GlobalConfiguration will be replaced for each &#064;MockitoPlugin annotation found. 
+ *
+ * @see MockitoAnnotations#initMocks(Object)
+ * @see org.mockito.runners.MockitoJUnitRunner
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+public @interface MockitoPlugin {
+
+    /**
+     * 
+     * @return the class, which should be used as the annotation engine for the test
+     */
+    public Class<? extends AnnotationEngine> annotationEngine() default InjectingAnnotationEngine.class;
+}

--- a/src/main/java/org/mockito/configuration/DefaultMockitoConfiguration.java
+++ b/src/main/java/org/mockito/configuration/DefaultMockitoConfiguration.java
@@ -4,7 +4,9 @@
  */
 package org.mockito.configuration;
 
+import org.mockito.MockitoPlugin;
 import org.mockito.ReturnValues;
+import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.configuration.InjectingAnnotationEngine;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsEmptyValues;
 import org.mockito.stubbing.Answer;
@@ -19,6 +21,25 @@ import org.mockito.stubbing.Answer;
 @SuppressWarnings("deprecation")//suppressed until ReturnValues are removed
 public class DefaultMockitoConfiguration implements IMockitoConfiguration {
     
+    private AnnotationEngine annotationEngine;
+    private ReturnsEmptyValues returnsEmptyValues = new ReturnsEmptyValues();
+
+    public DefaultMockitoConfiguration() {
+        annotationEngine = new InjectingAnnotationEngine();
+    }
+
+    public DefaultMockitoConfiguration(MockitoPlugin mockitoPlugin) {
+        if(mockitoPlugin == null) {
+            throw new MockitoException("mockitoPlugin is null");
+        }
+
+        try {
+            annotationEngine = (AnnotationEngine) mockitoPlugin.annotationEngine().newInstance();
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Unable to instantiate the specified annotation engine in the mockito plugin", e);
+        }
+    }
+
     /* (non-Javadoc)
      * @see org.mockito.IMockitoConfiguration#getReturnValues()
      */
@@ -29,14 +50,14 @@ public class DefaultMockitoConfiguration implements IMockitoConfiguration {
     }
 
     public Answer<Object> getDefaultAnswer() {
-        return new ReturnsEmptyValues();
+        return returnsEmptyValues;
     }
     
     /* (non-Javadoc)
      * @see org.mockito.IMockitoConfiguration#getAnnotationEngine()
      */
     public AnnotationEngine getAnnotationEngine() {
-        return new InjectingAnnotationEngine();
+        return annotationEngine;
     }
 
     /* (non-Javadoc)

--- a/src/main/java/org/mockito/internal/configuration/GlobalConfiguration.java
+++ b/src/main/java/org/mockito/internal/configuration/GlobalConfiguration.java
@@ -4,6 +4,7 @@
  */
 package org.mockito.internal.configuration;
 
+import org.mockito.MockitoPlugin;
 import org.mockito.ReturnValues;
 import org.mockito.configuration.AnnotationEngine;
 import org.mockito.configuration.DefaultMockitoConfiguration;
@@ -19,7 +20,7 @@ import java.io.Serializable;
 public class GlobalConfiguration implements IMockitoConfiguration, Serializable {
     private static final long serialVersionUID = -2860353062105505938L;
     
-    private static final ThreadLocal<IMockitoConfiguration> GLOBAL_CONFIGURATION = new ThreadLocal<IMockitoConfiguration>();
+    static final ThreadLocal<IMockitoConfiguration> GLOBAL_CONFIGURATION = new ThreadLocal<IMockitoConfiguration>();
 
     //back door for testing
     IMockitoConfiguration getIt() {
@@ -31,6 +32,10 @@ public class GlobalConfiguration implements IMockitoConfiguration, Serializable 
         if (GLOBAL_CONFIGURATION.get() == null) {
             GLOBAL_CONFIGURATION.set(createConfig());
         }
+    }
+
+    public GlobalConfiguration(MockitoPlugin mockitoPlugin) {
+        GLOBAL_CONFIGURATION.set(createConfig(mockitoPlugin));
     }
 
     private IMockitoConfiguration createConfig() {
@@ -66,4 +71,9 @@ public class GlobalConfiguration implements IMockitoConfiguration, Serializable 
     public Answer<Object> getDefaultAnswer() {
         return GLOBAL_CONFIGURATION.get().getDefaultAnswer();
     }
+    
+    private IMockitoConfiguration createConfig(MockitoPlugin mockitoPlugin) {
+        return new DefaultMockitoConfiguration(mockitoPlugin);
+    }
+
 }

--- a/src/test/java/org/mockito/internal/configuration/ConfigurationAccess.java
+++ b/src/test/java/org/mockito/internal/configuration/ConfigurationAccess.java
@@ -4,6 +4,7 @@
  */
 package org.mockito.internal.configuration;
 
+import org.mockito.configuration.IMockitoConfiguration;
 import org.mockito.configuration.MockitoConfiguration;
 
 public class ConfigurationAccess {
@@ -11,4 +12,13 @@ public class ConfigurationAccess {
     public static MockitoConfiguration getConfig() {
         return (MockitoConfiguration) new GlobalConfiguration().getIt();
     }
+    
+    public static IMockitoConfiguration getConfigAsInterface() {
+        return new GlobalConfiguration().getIt();
+    }
+    
+    public static void removeIt() {
+        GlobalConfiguration.GLOBAL_CONFIGURATION.remove();
+    }
+
 }

--- a/src/test/java/org/mockitousage/MockitoAnnotationsTest.java
+++ b/src/test/java/org/mockitousage/MockitoAnnotationsTest.java
@@ -1,0 +1,173 @@
+package org.mockitousage;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.internal.TextListener;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.MockitoPlugin;
+import org.mockito.configuration.AnnotationEngine;
+import org.mockito.internal.configuration.ConfigurationAccess;
+import org.mockito.internal.configuration.GlobalConfiguration;
+import org.mockito.internal.util.MockUtil;
+import org.mockito.runners.MockitoJUnitRunner;
+
+public class MockitoAnnotationsTest {
+
+    @Before
+    public void setUp() {
+        ConfigurationAccess.removeIt();
+    }
+    
+    @After
+    public void tearDown() {
+        ConfigurationAccess.removeIt();
+    }
+
+    @Test
+    public void should_process_the_testcase_using_default_annotation_engine() throws Exception {
+        NoMockitoPluginAnnotationTestClass noMockitoPluginAnnotationTestClass = new NoMockitoPluginAnnotationTestClass(); 
+
+        MockitoAnnotations.initMocks(noMockitoPluginAnnotationTestClass);
+        assertThat(isMock(noMockitoPluginAnnotationTestClass.someMock)).isTrue();
+    }
+
+    @Test
+    public void should_process_the_testcase_using_MyAnnotationEngine() throws Exception {
+        MockitoPluginAnnotationTestClass mockitoPluginAnnotationTestClass = new MockitoPluginAnnotationTestClass(); 
+
+        MockitoAnnotations.initMocks(mockitoPluginAnnotationTestClass);
+        
+        MyAnnotationEngine annotationEngine = (MyAnnotationEngine) new GlobalConfiguration().getAnnotationEngine();
+        assertThat(annotationEngine.processInvoked).isTrue();
+    }
+
+    @Test
+    public void ensure_when_that_different_testcases_can_have_different_annotation_engine() throws Exception {
+        JUnitCore runner = new JUnitCore();
+        runner.addListener(new TextListener(System.out));
+
+        Result result1 = runner.run(TestClass1.class);
+        AnnotationEngine annotationEngine1 = ConfigurationAccess.getConfigAsInterface().getAnnotationEngine();
+        assertThat(result1.getFailureCount()).isEqualTo(0);
+        assertThat(result1.wasSuccessful()).isTrue();
+        assertThat(annotationEngine1).isInstanceOf(MyAnnotationEngineForClass1.class);
+        MyAnnotationEngineForClass1 myAnnotationEngineForClass1 = (MyAnnotationEngineForClass1) annotationEngine1;
+        assertThat(myAnnotationEngineForClass1.processInvoked).isTrue();
+
+        Result result2 = runner.run(TestClass2.class);
+        AnnotationEngine annotationEngine2 = ConfigurationAccess.getConfigAsInterface().getAnnotationEngine();
+        assertThat(result2.getFailureCount()).isEqualTo(0);
+        assertThat(result2.wasSuccessful()).isTrue();
+        assertThat(annotationEngine2).isInstanceOf(MyAnnotationEngineForClass2.class);
+        MyAnnotationEngineForClass2 myAnnotationEngineForClass2 = (MyAnnotationEngineForClass2) annotationEngine2;
+        assertThat(myAnnotationEngineForClass2.processInvoked).isTrue();
+    }
+
+    @RunWith(MockitoJUnitRunner.class)
+    public static class NoMockitoPluginAnnotationTestClass {
+     
+        @Mock
+        public SomeMock someMock;
+    }
+    
+    public static interface SomeMock {
+        
+    }
+    
+    @RunWith(MockitoJUnitRunner.class)
+    @MockitoPlugin(annotationEngine=MyAnnotationEngine.class)
+    public static class MockitoPluginAnnotationTestClass {
+        
+        @Mock
+        public SomeMock someMock;
+    }
+    
+    public static class MyAnnotationEngine implements AnnotationEngine {
+
+        public boolean processInvoked = false;
+        
+        @Override
+        public Object createMockFor(Annotation annotation, Field field) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void process(Class<?> clazz, Object testInstance) {
+            processInvoked = true;
+        }
+    }
+
+    private boolean isMock(Object o) {
+        return new MockUtil().isMock(o);
+    }
+
+    
+
+    @RunWith(MockitoJUnitRunner.class)
+    @MockitoPlugin(annotationEngine=MyAnnotationEngineForClass1.class)
+    public static class TestClass1 {
+        
+        private SomeMock someMock;
+        
+        @Test
+        public void ensure_single_test_is_run() throws Exception {
+        }
+    }
+
+    @RunWith(MockitoJUnitRunner.class)
+    @MockitoPlugin(annotationEngine=MyAnnotationEngineForClass2.class)
+    public static class TestClass2 {
+        
+        private SomeMock someMock;
+        
+        @Test
+        public void ensure_single_test_is_run() throws Exception {
+        }
+    }
+
+    static class ClassToBeInjectedWithMocks {
+    }
+    
+    public static class MyAnnotationEngineForClass1 implements AnnotationEngine {
+
+        public boolean processInvoked = false;
+        
+        @Override
+        public Object createMockFor(Annotation annotation, Field field) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void process(Class<?> clazz, Object testInstance) {
+            processInvoked = true;
+        }
+    }
+
+    public static class MyAnnotationEngineForClass2 implements AnnotationEngine {
+
+        public boolean processInvoked = false;
+        
+        @Override
+        public Object createMockFor(Annotation annotation, Field field) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void process(Class<?> clazz, Object testInstance) {
+            processInvoked = true;
+        }
+    }
+
+
+    
+}

--- a/src/test/java/org/mockitousage/TestClassWithMockitPluginAnnotation.java
+++ b/src/test/java/org/mockitousage/TestClassWithMockitPluginAnnotation.java
@@ -1,0 +1,43 @@
+package org.mockitousage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoPlugin;
+import org.mockito.configuration.AnnotationEngine;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockitousage.TestClassWithMockitPluginAnnotation.MyAnnotationEngine;
+
+@RunWith(MockitoJUnitRunner.class)
+@MockitoPlugin(annotationEngine = MyAnnotationEngine.class)
+public class TestClassWithMockitPluginAnnotation {
+    @InjectMocks
+    private ClassToBeInjectedWithMocks classToBeInjectedWithMocks;
+    
+    @Test
+    public void ensure_class_is_instantiated_with_a_mock() throws Exception {
+        assertThat(classToBeInjectedWithMocks).isNull();
+    }
+    
+    public static class MyAnnotationEngine implements AnnotationEngine {
+
+        @Override
+        public Object createMockFor(Annotation annotation, Field field) {
+            return null;
+        }
+
+        @Override
+        public void process(Class<?> clazz, Object testInstance) {
+            return;
+        }
+    }
+
+    static class ClassToBeInjectedWithMocks {
+    }
+
+}

--- a/src/test/java/org/mockitousage/TestClassWithoutMockitPluginAnnotation.java
+++ b/src/test/java/org/mockitousage/TestClassWithoutMockitPluginAnnotation.java
@@ -1,0 +1,25 @@
+package org.mockitousage;
+
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockitoutil.TestBase;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TestClassWithoutMockitPluginAnnotation extends TestBase {
+    
+    @InjectMocks
+    private ClassToBeInjectedWithMocks classToBeInjectedWithMocks;
+    
+    @Test
+    public void ensure_class_is_instantiated_with_a_real_instance() throws Exception {
+        Assertions.assertThat(classToBeInjectedWithMocks).isInstanceOf(ClassToBeInjectedWithMocks.class);
+    }
+    
+    static class ClassToBeInjectedWithMocks {
+    }
+
+}

--- a/src/test/java/org/mockitousage/internal/configuration/DefaultMockitoConfigurationTest.java
+++ b/src/test/java/org/mockitousage/internal/configuration/DefaultMockitoConfigurationTest.java
@@ -1,0 +1,89 @@
+package org.mockitousage.internal.configuration;
+
+import static org.mockito.Mockito.when;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
+import org.mockito.MockitoPlugin;
+import org.mockito.configuration.AnnotationEngine;
+import org.mockito.configuration.DefaultMockitoConfiguration;
+import org.mockito.internal.configuration.InjectingAnnotationEngine;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.mockitoutil.TestBase;
+
+public class DefaultMockitoConfigurationTest extends TestBase {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none(); 
+    
+    @Test
+    public void should_have_injectingAnnotationEngine_when_using_default_constructor() throws Exception {
+        DefaultMockitoConfiguration defaultMockitoConfiguration = new DefaultMockitoConfiguration();
+        assertTrue(defaultMockitoConfiguration.getAnnotationEngine().getClass().equals(InjectingAnnotationEngine.class));
+    }
+
+    @Test
+    public void should_have_injectingAnnotationEngine_when_using_constructor_with_mockitplugin_annotation() throws Exception {
+        MockitoPlugin annotation = Mockito.mock(MockitoPlugin.class);
+        when(annotation.annotationEngine())
+            .thenAnswer(new Answer<Class<?>>() {
+                @Override
+                public Class<?> answer(InvocationOnMock invocation) throws Throwable {
+                    return MyEngine.class;
+                }
+            });
+        
+        DefaultMockitoConfiguration defaultMockitoConfiguration = new DefaultMockitoConfiguration(annotation);
+        assertTrue(defaultMockitoConfiguration.getAnnotationEngine().getClass().equals(MyEngine.class));
+    }
+    
+    @Test
+    public void should_throw_illegalargument_exception_when_constructor_is_private() throws Exception {
+        thrown.expect(IllegalArgumentException.class);
+        
+        MockitoPlugin annotation = Mockito.mock(MockitoPlugin.class);
+        when(annotation.annotationEngine())
+            .thenAnswer(new Answer<Class<?>>() {
+                @Override
+                public Class<?> answer(InvocationOnMock invocation) throws Throwable {
+                    return MyEngineWithPrivateConstructor.class;
+                }
+            });
+        
+        DefaultMockitoConfiguration defaultMockitoConfiguration = new DefaultMockitoConfiguration(annotation);
+        assertTrue(defaultMockitoConfiguration.getAnnotationEngine().getClass().equals(MyEngine.class));
+    }
+    
+    public static class MyEngine implements AnnotationEngine {
+
+        @Override
+        public Object createMockFor(Annotation annotation, Field field) {
+            return null;
+        }
+
+        @Override
+        public void process(Class<?> clazz, Object testInstance) {
+        }
+    }
+    
+    public static class MyEngineWithPrivateConstructor implements AnnotationEngine {
+        private MyEngineWithPrivateConstructor() {
+        }
+        
+        @Override
+        public Object createMockFor(Annotation annotation, Field field) {
+            return null;
+        }
+
+        @Override
+        public void process(Class<?> clazz, Object testInstance) {
+        }
+    }
+
+}


### PR DESCRIPTION
…case through annotation

In order to customize the annotation engine the current implementation requires that one implements a specific class (MockitoConfiguration) which specifies which annotation engine to use for the whole project.

As a consequence it is not possible to have several custom annotation engines within the same project.

This is a proposal how to achieve several annotation engine by using an annotation.

```java
@MockitoPlugin(annotationEngine = MyAnnotationEngine.class)
 public class ArticleManagerTest extends SampleBaseTestCase {
     @Mock private ArticleCalculator calculator;
     @Mock private  articleMonitor;
     private ArticleManager manager;
 }

 public class SampleBaseTestCase {
     @Before public void initMocks() {
         MockitoAnnotations.initMocks(this);
     }
 }
 
 public class MyAnnotationEngine implements AnnotationEngine {
     void process(Class<?> clazz, Object testInstance) {
         ... processing of logic to do the injection ...
     }
```