### PR TITLE
Ignore Groovy meta methods when instrumenting.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ test {
 }
 
 dependencies {
-    compile 'net.bytebuddy:byte-buddy:0.6.12'
+    compile 'net.bytebuddy:byte-buddy:0.6.14'
 
     provided "junit:junit:4.10", "org.hamcrest:hamcrest-core:1.3"
     compile "org.objenesis:objenesis:2.1"


### PR DESCRIPTION
Added a matcher to ignore any methods that are defined by the Groovy meta class system from instrumentation. This way, it is possible to create mocks of Groovy classes that behave appropriately in Groovy code.