### PR TITLE
Issue #268: Added support for generic arrays as return types.

### DIFF
--- a/src/test/java/org/mockito/internal/util/reflection/GenericArrayReturnTypeTest.java
+++ b/src/test/java/org/mockito/internal/util/reflection/GenericArrayReturnTypeTest.java
@@ -1,0 +1,37 @@
+package org.mockito.internal.util.reflection;
+
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.Mockito;
+
+import java.util.Set;
+
+import static org.mockito.Mockito.mock;
+
+public class GenericArrayReturnTypeTest {
+
+    @Test
+    public void toArrayTypedDoesNotWork() throws Exception {
+        Container container = mock(Container.class, Answers.RETURNS_DEEP_STUBS);
+        container.getInnerContainer().getTheProblem().toArray(new String[]{});
+    }
+
+    class Container {
+
+        private InnerContainer innerContainer;
+
+        public InnerContainer getInnerContainer() {
+            return innerContainer;
+        }
+    }
+
+    class InnerContainer {
+
+        private Set<String> theProblem;
+
+        public Set<String> getTheProblem() {
+            return theProblem;
+        }
+    }
+
+}


### PR DESCRIPTION
Solves https://github.com/mockito/mockito/issues/268 by explicitly checking for return types that represent a generic array and by resolving for the array's component type.