### PR TITLE
Added InvocationsCounter as VerificationMode. Fixes #77

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -17,6 +17,8 @@ import org.mockito.stubbing.*;
 import org.mockito.verification.*;
 import org.mockito.junit.*;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 /**
  * <p align="left"><img src="logo.png" srcset="logo@2x.png 2x" alt="Mockito logo"/></p>
  * Mockito library enables mocks creation, verification and stubbing.
@@ -2228,6 +2230,22 @@ public class Mockito extends Matchers {
     }
 
     /**
+     * Allows verifying exact number of invocations. E.g:
+     * <pre class="code"><code class="java">
+     *   AtomicInteger counter = new AtomicInteger();
+     *   counter.set(2);
+     *   verify(mock, times(counter)).someMethod("some arg");
+     * </code></pre>
+     *
+     * @param wantedNumberOfInvocations wanted number of invocations
+     *
+     * @return verification mode
+     */
+    public static VerificationMode times(AtomicInteger wantedNumberOfInvocations) {
+        return VerificationModeFactory.times(wantedNumberOfInvocations.get());
+    }
+
+    /**
      * Alias to <code>times(0)</code>, see {@link Mockito#times(int)}
      * <p>
      * Verifies that interaction did not happen. E.g:
@@ -2309,7 +2327,7 @@ public class Mockito extends Matchers {
      * @return  verification mode
      */
     public static VerificationMode calls( int wantedNumberOfInvocations ){
-        return VerificationModeFactory.calls( wantedNumberOfInvocations );
+        return VerificationModeFactory.calls(wantedNumberOfInvocations);
     }
 
     /**
@@ -2330,6 +2348,20 @@ public class Mockito extends Matchers {
      */
     public static VerificationMode only() {
         return VerificationModeFactory.only();
+    }
+
+    /**
+     * Allows countin of number of invocations. E.g:
+     * <pre class="code"><code class="java">
+     *   verify(mock, countInvocations(2)).someMethod("some arg");
+     * </code></pre>
+     *
+     * @param wantedNumberOfInvocations wanted number of invocations
+     *
+     * @return verification mode
+     */
+    public static VerificationMode countInvocations(AtomicInteger wantedNumberOfInvocations) {
+        return VerificationModeFactory.countInvocations(wantedNumberOfInvocations);
     }
 
     /**

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -2327,7 +2327,7 @@ public class Mockito extends Matchers {
      * @return  verification mode
      */
     public static VerificationMode calls( int wantedNumberOfInvocations ){
-        return VerificationModeFactory.calls(wantedNumberOfInvocations);
+        return VerificationModeFactory.calls( wantedNumberOfInvocations );
     }
 
     /**
@@ -2351,7 +2351,7 @@ public class Mockito extends Matchers {
     }
 
     /**
-     * Allows countin of number of invocations. E.g:
+     * Allows counting of number of invocations. E.g:
      * <pre class="code"><code class="java">
      *   verify(mock, countInvocations(2)).someMethod("some arg");
      * </code></pre>

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -2353,7 +2353,17 @@ public class Mockito extends Matchers {
     /**
      * Allows counting of number of invocations. E.g:
      * <pre class="code"><code class="java">
-     *   verify(mock, countInvocations(2)).someMethod("some arg");
+     *   AtomicInteger counter = new AtomicInteger();
+     *   verify(mock, countInvocations(counter)).someMethod("some arg");
+     *   verify(otherMock, times(counter)).someMethodThatShouldAlsoHaveBeenCalled();
+     * </code></pre>
+     *
+     * or by directly asserting the counter:
+     *
+     * <pre class="code"><code class="java">
+     *   AtomicInteger counter = new AtomicInteger();
+     *   verify(mock, countInvocations(counter)).someMethod("some arg");
+     *   assertEquals(2, counter.get());
      * </code></pre>
      *
      * @param wantedNumberOfInvocations wanted number of invocations

--- a/src/main/java/org/mockito/internal/verification/CountInvocations.java
+++ b/src/main/java/org/mockito/internal/verification/CountInvocations.java
@@ -1,0 +1,33 @@
+package org.mockito.internal.verification;
+
+import org.mockito.internal.invocation.InvocationsFinder;
+import org.mockito.internal.verification.api.VerificationData;
+import org.mockito.invocation.Invocation;
+import org.mockito.verification.VerificationMode;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Created by tim on 31-7-15.
+ */
+public class CountInvocations implements VerificationMode {
+
+    private AtomicInteger invocationsCounter;
+
+    public CountInvocations(AtomicInteger invocationsCounter) {
+        this.invocationsCounter = invocationsCounter;
+    }
+
+    @Override
+    public void verify(VerificationData data) {
+        InvocationsFinder finder = new InvocationsFinder();
+        List<Invocation> found = finder.findInvocations(data.getAllInvocations(), data.getWanted());
+        invocationsCounter.set(found.size());
+    }
+
+    @Override
+    public VerificationMode description(String description) {
+        return VerificationModeFactory.description(this, description);
+    }
+}

--- a/src/main/java/org/mockito/internal/verification/CountInvocations.java
+++ b/src/main/java/org/mockito/internal/verification/CountInvocations.java
@@ -8,9 +8,6 @@ import org.mockito.verification.VerificationMode;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-/**
- * Created by tim on 31-7-15.
- */
 public class CountInvocations implements VerificationMode {
 
     private AtomicInteger invocationsCounter;

--- a/src/main/java/org/mockito/internal/verification/Times.java
+++ b/src/main/java/org/mockito/internal/verification/Times.java
@@ -6,6 +6,7 @@
 package org.mockito.internal.verification;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.invocation.InvocationMatcher;
@@ -28,6 +29,10 @@ public class Times implements VerificationInOrderMode, VerificationMode {
             throw new MockitoException("Negative value is not allowed here");
         }
         this.wantedCount = wantedNumberOfInvocations;
+    }
+
+    public Times(AtomicInteger wantedNumberOfInvocations) {
+        this.wantedCount = wantedNumberOfInvocations.get();
     }
     
     public void verify(VerificationData data) {

--- a/src/main/java/org/mockito/internal/verification/Times.java
+++ b/src/main/java/org/mockito/internal/verification/Times.java
@@ -6,7 +6,6 @@
 package org.mockito.internal.verification;
 
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.invocation.InvocationMatcher;
@@ -29,10 +28,6 @@ public class Times implements VerificationInOrderMode, VerificationMode {
             throw new MockitoException("Negative value is not allowed here");
         }
         this.wantedCount = wantedNumberOfInvocations;
-    }
-
-    public Times(AtomicInteger wantedNumberOfInvocations) {
-        this.wantedCount = wantedNumberOfInvocations.get();
     }
     
     public void verify(VerificationData data) {

--- a/src/main/java/org/mockito/internal/verification/VerificationModeFactory.java
+++ b/src/main/java/org/mockito/internal/verification/VerificationModeFactory.java
@@ -7,6 +7,8 @@ package org.mockito.internal.verification;
 
 import org.mockito.verification.VerificationMode;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 public class VerificationModeFactory {
     
     public static VerificationMode atLeastOnce() {
@@ -35,6 +37,10 @@ public class VerificationModeFactory {
 
     public static VerificationMode atMost(int maxNumberOfInvocations) {
         return new AtMost(maxNumberOfInvocations);
+    }
+
+    public static VerificationMode countInvocations(AtomicInteger wantedNumberOfInvocations) {
+        return new CountInvocations(wantedNumberOfInvocations);
     }
     
     /**

--- a/src/test/java/org/mockitousage/verification/ExactNumberOfTimesVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/ExactNumberOfTimesVerificationTest.java
@@ -8,6 +8,7 @@ package org.mockitousage.verification;
 import static org.mockito.Mockito.*;
 
 import java.util.LinkedList;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -125,5 +126,49 @@ public class ExactNumberOfTimesVerificationTest extends TestBase {
             inOrder.verify(mock, never()).add("two");
             fail();
         } catch (VerificationInOrderFailure e) {}
+    }
+
+    @Test
+    public void should_invoke_method_same_number_of_times() {
+        Invokable invokable = mock(Invokable.class);
+        Invoker invoker = spy(new Invoker(invokable));
+
+        AtomicInteger counter = new AtomicInteger();
+
+        invoker.invokesOtherMethod();
+
+        verify(invoker, countInvocations(counter)).invokesOtherMethod();
+        verify(invokable, times(counter)).invokableMethod();
+    }
+
+    @Test
+    public void should_count_number_of_invocations() {
+        Invokable invokable = mock(Invokable.class);
+
+        AtomicInteger counter = new AtomicInteger();
+
+        invokable.invokableMethod();
+        invokable.invokableMethod();
+
+        verify(invokable, countInvocations(counter)).invokableMethod();
+        assertEquals(2, counter.get());
+    }
+
+    public class Invokable {
+
+        public void invokableMethod() {}
+    }
+
+    public class Invoker {
+
+        private Invokable invokable;
+
+        public Invoker(Invokable invokable) {
+            this.invokable = invokable;
+        }
+
+        public void invokesOtherMethod() {
+            this.invokable.invokableMethod();
+        }
     }
 }


### PR DESCRIPTION
In order to count the number of invocations,
InvocationsCounter can keep track of the number of invocations
using an AtomicInteger.
This AtomicInteger can then be used in Mockito.times(AtomicInteger)
or with Assert.assertEquals(int, int) in order to verify behaviour.