### PR TITLE
Reintroduce null check on MockUtil.isMock()

### DIFF
--- a/src/main/java/org/mockito/internal/util/MockUtil.java
+++ b/src/main/java/org/mockito/internal/util/MockUtil.java
@@ -70,7 +70,7 @@ public class MockUtil {
     }
 
     private <T> boolean isMockitoMock(T mock) {
-        return mockMaker.getHandler(mock) != null;
+        return mock != null && mockMaker.getHandler(mock) != null;
     }
 
     public MockName getMockName(Object mock) {


### PR DESCRIPTION
Will fix #243 - null check on MockUtil.isMock() was incorrectly removed after successive refactoring, this PR reintroduces null check