### PR TITLE
Correcting public website url in Maven POM

### DIFF
--- a/gradle/pom.gradle
+++ b/gradle/pom.gradle
@@ -6,7 +6,7 @@ publishing.publications.all {
         def root = asNode()
         root.appendNode('name', 'Mockito')
         root.appendNode('packaging', 'jar')
-        root.appendNode('url', 'http://www.mockito.org')
+        root.appendNode('url', 'http://mockito.org')
         root.appendNode('description', 'Mock objects library for java')
 
         def license = root.appendNode('licenses').appendNode('license')


### PR DESCRIPTION
http://www.mockito.org does not resolve correctly, updating to http://mockito.org