### PR TITLE
Add new API method to reset invocations of a mock, while maintaining all existing stubbing

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -1704,6 +1704,21 @@ public class Mockito extends Matchers {
     }
 
     /**
+     * Use this method in order to only clear invocations, when stubbing is non-trivial. Use-cases can be:
+     * <ul>
+     *     <li>You are using a dependency injection framework to inject your mocks.</li>
+     *     <li>The mock is used in a stateful scenario. For example a class is Singleton which depends on your mock.</li>
+     * </ul>
+     *
+     * <b>Try to avoid this method at all costs. Only clear invocations if you are unable to efficiently test your program.</b>
+     * @param <T> The type of the mocks
+     * @param mocks The mocks to clear the invocations for
+     */
+    public static <T> void clearInvocations(T ... mocks) {
+        MOCKITO_CORE.clearInvocations(mocks);
+    }
+
+    /**
      * Checks if any of given mocks has any unverified interaction.
      * <p>
      * You can use this method after you verified your mocks - to make sure that nothing

--- a/src/main/java/org/mockito/internal/MockitoCore.java
+++ b/src/main/java/org/mockito/internal/MockitoCore.java
@@ -95,6 +95,16 @@ public class MockitoCore {
             mockUtil.resetMock(m);
         }
     }
+
+    public <T> void clearInvocations(T ... mocks) {
+        mockingProgress.validateState();
+        mockingProgress.reset();
+        mockingProgress.resetOngoingStubbing();
+
+        for (T m : mocks) {
+            mockUtil.getMockHandler(m).getInvocationContainer().clearInvocations();
+        }
+    }
     
     public void verifyNoMoreInteractions(Object... mocks) {
         assertMocksNotEmpty(mocks);
@@ -182,4 +192,5 @@ public class MockitoCore {
     public MockingDetails mockingDetails(Object toInspect) {
         return new DefaultMockingDetails(toInspect, new MockUtil());
     }
+
 }

--- a/src/main/java/org/mockito/internal/stubbing/InvocationContainer.java
+++ b/src/main/java/org/mockito/internal/stubbing/InvocationContainer.java
@@ -12,5 +12,7 @@ import java.util.List;
 public interface InvocationContainer {
     List<Invocation> getInvocations();
 
+    void clearInvocations();
+
     List<StubbedInvocationMatcher> getStubbedInvocations();
 }

--- a/src/main/java/org/mockito/internal/stubbing/InvocationContainerImpl.java
+++ b/src/main/java/org/mockito/internal/stubbing/InvocationContainerImpl.java
@@ -121,6 +121,10 @@ public class InvocationContainerImpl implements InvocationContainer, Serializabl
         return registeredInvocations.getAll();
     }
 
+    public void clearInvocations() {
+        registeredInvocations.clear();
+    }
+
     public List<StubbedInvocationMatcher> getStubbedInvocations() {
         return stubbed;
     }

--- a/src/main/java/org/mockito/internal/verification/DefaultRegisteredInvocations.java
+++ b/src/main/java/org/mockito/internal/verification/DefaultRegisteredInvocations.java
@@ -44,6 +44,12 @@ public class DefaultRegisteredInvocations implements RegisteredInvocations, Seri
         return ListUtil.filter(copiedList, new RemoveToString());
     }
 
+    public void clear() {
+        synchronized (invocations) {
+            invocations.clear();
+        }
+    }
+
     public boolean isEmpty() {
         synchronized (invocations) {
             return invocations.isEmpty();

--- a/src/main/java/org/mockito/internal/verification/RegisteredInvocations.java
+++ b/src/main/java/org/mockito/internal/verification/RegisteredInvocations.java
@@ -21,6 +21,8 @@ public interface RegisteredInvocations {
 
     List<Invocation> getAll();
 
+    void clear();
+
     boolean isEmpty();
 
 }

--- a/src/main/java/org/mockito/internal/verification/SingleRegisteredInvocation.java
+++ b/src/main/java/org/mockito/internal/verification/SingleRegisteredInvocation.java
@@ -27,6 +27,10 @@ public class SingleRegisteredInvocation implements RegisteredInvocations, Serial
         return Collections.emptyList();
     }
 
+    public void clear() {
+        invocation = null;
+    }
+
     public boolean isEmpty() {
         return invocation == null;
     }

--- a/src/test/java/org/mockitousage/basicapi/ResetInvocationsTest.java
+++ b/src/test/java/org/mockitousage/basicapi/ResetInvocationsTest.java
@@ -1,0 +1,48 @@
+package org.mockitousage.basicapi;
+
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.exceptions.misusing.NotAMockException;
+import org.mockitousage.IMethods;
+import org.mockitoutil.TestBase;
+
+import static org.mockito.Mockito.*;
+
+public class ResetInvocationsTest extends TestBase {
+
+    @Mock IMethods methods;
+    @Mock IMethods moarMethods;
+
+    @Test
+    public void reset_invocations_should_reset_only_invocations() {
+        when(methods.simpleMethod()).thenReturn("return");
+
+        methods.simpleMethod();
+        verify(methods).simpleMethod();
+
+        clearInvocations(methods);
+
+        verifyNoMoreInteractions(methods);
+        assertEquals("return", methods.simpleMethod());
+    }
+
+    @Test
+    public void should_reset_invocations_on_multiple_mocks() {
+        methods.simpleMethod();
+        moarMethods.simpleMethod();
+
+        clearInvocations(methods, moarMethods);
+
+        verifyNoMoreInteractions(methods, moarMethods);
+    }
+
+    @Test(expected = NotAMockException.class)
+    public void resettingNonMockIsSafe() {
+        clearInvocations("");
+    }
+
+    @Test(expected = NotAMockException.class)
+    public void resettingNullIsSafe() {
+        clearInvocations(new Object[]{null});
+    }
+}


### PR DESCRIPTION
Add new API method to reset invocations of a mock, while maintaining all existing stubbing.

---------------------------
**EDIT by mockito team** : Fixes #183