### PR TITLE
Add optional answer to support mocked Builders

### DIFF
--- a/src/main/java/org/mockito/Answers.java
+++ b/src/main/java/org/mockito/Answers.java
@@ -5,6 +5,7 @@
 package org.mockito;
 
 import org.mockito.internal.stubbing.answers.CallsRealMethods;
+import org.mockito.internal.stubbing.defaultanswers.TriesToReturnSelf;
 import org.mockito.internal.stubbing.defaultanswers.GloballyConfiguredAnswer;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsDeepStubs;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsMocks;
@@ -68,7 +69,16 @@ public enum Answers implements Answer<Object>{
      *
      * @see org.mockito.Mockito#CALLS_REAL_METHODS
      */
-    CALLS_REAL_METHODS(new CallsRealMethods())
+    CALLS_REAL_METHODS(new CallsRealMethods()),
+
+    /**
+     * An answer that tries to return itself. This is useful for mocking {@code Builders}.
+     *
+     * <p>Please see the {@link org.mockito.Mockito#RETURNS_SELF} documentation for more details.</p>
+     *
+     * @see org.mockito.Mockito#RETURNS_SELF
+     */
+    RETURNS_SELF(new TriesToReturnSelf())
     ;
 
     private final Answer<Object> implementation;

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -1087,10 +1087,10 @@ import org.mockito.junit.*;
  * <p>
  * <pre class="code"><code class="java">
  *
- * // will print a custom message on verification failure 
+ * // will print a custom message on verification failure
  * verify(mock, description("This will print on failure")).someMethod();
- * 
- * // will work with any verification mode 
+ *
+ * // will work with any verification mode
  * verify(mock, times(2).description("someMethod should be called twice")).someMethod();
  * </code></pre>
  *
@@ -1130,7 +1130,7 @@ public class Mockito extends Matchers {
      * <p>
      * Example:
      * <pre class="code"><code class="java">
-     *   Foo mock = (Foo.class, RETURNS_SMART_NULLS);
+     *   Foo mock = mock(Foo.class, RETURNS_SMART_NULLS);
      *
      *   //calling unstubbed method here:
      *   Stuff stuff = mock.getStuff();
@@ -1278,6 +1278,78 @@ public class Mockito extends Matchers {
      * </code></pre>
      */
     public static final Answer<Object> CALLS_REAL_METHODS = Answers.CALLS_REAL_METHODS;
+
+    /**
+     * Optional <code>Answer</code> to be used with {@link Mockito#mock(Class, Answer)}.
+     *
+     * Allows Builder mocks to return itself whenever a method is invoked that returns a Type equal
+     * to the class or a superclass.
+     *
+     * <p><b>Keep in mind this answer uses the return type of a method.
+     * If this type is assignable to the class of the mock, it will return the mock.
+     * Therefore if you have a method returning a superclass (for example {@code Object}) it will match and return the mock.</b></p>
+     *
+     * Consider a HttpBuilder used in a HttpRequesterWithHeaders.
+     *
+     * <pre class="code"><code class="java">
+     * public class HttpRequesterWithHeaders {
+     *
+     *      private HttpBuilder builder;
+     *
+     *      public HttpRequesterWithHeaders(HttpBuilder builder) {
+     *          this.builder = builder;
+     *      }
+     *
+     *      public String request(String uri) {
+     *          return builder.withUrl(uri)
+     *                  .withHeader("Content-type: application/json")
+     *                  .withHeader("Authorization: Bearer")
+     *                  .request();
+     *      }
+     *  }
+     *
+     *  private static class HttpBuilder {
+     *
+     *      private String uri;
+     *      private List&lt;String&gt; headers;
+     *
+     *      public HttpBuilder() {
+     *          this.headers = new ArrayList&lt;String&gt;();
+     *      }
+     *
+     *       public HttpBuilder withUrl(String uri) {
+     *           this.uri = uri;
+     *           return this;
+     *       }
+     *
+     *       public HttpBuilder withHeader(String header) {
+     *           this.headers.add(header);
+     *           return this;
+     *       }
+     *
+     *       public String request() {
+     *          return uri + headers.toString();
+     *       }
+     *  }
+     * </code></pre>
+     *
+     * The following test will succeed
+     *
+     * <pre><code>
+     * &#064;Test
+     *  public void use_full_builder_with_terminating_method() {
+     *      HttpBuilder builder = mock(HttpBuilder.class, RETURNS_SELF);
+     *      HttpRequesterWithHeaders requester = new HttpRequesterWithHeaders(builder);
+     *      String response = "StatusCode: 200";
+     *
+     *      when(builder.request()).thenReturn(response);
+     *
+     *      assertThat(requester.request("URI")).isEqualTo(response);
+     *  }
+     * </code></pre>
+     */
+    public static final Answer<Object> RETURNS_SELF = Answers.RETURNS_SELF;
+
     /**
      * Creates mock object of given class or interface.
      * <p>
@@ -2475,7 +2547,7 @@ public class Mockito extends Matchers {
     public static MockSettings withSettings() {
         return new MockSettingsImpl().defaultAnswer(RETURNS_DEFAULTS);
     }
-    
+
     /**
      * Adds a description to be printed if verification fails.
      * <pre class="code"><code class="java">

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/TriesToReturnSelf.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/TriesToReturnSelf.java
@@ -1,0 +1,29 @@
+package org.mockito.internal.stubbing.defaultanswers;
+
+import org.mockito.internal.creation.settings.CreationSettings;
+import org.mockito.internal.util.MockUtil;
+import org.mockito.internal.util.reflection.GenericMetadataSupport;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.io.Serializable;
+
+public class TriesToReturnSelf implements Answer<Object>, Serializable{
+
+    private final MockUtil mockUtil = new MockUtil();
+
+    private ReturnsEmptyValues defaultReturn = new ReturnsEmptyValues();
+
+    public Object answer(InvocationOnMock invocation) throws Throwable {
+        Class<?> methodReturnType = invocation.getMethod().getReturnType();
+        Object mock = invocation.getMock();
+        Class<?> mockType = mockUtil.getMockHandler(mock).getMockSettings().getTypeToMock();
+
+        if (methodReturnType.isAssignableFrom(mockType)) {
+            return invocation.getMock();
+        }
+
+        return defaultReturn.returnValueFor(methodReturnType);
+    }
+
+}

--- a/src/test/java/org/mockitousage/stubbing/StubbingReturnsSelfTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingReturnsSelfTest.java
@@ -1,0 +1,151 @@
+package org.mockitousage.stubbing;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class StubbingReturnsSelfTest {
+
+    @Test
+    public void should_stub_builder_method() {
+        Builder builder = mock(Builder.class, RETURNS_SELF);
+
+        assertThat(builder.returnSelf()).isEqualTo(builder);
+    }
+
+    @Test
+    public void should_return_default_return_when_not_a_builder() {
+        Builder builder = mock(Builder.class, RETURNS_SELF);
+
+        assertThat(builder.returnString()).isEqualTo(null);
+    }
+
+    @Test
+    public void should_return_self_when_call_on_method_in_superclass() {
+        BuilderSubClass builder = mock(BuilderSubClass.class, RETURNS_SELF);
+
+        assertThat(builder.returnSelf()).isEqualTo(builder);
+    }
+
+    @Test
+    public void should_return_self_when_call_on_method_in_subclass() {
+        BuilderSubClass builder = mock(BuilderSubClass.class, RETURNS_SELF);
+
+        assertThat(builder.returnsSubClass()).isEqualTo(builder);
+    }
+
+    @Test
+    public void should_return_self_when_call_on_method_in_subclass_returns_superclass() {
+        BuilderSubClass builder = mock(BuilderSubClass.class, RETURNS_SELF);
+
+        assertThat(builder.returnSuperClass()).isEqualTo(builder);
+    }
+
+    @Test
+    public void should_return_stubbed_answer_when_call_on_method_returns_self() {
+        Builder builder = mock(Builder.class, RETURNS_SELF);
+        Builder anotherBuilder = mock(Builder.class, RETURNS_SELF);
+
+        when(builder.returnSelf()).thenReturn(anotherBuilder);
+
+        assertThat(builder.returnSelf().returnSelf()).isEqualTo(anotherBuilder);
+    }
+
+    @Test
+    public void should_not_fail_when_calling_void_returning_method() {
+        Builder builder = mock(Builder.class, RETURNS_SELF);
+
+        builder.returnNothing();
+    }
+
+    @Test
+    public void should_not_fail_when_calling_primitive_returning_method() {
+        Builder builder = mock(Builder.class, RETURNS_SELF);
+
+        assertThat(builder.returnInt()).isEqualTo(0);
+    }
+
+    @Test
+    public void use_full_builder_with_terminating_method() {
+        HttpBuilder builder = mock(HttpBuilder.class, RETURNS_SELF);
+        HttpRequesterWithHeaders requester = new HttpRequesterWithHeaders(builder);
+        String response = "StatusCode: 200";
+
+        when(builder.request()).thenReturn(response);
+
+        assertThat(requester.request("URI")).isEqualTo(response);
+    }
+
+    private static class Builder {
+
+        public Builder returnSelf() {
+            return this;
+        }
+
+        public String returnString() {
+            return "Self";
+        }
+
+        public void returnNothing() {}
+
+        public int returnInt() {
+            return 1;
+        }
+    }
+
+    private static class BuilderSubClass extends Builder {
+
+        public BuilderSubClass returnsSubClass() {
+            return this;
+        }
+
+        public Builder returnSuperClass() {
+            return this;
+        }
+    }
+
+    private static class HttpRequesterWithHeaders {
+
+        private HttpBuilder builder;
+
+        public HttpRequesterWithHeaders(HttpBuilder builder) {
+            this.builder = builder;
+        }
+
+        public String request(String uri) {
+            return builder.withUrl(uri)
+                    .withHeader("Content-type: application/json")
+                    .withHeader("Authorization: Bearer")
+                    .request();
+        }
+    }
+
+    private static class HttpBuilder {
+
+        private String uri;
+        private List<String> headers;
+
+        public HttpBuilder() {
+            this.headers = new ArrayList<String>();
+        }
+
+        public HttpBuilder withUrl(String uri) {
+            this.uri = uri;
+            return this;
+        }
+
+        public HttpBuilder withHeader(String header) {
+            this.headers.add(header);
+            return this;
+        }
+
+        public String request() {
+            return uri + headers.toString();
+        }
+
+    }
+}


### PR DESCRIPTION
When googling the mocking of builders, a lot of people said it was not possible with Mockito to support them in a clean way. `RETURNS_DEEPS_STUBS` does allow cascading, but can become quite fast very cumbersome.
The added `RETURNS_SELF` will try to return itself by looking at the method `returnType` and compare this with the class of the mock.