### PR TITLE
RFC: Allow the collection of stacktraces in LocationImpl to be disabled.

### DIFF
--- a/src/main/java/org/mockito/internal/debugging/LocationImpl.java
+++ b/src/main/java/org/mockito/internal/debugging/LocationImpl.java
@@ -4,31 +4,45 @@
  */
 package org.mockito.internal.debugging;
 
-import java.io.Serializable;
 import org.mockito.internal.exceptions.stacktrace.StackTraceFilter;
 import org.mockito.invocation.Location;
 
+import java.io.Serializable;
+
 public class LocationImpl implements Location, Serializable {
 
-    private static final long serialVersionUID = -9054861157390980624L;
-    private final Throwable stackTraceHolder;
-    private final StackTraceFilter stackTraceFilter;
+	private static final long serialVersionUID = -9054861157390980624L;
+	private final Throwable stackTraceHolder;
+	private final StackTraceFilter stackTraceFilter;
 
-    public LocationImpl() {
-        this(new StackTraceFilter());
-    }
+	/**
+	 * Ugly flag to disable the collection of stack traces. When writing tests
+	 * you ever want to set this to false. But if you use Mockito in production
+	 * to create production stubs you may want to save the runtime overhead of
+	 * generating the stacktrace on every stub method invocation.
+	 */
+	public static boolean ENABLE_STACKTRACE = true;
 
-    public LocationImpl(StackTraceFilter stackTraceFilter) {
-        this.stackTraceFilter = stackTraceFilter;
-        stackTraceHolder = new Throwable();
-    }
+	public LocationImpl() {
+		this(new StackTraceFilter());
+	}
 
-    @Override
-    public String toString() {
-        StackTraceElement[] filtered = stackTraceFilter.filter(stackTraceHolder.getStackTrace(), false);
-        if (filtered.length == 0) {
-            return "-> at <<unknown line>>";
-        }
-        return "-> at " + filtered[0].toString();
-    }
+	public LocationImpl(StackTraceFilter stackTraceFilter) {
+		this.stackTraceFilter = stackTraceFilter;
+		if (ENABLE_STACKTRACE)
+			stackTraceHolder = new Throwable();
+		else
+			stackTraceHolder = null;
+	}
+
+	@Override
+	public String toString() {
+		if (stackTraceHolder == null)
+			return "-> at <<unknown line>>";
+		StackTraceElement[] filtered = stackTraceFilter.filter(stackTraceHolder.getStackTrace(), false);
+		if (filtered.length == 0) {
+			return "-> at <<unknown line>>";
+		}
+		return "-> at " + filtered[0].toString();
+	}
 }

--- a/src/main/java/org/mockito/internal/debugging/LocationImpl.java
+++ b/src/main/java/org/mockito/internal/debugging/LocationImpl.java
@@ -11,38 +11,38 @@ import java.io.Serializable;
 
 public class LocationImpl implements Location, Serializable {
 
-	private static final long serialVersionUID = -9054861157390980624L;
-	private final Throwable stackTraceHolder;
-	private final StackTraceFilter stackTraceFilter;
+    private static final long serialVersionUID = -9054861157390980624L;
+    private final Throwable stackTraceHolder;
+    private final StackTraceFilter stackTraceFilter;
 
-	/**
-	 * Ugly flag to disable the collection of stack traces. When writing tests
-	 * you ever want to set this to false. But if you use Mockito in production
-	 * to create production stubs you may want to save the runtime overhead of
-	 * generating the stacktrace on every stub method invocation.
-	 */
-	public static boolean ENABLE_STACKTRACE = true;
+    /**
+     * Ugly flag to disable the collection of stack traces. When writing tests
+     * you ever want to set this to false. But if you use Mockito in production
+     * to create production stubs you may want to save the runtime overhead of
+     * generating the stacktrace on every stub method invocation.
+     */
+    public static boolean ENABLE_STACKTRACE = true;
 
-	public LocationImpl() {
-		this(new StackTraceFilter());
-	}
+    public LocationImpl() {
+        this(new StackTraceFilter());
+    }
 
-	public LocationImpl(StackTraceFilter stackTraceFilter) {
-		this.stackTraceFilter = stackTraceFilter;
-		if (ENABLE_STACKTRACE)
-			stackTraceHolder = new Throwable();
-		else
-			stackTraceHolder = null;
-	}
+    public LocationImpl(StackTraceFilter stackTraceFilter) {
+        this.stackTraceFilter = stackTraceFilter;
+        if (ENABLE_STACKTRACE)
+            stackTraceHolder = new Throwable();
+        else
+            stackTraceHolder = null;
+    }
 
-	@Override
-	public String toString() {
-		if (stackTraceHolder == null)
-			return "-> at <<unknown line>>";
-		StackTraceElement[] filtered = stackTraceFilter.filter(stackTraceHolder.getStackTrace(), false);
-		if (filtered.length == 0) {
-			return "-> at <<unknown line>>";
-		}
-		return "-> at " + filtered[0].toString();
-	}
+    @Override
+    public String toString() {
+        if (stackTraceHolder == null)
+            return "-> at <<unknown line>>";
+        StackTraceElement[] filtered = stackTraceFilter.filter(stackTraceHolder.getStackTrace(), false);
+        if (filtered.length == 0) {
+            return "-> at <<unknown line>>";
+        }
+        return "-> at " + filtered[0].toString();
+    }
 }

--- a/src/test/java/org/mockitousage/internal/debugging/LocationImplTest.java
+++ b/src/test/java/org/mockitousage/internal/debugging/LocationImplTest.java
@@ -12,25 +12,36 @@ import org.mockitoutil.TestBase;
 @SuppressWarnings("serial")
 public class LocationImplTest extends TestBase {
 
-    @Test
-    public void shouldLocationNotContainGetStackTraceMethod() {
-        assertContains("shouldLocationNotContainGetStackTraceMethod", new LocationImpl().toString());
-    }
+	@Test
+	public void shouldLocationNotContainGetStackTraceMethod() {
+		assertContains("shouldLocationNotContainGetStackTraceMethod", new LocationImpl().toString());
+	}
 
-    @Test
-    public void shouldBeSafeInCaseForSomeReasonFilteredStackTraceIsEmpty() {
-        //given
-        StackTraceFilter filterReturningEmptyArray = new StackTraceFilter() {
-            @Override
-            public StackTraceElement[] filter(StackTraceElement[] target, boolean keepTop) {
-                return new StackTraceElement[0];
-            }
-        };
+	@Test
+	public void shouldBeSafeInCaseForSomeReasonFilteredStackTraceIsEmpty() {
+		// given
+		StackTraceFilter filterReturningEmptyArray = new StackTraceFilter() {
+			@Override
+			public StackTraceElement[] filter(StackTraceElement[] target, boolean keepTop) {
+				return new StackTraceElement[0];
+			}
+		};
 
-        //when
-        String loc = new LocationImpl(filterReturningEmptyArray).toString();
+		// when
+		String loc = new LocationImpl(filterReturningEmptyArray).toString();
 
-        //then
-        assertEquals("-> at <<unknown line>>", loc);
-    }
+		// then
+		assertEquals("-> at <<unknown line>>", loc);
+	}
+
+	@Test
+	public void disableStackTraceTest() {
+		LocationImpl.ENABLE_STACKTRACE = false;
+		try {
+			assertEquals("-> at <<unknown line>>", new LocationImpl().toString());
+		} finally {
+			LocationImpl.ENABLE_STACKTRACE = true;
+		}
+		assertNotContains("-> at <<unknown line>>", new LocationImpl().toString());
+	}
 }

--- a/src/test/java/org/mockitousage/internal/debugging/LocationImplTest.java
+++ b/src/test/java/org/mockitousage/internal/debugging/LocationImplTest.java
@@ -12,36 +12,36 @@ import org.mockitoutil.TestBase;
 @SuppressWarnings("serial")
 public class LocationImplTest extends TestBase {
 
-	@Test
-	public void shouldLocationNotContainGetStackTraceMethod() {
-		assertContains("shouldLocationNotContainGetStackTraceMethod", new LocationImpl().toString());
-	}
+    @Test
+    public void shouldLocationNotContainGetStackTraceMethod() {
+        assertContains("shouldLocationNotContainGetStackTraceMethod", new LocationImpl().toString());
+    }
 
-	@Test
-	public void shouldBeSafeInCaseForSomeReasonFilteredStackTraceIsEmpty() {
-		// given
-		StackTraceFilter filterReturningEmptyArray = new StackTraceFilter() {
-			@Override
-			public StackTraceElement[] filter(StackTraceElement[] target, boolean keepTop) {
-				return new StackTraceElement[0];
-			}
-		};
+    @Test
+    public void shouldBeSafeInCaseForSomeReasonFilteredStackTraceIsEmpty() {
+        // given
+        StackTraceFilter filterReturningEmptyArray = new StackTraceFilter() {
+            @Override
+            public StackTraceElement[] filter(StackTraceElement[] target, boolean keepTop) {
+                return new StackTraceElement[0];
+            }
+        };
 
-		// when
-		String loc = new LocationImpl(filterReturningEmptyArray).toString();
+        // when
+        String loc = new LocationImpl(filterReturningEmptyArray).toString();
 
-		// then
-		assertEquals("-> at <<unknown line>>", loc);
-	}
+        // then
+        assertEquals("-> at <<unknown line>>", loc);
+    }
 
-	@Test
-	public void disableStackTraceTest() {
-		LocationImpl.ENABLE_STACKTRACE = false;
-		try {
-			assertEquals("-> at <<unknown line>>", new LocationImpl().toString());
-		} finally {
-			LocationImpl.ENABLE_STACKTRACE = true;
-		}
-		assertNotContains("-> at <<unknown line>>", new LocationImpl().toString());
-	}
+    @Test
+    public void disableStackTraceTest() {
+        LocationImpl.ENABLE_STACKTRACE = false;
+        try {
+            assertEquals("-> at <<unknown line>>", new LocationImpl().toString());
+        } finally {
+            LocationImpl.ENABLE_STACKTRACE = true;
+        }
+        assertNotContains("-> at <<unknown line>>", new LocationImpl().toString());
+    }
 }


### PR DESCRIPTION
I use mockito not only for my test drivers, but also in production to stub objects in my "Frontend-Facade-Model", which is used for Freemarker templates. Instead of null, which the people writing the frontend templates dont really understand, they always get a "valid" object. In the case that an object really does not exist i create (and reuse) a stub only mock for it.

This works quite well, but in my server profiling LocationImpl() is very dominating. This is because of the new Throwable(), which gathers the stack trace on *every* method invocation on the mock. Which is of course fine and needed in test divers. But for my production use I don`t need the stack traces, they just slow everything down...

This is a minimal quick&dirty implementation, which allows to disable the stack trace gathering globally. It is not intended to be commit as is. 

What would be the clean way to disable the stack trace gathering? Is the "stubOnly()" setting enough indication that the user does not want / need the stack trace? Or should there be an other setting?

There are (if IDEA is correct) currently 31 new LocationImpl() calls in the mockito source. Making the construction of the LocationImpl  configurable would mean patching many places. I have no idea if it is worth the effort.