### PR TITLE
Add support for answerClass in @Mock

### DIFF
--- a/src/main/java/org/mockito/Mock.java
+++ b/src/main/java/org/mockito/Mock.java
@@ -4,6 +4,8 @@
  */
 package org.mockito;
 
+import org.mockito.stubbing.Answer;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -28,11 +30,12 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *       &#064;Mock(name = "database") private ArticleDatabase dbMock;
  *       &#064;Mock(answer = RETURNS_MOCKS) private UserProvider userProvider;
  *       &#064;Mock(extraInterfaces = {Queue.class, Observer.class}) private  articleMonitor;
+ *       &#064;Mock(answerClass = CustomAnswerClass.class) private StateHandler handler
  *
  *       private ArticleManager manager;
  *
  *       &#064;Before public void setup() {
- *           manager = new ArticleManager(userProvider, database, calculator, articleMonitor);
+ *           manager = new ArticleManager(userProvider, database, calculator, articleMonitor, handler);
  *       }
  *   }
  *
@@ -70,4 +73,6 @@ public @interface Mock {
     Class<?>[] extraInterfaces() default {};
     
     boolean serializable() default false;
+
+    Class<? extends Answer> answerClass() default Answer.class;
 }

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -66,6 +66,7 @@ import org.mockito.junit.*;
  *      <a href="#32">33. (new) Mockito JUnit rule (Since 1.10.17)</a><br/>
  *      <a href="#34">34. (new) Switch <em>on</em> or <em>off</em> plugins (Since 1.10.15)</a><br/>
  *      <a href="#35">35. (new) Custom verification failure message (Since 2.0.0)</a><br/>
+ *      <a href="#36">36. (new) Support for user-written Answer Classes when using @Mock</a><br/>
  * </b>
  *
  * <h3 id="0">0. <a class="meaningful_link" href="#verification">Migrating to 2.0</a></h3>
@@ -1092,6 +1093,41 @@ import org.mockito.junit.*;
  * 
  * // will work with any verification mode 
  * verify(mock, times(2).description("someMethod should be called twice")).someMethod();
+ * </code></pre>
+ *
+ * <h3 id="36">36. <a class="meaningful_link" href="#User_written_answer_classes">Support for user-written Answer Classes when using @Mock</a> (Since 2.0.0)</h3>
+ * <p>
+ * Allows specifying a customer Answer beyond those provided in org.mockito.Answers. This is in line with the functionality
+ * provided by org.mockito.Mockito.mock(Object.class, someCustomAnswer)
+ * <p>
+ * Examples:
+ * <p>
+ * <pre class="code"><code class="java">
+ *
+ * class MyAnswerClass implements Answer<MyObject> {
+ *   @Override
+ *   public MyObject answer(InvocationOnMock invocation) throws Throwable {
+ *     return buildObjectBasedOnInvocation(invocation);
+ *   }
+ *
+ *   public MyObject buildObjectBasedOnInvocation(InvocationOnMock invocation) {...}
+ * }
+ *
+ * @Mock(answerClass=MyAnswerClass.class)
+ * private MyObject myMockedObject;
+ *
+ * @Before
+ * public void setUp() {
+ *     initMocks(this);
+ *     when(myMockedObject.someMethod()).thenReturn(mockedResponse);
+ * }
+ *
+ * @Test
+ * public void test() {
+ *     myMockedObject.someMethod(); // returns mockedResponse
+ *     myMockedObject.someOtherMethod(); // returns based on MyAnswerClass.answer(invocation)
+ * }
+ *
  * </code></pre>
  *
  * TODO rework the documentation, write about hamcrest.

--- a/src/main/java/org/mockito/exceptions/Reporter.java
+++ b/src/main/java/org/mockito/exceptions/Reporter.java
@@ -829,6 +829,11 @@ public class Reporter {
                 "This may happen with doThrow(Class)|thenThrow(Class) family of methods if passing null parameter."));
     }
 
+    public void answerAndCustomAnswerInMockAnnotationNotAllowed(String fieldName) {
+        throw new MockitoException("You cannot define answer and customAnswer at the same time for field " + fieldName);
+
+    }
+
     private MockName safelyGetMockName(Object mock) {
         return new MockUtil().getMockName(mock);
     }

--- a/src/test/java/org/mockitousage/annotation/MockWithCustomAnswerAnnotationsTest.java
+++ b/src/test/java/org/mockitousage/annotation/MockWithCustomAnswerAnnotationsTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockitousage.annotation;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.exceptions.base.MockitoException;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.mockitousage.IMethods;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+@SuppressWarnings("unchecked")
+public class MockWithCustomAnswerAnnotationsTest {
+
+    public static final int MOCKED_LIST_SIZE = 3;
+    @Mock(answerClass = MyCustomAnswerClass.class)
+    IMethods mockWithCustomAnswer;
+
+    @Mock(answerClass = MyCustomAnswerWithMultipleConstructors.class)
+    IMethods mockWithCustomAnswerHavingMultipleConstructors;
+
+    @Mock(answerClass = ListCustomAnswer.class)
+    List<String> mockedList;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+    }
+
+    @Test
+    public void shouldUseCustomAnswer() {
+        assertSame(MyCustomAnswerClass.returnedObject, mockWithCustomAnswer.objectReturningMethodNoArgs());
+    }
+
+    @Test
+    public void should_choose_default_constructor() {
+        assertSame(MyCustomAnswerClass.returnedObject, mockWithCustomAnswerHavingMultipleConstructors.objectReturningMethodNoArgs());
+    }
+
+
+    @Test
+    public void should_throw_exception_when_custom_answer_cannot_be_instantiated() throws NoSuchFieldException {
+        //This roundabout way of testing is necessary because initMocks() will attempt to inialize all @Mocks
+        //in a class at once. Thus, our "failing @Mocks" must be in different classes
+
+        class should_throw_exception_when_custom_answer_cannot_be_instantiated_test_class {
+            @Mock(answerClass = NotInstantiableClass.class)
+            private Object mockObjectWithAnswerClassThatCannotBeInstantiated;
+
+            public void innerTest() {
+                try {
+                    initMocks(this);
+                    fail("RuntimeException expected ");
+                } catch (MockitoException ex) {
+                    assertEquals("Custom answer cannot be instantiated",ex.getMessage());
+                }
+            }
+        }
+
+        new should_throw_exception_when_custom_answer_cannot_be_instantiated_test_class().innerTest();
+
+    }
+
+    @Test
+    public void should_throw_exception_when_custom_answer_throws_exception_in_constructor() throws NoSuchFieldException {
+        class should_throw_exception_when_custom_answer_throws_exception_in_constructor_test_class {
+            @Mock(answerClass=AnswerThrowingConstructor.class)
+            private Object mockObjectWithAnswerClassThatThrowsException;
+
+            public void innerTest() {
+                try {
+                    initMocks(this);
+                    fail("RuntimeException expected ");
+                } catch (MockitoException ex) {
+                    assertEquals("Custom answer cannot be instantiated",ex.getMessage());
+                }
+            }
+        }
+
+        new should_throw_exception_when_custom_answer_throws_exception_in_constructor_test_class().innerTest();
+
+    }
+
+    @Test
+    public void should_throw_exception_when_both_answer_and_answer_class_are_defined() throws NoSuchFieldException {
+        class should_throw_exception_when_both_answer_and_answer_class_are_defined_test_class {
+            @Mock(answerClass=MyCustomAnswerClass.class, answer=Answers.RETURNS_DEEP_STUBS)
+            private Object mockObjectWithBothAnswerAndAnswerClassDefined;
+
+            public void innerTest() {
+                try {
+                    initMocks(this);
+                    fail("RuntimeException expected");
+                } catch (MockitoException ex) {
+                    assertEquals(ex.getMessage(), "You cannot define answer and customAnswer at the same time for field returnedObject");
+                }
+            }
+        }
+    }
+
+    @Test
+    public void custom_answer_integration_test() {
+
+        assertEquals(mockedList.size(),MOCKED_LIST_SIZE);
+
+    }
+
+    public static class MyCustomAnswerClass implements Answer<Object> {
+
+        static Object returnedObject = new Object();
+
+        @Override
+        public Object answer(InvocationOnMock invocation) throws Throwable {
+            return returnedObject;
+        }
+    }
+
+    public static class MyCustomAnswerWithMultipleConstructors implements Answer<Object> {
+
+        public MyCustomAnswerWithMultipleConstructors() {
+        }
+
+        public MyCustomAnswerWithMultipleConstructors(String arg1) {
+        }
+
+        @Override
+        public Object answer(InvocationOnMock invocation) throws Throwable {
+            return MyCustomAnswerClass.returnedObject;
+        }
+    }
+
+    private class NotInstantiableClass implements Answer<Object> {
+        @Override
+        public Object answer(InvocationOnMock invocation) throws Throwable {
+            return null;
+        }
+    }
+
+    public static class AnswerThrowingConstructor implements Answer<Object> {
+
+        public AnswerThrowingConstructor() {
+            throw new RuntimeException("throwing");
+        }
+
+        @Override
+        public Object answer(InvocationOnMock invocation) throws Throwable {
+            return null;
+        }
+    }
+
+
+    public static class ListCustomAnswer implements Answer<Integer> {
+        @Override
+        public Integer answer(InvocationOnMock invocation) throws Throwable {
+            return MOCKED_LIST_SIZE;
+        }
+    }
+}


### PR DESCRIPTION
See [this issue](https://code.google.com/p/mockito/issues/detail?id=345).

All credit for this change goes to kretes@, who actually authored it and created the [initial PR](https://github.com/mockito/mockito/pull/40) - I simply attended to the review comments and resubmitted since it appeared to have lain dormant for over a year.