### PR TITLE
Eliminate direct dependency on ObjenesisInstantiator

### DIFF
--- a/src/main/java/org/mockito/internal/configuration/plugins/PluginRegistry.java
+++ b/src/main/java/org/mockito/internal/configuration/plugins/PluginRegistry.java
@@ -1,5 +1,6 @@
 package org.mockito.internal.configuration.plugins;
 
+import org.mockito.plugins.InstantiatorProvider;
 import org.mockito.plugins.MockMaker;
 import org.mockito.plugins.PluginSwitch;
 import org.mockito.plugins.StackTraceCleanerProvider;
@@ -14,6 +15,9 @@ class PluginRegistry {
 
     private final StackTraceCleanerProvider stackTraceCleanerProvider
             = new PluginLoader(pluginSwitch).loadPlugin(StackTraceCleanerProvider.class, "org.mockito.internal.exceptions.stacktrace.DefaultStackTraceCleanerProvider");
+
+    private final InstantiatorProvider instantiatorProvider
+            = new PluginLoader(pluginSwitch).loadPlugin(InstantiatorProvider.class, "org.mockito.internal.creation.instance.DefaultInstantiatorProvider");
 
     /**
      * The implementation of the stack trace cleaner
@@ -31,5 +35,15 @@ class PluginRegistry {
      */
     MockMaker getMockMaker() {
         return mockMaker;
+    }
+
+    /**
+     * Returns the instantiator provider available for the current runtime.
+     *
+     * <p>Returns {@link org.mockito.internal.creation.instance.DefaultInstantiatorProvider} if no
+     * {@link org.mockito.plugins.InstantiatorProvider} extension exists or is visible in the current classpath.</p>
+     */
+    InstantiatorProvider getInstantiatorProvider() {
+      return instantiatorProvider;
     }
 }

--- a/src/main/java/org/mockito/internal/configuration/plugins/Plugins.java
+++ b/src/main/java/org/mockito/internal/configuration/plugins/Plugins.java
@@ -1,5 +1,6 @@
 package org.mockito.internal.configuration.plugins;
 
+import org.mockito.plugins.InstantiatorProvider;
 import org.mockito.plugins.MockMaker;
 import org.mockito.plugins.StackTraceCleanerProvider;
 
@@ -25,5 +26,15 @@ public class Plugins {
      */
     public static MockMaker getMockMaker() {
         return registry.getMockMaker();
+    }
+
+    /**
+     * Returns the instantiator provider available for the current runtime.
+     *
+     * <p>Returns {@link org.mockito.internal.creation.instance.DefaultInstantiatorProvider} if no
+     * {@link org.mockito.plugins.InstantiatorProvider} extension exists or is visible in the current classpath.</p>
+     */
+    public static InstantiatorProvider getInstantiatorProvider() {
+      return registry.getInstantiatorProvider();
     }
 }

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMaker.java
@@ -2,9 +2,9 @@ package org.mockito.internal.creation.bytebuddy;
 
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.InternalMockHandler;
+import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.internal.creation.bytebuddy.MockMethodInterceptor.MockAccess;
 import org.mockito.internal.creation.instance.Instantiator;
-import org.mockito.internal.creation.instance.InstantiatorProvider;
 import org.mockito.invocation.MockHandler;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.mock.SerializableMode;
@@ -26,7 +26,7 @@ public class ByteBuddyMockMaker implements MockMaker {
     public <T> T createMock(MockCreationSettings<T> settings, MockHandler handler) {
         Class<T> mockedProxyType = createProxyClass(mockWithFeaturesFrom(settings));
 
-        Instantiator instantiator = new InstantiatorProvider().getInstantiator(settings);
+        Instantiator instantiator = Plugins.getInstantiatorProvider().getInstantiator(settings);
         T mockInstance = null;
         try {
             mockInstance = instantiator.newInstance(mockedProxyType);

--- a/src/main/java/org/mockito/internal/creation/instance/DefaultInstantiatorProvider.java
+++ b/src/main/java/org/mockito/internal/creation/instance/DefaultInstantiatorProvider.java
@@ -1,13 +1,14 @@
 package org.mockito.internal.creation.instance;
 
 import org.mockito.mock.MockCreationSettings;
+import org.mockito.plugins.InstantiatorProvider;
 
-public class InstantiatorProvider {
+public class DefaultInstantiatorProvider implements InstantiatorProvider {
 
     private final static Instantiator INSTANCE = new ObjenesisInstantiator();
 
-    public Instantiator getInstantiator(MockCreationSettings settings) {
-        if (settings.isUsingConstructor()) {
+    public Instantiator getInstantiator(MockCreationSettings<?> settings) {
+        if (settings != null && settings.isUsingConstructor()) {
             return new ConstructorInstantiator(settings.getOuterClassInstance());
         } else {
             return INSTANCE;

--- a/src/main/java/org/mockito/internal/stubbing/answers/ClonesArguments.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/ClonesArguments.java
@@ -4,11 +4,12 @@
  */
 package org.mockito.internal.stubbing.answers;
 
+import org.mockito.internal.configuration.plugins.Plugins;
+import org.mockito.internal.creation.instance.Instantiator;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsEmptyValues;
 import org.mockito.internal.util.reflection.LenientCopyTool;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.objenesis.ObjenesisHelper;
 
 //TODO this needs documentation and further analysis - what if someone changes the answer?
 //we might think about implementing it straight on MockSettings
@@ -17,7 +18,8 @@ public class ClonesArguments implements Answer<Object> {
         Object[] arguments = invocation.getArguments();
         for (int i = 0; i < arguments.length; i++) {
             Object from = arguments[i];
-            Object newInstance = ObjenesisHelper.newInstance(from.getClass());
+            Instantiator instantiator = Plugins.getInstantiatorProvider().getInstantiator(null);
+            Object newInstance = instantiator.newInstance(from.getClass());
             new LenientCopyTool().copyToRealObject(from, newInstance);
             arguments[i] = newInstance;
         }

--- a/src/main/java/org/mockito/plugins/InstantiatorProvider.java
+++ b/src/main/java/org/mockito/plugins/InstantiatorProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.plugins;
+
+import org.mockito.internal.creation.instance.Instantiator;
+import org.mockito.mock.MockCreationSettings;
+
+/**
+ * <p>
+ *     Mockito will invoke this interface in order to fetch an instance instantiator provider.
+ * </p>
+ *
+ * <p>
+ *     By default, an internal byte-buddy/asm/objenesis based implementation is used.
+ * </p>
+ *
+ * <h3>Using the extension point</h3>
+ *
+ * <p>
+ *     The plugin mechanism of mockito works in a similar way as the
+ *     {@link java.util.ServiceLoader}, however instead of looking in the <code>META-INF</code>
+ *     directory, Mockito will look in <code>mockito-extensions</code> directory.
+ *     <em>The reason for that is that Android SDK strips jar from the <code>META-INF</code>
+ *     directory when creating an APK.</em>
+ * </p>
+ *
+ * <ol style="list-style-type: lower-alpha">
+ *     <li>The implementation itself, for example
+ *         <code>org.awesome.mockito.AwesomeInstantiatorProvider</code> that implements the
+ *         <code>InstantiatorProvider</code>.</li>
+ *     <li>A file "<code>mockito-extensions/org.mockito.plugins.InstantiatorProvider</code>".
+ *         The content of this file is exactly a <strong>one</strong> line with the qualified
+ *         name: <code>org.awesome.mockito.AwesomeInstantiatorProvider</code>.</li>
+ * </ol></p>
+ *
+ * <p>
+ *     Note that if several <code>mockito-extensions/org.mockito.plugins.InstantiatorProvider</code>
+ *     files exists in the classpath, Mockito will only use the first returned by the standard
+ *     {@link ClassLoader#getResource} mechanism.
+ * <p>
+ *     So just create a custom implementation of {@link InstantiatorProvider} and place the
+ *     qualified name in the following file
+ *     <code>mockito-extensions/org.mockito.plugins.InstantiatorProvider</code>.
+ * </p>
+ *
+ * @since 21.10.15
+ */
+public interface InstantiatorProvider {
+
+    /**
+     * Returns an instantiator, used to create new class instances.
+     */
+    Instantiator getInstantiator(MockCreationSettings<?> settings);
+}


### PR DESCRIPTION
Updated InstantiatorProvider to be a plug-in, to eliminate direct dependency on ObjenesisInstantiator. This allows Mockito to be used by runtimes that don't execute bytecode, such as j2objc-translated code on iOS.