### PR TITLE
Fixes #311: Add shouldHaveNoMoreInteractions() to BDDMockito

### DIFF
--- a/src/main/java/org/mockito/BDDMockito.java
+++ b/src/main/java/org/mockito/BDDMockito.java
@@ -57,6 +57,7 @@ import org.mockito.verification.VerificationMode;
  *   person.ride(bike);
  *
  *   then(person).should(times(2)).ride(bike);
+ *   then(person).shouldHaveNoMoreInteractions();
  *   then(police).shouldHaveZeroInteractions();
  * </code></pre>
  * <p>
@@ -256,6 +257,12 @@ public class BDDMockito extends Mockito {
          * @since 2.0
          */
         void shouldHaveZeroInteractions();
+
+        /**
+         * @see #verifyNoMoreInteractions(Object...)
+         * @since 2.0
+         */
+        void shouldHaveNoMoreInteractions();
     }
 
     /**
@@ -308,6 +315,14 @@ public class BDDMockito extends Mockito {
          */
         public void shouldHaveZeroInteractions() {
             verifyZeroInteractions(mock);
+        }
+
+        /**
+         * @see #verifyNoMoreInteractions(Object...)
+         * @since 2.0
+         */
+        public void shouldHaveNoMoreInteractions() {
+            verifyNoMoreInteractions(mock);
         }
     }
 

--- a/src/test/java/org/mockitousage/customization/BDDMockitoTest.java
+++ b/src/test/java/org/mockitousage/customization/BDDMockitoTest.java
@@ -246,6 +246,7 @@ public class BDDMockitoTest extends TestBase {
         mock.booleanObjectReturningMethod();
 
         then(mock).should().booleanObjectReturningMethod();
+        then(mock).shouldHaveNoMoreInteractions();
     }
 
     @Test
@@ -260,6 +261,18 @@ public class BDDMockitoTest extends TestBase {
         try {
             then(mock).shouldHaveZeroInteractions();
             fail("should have reported this interaction wasn't wanted");
+        } catch (NoInteractionsWanted expected) { }
+    }
+
+    @Test
+    public void should_fail_when_mock_had_more_interactions_than_expected() {
+        mock.booleanObjectReturningMethod();
+        mock.byteObjectReturningMethod();
+
+        then(mock).should().booleanObjectReturningMethod();
+        try {
+            then(mock).shouldHaveNoMoreInteractions();
+            fail("should have reported that no more interactions were wanted");
         } catch (NoInteractionsWanted expected) { }
     }
 


### PR DESCRIPTION
Replicates `verifyNoMoreInteractions` on the BDD API.

-----------------------------------
**EDIT by mockito team** : Fixes #311
