### PR TITLE
Modify StackTraceFilter to not exclude "good" stack trace elements

### DIFF
--- a/src/main/java/org/mockito/internal/exceptions/stacktrace/StackTraceFilter.java
+++ b/src/main/java/org/mockito/internal/exceptions/stacktrace/StackTraceFilter.java
@@ -10,8 +10,6 @@ import org.mockito.internal.configuration.plugins.Plugins;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 
 public class StackTraceFilter implements Serializable {
@@ -20,38 +18,22 @@ public class StackTraceFilter implements Serializable {
 
     private static final StackTraceCleaner CLEANER =
             Plugins.getStackTraceCleanerProvider().getStackTraceCleaner(new DefaultStackTraceCleaner());
-    
+
     /**
      * Example how the filter works (+/- means good/bad):
-     * [a+, b+, c-, d+, e+, f-, g+] -> [a+, b+, g+]
-     * Basically removes all bad from the middle. If any good are in the middle of bad those are also removed. 
+     * [a+, b+, c-, d+, e+, f-, g+] -> [a+, b+, d+, e+, g+]
+     * Basically removes all bad from the middle.
+     * <strike>If any good are in the middle of bad those are also removed.</strike>
      */
     public StackTraceElement[] filter(StackTraceElement[] target, boolean keepTop) {
         //TODO: profile
-        List<StackTraceElement> unfilteredStackTrace = Arrays.asList(target);
-        
-        int lastBad = -1;
-        int firstBad = -1;
-        for (int i = 0; i < unfilteredStackTrace.size(); i++) {
-            if (!CLEANER.isOut(unfilteredStackTrace.get(i))) {
-                continue;
-            }
-            lastBad = i;
-            if (firstBad == -1) {
-                firstBad = i;
+        final List<StackTraceElement> filtered = new ArrayList<StackTraceElement>();
+        for (StackTraceElement aTarget : target) {
+            if (!CLEANER.isOut(aTarget)) {
+                filtered.add(aTarget);
             }
         }
-        
-        List<StackTraceElement> top;
-        if (keepTop && firstBad != -1) {
-            top = unfilteredStackTrace.subList(0, firstBad);
-        } else {
-            top = new LinkedList<StackTraceElement>();
-        }
-        
-        List<StackTraceElement> bottom = unfilteredStackTrace.subList(lastBad + 1, unfilteredStackTrace.size());
-        List<StackTraceElement> filtered = new ArrayList<StackTraceElement>(top);
-        filtered.addAll(bottom);
-        return filtered.toArray(new StackTraceElement[]{});
+        StackTraceElement[] result = new StackTraceElement[filtered.size()];
+        return filtered.toArray(result);
     }
 }

--- a/src/test/java/org/mockito/internal/exceptions/stacktrace/StackTraceFilterTest.java
+++ b/src/test/java/org/mockito/internal/exceptions/stacktrace/StackTraceFilterTest.java
@@ -40,7 +40,7 @@ public class StackTraceFilterTest extends TestBase {
     }
     
     @Test
-    public void shouldFilterOutTracesMiddleBadTraces() {
+    public void shouldNotFilterOutTracesMiddleGoodTraces() {
         StackTraceElement[] t = new TraceBuilder().classes(
                 "org.test.MockitoSampleTest",
                 "org.test.TestSupport",
@@ -51,7 +51,7 @@ public class StackTraceFilterTest extends TestBase {
         
         StackTraceElement[] filtered = filter.filter(t, false);
         
-        assertThat(filtered, hasOnlyThoseClasses("org.test.TestSupport", "org.test.MockitoSampleTest"));
+        assertThat(filtered, hasOnlyThoseClasses("org.test.TestSupport", "org.test.TestSupport", "org.test.MockitoSampleTest"));
     }
     
     @Test


### PR DESCRIPTION
currently StackTraceFilter filters in this way (example from javadoc):
[a+, b+, c-, d+, e+, f-, g+] -> [a+, b+, g+]

this patch makes it work:
[a+, b+, c-, d+, e+, f-, g+] -> [a+, b+, d+, e+, g+]

Not sure why it was implemented first time in this strange manner.

------------------------------------
**EDIT by Mockito team** : Fixes #316