### PR TITLE
Fixes #256 :Alternative fix to #259, windows build

### DIFF
--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -40,8 +40,8 @@ task mockitoJavadoc(type: Javadoc) {
         <script type="text/javascript">
           var usingOldIE = \$.browser.msie && parseInt(\$.browser.version) < 9;
           if(!usingOldIE) {
-              \$("head").append("<link rel=\\"shortcut icon\\" href=\\"{@docRoot}/favicon.ico?v=cafebabe\\">")
-              \$("head", window.parent.document).append("<link rel=\\"shortcut icon\\" href=\\"{@docRoot}/favicon.ico?v=cafebabe\\">")
+              \$("head").append("<link rel=\\"shortcut icon\\" href=\\"{@docRoot}/favicon.ico?v=cafebabe\\">");
+              \$("head", window.parent.document).append("<link rel=\\"shortcut icon\\" href=\\"{@docRoot}/favicon.ico?v=cafebabe\\">");
               hljs.initHighlightingOnLoad();
               \$("pre.code").css("font-size", "0.9em");
               injectProjectVersionForJavadocJDK6("Mockito ${project.version} API",
@@ -49,7 +49,7 @@ task mockitoJavadoc(type: Javadoc) {
                                                  "em#mockito-version-header-javadoc7-footer");
           }
         </script>
-    """)
+    """.replaceAll(/\r|\n/, ""))
 //    options.stylesheetFile file("src/javadoc/stylesheet.css")
 //    options.addStringOption('top', 'some html')
     if (JavaVersion.current().isJava8Compatible()) {


### PR DESCRIPTION
  *Allows user to build on windows by collapsing the heredoc into a single
  line before it's shipped off to JavaDoc.
  *Tested the generated Javadoc for markup errors, and added semicolons to
  compensate.