### PR TITLE
Show correct location of unwanted interaction with mock when using MockitoJUnitRule

### DIFF
--- a/src/main/java/org/mockito/internal/exceptions/stacktrace/DefaultStackTraceCleaner.java
+++ b/src/main/java/org/mockito/internal/exceptions/stacktrace/DefaultStackTraceCleaner.java
@@ -12,6 +12,8 @@ public class DefaultStackTraceCleaner implements StackTraceCleaner {
         boolean fromOrgMockito = e.getClassName().startsWith("org.mockito.");
         boolean isRunner = e.getClassName().startsWith("org.mockito.runners.");
         boolean isInternalRunner = e.getClassName().startsWith("org.mockito.internal.runners.");
-        return (fromMockObject || fromByteBuddyMockObject || fromOrgMockito) && !isRunner && !isInternalRunner;
+        boolean isJUnitRule = e.getClassName().startsWith("org.mockito.internal.junit.JUnitRule");
+        return (fromMockObject || fromByteBuddyMockObject || fromOrgMockito)
+                && !isRunner && !isInternalRunner && !isJUnitRule;
     }
 }

--- a/src/test/java/org/mockito/internal/exceptions/stacktrace/StackTraceFilterTest.java
+++ b/src/test/java/org/mockito/internal/exceptions/stacktrace/StackTraceFilterTest.java
@@ -26,7 +26,20 @@ public class StackTraceFilterTest extends TestBase {
         
         assertThat(filtered, hasOnlyThoseClasses("MockitoExampleTest"));
     }
-    
+
+    @Test
+    public void shouldFilterOutByteBuddyGarbage() {
+        StackTraceElement[] t = new TraceBuilder().classes(
+                "MockitoExampleTest",
+                "org.testcase.MockedClass$MockitoMock$1882975947.doSomething(Unknown Source)"
+        ).toTraceArray();
+
+        StackTraceElement[] filtered = filter.filter(t, false);
+
+        assertThat(filtered, hasOnlyThoseClasses("MockitoExampleTest"));
+    }
+
+
     @Test
     public void shouldFilterOutMockitoPackage() {
         StackTraceElement[] t = new TraceBuilder().classes(

--- a/src/test/java/org/mockito/internal/exceptions/stacktrace/StackTraceFilterTest.java
+++ b/src/test/java/org/mockito/internal/exceptions/stacktrace/StackTraceFilterTest.java
@@ -67,6 +67,22 @@ public class StackTraceFilterTest extends TestBase {
         
         assertThat(filtered, hasOnlyThoseClasses("org.test.MockitoSampleTest", "junit.stuff", "org.mockito.runners.Runner"));
     }
+
+    @Test
+    public void shouldNotFilterElementsAboveMockitoJUnitRule() {
+        StackTraceElement[] t = new TraceBuilder().classes(
+                "org.mockito.internal.junit.JUnitRule$1.evaluate(JUnitRule.java:16)",
+                "org.mockito.runners.Runner",
+                "junit.stuff",
+                "org.test.MockitoSampleTest",
+                "org.mockito.internal.MockitoCore.verifyNoMoreInteractions",
+                "org.mockito.internal.debugging.LocationImpl"
+        ).toTraceArray();
+
+        StackTraceElement[] filtered = filter.filter(t, false);
+
+        assertThat(filtered, hasOnlyThoseClasses("org.test.MockitoSampleTest", "junit.stuff", "org.mockito.runners.Runner","org.mockito.internal.junit.JUnitRule$1.evaluate(JUnitRule.java:16)"));
+    }
     
     @Test
     public void shouldKeepInternalRunners() {


### PR DESCRIPTION
This pull request by @indy5858 and me changes the stacktrace filtering so that when using `MockitoJUnitRule` the correct location of an unwanted interaction with a mock.

Before this commit the location on an unwanted interaction was not
reported properly. Instead of

```
No interactions wanted here:
-> at <package>.<TestClass>.<testMethod>(<TestClass.java>:<lineNumber>)
```
the assertion message said:
```
No interactions wanted here:
-> at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
```

The issue with the current behaviour in master is that all stacktrace elements above an element containing "org.mockito." are removed. As `org.mockito.internal.junit.JUnitRule` fullfills this condition and comes below the "payload" (i.e. test code and code under test) stack elements the interesting part of the stack is filtered.
In case the pull request #317 (which we only found after hacking on this) is merged this pull becomes obsolete except for the two tests that are added:
* checking that the "payload" stack elements aren't removed from the stack and
* a test for removal of the Byte Buddy stack elements.