### PR TITLE
Use the new issue/pr templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,8 +5,8 @@
 
 **If looking for support**
 
-* Go to the [mockito mailing-list](http://groups.google.com/group/mockito) (moderated)
 * Search / Ask question on [stackoverflow](http://stackoverflow.com)
+* Go to the [mockito mailing-list](http://groups.google.com/group/mockito) (moderated)
 * Issues should always have a [Short, Self Contained, Correct (Compilable), Example](http://sscce.org) (same as any question on stackoverflow.com)
 
 # Contributing to Mockito

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -22,3 +22,4 @@ check that
        (same as any question on stackoverflow.com)
  - [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/master/.github/CONTRIBUTING.md)
 
+

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,24 @@
+> Hey,
+> 
+> First thanks for reporting, in order to help us to classify issue can you make sure the following check boxes are checked ?
+> 
+> If this is about mockito usage, the better way is to reach out to
+> 
+>  - stackoverflow : http://stackoverflow.com/questions/tagged/mockito
+>  - the mailing-list  : https://groups.google.com/forum/#!forum/mockito / mockito@googlegroups.com
+>    (Note mailing-list is moderated to avoid spam)
+>
+> _This block can be removed_
+> _Something wrong in the template fix it here `.github/ISSUE_TEMPLATE.md`
+
+
+check that
+
+ - [ ] The mockito message in the stacktrace have useful information, but it didn't help
+ - [ ] The problematic code (if that's possible) is copied here;
+       Note that some configuration are impossible to mock via Mockito
+ - [ ] Provide versions (mockito / jdk / os / any other relevant information)
+ - [ ] Provide a [Short, Self Contained, Correct (Compilable), Example](http://sscce.org) of the issue
+       (same as any question on stackoverflow.com)
+ - [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/master/.github/CONTRIBUTING.md)
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+> Hey, 
+> 
+> Thanks for the contribution, this is awesome.
+> As you may have read, project members have somehow an opinionated view on what and how should be
+> Mockito, e.g. we don't want mockito to be a feature bloat.
+> There may be a thorough review, with feedback -> code change loop.
+> 
+> _This block can be removed_
+> _Something wrong in the template fix it here `.github/PULL_REQUEST_TEMPLATE.md`
+
+
+check list
+
+ - [ ] PR should be motivated, i.e. what does it fix, why, and if relevant how
+ - [ ] If possible / relevant include an example in the description, that could help all readers
+       including project members to get a better picture of the change
+ - [ ] Avoid other runtime dependencies
+ - [ ] Meaningful commit history ; intention is important please rebase your commit history so that each
+       commit is meaningful and help the people that will explore a change in 2 years
+ - [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/master/.github/CONTRIBUTING.md)
+ - [ ] Mention `Fixes #<issue number>` in the description _if relevant_
+ - [ ] At least one commit should mention `Fixes #<issue number>` _if relevant_

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,3 +20,4 @@ check list
  - [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/master/.github/CONTRIBUTING.md)
  - [ ] Mention `Fixes #<issue number>` in the description _if relevant_
  - [ ] At least one commit should mention `Fixes #<issue number>` _if relevant_
+

--- a/README.md
+++ b/README.md
@@ -58,6 +58,6 @@ Then, _open_ the generated *.ipr file in IDEA.
 
 All you want to know about Mockito is hosted at [The Mockito Site](http://site.mockito.org) which is [Open Source](https://github.com/mockito/mockito.github.io) and likes [pull requests](https://github.com/mockito/mockito.github.io/pulls), too.
 
-Want to contribute? Take a look at the [Contributing Guide](https://github.com/mockito/mockito/blob/master/CONTRIBUTING.md).
+Want to contribute? Take a look at the [Contributing Guide](https://github.com/mockito/mockito/blob/master/.github/CONTRIBUTING.md).
 
 Enjoy Mockito!


### PR DESCRIPTION
Github offers now Issue and Pull Requests templates. In order to channel user feedback and contribution, this PR initiates those templates.

See GH documentation on the matter : https://help.github.com/articles/helping-people-contribute-to-your-project/

Note the introduction of the `.github` folder where contributing guidelines and templates will be located.