### PR TITLE
#365 Simplified the API to get an argument in custom Answer's

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,8 +5,8 @@
 
 **If looking for support**
 
-* Go to the [mockito mailing-list](http://groups.google.com/group/mockito) (moderated)
 * Search / Ask question on [stackoverflow](http://stackoverflow.com)
+* Go to the [mockito mailing-list](http://groups.google.com/group/mockito) (moderated)
 * Issues should always have a [Short, Self Contained, Correct (Compilable), Example](http://sscce.org) (same as any question on stackoverflow.com)
 
 # Contributing to Mockito

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,25 @@
+> Hey,
+> 
+> First thanks for reporting, in order to help us to classify issue can you make sure the following check boxes are checked ?
+> 
+> If this is about mockito usage, the better way is to reach out to
+> 
+>  - stackoverflow : http://stackoverflow.com/questions/tagged/mockito
+>  - the mailing-list  : https://groups.google.com/forum/#!forum/mockito / mockito@googlegroups.com
+>    (Note mailing-list is moderated to avoid spam)
+>
+> _This block can be removed_
+> _Something wrong in the template fix it here `.github/ISSUE_TEMPLATE.md`
+
+
+check that
+
+ - [ ] The mockito message in the stacktrace have useful information, but it didn't help
+ - [ ] The problematic code (if that's possible) is copied here;
+       Note that some configuration are impossible to mock via Mockito
+ - [ ] Provide versions (mockito / jdk / os / any other relevant information)
+ - [ ] Provide a [Short, Self Contained, Correct (Compilable), Example](http://sscce.org) of the issue
+       (same as any question on stackoverflow.com)
+ - [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/master/.github/CONTRIBUTING.md)
+
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+> Hey, 
+> 
+> Thanks for the contribution, this is awesome.
+> As you may have read, project members have somehow an opinionated view on what and how should be
+> Mockito, e.g. we don't want mockito to be a feature bloat.
+> There may be a thorough review, with feedback -> code change loop.
+> 
+> _This block can be removed_
+> _Something wrong in the template fix it here `.github/PULL_REQUEST_TEMPLATE.md`
+
+
+check list
+
+ - [ ] PR should be motivated, i.e. what does it fix, why, and if relevant how
+ - [ ] If possible / relevant include an example in the description, that could help all readers
+       including project members to get a better picture of the change
+ - [ ] Avoid other runtime dependencies
+ - [ ] Meaningful commit history ; intention is important please rebase your commit history so that each
+       commit is meaningful and help the people that will explore a change in 2 years
+ - [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/master/.github/CONTRIBUTING.md)
+ - [ ] Mention `Fixes #<issue number>` in the description _if relevant_
+ - [ ] At least one commit should mention `Fixes #<issue number>` _if relevant_
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,18 @@
 # More details on how to configure the Travis build
 # http://docs.travis-ci.com/user/build-configuration/
 
-# Enabling container based infrastructure hoping it will help the build speed
-# see http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+# Speed up build by leversging travis caches
+before_cache:
+  - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
 
-sudo: false
+# Enabling container based infrastructure hoping it will help the build speed <= this didn't work well, so it's reverted
+# see http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+sudo: true
+
 language: java
 jdk:
 - oraclejdk7
@@ -12,6 +20,7 @@ env:
   matrix:
   - TERM=dumb
   global:
+  - GRADLE_OPTS="-XX:+UseCompressedOops -Djava.awt.headless=true"
   - secure: ZjU6SpkLzTAJr9qmxKDSI0uA8eJ/r5n58/equD6ifDlCBUasxPxOwaIARuNjhH45UCFOQDO9HMmvD7IWufyYl0OpACMM6MZ/0JX5Qsd+vhmBGirl6H3rRbVpvyoSI1J2xqJXy9/yTU54IYMDv3R7suinvmKXYHCqJ3h7ke+m4Ik=
   - secure: SDwSEK8W+GU78fVLi+P0k+v5eYK1fevz1Z0Htsjta2PRr0DicL6CMTNLxi48c3vXT+GHL6W8uojmfRwnHd8yyRZu2nW4Hda5rWB3de6Nz64lOZFYUbvoZfj9TdCgDYn+u2jUkm6+C76ZlPtfQhS97uZCb9iCDSdm1JErpng5e6g=
   - secure: aRk3elhhgDvXc2RyKAOcn9UF4w5U2zgFqUEEwdZ/r5DLrlKlA0aDE3pBZhST479nHIVEjF3w/SjePmfc9K/JPp2cLE12qHBT5mp4F2MZhNkBDay4vsXLwkhWsyQLz85VrvR/QkeCbLXSQBCZsy/KI8PwwMIrcEH6rAoo+1MYTos=
@@ -23,7 +32,5 @@ install:
 script:
   - ./gradlew ciBuild release
 after_success:
-#  - ./gradlew --stacktrace cobertura coveralls
-#  - ./gradlew --stacktrace coverageReport
-#  - "cp build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml jacoco.xml"
-#  - bash <(curl -s https://codecov.io/bash)
+  - ./gradlew --stacktrace coverageReport && cp build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml jacoco.xml || echo "Code coverage failed"
+  - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"

--- a/README.md
+++ b/README.md
@@ -58,6 +58,6 @@ Then, _open_ the generated *.ipr file in IDEA.
 
 All you want to know about Mockito is hosted at [The Mockito Site](http://site.mockito.org) which is [Open Source](https://github.com/mockito/mockito.github.io) and likes [pull requests](https://github.com/mockito/mockito.github.io/pulls), too.
 
-Want to contribute? Take a look at the [Contributing Guide](https://github.com/mockito/mockito/blob/master/CONTRIBUTING.md).
+Want to contribute? Take a look at the [Contributing Guide](https://github.com/mockito/mockito/blob/master/.github/CONTRIBUTING.md).
 
 Enjoy Mockito!

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ test {
 }
 
 dependencies {
-    compile 'net.bytebuddy:byte-buddy:1.2.3'
+    compile 'net.bytebuddy:byte-buddy:1.2.1'
 
     provided "junit:junit:4.10", "org.hamcrest:hamcrest-core:1.3"
     compile "org.objenesis:objenesis:2.1"

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ apply from: 'gradle/version.gradle'
 apply from: "gradle/ide.gradle"
 apply from: 'gradle/coverage.gradle'
 apply from: 'gradle/osgi.gradle'
+apply from: 'gradle/gradle-fix.gradle'
 
 allprojects {
     repositories {

--- a/doc/release-notes/official.md
+++ b/doc/release-notes/official.md
@@ -1,3 +1,15 @@
+### 2.0.44-beta (2016-03-09 14:16 UTC)
+
+* Authors: 3
+* Commits: 8
+  * 5: Brice Dutheil
+  * 2: Jan Tarnowski
+  * 1: Evgeny Astafev
+* Improvements: 3
+  * Use the new issue/pr templates [(#361)](https://github.com/mockito/mockito/pull/361)
+  * Issue #345 : Removes previously verified invocations when capturing argument is combined with after and atMost verifiers [(#349)](https://github.com/mockito/mockito/pull/349)
+  * Modify StackTraceFilter to not exclude "good" stack trace elements [(#317)](https://github.com/mockito/mockito/pull/317)
+
 ### 2.0.43-beta (2016-02-23 14:04 UTC)
 
 * Authors: 2

--- a/gradle/coverage.gradle
+++ b/gradle/coverage.gradle
@@ -1,5 +1,11 @@
 apply plugin: 'jacoco'
 
+// TODO later include subprojects, possible ideas https://gist.github.com/aalmiray/e6f54aa4b3803be0bcac
+
+jacoco {
+    toolVersion = "0.7.6.201602180812"
+}
+
 task mockitoCoverage(type: JacocoReport, dependsOn: "test") {
     executionData files("${buildDir}/jacoco/test.exec")
 

--- a/gradle/gradle-fix.gradle
+++ b/gradle/gradle-fix.gradle
@@ -1,0 +1,13 @@
+
+// GradleWorkerMain ignores options available in the environment, so we have to pass them there
+
+allprojects {
+    tasks.withType(JavaForkOptions) {
+        // should improve memory on a 64bit JVM
+        jvmArgs "-XX:+UseCompressedOops"
+
+        // should avoid GradleWorkerMain to steal focus
+        jvmArgs "-Djava.awt.headless=true"
+        jvmArgs "-Dapple.awt.UIElement=true"
+    }
+}

--- a/gradle/osgi.gradle
+++ b/gradle/osgi.gradle
@@ -19,7 +19,7 @@ afterEvaluate {
                     "org.mockito.*;version=${project.version}"
 
             instruction 'Import-Package',
-                    'net.bytebuddy.*;version=1.2.3',
+                    'net.bytebuddy.*;version=1.2.1',
                     'junit.*;resolution:=optional',
                     'org.junit.*;resolution:=optional',
                     'org.hamcrest;version="[1.0,2.0)"',

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Feb 15 22:24:07 CET 2015
+#Sun Mar 09 16:13:07 CET 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.11-all.zip

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InterceptedInvocation.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InterceptedInvocation.java
@@ -114,7 +114,12 @@ class InterceptedInvocation implements Invocation, VerificationAwareInvocation {
 
     @Override
     @SuppressWarnings("unchecked")
+    @Deprecated
     public <T> T getArgumentAt(int index, Class<T> clazz) {
+        return getArgument(index);
+    }
+
+    public <T> T getArgument(int index) {
         return (T) arguments[index];
     }
 

--- a/src/main/java/org/mockito/internal/exceptions/stacktrace/StackTraceFilter.java
+++ b/src/main/java/org/mockito/internal/exceptions/stacktrace/StackTraceFilter.java
@@ -10,8 +10,6 @@ import org.mockito.internal.configuration.plugins.Plugins;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 
 public class StackTraceFilter implements Serializable {
@@ -20,38 +18,22 @@ public class StackTraceFilter implements Serializable {
 
     private static final StackTraceCleaner CLEANER =
             Plugins.getStackTraceCleanerProvider().getStackTraceCleaner(new DefaultStackTraceCleaner());
-    
+
     /**
      * Example how the filter works (+/- means good/bad):
-     * [a+, b+, c-, d+, e+, f-, g+] -> [a+, b+, g+]
-     * Basically removes all bad from the middle. If any good are in the middle of bad those are also removed. 
+     * [a+, b+, c-, d+, e+, f-, g+] -> [a+, b+, d+, e+, g+]
+     * Basically removes all bad from the middle.
+     * <strike>If any good are in the middle of bad those are also removed.</strike>
      */
     public StackTraceElement[] filter(StackTraceElement[] target, boolean keepTop) {
         //TODO: profile
-        List<StackTraceElement> unfilteredStackTrace = Arrays.asList(target);
-        
-        int lastBad = -1;
-        int firstBad = -1;
-        for (int i = 0; i < unfilteredStackTrace.size(); i++) {
-            if (!CLEANER.isOut(unfilteredStackTrace.get(i))) {
-                continue;
-            }
-            lastBad = i;
-            if (firstBad == -1) {
-                firstBad = i;
+        final List<StackTraceElement> filtered = new ArrayList<StackTraceElement>();
+        for (StackTraceElement aTarget : target) {
+            if (!CLEANER.isOut(aTarget)) {
+                filtered.add(aTarget);
             }
         }
-        
-        List<StackTraceElement> top;
-        if (keepTop && firstBad != -1) {
-            top = unfilteredStackTrace.subList(0, firstBad);
-        } else {
-            top = new LinkedList<StackTraceElement>();
-        }
-        
-        List<StackTraceElement> bottom = unfilteredStackTrace.subList(lastBad + 1, unfilteredStackTrace.size());
-        List<StackTraceElement> filtered = new ArrayList<StackTraceElement>(top);
-        filtered.addAll(bottom);
-        return filtered.toArray(new StackTraceElement[]{});
+        StackTraceElement[] result = new StackTraceElement[filtered.size()];
+        return filtered.toArray(result);
     }
 }

--- a/src/main/java/org/mockito/internal/invocation/InvocationImpl.java
+++ b/src/main/java/org/mockito/internal/invocation/InvocationImpl.java
@@ -62,7 +62,12 @@ public class InvocationImpl implements Invocation, VerificationAwareInvocation {
         return arguments;
     }
 
+    @Deprecated
     public <T> T getArgumentAt(int index, Class<T> clazz) {
+        return getArgument(index);
+    }
+
+    public <T> T getArgument(int index) {
         return (T) arguments[index];
     }
 

--- a/src/main/java/org/mockito/internal/verification/AtMost.java
+++ b/src/main/java/org/mockito/internal/verification/AtMost.java
@@ -5,6 +5,7 @@
 
 package org.mockito.internal.verification;
 
+import java.util.Iterator;
 import java.util.List;
 
 import org.mockito.exceptions.Reporter;
@@ -38,12 +39,22 @@ public class AtMost implements VerificationMode {
         if (foundSize > maxNumberOfInvocations) {
             new Reporter().wantedAtMostX(maxNumberOfInvocations, foundSize);
         }
-        
+
+        removeAlreadyVerified(found);
         invocationMarker.markVerified(found, wanted);
     }
 
     @Override
     public VerificationMode description(String description) {
         return VerificationModeFactory.description(this, description);
+    }
+
+    private void removeAlreadyVerified(List<Invocation> invocations) {
+        for (Iterator<Invocation> iterator = invocations.iterator(); iterator.hasNext(); ) {
+            Invocation i = iterator.next();
+            if (i.isVerified()) {
+                iterator.remove();
+            }
+        }
     }
 }

--- a/src/main/java/org/mockito/invocation/InvocationOnMock.java
+++ b/src/main/java/org/mockito/invocation/InvocationOnMock.java
@@ -41,9 +41,16 @@ public interface InvocationOnMock extends Serializable {
     * @param index argument position
     * @param clazz argument type
     * @return casted argument on position
+    * @deprecated use {@link #getArgument(int)}
     */
     <T> T getArgumentAt(int index, Class<T> clazz);
 
+    /**
+     * Returns casted argument at the given index
+     * @param index the zero based argument index
+     * @return casted argument
+     */
+    <T> T getArgument(int index);
 
     /**
      * calls real method

--- a/src/test/java/org/mockito/internal/exceptions/stacktrace/StackTraceFilterTest.java
+++ b/src/test/java/org/mockito/internal/exceptions/stacktrace/StackTraceFilterTest.java
@@ -53,7 +53,7 @@ public class StackTraceFilterTest extends TestBase {
     }
     
     @Test
-    public void shouldFilterOutTracesMiddleBadTraces() {
+    public void shouldNotFilterOutTracesMiddleGoodTraces() {
         StackTraceElement[] t = new TraceBuilder().classes(
                 "org.test.MockitoSampleTest",
                 "org.test.TestSupport",
@@ -64,7 +64,7 @@ public class StackTraceFilterTest extends TestBase {
         
         StackTraceElement[] filtered = filter.filter(t, false);
         
-        assertThat(filtered, hasOnlyThoseClasses("org.test.TestSupport", "org.test.MockitoSampleTest"));
+        assertThat(filtered, hasOnlyThoseClasses("org.test.TestSupport", "org.test.TestSupport", "org.test.MockitoSampleTest"));
     }
     
     @Test

--- a/src/test/java/org/mockitousage/bugs/MockitoRunnerBreaksWhenNoTestMethodsTest.java
+++ b/src/test/java/org/mockitousage/bugs/MockitoRunnerBreaksWhenNoTestMethodsTest.java
@@ -13,6 +13,9 @@ import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.mockitoutil.TestBase;
 
+import java.io.OutputStream;
+import java.io.PrintStream;
+
 
 // @Ignore("for demo only. this test cannot be enabled as it fails :)")
 public class MockitoRunnerBreaksWhenNoTestMethodsTest extends TestBase {
@@ -20,7 +23,8 @@ public class MockitoRunnerBreaksWhenNoTestMethodsTest extends TestBase {
     @Test
     public void ensure_the_test_runner_breaks() throws Exception {
         JUnitCore runner = new JUnitCore();
-        runner.addListener(new TextListener(System.out));
+//        runner.addListener(new TextListener(System.out));
+        runner.addListener(new TextListener(DevNull.out));
 
         Result result = runner.run(TestClassWithoutTestMethod.class);
 
@@ -33,4 +37,14 @@ public class MockitoRunnerBreaksWhenNoTestMethodsTest extends TestBase {
         public void notATestMethod() { }
     }
 
+    public static final class DevNull {
+        public final static PrintStream out = new PrintStream(new OutputStream() {
+            public void close() {}
+            public void flush() {}
+            public void write(byte[] b) {}
+            public void write(byte[] b, int off, int len) {}
+            public void write(int b) {}
+
+        } );
+    }
 }

--- a/src/test/java/org/mockitousage/stubbing/StubbingWithCustomAnswerTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingWithCustomAnswerTest.java
@@ -28,7 +28,7 @@ public class StubbingWithCustomAnswerTest extends TestBase {
     public void shouldAnswer() throws Exception {
         when(mock.simpleMethod(anyString())).thenAnswer(new Answer<String>() {
             public String answer(InvocationOnMock invocation) throws Throwable {
-                String arg = (String) invocation.getArgument(0);
+                String arg = invocation.getArgument(0);
 
                 return invocation.getMethod().getName() + "-" + arg;
             }

--- a/src/test/java/org/mockitousage/stubbing/StubbingWithCustomAnswerTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingWithCustomAnswerTest.java
@@ -28,7 +28,7 @@ public class StubbingWithCustomAnswerTest extends TestBase {
     public void shouldAnswer() throws Exception {
         when(mock.simpleMethod(anyString())).thenAnswer(new Answer<String>() {
             public String answer(InvocationOnMock invocation) throws Throwable {
-                String arg = (String) invocation.getArguments()[0];
+                String arg = (String) invocation.getArgument(0);
 
                 return invocation.getMethod().getName() + "-" + arg;
             }

--- a/src/test/java/org/mockitousage/verification/VerificationAfterDelayTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationAfterDelayTest.java
@@ -15,6 +15,8 @@ import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.exceptions.base.MockitoAssertionError;
 import org.mockitoutil.TestBase;
@@ -28,6 +30,9 @@ public class VerificationAfterDelayTest extends TestBase {
     private List<String> mock;
 
     private List<Exception> exceptions = new LinkedList<Exception>();
+
+    @Captor
+    private ArgumentCaptor<String> stringArgumentCaptor;
 
     @After
     public void teardown() {
@@ -104,6 +109,31 @@ public class VerificationAfterDelayTest extends TestBase {
         // then
         expected.expect(MockitoAssertionError.class);
         verify(mock, after(10000).never()).clear();
+    }
+
+    /**
+     * Test for issue #345.
+     */
+    @Test
+    public void shouldReturnListOfArgumentsWithSameSizeAsGivenInAtMostVerification() {
+        // given
+        int n = 3;
+
+        // when
+        exerciseMockNTimes(n);
+
+        // then
+        verify(mock, after(200).atMost(n)).add(stringArgumentCaptor.capture());
+        assertEquals(n, stringArgumentCaptor.getAllValues().size());
+        assertEquals("0", stringArgumentCaptor.getAllValues().get(0));
+        assertEquals("1", stringArgumentCaptor.getAllValues().get(1));
+        assertEquals("2", stringArgumentCaptor.getAllValues().get(2));
+    }
+
+    private void exerciseMockNTimes(int n) {
+        for (int i = 0; i < n; i++) {
+            mock.add(String.valueOf(i));
+        }
     }
 
     private Thread waitAndExerciseMock(final int sleep) {

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-version=2.0.44-beta
+version=2.0.45-beta
 mockito.testng.version=1.0


### PR DESCRIPTION
This pull request fixes #365 by introducing `T getArgument(int)` and deprecating `T getArgumentAt(int,Class<T>)` in type `InvocationOnMock`. This improves the readabilty of custom Answers. 

Now we can write: `String text = invocation.getArgument(1) ` 
Instead of: `String text = invocation.getArgumentAt(1,String.class) `
