### PR TITLE
Travis / CI improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 # More details on how to configure the Travis build
 # http://docs.travis-ci.com/user/build-configuration/
 
+# Speed up build by leversging travis caches
+before_cache:
+  - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+
 # Enabling container based infrastructure hoping it will help the build speed <= this didn't work well, so it's reverted
 # see http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,5 @@ install:
 script:
   - ./gradlew ciBuild release
 after_success:
-  - ./gradlew --stacktrace coverageReport
-  - "cp build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml jacoco.xml"
-  - bash <(curl -s https://codecov.io/bash)
+  - ./gradlew --stacktrace coverageReport && cp build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml jacoco.xml || echo "Code coverage failed"
+  - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ install:
 script:
   - ./gradlew ciBuild release
 after_success:
-#  - ./gradlew --stacktrace cobertura coveralls
-#  - ./gradlew --stacktrace coverageReport
-#  - "cp build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml jacoco.xml"
-#  - bash <(curl -s https://codecov.io/bash)
+  - ./gradlew --stacktrace coverageReport
+  - "cp build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml jacoco.xml"
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 # More details on how to configure the Travis build
 # http://docs.travis-ci.com/user/build-configuration/
 
-# Enabling container based infrastructure hoping it will help the build speed
+# Enabling container based infrastructure hoping it will help the build speed <= this didn't work well, so it's reverted
 # see http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+sudo: true
 
-sudo: false
 language: java
 jdk:
 - oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   matrix:
   - TERM=dumb
   global:
+  - GRADLE_OPTS="-XX:+UseCompressedOops -Djava.awt.headless=true"
   - secure: ZjU6SpkLzTAJr9qmxKDSI0uA8eJ/r5n58/equD6ifDlCBUasxPxOwaIARuNjhH45UCFOQDO9HMmvD7IWufyYl0OpACMM6MZ/0JX5Qsd+vhmBGirl6H3rRbVpvyoSI1J2xqJXy9/yTU54IYMDv3R7suinvmKXYHCqJ3h7ke+m4Ik=
   - secure: SDwSEK8W+GU78fVLi+P0k+v5eYK1fevz1Z0Htsjta2PRr0DicL6CMTNLxi48c3vXT+GHL6W8uojmfRwnHd8yyRZu2nW4Hda5rWB3de6Nz64lOZFYUbvoZfj9TdCgDYn+u2jUkm6+C76ZlPtfQhS97uZCb9iCDSdm1JErpng5e6g=
   - secure: aRk3elhhgDvXc2RyKAOcn9UF4w5U2zgFqUEEwdZ/r5DLrlKlA0aDE3pBZhST479nHIVEjF3w/SjePmfc9K/JPp2cLE12qHBT5mp4F2MZhNkBDay4vsXLwkhWsyQLz85VrvR/QkeCbLXSQBCZsy/KI8PwwMIrcEH6rAoo+1MYTos=

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ apply from: 'gradle/version.gradle'
 apply from: "gradle/ide.gradle"
 apply from: 'gradle/coverage.gradle'
 apply from: 'gradle/osgi.gradle'
+apply from: 'gradle/gradle-fix.gradle'
 
 allprojects {
     repositories {

--- a/gradle/coverage.gradle
+++ b/gradle/coverage.gradle
@@ -1,5 +1,11 @@
 apply plugin: 'jacoco'
 
+// TODO later include subprojects, possible ideas https://gist.github.com/aalmiray/e6f54aa4b3803be0bcac
+
+jacoco {
+    toolVersion = "0.7.6.201602180812"
+}
+
 task mockitoCoverage(type: JacocoReport, dependsOn: "test") {
     executionData files("${buildDir}/jacoco/test.exec")
 

--- a/gradle/gradle-fix.gradle
+++ b/gradle/gradle-fix.gradle
@@ -1,0 +1,13 @@
+
+// GradleWorkerMain ignores options available in the environment, so we have to pass them there
+
+allprojects {
+    tasks.withType(JavaForkOptions) {
+        // should improve memory on a 64bit JVM
+        jvmArgs "-XX:+UseCompressedOops"
+
+        // should avoid GradleWorkerMain to steal focus
+        jvmArgs "-Djava.awt.headless=true"
+        jvmArgs "-Dapple.awt.UIElement=true"
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Feb 15 22:24:07 CET 2015
+#Sun Mar 09 16:13:07 CET 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.11-all.zip

--- a/src/test/java/org/mockitousage/bugs/MockitoRunnerBreaksWhenNoTestMethodsTest.java
+++ b/src/test/java/org/mockitousage/bugs/MockitoRunnerBreaksWhenNoTestMethodsTest.java
@@ -13,6 +13,9 @@ import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.mockitoutil.TestBase;
 
+import java.io.OutputStream;
+import java.io.PrintStream;
+
 
 // @Ignore("for demo only. this test cannot be enabled as it fails :)")
 public class MockitoRunnerBreaksWhenNoTestMethodsTest extends TestBase {
@@ -20,7 +23,8 @@ public class MockitoRunnerBreaksWhenNoTestMethodsTest extends TestBase {
     @Test
     public void ensure_the_test_runner_breaks() throws Exception {
         JUnitCore runner = new JUnitCore();
-        runner.addListener(new TextListener(System.out));
+//        runner.addListener(new TextListener(System.out));
+        runner.addListener(new TextListener(DevNull.out));
 
         Result result = runner.run(TestClassWithoutTestMethod.class);
 
@@ -33,4 +37,14 @@ public class MockitoRunnerBreaksWhenNoTestMethodsTest extends TestBase {
         public void notATestMethod() { }
     }
 
+    public static final class DevNull {
+        public final static PrintStream out = new PrintStream(new OutputStream() {
+            public void close() {}
+            public void flush() {}
+            public void write(byte[] b) {}
+            public void write(byte[] b, int off, int len) {}
+            public void write(int b) {}
+
+        } );
+    }
 }


### PR DESCRIPTION
Travis CI jobs were failing inconsistently, 

The gradle forked process that executed tests was killed by the travis VM, hence the build failed with the following log without much clue, but the exit status code `137`. 
```
* What went wrong:
Execution failed for task ':test'.
> Process 'Gradle Test Executor 1' finished with non-zero exit value 137
```

_On the JVM it is the same as bash or zsh, when a program is "closed" with a signal, the exit code is `128` + the signal code._ There `137 = 128 + 9`, in other words the process ha received the `SIGKILL` signal. Other project have experienced that since a month (e.g. https://github.com/travis-ci/travis-ci/issues/5582).

**Indeed removing the container mode made the build run correctly.**

I took the time to tweak a bit more the build

- by leveraging the travis caches for gradle downloads
- by using the compressed oops for the 64bit JVMs (it should help only a little bit)
- by upgrading to gradle 2.11
- by reactivating code coverage