### PR TITLE
Fix #368 Class cast exception in PluginLoader.loadPlugin

### DIFF
--- a/src/main/java/org/mockito/internal/configuration/plugins/PluginRegistry.java
+++ b/src/main/java/org/mockito/internal/configuration/plugins/PluginRegistry.java
@@ -30,7 +30,7 @@ class PluginRegistry {
     /**
      * Returns the implementation of the mock maker available for the current runtime.
      *
-     * <p>Returns {@link org.mockito.internal.creation.cglib.CglibMockMaker} if no
+     * <p>Returns {@link org.mockito.internal.creation.bytebuddy.ByteBuddyMockMaker} if no
      * {@link org.mockito.plugins.MockMaker} extension exists or is visible in the current classpath.</p>
      */
     MockMaker getMockMaker() {

--- a/src/test/java/org/mockito/internal/configuration/plugins/DefaultPlugin.java
+++ b/src/test/java/org/mockito/internal/configuration/plugins/DefaultPlugin.java
@@ -1,0 +1,8 @@
+package org.mockito.internal.configuration.plugins;
+
+/**
+ *
+ */
+class DefaultPlugin implements PluginInterface {
+
+}

--- a/src/test/java/org/mockito/internal/configuration/plugins/PluginImpl.java
+++ b/src/test/java/org/mockito/internal/configuration/plugins/PluginImpl.java
@@ -1,0 +1,8 @@
+package org.mockito.internal.configuration.plugins;
+
+/**
+ *
+ */
+public class PluginImpl implements PluginInterface {
+
+}

--- a/src/test/java/org/mockito/internal/configuration/plugins/PluginInterface.java
+++ b/src/test/java/org/mockito/internal/configuration/plugins/PluginInterface.java
@@ -1,0 +1,7 @@
+package org.mockito.internal.configuration.plugins;
+
+/**
+ *
+ */
+interface PluginInterface {
+}

--- a/src/test/java/org/mockito/internal/configuration/plugins/PluginLoaderTest.java
+++ b/src/test/java/org/mockito/internal/configuration/plugins/PluginLoaderTest.java
@@ -1,0 +1,77 @@
+package org.mockito.internal.configuration.plugins;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockitoutil.ClassLoaders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test PluginLoader. This test check that loaded plugin can be assigned to fields of classes what loaded by
+ * application class loader
+ */
+public class PluginLoaderTest {
+
+    private static final String PLUGIN_RESOURCE_CONTENT = PluginImpl.class.getName();
+    private static final String PLUGIN_RESOURCE_PATH = "mockito-extensions/org.mockito.internal.configuration.plugins.PluginInterface";
+    private PluginLoader pluginLoader;
+
+    @Before
+    public void setUp() {
+        pluginLoader = new PluginLoader(new DefaultPluginSwitch());
+    }
+
+    @Test
+    public void should_load_custom_plugin_without_context_classloader() {
+
+        Object pluginInterface = loadPlugin();
+
+        assertThatCustomPluginLoaded(pluginInterface);
+    }
+
+
+    @Test
+    public void should_load_custom_plugin_with_custom_context_classloader() throws Exception {
+
+        ClassLoader classLoader = ClassLoaders.inMemoryClassLoader()
+                                              .withClassDefinition(PLUGIN_RESOURCE_PATH, PLUGIN_RESOURCE_CONTENT.getBytes("UTF-8"))
+                                              .build();
+
+        Thread.currentThread().setContextClassLoader(classLoader);
+
+        Object plugin = loadPlugin();
+
+        assertThatCustomPluginLoaded(plugin);
+    }
+
+    @Test
+    public void should_load_default_plugin_with_custom_context_classloader() throws Exception {
+
+        ClassLoader classLoader = ClassLoaders.inMemoryClassLoader().build();
+
+        Thread.currentThread().setContextClassLoader(classLoader);
+
+        Object plugin = loadPlugin();
+
+        assertThatDefaultPluginLoaded(plugin);
+    }
+
+    private Object loadPlugin() {
+        return pluginLoader.loadPlugin(PluginInterface.class, DefaultPlugin.class.getName());
+    }
+
+    private void assertThatCustomPluginLoaded(Object plugin) {
+
+        assertThat(plugin.getClass())
+                .describedAs("Loaded plugin class '%s' is not assignable to local class '%s'", plugin.getClass(), PluginImpl.class)
+                .isAssignableFrom(PluginImpl.class);
+    }
+
+    private void assertThatDefaultPluginLoaded(Object plugin) {
+        assertThat(plugin.getClass())
+                .describedAs("Loaded plugin class '%s' is not assignable to  default plugin local class '%s'", plugin.getClass(), DefaultPlugin.class)
+                .isAssignableFrom(DefaultPlugin.class);
+    }
+
+
+}

--- a/src/test/resources/mockito-extensions/org.mockito.internal.configuration.plugins.PluginInterface
+++ b/src/test/resources/mockito-extensions/org.mockito.internal.configuration.plugins.PluginInterface
@@ -1,0 +1,2 @@
+org.mockito.internal.configuration.plugins.PluginImpl
+# Used for test : org.mockito.internal.configuration.plugins.PluginLoaderTest


### PR DESCRIPTION
Fix issue #368 

- Use `Class.forName` to get plugin implementer class instead loading via context class loader 
- Use `RuntimeException` instead `MockitoException` because `MockitoException` depends on `PluginLoader` and if something incorrect with loader then stack trace  will be also incorrect. 

I don't understand why context class loader was used, because anyway other classes that use plugin is loaded by class loaded of current class. 