### PR TITLE
Fixes #365 Simplify the InvocationOnMock-API to get a casted argument

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InterceptedInvocation.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InterceptedInvocation.java
@@ -113,9 +113,14 @@ class InterceptedInvocation implements Invocation, VerificationAwareInvocation {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
+    @Deprecated
     public <T> T getArgumentAt(int index, Class<T> clazz) {
-        return (T) arguments[index];
+        return (T) getArgument(index);
+    }
+
+    @Override
+    public <T> T getArgument(int index) {
+        return (T)arguments[index];
     }
 
     @Override

--- a/src/main/java/org/mockito/internal/invocation/InvocationImpl.java
+++ b/src/main/java/org/mockito/internal/invocation/InvocationImpl.java
@@ -62,9 +62,16 @@ public class InvocationImpl implements Invocation, VerificationAwareInvocation {
         return arguments;
     }
 
+    @Deprecated
     public <T> T getArgumentAt(int index, Class<T> clazz) {
-        return (T) arguments[index];
+        return (T) getArgument(index);
     }
+
+    public <T> T getArgument(int index) {
+        return (T)arguments[index];
+    }
+
+
 
     public boolean isVerified() {
         return verified || isIgnoredForVerification;

--- a/src/main/java/org/mockito/internal/invocation/InvocationMatcher.java
+++ b/src/main/java/org/mockito/internal/invocation/InvocationMatcher.java
@@ -122,7 +122,7 @@ public class InvocationMatcher implements DescribedInvocation, CapturesArguments
         for (int position = 0; position < regularArgumentsSize(invocation); position++) {
             ArgumentMatcher m = matchers.get(position);
             if (m instanceof CapturesArguments) {
-                ((CapturesArguments) m).captureFrom(invocation.getArgumentAt(position, Object.class));
+                ((CapturesArguments) m).captureFrom(invocation.getArgument(position));
             }
         }
     }

--- a/src/main/java/org/mockito/internal/stubbing/answers/ReturnsArgumentAt.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/ReturnsArgumentAt.java
@@ -39,7 +39,7 @@ public class ReturnsArgumentAt implements Answer<Object>, Serializable {
 
     public Object answer(InvocationOnMock invocation) throws Throwable {
         validateIndexWithinInvocationRange(invocation);
-        return invocation.getArguments()[actualArgumentPosition(invocation)];
+        return invocation.getArgument(actualArgumentPosition(invocation));
     }
 
 

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValues.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValues.java
@@ -72,7 +72,7 @@ public class ReturnsEmptyValues implements Answer<Object>, Serializable {
             //see issue 184.
             //mocks by default should return 0 if references are the same, otherwise some other value because they are not the same. Hence we return 1 (anything but 0 is good).
             //Only for compareTo() method by the Comparable interface
-            return invocation.getMock() == invocation.getArguments()[0] ? 0 : 1;
+            return invocation.getMock() == invocation.getArgument(0) ? 0 : 1;
         }
         
         Class<?> returnType = invocation.getMethod().getReturnType();

--- a/src/main/java/org/mockito/invocation/InvocationOnMock.java
+++ b/src/main/java/org/mockito/invocation/InvocationOnMock.java
@@ -41,8 +41,17 @@ public interface InvocationOnMock extends Serializable {
     * @param index argument position
     * @param clazz argument type
     * @return casted argument on position
+     * @deprecated  use {@link #getArgument(int)}
     */
+    @Deprecated
     <T> T getArgumentAt(int index, Class<T> clazz);
+
+    /**
+     * Returns casted argument at the given index
+     * @param index argument index
+     * @return casted argument at the given index
+     */
+    <T> T getArgument(int index);
 
 
     /**

--- a/src/test/java/org/mockito/internal/AllInvocationsFinderTest.java
+++ b/src/test/java/org/mockito/internal/AllInvocationsFinderTest.java
@@ -54,6 +54,6 @@ public class AllInvocationsFinderTest extends TestBase {
     }
 
     private void assertArgumentEquals(Object argumentValue, Invocation invocation) {
-        assertEquals(argumentValue, invocation.getArguments()[0]);
+        assertEquals(argumentValue, invocation.getArgument(0));
     }
 }

--- a/src/test/java/org/mockito/internal/invocation/InvocationImplTest.java
+++ b/src/test/java/org/mockito/internal/invocation/InvocationImplTest.java
@@ -156,7 +156,7 @@ public class InvocationImplTest extends TestBase {
             argTypes(int.class, int.class).args(1, argument).toInvocation();
 
         //when
-        int secondArgument = invocationOnInterface.getArgumentAt(1, int.class);
+        int secondArgument = invocationOnInterface.getArgument(1);
 
         //then
         assertTrue(secondArgument == argument);

--- a/src/test/java/org/mockitousage/PlaygroundWithDemoOfUnclonedParametersProblemTest.java
+++ b/src/test/java/org/mockitousage/PlaygroundWithDemoOfUnclonedParametersProblemTest.java
@@ -75,7 +75,7 @@ public class PlaygroundWithDemoOfUnclonedParametersProblemTest extends TestBase 
     private Answer byCheckingLogEquals(final ImportLogBean status) {
         return new Answer() {
             public Object answer(InvocationOnMock invocation) throws Throwable {
-                ImportLogBean bean = (ImportLogBean) invocation.getArguments()[0];
+                ImportLogBean bean =  invocation.getArgument(0);
                 assertEquals(status, bean);
                 return null;
             }

--- a/src/test/java/org/mockitousage/customization/BDDMockitoTest.java
+++ b/src/test/java/org/mockitousage/customization/BDDMockitoTest.java
@@ -68,7 +68,7 @@ public class BDDMockitoTest extends TestBase {
     public void should_stub_with_answer() throws Exception {
         given(mock.simpleMethod(anyString())).willAnswer(new Answer<String>() {
             public String answer(InvocationOnMock invocation) throws Throwable {
-                return (String) invocation.getArguments()[0];
+                return  invocation.getArgument(0);
             }});
 
         Assertions.assertThat(mock.simpleMethod("foo")).isEqualTo("foo");
@@ -78,7 +78,7 @@ public class BDDMockitoTest extends TestBase {
     public void should_stub_with_will_answer_alias() throws Exception {
         given(mock.simpleMethod(anyString())).will(new Answer<String>() {
             public String answer(InvocationOnMock invocation) throws Throwable {
-                return (String) invocation.getArguments()[0];
+                return  invocation.getArgument(0);
             }
         });
 
@@ -184,7 +184,7 @@ public class BDDMockitoTest extends TestBase {
     public void should_stub_using_do_answer_style() throws Exception {
         willAnswer(new Answer<String>() {
             public String answer(InvocationOnMock invocation) throws Throwable {
-                return (String) invocation.getArguments()[0];
+                return  invocation.getArgument(0);
             }
         })
                 .given(mock).simpleMethod(anyString());

--- a/src/test/java/org/mockitousage/stubbing/StubbingWithCustomAnswerTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingWithCustomAnswerTest.java
@@ -28,7 +28,7 @@ public class StubbingWithCustomAnswerTest extends TestBase {
     public void shouldAnswer() throws Exception {
         when(mock.simpleMethod(anyString())).thenAnswer(new Answer<String>() {
             public String answer(InvocationOnMock invocation) throws Throwable {
-                String arg = (String) invocation.getArguments()[0];
+                String arg =  invocation.getArgument(0);
 
                 return invocation.getMethod().getName() + "-" + arg;
             }


### PR DESCRIPTION
This pull request fixes #365 by introducing `T getArgument(int)` and deprecating `T getArgumentAt(int,Class<T>)` in type `InvocationOnMock`. This improves the readabilty of custom Answers. 

This...
`String text = invocation.getArgumentAt(1,String.class) ` 
can be replaced by... 
`String text = invocation.getArgument(1) ` 

