### PR TITLE
Fixes #312.  Added documentation in OngoingStubbing.thenThrow().

### DIFF
--- a/src/main/java/org/mockito/stubbing/OngoingStubbing.java
+++ b/src/main/java/org/mockito/stubbing/OngoingStubbing.java
@@ -102,6 +102,10 @@ public interface OngoingStubbing<T> extends IOngoingStubbing {
      * If throwable is null then exception will be thrown.
      * <p>
      * See examples in javadoc for {@link Mockito#when}
+     * 
+     * <p>Note depending on the JVM, stack trace information may not be available in
+     * the generated throwable instance.  If you require stack trace information,
+     * use {@link OngoingStubbing#thenThrow(Throwable...)} instead.
      *
      * @param throwableType to be thrown on method invocation
      *
@@ -129,9 +133,11 @@ public interface OngoingStubbing<T> extends IOngoingStubbing {
      * <p>
      * See examples in javadoc for {@link Mockito#when}
      *
-     *
      * <p>Note since JDK 7, invoking this method will raise a compiler warning "possible heap pollution",
      * this API is safe to use. If you don't want to see this warning it is possible to chain {@link #thenThrow(Class)}
+     * <p>Note depending on the JVM, stack trace information may not be available in
+     * the generated throwable instance.  If you require stack trace information,
+     * use {@link OngoingStubbing#thenThrow(Throwable...)} instead.
      *
      * @param toBeThrown to be thrown on method invocation
      * @param nextToBeThrown next to be thrown on method invocation


### PR DESCRIPTION
This fixes #312.  Added documentation in OngoingStubbing.thenThrow where new ThrowsExceptionClass() is used to create a new Throwable using Objenesis.