### PR TITLE
Lazily verify without calling collector.verify()

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -7,7 +7,6 @@ package org.mockito;
 import org.mockito.internal.MockitoCore;
 import org.mockito.internal.creation.MockSettingsImpl;
 import org.mockito.internal.debugging.MockitoDebuggerImpl;
-import org.mockito.internal.stubbing.answers.*;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsEmptyValues;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsMoreEmptyValues;
 import org.mockito.internal.verification.VerificationModeFactory;

--- a/src/main/java/org/mockito/internal/MockitoCore.java
+++ b/src/main/java/org/mockito/internal/MockitoCore.java
@@ -72,7 +72,8 @@ public class MockitoCore {
         } else if (!mockUtil.isMock(mock)) {
             reporter.notAMockPassedToVerify(mock.getClass());
         }
-        mockingProgress.verificationStarted(new MockAwareVerificationMode(mock, mode));
+        VerificationMode actualMode = this.mockingProgress.maybeVerifyLazily(mode);
+        mockingProgress.verificationStarted(new MockAwareVerificationMode(mock, actualMode));
         return mock;
     }
     
@@ -182,5 +183,4 @@ public class MockitoCore {
     public MockingDetails mockingDetails(Object toInspect) {
         return new DefaultMockingDetails(toInspect, new MockUtil());
     }
-
 }

--- a/src/main/java/org/mockito/internal/progress/MockingProgress.java
+++ b/src/main/java/org/mockito/internal/progress/MockingProgress.java
@@ -9,6 +9,7 @@ import org.mockito.internal.listeners.MockingProgressListener;
 import org.mockito.invocation.Invocation;
 import org.mockito.stubbing.OngoingStubbing;
 import org.mockito.verification.VerificationMode;
+import org.mockito.verification.VerificationStrategy;
 
 public interface MockingProgress {
     
@@ -39,4 +40,8 @@ public interface MockingProgress {
     void mockingStarted(Object mock, Class classToMock);
 
     void setListener(MockingProgressListener listener);
+
+    void setVerificationStrategy(VerificationStrategy strategy);
+
+    VerificationMode maybeVerifyLazily(VerificationMode mode);
 }

--- a/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
+++ b/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
@@ -15,6 +15,7 @@ import org.mockito.invocation.Invocation;
 import org.mockito.invocation.Location;
 import org.mockito.stubbing.OngoingStubbing;
 import org.mockito.verification.VerificationMode;
+import org.mockito.verification.VerificationStrategy;
 
 @SuppressWarnings("unchecked")
 public class MockingProgressImpl implements MockingProgress {
@@ -26,6 +27,19 @@ public class MockingProgressImpl implements MockingProgress {
     private Localized<VerificationMode> verificationMode;
     private Location stubbingInProgress = null;
     private MockingProgressListener listener;
+    private VerificationStrategy verificationStrategy;
+
+    public MockingProgressImpl() {
+        this.verificationStrategy = getDefaultVerificationStrategy();
+    }
+
+    public static VerificationStrategy getDefaultVerificationStrategy() {
+        return new VerificationStrategy() {
+            public VerificationMode maybeVerifyLazily(VerificationMode mode) {
+                return mode;
+            }
+        };
+    }
 
     public void reportOngoingStubbing(OngoingStubbing iOngoingStubbing) {
         this.ongoingStubbing = iOngoingStubbing;
@@ -119,5 +133,13 @@ public class MockingProgressImpl implements MockingProgress {
 
     public void setListener(MockingProgressListener listener) {
         this.listener = listener;
+    }
+
+    public void setVerificationStrategy(VerificationStrategy strategy) {
+        this.verificationStrategy = strategy;
+    }
+
+    public VerificationMode maybeVerifyLazily(VerificationMode mode) {
+        return this.verificationStrategy.maybeVerifyLazily(mode);
     }
 }

--- a/src/main/java/org/mockito/internal/progress/ThreadSafeMockingProgress.java
+++ b/src/main/java/org/mockito/internal/progress/ThreadSafeMockingProgress.java
@@ -9,6 +9,7 @@ import org.mockito.internal.listeners.MockingProgressListener;
 import org.mockito.invocation.Invocation;
 import org.mockito.stubbing.OngoingStubbing;
 import org.mockito.verification.VerificationMode;
+import org.mockito.verification.VerificationStrategy;
 
 import java.io.Serializable;
 
@@ -75,5 +76,13 @@ public class ThreadSafeMockingProgress implements MockingProgress, Serializable 
 
     public void setListener(MockingProgressListener listener) {
         threadSafely().setListener(listener);
+    }
+
+    public void setVerificationStrategy(VerificationStrategy strategy) {
+        threadSafely().setVerificationStrategy(strategy);
+    }
+
+    public VerificationMode maybeVerifyLazily(VerificationMode mode) {
+        return threadSafely().maybeVerifyLazily(mode);
     }
 }

--- a/src/main/java/org/mockito/internal/verification/MockAwareVerificationMode.java
+++ b/src/main/java/org/mockito/internal/verification/MockAwareVerificationMode.java
@@ -25,7 +25,6 @@ public class MockAwareVerificationMode implements VerificationMode {
         return mock;
     }
 
-    @Override
     public VerificationMode description(String description) {
         return VerificationModeFactory.description(this, description);
     }

--- a/src/main/java/org/mockito/junit/VerificationCollector.java
+++ b/src/main/java/org/mockito/junit/VerificationCollector.java
@@ -19,8 +19,8 @@ import org.mockito.verification.VerificationMode;
  *   public void should_fail() {
  *       IMethods methods = mock(IMethods.class);
  *
- *       collector.verify(methods).byteReturningMethod();
- *       collector.verify(methods).simpleMethod();
+ *       verify(methods).byteReturningMethod();
+ *       verify(methods).simpleMethod();
  *   }
  * </code></pre>
  *
@@ -30,33 +30,22 @@ import org.mockito.verification.VerificationMode;
 public interface VerificationCollector extends TestRule {
 
     /**
-     * Lazily verify certain behaviour happened once.
-     *
-     * @see org.mockito.Mockito#verify(Object)
-     *
-     * @param <T> The type of the mock
-     * @param mock to be verified
-     * @return mock object itself
-     */
-    <T> T verify(T mock);
-
-    /**
-     * Lazily verify certain behaviour happened at least once / exact number of times / never.
-     *
-     * @see org.mockito.Mockito#verify(Object, VerificationMode)
-     *
-     * @param mock to be verified
-     * @param mode times(x), atLeastOnce() or never()
-     * @param <T> The type of the mock
-     * @return mock object itself
-     */
-    <T> T verify(T mock, VerificationMode mode);
-
-    /**
      * Collect all lazily verified behaviour. If there were failed verifications, it will
      * throw a MockitoAssertionError containing all messages indicating the failed verifications.
      *
      * @throws MockitoAssertionError If there were failed verifications
      */
     void collectAndReport() throws MockitoAssertionError;
+
+    /**
+     * Enforce all verifications are performed lazily. This method is automatically called when
+     * used as JUnitRule.
+     *
+     * You should only use this method if you are using a VerificationCollector
+     * inside a method where only this method should be verified lazily. The other methods can
+     * still be verified directly.
+     *
+     * @return this
+     */
+    VerificationCollector assertLazily();
 }

--- a/src/main/java/org/mockito/verification/VerificationStrategy.java
+++ b/src/main/java/org/mockito/verification/VerificationStrategy.java
@@ -1,0 +1,16 @@
+package org.mockito.verification;
+
+/**
+ * Strategy to possibly lazily perform verifications.
+ */
+public interface VerificationStrategy {
+
+    /**
+     * Possibly wrap the given VerificationMode and return a wrapping
+     * VerificationMode instead.
+     *
+     * @param mode The original mode.
+     * @return A wrapping mode that uses the original mode.
+     */
+    VerificationMode maybeVerifyLazily(VerificationMode mode);
+}

--- a/src/test/java/org/mockitousage/junitrule/VerificationCollectorImplTest.java
+++ b/src/test/java/org/mockitousage/junitrule/VerificationCollectorImplTest.java
@@ -14,38 +14,39 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 public class VerificationCollectorImplTest {
 
     @Test
     public void should_not_throw_any_exceptions_when_verifications_are_succesful() {
-        VerificationCollector collector = MockitoJUnit.collector();
+        VerificationCollector collector = MockitoJUnit.collector().assertLazily();
 
         IMethods methods = mock(IMethods.class);
         methods.simpleMethod();
 
-        collector.verify(methods).simpleMethod();
+        verify(methods).simpleMethod();
         collector.collectAndReport();
     }
 
     @Test(expected = MockitoAssertionError.class)
     public void should_collect_verification_failures() {
-        VerificationCollector collector = MockitoJUnit.collector();
+        VerificationCollector collector = MockitoJUnit.collector().assertLazily();
 
         IMethods methods = mock(IMethods.class);
 
-        collector.verify(methods).simpleMethod();
+        verify(methods).simpleMethod();
         collector.collectAndReport();
     }
 
     @Test
     public void should_collect_multiple_verification_failures() {
-        VerificationCollector collector = MockitoJUnit.collector();
+        VerificationCollector collector = MockitoJUnit.collector().assertLazily();
 
         IMethods methods = mock(IMethods.class);
 
-        collector.verify(methods).simpleMethod();
-        collector.verify(methods).byteReturningMethod();
+        verify(methods).simpleMethod();
+        verify(methods).byteReturningMethod();
         try {
             collector.collectAndReport();
             fail();
@@ -57,25 +58,25 @@ public class VerificationCollectorImplTest {
 
     @Test
     public void should_only_collect_failures_ignore_succesful_verifications() {
-        VerificationCollector collector = MockitoJUnit.collector();
+        VerificationCollector collector = MockitoJUnit.collector().assertLazily();
 
         IMethods methods = mock(IMethods.class);
 
-        collector.verify(methods, never()).simpleMethod();
-        collector.verify(methods).byteReturningMethod();
+        verify(methods, never()).simpleMethod();
+        verify(methods).byteReturningMethod();
 
         this.assertAtLeastOneFailure(collector);
     }
 
     @Test
     public void should_continue_collecting_after_failing_verification() {
-        VerificationCollector collector = MockitoJUnit.collector();
+        VerificationCollector collector = MockitoJUnit.collector().assertLazily();
 
         IMethods methods = mock(IMethods.class);
         methods.simpleMethod();
 
-        collector.verify(methods).byteReturningMethod();
-        collector.verify(methods).simpleMethod();
+        verify(methods).byteReturningMethod();
+        verify(methods).simpleMethod();
 
         this.assertAtLeastOneFailure(collector);
     }
@@ -109,7 +110,7 @@ public class VerificationCollectorImplTest {
         public void should_fail() {
             IMethods methods = mock(IMethods.class);
 
-            collector.verify(methods).simpleMethod();
+            verify(methods).simpleMethod();
         }
 
         @Test
@@ -117,7 +118,7 @@ public class VerificationCollectorImplTest {
             IMethods methods = mock(IMethods.class);
             methods.simpleMethod();
 
-            collector.verify(methods).simpleMethod();
+            verify(methods).simpleMethod();
         }
     }
 }


### PR DESCRIPTION
As originally requested in #287: lazily verify all `Mockito.verify(...)` calls inside JUnit test cases.


