### PR TITLE
Fixes 409 : Add selective matching for ArgumentCaptor

### DIFF
--- a/src/main/java/org/mockito/internal/matchers/CapturingMatcher.java
+++ b/src/main/java/org/mockito/internal/matchers/CapturingMatcher.java
@@ -13,12 +13,25 @@ import java.util.List;
 
 @SuppressWarnings("unchecked")
 public class CapturingMatcher<T> implements ArgumentMatcher<T>, CapturesArguments, VarargMatcher, Serializable {
-    
+
     private final LinkedList<Object> arguments = new LinkedList<Object>();
+    private final ArgumentMatcher<T> argumentMatcher;
+
+    public CapturingMatcher() {
+        this(new ArgumentMatcher<T>() {
+            public boolean matches(Object argument) {
+                return true;
+            }
+        });
+    }
+
+    public CapturingMatcher(ArgumentMatcher<T> argumentMatcher) {
+        this.argumentMatcher = argumentMatcher;
+    }
 
     public boolean matches(Object argument) {
-        return true;
-    }    
+        return argumentMatcher.matches(argument);
+    }
 
     public String toString() {
         return "<Capturing argument>";

--- a/src/test/java/org/mockito/ArgumentCaptorTest.java
+++ b/src/test/java/org/mockito/ArgumentCaptorTest.java
@@ -6,24 +6,73 @@ package org.mockito;
 
 import org.junit.After;
 import org.junit.Test;
+import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.progress.HandyReturnValues;
 import org.mockitoutil.TestBase;
 
+import java.util.List;
+
 @SuppressWarnings("unchecked")
 public class ArgumentCaptorTest extends TestBase {
-    
+
     @Test
     public void tell_handy_return_values_to_return_value_for() throws Exception {
         //given
-        final Object expected = new Object(); 
+        final Object expected = new Object();
         ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
         argumentCaptor.handyReturnValues = will_return(expected);
-        
+
         //when
         Object returned = argumentCaptor.capture();
 
         //then
         assertEquals(expected, returned);
+    }
+
+    @Test
+    public void should_capture_matched_arguments() throws Exception {
+        //given
+        final String testString = "myTestString";
+        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class, new ArgumentMatcher() {
+            public boolean matches(Object argument) {
+                return argument.equals(testString);
+            }
+        });
+
+        List list = Mockito.mock(List.class);
+
+        //when
+        list.add(testString);
+
+        //then
+        Mockito.verify(list).add(argumentCaptor.capture());
+        assertEquals(argumentCaptor.getValue(), testString);
+    }
+
+    @Test
+    public void should_exclude_unmatched_arguments() {
+        //given
+        final String testString = "myTestString";
+        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class, new ArgumentMatcher() {
+            public boolean matches(Object argument) {
+                return argument.equals(testString);
+            }
+        });
+
+        List list = Mockito.mock(List.class);
+
+        //when
+        list.add("notMyTestString");
+
+        //then
+        Mockito.verify(list, Mockito.never()).add(argumentCaptor.capture());
+
+        try {
+            assertEquals(argumentCaptor.getValue(), testString);
+            fail();
+        } catch (MockitoException e) {
+
+        }
     }
 
     private HandyReturnValues will_return(final Object expected) {


### PR DESCRIPTION
Detailed the issue first (https://github.com/mockito/mockito/issues/409). Not 100% sure where to put example usages, and other documentation. Happy to change things accordingly.

Details:
- added ArgumentCaptor#forClass(Class, ArgumentMatcher)
- modified ArgumentCaptor and CapturingMatcher to support a custom matcher

