### PR TITLE
Fixes #379 Mockito.after(..) doesn't verify in a loop anymore

### DIFF
--- a/src/main/java/org/mockito/internal/verification/VerificationAfterDelayImpl.java
+++ b/src/main/java/org/mockito/internal/verification/VerificationAfterDelayImpl.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.verification;
+
+import org.mockito.internal.verification.api.VerificationData;
+import org.mockito.verification.VerificationMode;
+
+/**
+ * Verifies that another verification mode (the delegate) is satisfied after a
+ * certain timeframe, measured from the call to verify().
+ */
+public class VerificationAfterDelayImpl implements VerificationMode {
+
+	private final long delayMillis;
+	private final VerificationMode delegate;
+	
+
+	/**
+	 * Create this verification mode, to be used to verify invocation ongoing
+	 * data later.
+	 *
+	 * @param delayMillis
+	 *            The frequency to poll delegate.verify(), to check whether the
+	 *            delegate has been satisfied
+	 * @param delegate
+	 *            The verification mode to delegate overall success or failure
+	 *            to
+	 */
+	public VerificationAfterDelayImpl(long delayMillis, VerificationMode delegate) {
+		this.delayMillis = delayMillis;
+		this.delegate = delegate;
+	}
+
+	/**
+	 * Verify the given ongoing verification data, and confirm that it satisfies
+	 * the delegate verification mode after a given delay.
+	 */
+	public void verify(VerificationData data) {
+		try {
+			Thread.sleep(delayMillis);
+			delegate.verify(data);
+		} catch (InterruptedException e) {
+			throw new RuntimeException("Thread sleep has been interrupted", e);
+		}
+
+	}
+
+	public VerificationAfterDelayImpl copyWithVerificationMode(VerificationMode verificationMode) {
+		return new VerificationAfterDelayImpl(delayMillis,  verificationMode);
+	}
+
+	@Override
+	public VerificationMode description(String description) {
+		return VerificationModeFactory.description(this, description);
+	}
+}

--- a/src/main/java/org/mockito/internal/verification/VerificationAfterDelayImpl.java
+++ b/src/main/java/org/mockito/internal/verification/VerificationAfterDelayImpl.java
@@ -52,7 +52,7 @@ public class VerificationAfterDelayImpl implements VerificationMode {
 	      long remainingMillis = delayMillis;
 	      long end = System.currentTimeMillis() + remainingMillis;
 
-	      while (true) {
+	      while (remainingMillis>0) {
 	        try {
 	          Thread.sleep(remainingMillis);
 	          break;

--- a/src/main/java/org/mockito/internal/verification/VerificationAfterDelayImpl.java
+++ b/src/main/java/org/mockito/internal/verification/VerificationAfterDelayImpl.java
@@ -4,6 +4,7 @@
  */
 package org.mockito.internal.verification;
 
+import org.mockito.exceptions.Reporter;
 import org.mockito.internal.verification.api.VerificationData;
 import org.mockito.verification.VerificationMode;
 
@@ -29,10 +30,12 @@ public class VerificationAfterDelayImpl implements VerificationMode {
 	 *            to
 	 */
 	public VerificationAfterDelayImpl(long delayMillis, VerificationMode delegate) {
+		checkNotNegative(delayMillis);
 		this.delayMillis = delayMillis;
 		this.delegate = delegate;
 	}
 
+	
 	/**
 	 * Verify the given ongoing verification data, and confirm that it satisfies
 	 * the delegate verification mode after a given delay.
@@ -47,12 +50,18 @@ public class VerificationAfterDelayImpl implements VerificationMode {
 
 	}
 
+	public VerificationMode description(String description) {
+		return VerificationModeFactory.description(this, description);
+	}
+	
 	public VerificationAfterDelayImpl copyWithVerificationMode(VerificationMode verificationMode) {
 		return new VerificationAfterDelayImpl(delayMillis,  verificationMode);
 	}
 
-	@Override
-	public VerificationMode description(String description) {
-		return VerificationModeFactory.description(this, description);
+
+	private static void checkNotNegative(long delayMillis) {
+		if (delayMillis<0)
+			new Reporter().cannotCreateTimerWithNegativeDurationTime(delayMillis);
 	}
+
 }

--- a/src/main/java/org/mockito/verification/After.java
+++ b/src/main/java/org/mockito/verification/After.java
@@ -7,7 +7,6 @@ import org.mockito.internal.verification.VerificationModeFactory;
  * See the javadoc for {@link VerificationAfterDelay}
  * <p>
  * Typically, you won't use this class explicitly. Instead use timeout() method on Mockito class.
- * See javadoc for {@link VerificationWithTimeout}
  */  
 public class After extends VerificationWrapper<VerificationAfterDelayImpl> implements VerificationAfterDelay {
     
@@ -24,7 +23,6 @@ public class After extends VerificationWrapper<VerificationAfterDelayImpl> imple
         return new After(wrappedVerification.copyWithVerificationMode(verificationMode));
     }
 
-    @Override
     public VerificationMode description(String description) {
         return VerificationModeFactory.description(this, description);
     }

--- a/src/main/java/org/mockito/verification/After.java
+++ b/src/main/java/org/mockito/verification/After.java
@@ -1,7 +1,7 @@
 package org.mockito.verification;
 
+import org.mockito.internal.verification.VerificationAfterDelayImpl;
 import org.mockito.internal.verification.VerificationModeFactory;
-import org.mockito.internal.verification.VerificationOverTimeImpl;
 
 /**
  * See the javadoc for {@link VerificationAfterDelay}
@@ -9,23 +9,13 @@ import org.mockito.internal.verification.VerificationOverTimeImpl;
  * Typically, you won't use this class explicitly. Instead use timeout() method on Mockito class.
  * See javadoc for {@link VerificationWithTimeout}
  */  
-public class After extends VerificationWrapper<VerificationOverTimeImpl> implements VerificationAfterDelay {
+public class After extends VerificationWrapper<VerificationAfterDelayImpl> implements VerificationAfterDelay {
     
-    /**
-     * See the javadoc for {@link VerificationAfterDelay}
-     * <p>
-     * Typically, you won't use this class explicitly. Instead use timeout() method on Mockito class.
-     * See javadoc for {@link VerificationWithTimeout}
-     */
-    public After(long delayMillis, VerificationMode verificationMode) {
-        this(10, delayMillis, verificationMode);
-    }
-    
-    After(long pollingPeriod, long delayMillis, VerificationMode verificationMode) {
-        this(new VerificationOverTimeImpl(pollingPeriod, delayMillis, verificationMode, false));
+    public After(long pollingPeriod, VerificationMode verificationMode) {
+        this(new VerificationAfterDelayImpl(pollingPeriod, verificationMode));
     }
 
-    After(VerificationOverTimeImpl verificationOverTime) {
+    private After(VerificationAfterDelayImpl verificationOverTime) {
         super(verificationOverTime);
     }
 

--- a/src/main/java/org/mockito/verification/After.java
+++ b/src/main/java/org/mockito/verification/After.java
@@ -23,6 +23,7 @@ public class After extends VerificationWrapper<VerificationAfterDelayImpl> imple
         return new After(wrappedVerification.copyWithVerificationMode(verificationMode));
     }
 
+    @Override
     public VerificationMode description(String description) {
         return VerificationModeFactory.description(this, description);
     }


### PR DESCRIPTION
Fixes #379

The implementation of Mockito.after(..) doesn't loop anymore but waits until the specified time is elapsed, as specified in the JavaDoc of `Mockito.after(long)`.