### PR TITLE
Add new WithinRange VerificationMode

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -7,15 +7,15 @@ package org.mockito;
 import org.mockito.internal.MockitoCore;
 import org.mockito.internal.creation.MockSettingsImpl;
 import org.mockito.internal.debugging.MockitoDebuggerImpl;
-import org.mockito.internal.stubbing.answers.*;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsEmptyValues;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsMoreEmptyValues;
 import org.mockito.internal.verification.VerificationModeFactory;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.mockito.mock.SerializableMode;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.*;
 import org.mockito.verification.*;
-import org.mockito.junit.*;
 
 /**
  * <p align="left"><img src="logo.png" srcset="logo@2x.png 2x" alt="Mockito logo"/></p>
@@ -250,6 +250,11 @@ import org.mockito.junit.*;
  * verify(mockedList, atLeastOnce()).add("three times");
  * verify(mockedList, atLeast(2)).add("five times");
  * verify(mockedList, atMost(5)).add("three times");
+ *
+ * //verification using withinRange()
+ * verify(mockedList, withinRange(1, 3)).add("once")
+ * verify(mockedList, withinRange(1, 3)).add("twice");
+ * verify(mockedList, withinRange(1, 3)).add("three times");
  *
  * </code></pre>
  *
@@ -2345,6 +2350,25 @@ public class Mockito extends Matchers {
      */
     public static VerificationMode atMost(int maxNumberOfInvocations) {
         return VerificationModeFactory.atMost(maxNumberOfInvocations);
+    }
+
+    /**
+     * Allows verifying number of invocations within range. E.g:
+     * <pre class="code"><code class="java">
+     *   verify(mock, withinRange(1, 3)).someMethod("some arg");
+     * </code></pre>
+     *
+     * See examples in javadoc for {@link Mockito} class
+     *
+     * @param minNumberOfInvocations minimum number of invocations
+     * @param maxNumberOfInvocations max number of invocations
+     *
+     * @return verification mode
+     *
+     * @since 2.0.0
+     */
+    public static VerificationMode withinRange(int minNumberOfInvocations, int maxNumberOfInvocations) {
+        return VerificationModeFactory.withinRange(minNumberOfInvocations, maxNumberOfInvocations);
     }
 
     /**

--- a/src/main/java/org/mockito/internal/verification/VerificationModeFactory.java
+++ b/src/main/java/org/mockito/internal/verification/VerificationModeFactory.java
@@ -36,6 +36,10 @@ public class VerificationModeFactory {
     public static VerificationMode atMost(int maxNumberOfInvocations) {
         return new AtMost(maxNumberOfInvocations);
     }
+
+    public static VerificationMode withinRange(int minNumberOfInvocations, int maxNumberOfInvocations) {
+        return new WithinRange(minNumberOfInvocations, maxNumberOfInvocations);
+    }
     
     /**
      * Verification mode will prepend the specified failure message if verification fails with the given implementation.

--- a/src/main/java/org/mockito/internal/verification/WithinRange.java
+++ b/src/main/java/org/mockito/internal/verification/WithinRange.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito.internal.verification;
+
+import org.mockito.exceptions.base.MockitoException;
+import org.mockito.internal.invocation.InvocationMatcher;
+import org.mockito.internal.verification.api.VerificationData;
+import org.mockito.internal.verification.checkers.MissingInvocationChecker;
+import org.mockito.internal.verification.checkers.NumberOfInvocationsWithinRangeChecker;
+import org.mockito.invocation.Invocation;
+import org.mockito.verification.VerificationMode;
+
+import java.util.List;
+
+public class WithinRange implements VerificationMode {
+
+    private final int minNumberOfInvocations;
+    private final int maxNumberOfInvocations;
+
+    private final MissingInvocationChecker missingInvocationChecker = new MissingInvocationChecker();
+    private final NumberOfInvocationsWithinRangeChecker invocationsWithinRangeChecker = new NumberOfInvocationsWithinRangeChecker();
+
+    public WithinRange(int minNumberOfInvocations, int maxNumberOfInvocations) {
+        if (minNumberOfInvocations < 0 || maxNumberOfInvocations < 0) {
+            throw new MockitoException("Negative values are not allowed here");
+        } else if (minNumberOfInvocations > maxNumberOfInvocations) {
+            throw new MockitoException("Minimum number of invocations cannot be higher than max number of invocations");
+        }
+        this.minNumberOfInvocations = minNumberOfInvocations;
+        this.maxNumberOfInvocations = maxNumberOfInvocations;
+    }
+
+    @Override
+    public void verify(VerificationData data) {
+        List<Invocation> invocations = data.getAllInvocations();
+        InvocationMatcher wanted = data.getWanted();
+
+        if (minNumberOfInvocations > 0) {
+            missingInvocationChecker.check(invocations, wanted);
+        }
+        invocationsWithinRangeChecker.check(invocations, wanted, minNumberOfInvocations, maxNumberOfInvocations);
+    }
+
+    @Override
+    public String toString() {
+        return "Wanted invocations count: within range from " + minNumberOfInvocations + " to " + maxNumberOfInvocations;
+    }
+
+    @Override
+    public VerificationMode description(String description) {
+        return VerificationModeFactory.description(this, description);
+    }
+}

--- a/src/main/java/org/mockito/internal/verification/checkers/NumberOfInvocationsChecker.java
+++ b/src/main/java/org/mockito/internal/verification/checkers/NumberOfInvocationsChecker.java
@@ -5,46 +5,26 @@
 
 package org.mockito.internal.verification.checkers;
 
-import java.util.List;
-
 import org.mockito.exceptions.Reporter;
 import org.mockito.internal.invocation.InvocationMatcher;
-import org.mockito.internal.invocation.InvocationMarker;
 import org.mockito.internal.invocation.InvocationsFinder;
-import org.mockito.internal.reporting.Discrepancy;
 import org.mockito.invocation.Invocation;
-import org.mockito.invocation.Location;
+
+import java.util.List;
 
 public class NumberOfInvocationsChecker {
     
-    private final Reporter reporter;
-    private final InvocationsFinder finder;
-    private final InvocationMarker invocationMarker = new InvocationMarker();
+    private final NumberOfInvocationsWithinRangeChecker withinRangeChecker;
 
     public NumberOfInvocationsChecker() {
-        this(new Reporter(), new InvocationsFinder());
+        this.withinRangeChecker = new NumberOfInvocationsWithinRangeChecker();
     }
     
     NumberOfInvocationsChecker(Reporter reporter, InvocationsFinder finder) {
-        this.reporter = reporter;
-        this.finder = finder;
+        this.withinRangeChecker = new NumberOfInvocationsWithinRangeChecker(reporter, finder);
     }
     
     public void check(List<Invocation> invocations, InvocationMatcher wanted, int wantedCount) {
-        List<Invocation> actualInvocations = finder.findInvocations(invocations, wanted);
-        
-        int actualCount = actualInvocations.size();
-        if (wantedCount > actualCount) {
-            Location lastInvocation = finder.getLastLocation(actualInvocations);
-            reporter.tooLittleActualInvocations(new Discrepancy(wantedCount, actualCount), wanted, lastInvocation);
-        } else if (wantedCount == 0 && actualCount > 0) {
-            Location firstUndesired = actualInvocations.get(wantedCount).getLocation();
-            reporter.neverWantedButInvoked(wanted, firstUndesired); 
-        } else if (wantedCount < actualCount) {
-            Location firstUndesired = actualInvocations.get(wantedCount).getLocation();
-            reporter.tooManyActualInvocations(wantedCount, actualCount, wanted, firstUndesired);
-        }
-        
-        invocationMarker.markVerified(actualInvocations, wanted);
+        withinRangeChecker.check(invocations, wanted, wantedCount, wantedCount);
     }
 }

--- a/src/main/java/org/mockito/internal/verification/checkers/NumberOfInvocationsWithinRangeChecker.java
+++ b/src/main/java/org/mockito/internal/verification/checkers/NumberOfInvocationsWithinRangeChecker.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito.internal.verification.checkers;
+
+import org.mockito.exceptions.Reporter;
+import org.mockito.internal.invocation.InvocationMarker;
+import org.mockito.internal.invocation.InvocationMatcher;
+import org.mockito.internal.invocation.InvocationsFinder;
+import org.mockito.internal.reporting.Discrepancy;
+import org.mockito.invocation.Invocation;
+import org.mockito.invocation.Location;
+
+import java.util.List;
+
+public class NumberOfInvocationsWithinRangeChecker {
+
+    private final Reporter reporter;
+    private final InvocationsFinder finder;
+    private final InvocationMarker invocationMarker = new InvocationMarker();
+
+    public NumberOfInvocationsWithinRangeChecker() {
+        this(new Reporter(), new InvocationsFinder());
+    }
+
+    NumberOfInvocationsWithinRangeChecker(Reporter reporter, InvocationsFinder finder) {
+        this.reporter = reporter;
+        this.finder = finder;
+    }
+
+    public void check(List<Invocation> invocations, InvocationMatcher wanted, int minNumberOfInvocations, int maxNumberOfInvocations) {
+        List<Invocation> actualInvocations = finder.findInvocations(invocations, wanted);
+
+        int actualCount = actualInvocations.size();
+        if (actualCount < minNumberOfInvocations) {
+            Location lastInvocation = finder.getLastLocation(actualInvocations);
+            reporter.tooLittleActualInvocations(new Discrepancy(minNumberOfInvocations, actualCount), wanted, lastInvocation);
+        } else if (maxNumberOfInvocations == 0 && actualCount > 0) {
+            Location firstUndesired = actualInvocations.get(maxNumberOfInvocations).getLocation();
+            reporter.neverWantedButInvoked(wanted, firstUndesired);
+        } else if (actualCount > maxNumberOfInvocations) {
+            Location firstUndesired = actualInvocations.get(maxNumberOfInvocations).getLocation();
+            reporter.tooManyActualInvocations(maxNumberOfInvocations, actualCount, wanted, firstUndesired);
+        }
+
+        invocationMarker.markVerified(actualInvocations, wanted);
+    }
+}

--- a/src/main/java/org/mockito/verification/VerificationAfterDelay.java
+++ b/src/main/java/org/mockito/verification/VerificationAfterDelay.java
@@ -54,6 +54,11 @@ public interface VerificationAfterDelay extends VerificationMode {
      * unless too many invocations occur (in which case there will be an immediate failure)
      */
     public VerificationMode atMost(int maxNumberOfInvocations);
+
+    /**
+     * Verifies that there are invocations within range during the given period. This will wait the full period given.
+     */
+    public VerificationMode withinRange(int minNumberOfInvocations, int maxNumberOfInvocations);
     
     /**
      * Verifies that there the given method is invoked and is the only method invoked. This will wait the full 

--- a/src/main/java/org/mockito/verification/VerificationWrapper.java
+++ b/src/main/java/org/mockito/verification/VerificationWrapper.java
@@ -37,6 +37,10 @@ public abstract class VerificationWrapper<WrapperType extends VerificationMode> 
         return copySelfWithNewVerificationMode(VerificationModeFactory.atMost(maxNumberOfInvocations));
     }
 
+    public VerificationMode withinRange(int minNumberOfInvocations, int maxNumberOfInvocations) {
+        return copySelfWithNewVerificationMode(VerificationModeFactory.withinRange(minNumberOfInvocations, maxNumberOfInvocations));
+    }
+
     public VerificationMode only() {
         return copySelfWithNewVerificationMode(VerificationModeFactory.only());
     }

--- a/src/test/java/org/mockito/internal/progress/WithinRangeTest.java
+++ b/src/test/java/org/mockito/internal/progress/WithinRangeTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito.internal.progress;
+
+import org.junit.Test;
+import org.mockito.exceptions.base.MockitoException;
+import org.mockito.internal.verification.VerificationModeFactory;
+import org.mockitoutil.TestBase;
+
+public class WithinRangeTest extends TestBase {
+
+    @Test
+    public void shouldNotAllowNegativeMinNumberOfInvocations() throws Exception {
+        try {
+            VerificationModeFactory.withinRange(-50, 50);
+            fail();
+        } catch (MockitoException e) {
+            assertEquals("Negative values are not allowed here", e.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldNotAllowNegativeMaxNumberOfInvocations() throws Exception {
+        try {
+            VerificationModeFactory.withinRange(50, -50);
+            fail();
+        } catch (MockitoException e) {
+            assertEquals("Negative values are not allowed here", e.getMessage());
+        }
+    }
+    @Test
+    public void shouldNotAllowMinNumberOfInvocationsToBeHigherThanMaxOne() throws Exception {
+        try {
+            VerificationModeFactory.withinRange(2, 1);
+            fail();
+        } catch (MockitoException e) {
+            assertEquals("Minimum number of invocations cannot be higher than max number of invocations", e.getMessage());
+        }
+    }
+}

--- a/src/test/java/org/mockito/internal/verification/checkers/NumberOfInvocationsWithinRangeCheckerTest.java
+++ b/src/test/java/org/mockito/internal/verification/checkers/NumberOfInvocationsWithinRangeCheckerTest.java
@@ -16,9 +16,9 @@ import java.util.LinkedList;
 
 import static java.util.Arrays.asList;
 
-public class NumberOfInvocationsCheckerTest extends TestBase {
+public class NumberOfInvocationsWithinRangeCheckerTest extends TestBase {
 
-    private NumberOfInvocationsChecker checker;
+    private NumberOfInvocationsWithinRangeChecker checker;
     private WithinRangeReporterStub reporterStub;
     private InvocationMatcher wanted;
     private LinkedList<Invocation> invocations;
@@ -28,7 +28,7 @@ public class NumberOfInvocationsCheckerTest extends TestBase {
     public void setup() {
         reporterStub = new WithinRangeReporterStub();
         finderStub = new InvocationsFinderStub();
-        checker = new NumberOfInvocationsChecker(reporterStub, finderStub);
+        checker = new NumberOfInvocationsWithinRangeChecker(reporterStub, finderStub);
         
         wanted = new InvocationBuilder().toInvocationMatcher();
         invocations = new LinkedList<Invocation>(asList(new InvocationBuilder().toInvocation()));
@@ -38,10 +38,10 @@ public class NumberOfInvocationsCheckerTest extends TestBase {
     public void shouldReportTooLittleActual() throws Exception {
         finderStub.actualToReturn.add(new InvocationBuilder().toInvocation());
         
-        checker.check(invocations, wanted, 100);
+        checker.check(invocations, wanted, 2, 3);
         
         assertEquals(1, reporterStub.actualCount);
-        assertEquals(100, reporterStub.wantedCount);
+        assertEquals(2, reporterStub.wantedCount);
         assertEquals(wanted, reporterStub.wanted);
     }
 
@@ -52,7 +52,7 @@ public class NumberOfInvocationsCheckerTest extends TestBase {
         
         finderStub.actualToReturn.addAll(asList(first, second));
         
-        checker.check(invocations, wanted, 100);
+        checker.check(invocations, wanted, 3, 4);
         
         assertSame(second.getLocation(), reporterStub.location);
     }
@@ -61,7 +61,7 @@ public class NumberOfInvocationsCheckerTest extends TestBase {
     public void shouldNotReportWithLastInvocationStackTraceIfNoInvocationsFound() throws Exception {
         assertTrue(finderStub.actualToReturn.isEmpty());
         
-        checker.check(invocations, wanted, 100);
+        checker.check(invocations, wanted, 1, 2);
         
         assertNull(reporterStub.location);
     }
@@ -74,7 +74,7 @@ public class NumberOfInvocationsCheckerTest extends TestBase {
         
         finderStub.actualToReturn.addAll(asList(first, second, third));
         
-        checker.check(invocations, wanted, 2);
+        checker.check(invocations, wanted, 1, 2);
         
         assertSame(third.getLocation(), reporterStub.location);
     }
@@ -84,7 +84,7 @@ public class NumberOfInvocationsCheckerTest extends TestBase {
         finderStub.actualToReturn.add(new InvocationBuilder().toInvocation());
         finderStub.actualToReturn.add(new InvocationBuilder().toInvocation());
         
-        checker.check(invocations, wanted, 1);
+        checker.check(invocations, wanted, 0, 1);
         
         assertEquals(2, reporterStub.actualCount);
         assertEquals(1, reporterStub.wantedCount);
@@ -96,20 +96,56 @@ public class NumberOfInvocationsCheckerTest extends TestBase {
         Invocation invocation = new InvocationBuilder().toInvocation();
         finderStub.actualToReturn.add(invocation);
         
-        checker.check(invocations, wanted, 0);
+        checker.check(invocations, wanted, 0, 0);
         
         assertEquals(wanted, reporterStub.wanted);
         assertEquals(invocation.getLocation(), reporterStub.location);
     }
     
     @Test
-    public void shouldMarkInvocationsAsVerified() throws Exception {
+    public void shouldMarkInvocationsAsVerifiedWhenRangeIsOneElement() throws Exception {
         Invocation invocation = new InvocationBuilder().toInvocation();
         finderStub.actualToReturn.add(invocation);
         assertFalse(invocation.isVerified());
         
-        checker.check(invocations, wanted, 1);
+        checker.check(invocations, wanted, 1, 1);
         
+        assertTrue(invocation.isVerified());
+    }
+
+    @Test
+    public void shouldMarkInvocationsAsVerifiedWhenAtTheBottomOfRange() throws Exception {
+        Invocation invocation = new InvocationBuilder().toInvocation();
+        finderStub.actualToReturn.add(invocation);
+        assertFalse(invocation.isVerified());
+
+        checker.check(invocations, wanted, 1, 3);
+
+        assertTrue(invocation.isVerified());
+    }
+
+    @Test
+    public void shouldMarkInvocationsAsVerifiedWhenInTheMiddleOfRange() throws Exception {
+        Invocation invocation = new InvocationBuilder().toInvocation();
+        finderStub.actualToReturn.add(invocation);
+        finderStub.actualToReturn.add(invocation);
+        assertFalse(invocation.isVerified());
+
+        checker.check(invocations, wanted, 1, 3);
+
+        assertTrue(invocation.isVerified());
+    }
+
+    @Test
+    public void shouldMarkInvocationsAsVerifiedWhenAtTheTopOfRange() throws Exception {
+        Invocation invocation = new InvocationBuilder().toInvocation();
+        finderStub.actualToReturn.add(invocation);
+        finderStub.actualToReturn.add(invocation);
+        finderStub.actualToReturn.add(invocation);
+        assertFalse(invocation.isVerified());
+
+        checker.check(invocations, wanted, 1, 3);
+
         assertTrue(invocation.isVerified());
     }
 }

--- a/src/test/java/org/mockito/internal/verification/checkers/WithinRangeReporterStub.java
+++ b/src/test/java/org/mockito/internal/verification/checkers/WithinRangeReporterStub.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito.internal.verification.checkers;
+
+import org.mockito.exceptions.Reporter;
+import org.mockito.invocation.DescribedInvocation;
+import org.mockito.invocation.Location;
+
+public class WithinRangeReporterStub extends Reporter {
+
+    int wantedCount;
+    int actualCount;
+    DescribedInvocation wanted;
+    Location location;
+
+    @Override public void tooLittleActualInvocations(org.mockito.internal.reporting.Discrepancy discrepancy, DescribedInvocation wanted, Location lastActualLocation) {
+        this.wantedCount = discrepancy.getWantedCount();
+        this.actualCount = discrepancy.getActualCount();
+        this.wanted = wanted;
+        this.location = lastActualLocation;
+    }
+
+    @Override public void tooManyActualInvocations(int wantedCount, int actualCount, DescribedInvocation wanted, Location firstUndesired) {
+        this.wantedCount = wantedCount;
+        this.actualCount = actualCount;
+        this.wanted = wanted;
+        this.location = firstUndesired;
+    }
+
+    @Override
+    public void neverWantedButInvoked(DescribedInvocation wanted, Location firstUndesired) {
+        this.wanted = wanted;
+        this.location = firstUndesired;
+    }
+}

--- a/src/test/java/org/mockitousage/verification/NumberOfTimesWithinRangeVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/NumberOfTimesWithinRangeVerificationTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockitousage.verification;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.exceptions.verification.NeverWantedButInvoked;
+import org.mockito.exceptions.verification.TooLittleActualInvocations;
+import org.mockito.exceptions.verification.TooManyActualInvocations;
+import org.mockito.exceptions.verification.WantedButNotInvoked;
+import org.mockitoutil.TestBase;
+
+import java.util.LinkedList;
+
+import static org.mockito.Mockito.*;
+
+@SuppressWarnings("unchecked")
+public class NumberOfTimesWithinRangeVerificationTest extends TestBase {
+
+    private LinkedList mock;
+
+    @Before
+    public void setup() {
+        mock = mock(LinkedList.class);
+    }
+
+    @Test
+    public void shouldDetectTooLittleActualInvocations() throws Exception {
+        mock.clear();
+        mock.clear();
+
+        verify(mock, withinRange(2, 3)).clear();
+        try {
+            verify(mock, withinRange(3, 4)).clear();
+            fail();
+        } catch (TooLittleActualInvocations e) {
+            assertContains("Wanted 3 times", e.getMessage());
+            assertContains("was 2", e.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldDetectTooManyActualInvocations() throws Exception {
+        mock.clear();
+        mock.clear();
+
+        verify(mock, withinRange(2, 3)).clear();
+        try {
+            verify(mock, withinRange(0, 1)).clear();
+            fail();
+        } catch (TooManyActualInvocations e) {
+            assertContains("Wanted 1 time", e.getMessage());
+            assertContains("was 2 times", e.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldDetectActualInvocationsCountIsMoreThanZero() throws Exception {
+        verify(mock, withinRange(0, 0)).clear();
+        try {
+            verify(mock, withinRange(1, 2)).clear();
+            fail();
+        } catch (WantedButNotInvoked e) {}
+    }
+
+    @Test
+    public void shouldDetectActuallyCalledOnce() throws Exception {
+        mock.clear();
+
+        try {
+            verify(mock, withinRange(0, 0)).clear();
+            fail();
+        } catch (NeverWantedButInvoked e) {
+            assertContains("Never wanted here", e.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldNotCountInStubbedInvocations() throws Exception {
+        when(mock.add("test")).thenReturn(false);
+        when(mock.add("test")).thenReturn(true);
+
+        mock.add("test");
+        mock.add("test");
+
+        verify(mock, withinRange(2, 3)).add("test");
+    }
+
+    @Test
+    public void shouldPassWhenMethodsActuallyNotCalled() throws Exception {
+        verify(mock, withinRange(0, 0)).clear();
+        verify(mock, withinRange(0, 0)).add("yes, I wasn't called");
+    }
+
+    @Test
+    public void shouldPassWhenRangeIsOneElement() throws Exception {
+        mock.clear();
+
+        verify(mock, withinRange(1, 1)).clear();
+    }
+
+    @Test
+    public void shouldPassWhenAtTheBottomOfRange() throws Exception {
+        mock.clear();
+
+        verify(mock, withinRange(1, 3)).clear();
+    }
+
+    @Test
+    public void shouldPassWhenInTheMiddleOfRange() throws Exception {
+        mock.clear();
+        mock.clear();
+
+        verify(mock, withinRange(1, 3)).clear();
+    }
+
+    @Test
+    public void shouldPassWhenAtTheTopOfRange() throws Exception {
+        mock.clear();
+        mock.clear();
+        mock.clear();
+
+        verify(mock, withinRange(1, 3)).clear();
+    }
+}

--- a/src/test/java/org/mockitousage/verification/VerificationAfterDelayTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationAfterDelayTest.java
@@ -4,13 +4,6 @@
 
 package org.mockitousage.verification;
 
-import static org.mockito.Mockito.after;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
-import java.util.LinkedList;
-import java.util.List;
-
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -20,6 +13,11 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.exceptions.base.MockitoAssertionError;
 import org.mockitoutil.TestBase;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
 
 public class VerificationAfterDelayTest extends TestBase {
     
@@ -62,6 +60,18 @@ public class VerificationAfterDelayTest extends TestBase {
 
         // then
         verify(mock, after(100).atLeast(1)).clear();
+    }
+
+    @Test
+    public void shouldVerifyNormallyWithWithinRange() throws Exception {
+        // given
+        Thread t = waitAndExerciseMock(20);
+
+        // when
+        t.start();
+
+        // then
+        verify(mock, after(100).withinRange(1, 3)).clear();
     }
 
     @Test


### PR DESCRIPTION
Add new `WithinRange` `VerificationMode` which allows to verify that method use count is within given range. For example all situations below will be verified successfully:

```
verify(mockedList, withinRange(1, 3)).add("once")
verify(mockedList, withinRange(1, 3)).add("twice");
verify(mockedList, withinRange(1, 3)).add("three times");
```

And those situations will fail:

```
verify(mockedList, withinRange(1, 3)).add("never")
verify(mockedList, withinRange(1, 3)).add("four times");
```

The need for this `VerificationMode` appeared in our project when we tested web service methods which can fail at first time, then application will login and then web service method will retry. But this web service method can as well be successful at first time. So in this situation we wanted to verify if method was called once or twice, but not less or more. It wasn't possible with available `VerificationMode`s and that's why I decided to create additional one.

I hope that you will find this new feature useful :)

Best regards,
Karol Żmuda
