### PR TITLE
Fixes #422 : Add support for setting private static final fields to Whitebox

### DIFF
--- a/src/main/java/org/mockito/internal/util/reflection/Whitebox.java
+++ b/src/main/java/org/mockito/internal/util/reflection/Whitebox.java
@@ -5,11 +5,18 @@
 package org.mockito.internal.util.reflection;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 
 public class Whitebox {
 
     public static Object getInternalState(Object target, String field) {
-        Class<?> c = target.getClass();
+        Class<?> c;
+        if(target instanceof Class){
+            c = (Class<?>) target;
+            target = null;
+        } else {
+            c = target.getClass();
+        }
         try {
             Field f = getFieldFromHierarchy(c, field);
             f.setAccessible(true);
@@ -20,13 +27,31 @@ public class Whitebox {
     }
 
     public static void setInternalState(Object target, String field, Object value) {
-        Class<?> c = target.getClass();
+        Class<?> c;
+        if(target instanceof Class){
+            c = (Class<?>) target;
+            target = null;
+        } else {
+            c = target.getClass();
+        }
         try {
             Field f = getFieldFromHierarchy(c, field);
             f.setAccessible(true);
+            removeFinalModifierIfPresent(f);
             f.set(target, value);
         } catch (Exception e) {
             throw new RuntimeException("Unable to set internal state on a private field. Please report to mockito mailing list.", e);
+        }
+    }
+
+    private static void removeFinalModifierIfPresent(Field fieldToRemoveFinalFrom) throws IllegalAccessException, NoSuchFieldException {
+        int fieldModifiersMask = fieldToRemoveFinalFrom.getModifiers();
+        boolean isFinalModifierPresent = (fieldModifiersMask & Modifier.FINAL) == Modifier.FINAL;
+        if (isFinalModifierPresent) {
+            Field modifiersField = Field.class.getDeclaredField("modifiers");
+            modifiersField.setAccessible(true);
+            int fieldModifiersMaskWithoutFinal = fieldModifiersMask & ~Modifier.FINAL;
+            modifiersField.setInt(fieldToRemoveFinalFrom, fieldModifiersMaskWithoutFinal);
         }
     }
 

--- a/src/main/java/org/mockito/internal/util/reflection/Whitebox.java
+++ b/src/main/java/org/mockito/internal/util/reflection/Whitebox.java
@@ -9,36 +9,38 @@ import java.lang.reflect.Modifier;
 
 public class Whitebox {
 
-    public static Object getInternalState(Object target, String field) {
-        Class<?> c;
-        if(target instanceof Class){
-            c = (Class<?>) target;
-            target = null;
-        } else {
-            c = target.getClass();
-        }
+    public static Object getInternalState(Object targetInstance, String fieldName) {
+        return getInternalState(targetInstance.getClass(), targetInstance, fieldName);
+    }
+
+    public static Object getInternalState(Class targetClass, String fieldName) {
+        return getInternalState(targetClass, null, fieldName);
+    }
+
+    private static Object getInternalState(Class<?> targetClass, Object targetInstance, String fieldName) {
         try {
-            Field f = getFieldFromHierarchy(c, field);
+            Field f = getFieldFromHierarchy(targetClass, fieldName);
             f.setAccessible(true);
-            return f.get(target);
+            return f.get(targetInstance);
         } catch (Exception e) {
             throw new RuntimeException("Unable to get internal state on a private field. Please report to mockito mailing list.", e);
         }
     }
 
-    public static void setInternalState(Object target, String field, Object value) {
-        Class<?> c;
-        if(target instanceof Class){
-            c = (Class<?>) target;
-            target = null;
-        } else {
-            c = target.getClass();
-        }
+    public static void setInternalState(Object targetInstance, String fieldName, Object value) {
+        setInternalState(targetInstance.getClass(), targetInstance, fieldName, value);
+    }
+
+    public static void setInternalState(Class targetClass, String fieldName, Object value) {
+        setInternalState(targetClass, null, fieldName, value);
+    }
+
+    private static void setInternalState(Class targetClass, Object targetInstance, String fieldName, Object value) {
         try {
-            Field f = getFieldFromHierarchy(c, field);
+            Field f = getFieldFromHierarchy(targetClass, fieldName);
             f.setAccessible(true);
             removeFinalModifierIfPresent(f);
-            f.set(target, value);
+            f.set(targetInstance, value);
         } catch (Exception e) {
             throw new RuntimeException("Unable to set internal state on a private field. Please report to mockito mailing list.", e);
         }

--- a/src/test/java/org/mockito/internal/util/reflection/DummyParentClassForTests.java
+++ b/src/test/java/org/mockito/internal/util/reflection/DummyParentClassForTests.java
@@ -4,7 +4,12 @@
  */
 package org.mockito.internal.util.reflection;
 
+import java.util.logging.Logger;
+
 public class DummyParentClassForTests {
+
+    @SuppressWarnings("unused")//I know, I know. We're doing nasty reflection hacks here...
+    private static final Logger LOG = Logger.getLogger(DummyParentClassForTests.class.toString());
 
     @SuppressWarnings("unused")//I know, I know. We're doing nasty reflection hacks here...
     private String somePrivateField;

--- a/src/test/java/org/mockito/internal/util/reflection/WhiteboxTest.java
+++ b/src/test/java/org/mockito/internal/util/reflection/WhiteboxTest.java
@@ -5,9 +5,15 @@
 package org.mockito.internal.util.reflection;
 
 import org.junit.Test;
+import org.mockito.Mock;
 import org.mockitoutil.TestBase;
 
+import java.util.logging.Logger;
+
 public class WhiteboxTest extends TestBase {
+
+    @Mock
+    Logger mockLogger;
 
     @Test
     public void private_state() {
@@ -18,5 +24,14 @@ public class WhiteboxTest extends TestBase {
         //then
         Object internalState = Whitebox.getInternalState(dummy, "somePrivateField");
         assertEquals("cool!", internalState);
+    }
+
+    @Test
+    public void private_static_final_state() {
+        //when
+        Whitebox.setInternalState(DummyParentClassForTests.class, "LOG", mockLogger);
+        //then
+        Object internalState = Whitebox.getInternalState(DummyParentClassForTests.class, "LOG");
+        assertEquals(mockLogger, internalState);
     }
 }


### PR DESCRIPTION
Please see issue #422.
This pull request allows setting `private static final` fields and reading for static fields.

```java
Whitebox.setInternalState(ClassToTest.class, "LOG", mockLog);
Logger privateStaticLogger = Whitebox.getInternalState(ClassToTest.class, "LOG");
```

Please accept my pull request :)