### PR TITLE
remove override annotations for interface methods as this requires at…

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMaker.java
@@ -22,7 +22,6 @@ public class ByteBuddyMockMaker implements MockMaker {
         cachingMockBytecodeGenerator = new CachingMockBytecodeGenerator();
     }
 
-    @Override
     public <T> T createMock(MockCreationSettings<T> settings, MockHandler handler) {
         Class<T> mockedProxyType = createProxyClass(mockWithFeaturesFrom(settings));
 
@@ -79,7 +78,6 @@ public class ByteBuddyMockMaker implements MockMaker {
         return instance == null ? "null" : describeClass(instance.getClass());
     }
 
-    @Override
     public MockHandler getHandler(Object mock) {
         if (!(mock instanceof MockAccess)) {
             return null;
@@ -87,22 +85,18 @@ public class ByteBuddyMockMaker implements MockMaker {
         return ((MockAccess) mock).getMockitoInterceptor().getMockHandler();
     }
 
-    @Override
     public void resetMock(Object mock, MockHandler newHandler, MockCreationSettings settings) {
         ((MockAccess) mock).setMockitoInterceptor(
                 new MockMethodInterceptor(asInternalMockHandler(newHandler), settings)
         );
     }
 
-    @Override
     public TypeMockability isTypeMockable(final Class<?> type) {
         return new TypeMockability() {
-            @Override
             public boolean mockable() {
                 return !type.isPrimitive() && !Modifier.isFinal(type.getModifiers());
             }
 
-            @Override
             public String nonMockableReason() {
                 //TODO SF does not seem to have test coverage. What is the expected value when type mockable
                 if(type.isPrimitive()) {

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InterceptedInvocation.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InterceptedInvocation.java
@@ -49,77 +49,62 @@ class InterceptedInvocation implements Invocation, VerificationAwareInvocation {
         location = new LocationImpl();
     }
 
-    @Override
     public boolean isVerified() {
         return verified || isIgnoredForVerification;
     }
 
-    @Override
     public int getSequenceNumber() {
         return sequenceNumber;
     }
 
-    @Override
     public Location getLocation() {
         return location;
     }
 
-    @Override
     public Object[] getRawArguments() {
         return rawArguments;
     }
 
-    @Override
     public Class getRawReturnType() {
         return mockitoMethod.getReturnType();
     }
 
-    @Override
     public void markVerified() {
         verified = true;
     }
 
-    @Override
     public StubInfo stubInfo() {
         return stubInfo;
     }
 
-    @Override
     public void markStubbed(StubInfo stubInfo) {
         this.stubInfo = stubInfo;
     }
 
-    @Override
     public boolean isIgnoredForVerification() {
         return isIgnoredForVerification;
     }
 
-    @Override
     public void ignoreForVerification() {
         isIgnoredForVerification = true;
     }
 
-    @Override
     public Object getMock() {
         return mock;
     }
 
-    @Override
     public Method getMethod() {
         return mockitoMethod.getJavaMethod();
     }
 
-    @Override
     public Object[] getArguments() {
         return arguments;
     }
 
-    @Override
     public <T> T getArgument(int index) {
         return (T)arguments[index];
     }
 
-    @Override
     public Object callRealMethod() throws Throwable {
         if (!superMethod.isInvokable()) {
             throw cannotCallAbstractRealMethod();
@@ -158,12 +143,10 @@ class InterceptedInvocation implements Invocation, VerificationAwareInvocation {
 
             INSTANCE;
 
-            @Override
             public boolean isInvokable() {
                 return false;
             }
 
-            @Override
             public Object invoke() {
                 throw new IllegalStateException();
             }
@@ -179,12 +162,10 @@ class InterceptedInvocation implements Invocation, VerificationAwareInvocation {
                 this.callable = callable;
             }
 
-            @Override
             public boolean isInvokable() {
                 return true;
             }
 
-            @Override
             public Object invoke() throws Throwable {
                 try {
                     return callable.call();

--- a/src/main/java/org/mockito/internal/exceptions/stacktrace/DefaultStackTraceCleaner.java
+++ b/src/main/java/org/mockito/internal/exceptions/stacktrace/DefaultStackTraceCleaner.java
@@ -7,7 +7,6 @@ import org.mockito.exceptions.stacktrace.StackTraceCleaner;
 */
 public class DefaultStackTraceCleaner implements StackTraceCleaner {
 
-	@Override
 	public boolean isOut(StackTraceElement e) {
 		if (isFromMockitoRunner(e.getClassName()) || isFromMockitoRule(e.getClassName())) {
 			return false;

--- a/src/main/java/org/mockito/internal/junit/JUnitRule.java
+++ b/src/main/java/org/mockito/internal/junit/JUnitRule.java
@@ -18,7 +18,7 @@ public class JUnitRule implements MockitoRule {
 	public JUnitRule(MockitoLogger logger) {
 		this.logger = logger;
 	}
-	@Override
+
 	public Statement apply(final Statement base, FrameworkMethod method, final Object target) {
 		return new Statement() {
             @Override

--- a/src/main/java/org/mockito/internal/util/DefaultMockingDetails.java
+++ b/src/main/java/org/mockito/internal/util/DefaultMockingDetails.java
@@ -24,27 +24,22 @@ public class DefaultMockingDetails implements MockingDetails {
         this.delegate = delegate;
     }
 
-    @Override
     public boolean isMock(){
         return delegate.isMock(toInspect);
     }
 
-    @Override
     public boolean isSpy(){
         return delegate.isSpy(toInspect);
     }
 
-    @Override
     public Collection<Invocation> getInvocations() {
         return delegate.getMockHandler(toInspect).getInvocationContainer().getInvocations();
     }
 
-    @Override
     public Class<?> getMockedType() {
         return delegate.getMockHandler(toInspect).getMockSettings().getTypeToMock();
     }
 
-    @Override
     @SuppressWarnings("unchecked")
     public Set<Class> getExtraInterfaces() {
         return delegate.getMockHandler(toInspect).getMockSettings().getExtraInterfaces();

--- a/src/main/java/org/mockito/internal/verification/AtLeast.java
+++ b/src/main/java/org/mockito/internal/verification/AtLeast.java
@@ -59,7 +59,6 @@ public class AtLeast implements VerificationInOrderMode, VerificationMode {
         return "Wanted invocations count: at least " + wantedCount;
     }
 
-    @Override
     public VerificationMode description(String description) {
         return VerificationModeFactory.description(this, description);
     }

--- a/src/main/java/org/mockito/internal/verification/AtMost.java
+++ b/src/main/java/org/mockito/internal/verification/AtMost.java
@@ -44,7 +44,6 @@ public class AtMost implements VerificationMode {
         markVerified(found, wanted);
     }
 
-    @Override
     public VerificationMode description(String description) {
         return VerificationModeFactory.description(this, description);
     }

--- a/src/main/java/org/mockito/internal/verification/Calls.java
+++ b/src/main/java/org/mockito/internal/verification/Calls.java
@@ -46,7 +46,6 @@ public class Calls implements VerificationMode, VerificationInOrderMode {
         return "Wanted invocations count (non-greedy): " + wantedCount;
     }
 
-    @Override
     public VerificationMode description(String description) {
         return VerificationModeFactory.description(this, description);
     }

--- a/src/main/java/org/mockito/internal/verification/Description.java
+++ b/src/main/java/org/mockito/internal/verification/Description.java
@@ -30,7 +30,6 @@ public class Description implements VerificationMode {
      * Prepends the custom failure message if verification fails.
      * @param data 
      */
-    @Override
     public void verify(VerificationData data) {
         try {
             verification.verify(data);
@@ -40,7 +39,6 @@ public class Description implements VerificationMode {
         }
     } 
 
-    @Override
     public VerificationMode description(String description) {
         return VerificationModeFactory.description(this, description);
     }

--- a/src/main/java/org/mockito/internal/verification/InOrderWrapper.java
+++ b/src/main/java/org/mockito/internal/verification/InOrderWrapper.java
@@ -30,7 +30,6 @@ public class InOrderWrapper implements VerificationMode {
         mode.verifyInOrder(dataInOrder);
     }
 
-    @Override
     public VerificationMode description(String description) {
         return VerificationModeFactory.description(this, description);
     }

--- a/src/main/java/org/mockito/internal/verification/NoMoreInteractions.java
+++ b/src/main/java/org/mockito/internal/verification/NoMoreInteractions.java
@@ -37,7 +37,6 @@ public class NoMoreInteractions implements VerificationMode, VerificationInOrder
         }
     }
 
-    @Override
     public VerificationMode description(String description) {
         return VerificationModeFactory.description(this, description);
     }

--- a/src/main/java/org/mockito/internal/verification/Times.java
+++ b/src/main/java/org/mockito/internal/verification/Times.java
@@ -56,7 +56,6 @@ public class Times implements VerificationInOrderMode, VerificationMode {
         return "Wanted invocations count: " + wantedCount;
     }
 
-    @Override
     public VerificationMode description(String description) {
         return VerificationModeFactory.description(this, description);
     }

--- a/src/main/java/org/mockito/internal/verification/VerificationOverTimeImpl.java
+++ b/src/main/java/org/mockito/internal/verification/VerificationOverTimeImpl.java
@@ -120,7 +120,6 @@ public class VerificationOverTimeImpl implements VerificationMode {
         }
     }
 
-    @Override
     public VerificationMode description(String description) {
         return VerificationModeFactory.description(this, description);
     }

--- a/src/main/java/org/mockito/verification/After.java
+++ b/src/main/java/org/mockito/verification/After.java
@@ -34,7 +34,6 @@ public class After extends VerificationWrapper<VerificationOverTimeImpl> impleme
         return new After(wrappedVerification.copyWithVerificationMode(verificationMode));
     }
 
-    @Override
     public VerificationMode description(String description) {
         return VerificationModeFactory.description(this, description);
     }

--- a/src/main/java/org/mockito/verification/Timeout.java
+++ b/src/main/java/org/mockito/verification/Timeout.java
@@ -58,7 +58,6 @@ public class Timeout extends VerificationWrapper<VerificationOverTimeImpl> imple
         throw atMostAndNeverShouldNotBeUsedWithTimeout();
     }
 
-    @Override
     public VerificationMode description(String description) {
         return VerificationModeFactory.description(this, description);
     }

--- a/src/test/java/org/mockito/AnnotationsAreCopiedFromMockedTypeTest.java
+++ b/src/test/java/org/mockito/AnnotationsAreCopiedFromMockedTypeTest.java
@@ -49,12 +49,10 @@ public class AnnotationsAreCopiedFromMockedTypeTest {
         final Annotation[] firstParamAnnotations = method.getParameterAnnotations()[0];
 
         return new AnnotatedElement() {
-            @Override
             public boolean isAnnotationPresent(Class<? extends Annotation> annotationClass) {
                 return getAnnotation(annotationClass) != null;
             }
 
-            @Override
             @SuppressWarnings("unchecked")
             public <T extends Annotation> T getAnnotation(Class<T> annotationClass) {
                 for (Annotation firstParamAnnotation : firstParamAnnotations) {
@@ -65,12 +63,10 @@ public class AnnotationsAreCopiedFromMockedTypeTest {
                 return null;
             }
 
-            @Override
             public Annotation[] getAnnotations() {
                 return firstParamAnnotations;
             }
 
-            @Override
             public Annotation[] getDeclaredAnnotations() {
                 return firstParamAnnotations;
             }

--- a/src/test/java/org/mockito/internal/stubbing/defaultanswers/ForwardsInvocationsTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/defaultanswers/ForwardsInvocationsTest.java
@@ -10,7 +10,6 @@ public class ForwardsInvocationsTest extends TestBase {
     }
 
     private static final class FooImpl implements Foo {
-        @Override
         public int bar(String baz, Object... args) {
             return baz.length() + args.length;
         }

--- a/src/test/java/org/mockitousage/CompilationWarningsTest.java
+++ b/src/test/java/org/mockitousage/CompilationWarningsTest.java
@@ -102,7 +102,6 @@ public class CompilationWarningsTest {
 
     private static Answer<?> ignore() {
         return new Answer<Object>() {
-            @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
                 return null;
             }

--- a/src/test/java/org/mockitousage/bugs/BridgeMethodsHitAgainTest.java
+++ b/src/test/java/org/mockitousage/bugs/BridgeMethodsHitAgainTest.java
@@ -34,7 +34,6 @@ public class BridgeMethodsHitAgainTest extends TestBase {
   }
 
   public interface Extended extends Base<String> {
-    @Override
     int test(String value);
   }
 

--- a/src/test/java/org/mockitousage/stubbing/StubbingWithDelegateVarArgsTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingWithDelegateVarArgsTest.java
@@ -15,7 +15,6 @@ public class StubbingWithDelegateVarArgsTest {
 
     private static final class FooImpl implements Foo {
 
-        @Override
         public int bar(String baz, Object... args) {
             return args != null ? args.length : -1; // simple return argument count
         }


### PR DESCRIPTION
… least java 1.6

`build.gradle` claims that mockito can be compiled with java 1.5, so these annotations have to go. If mockito moves to 1.6+ (imho there is no need to support java 1.5 anymore), this pull request makes no sense.