### PR TITLE
downgrade assertj-core version to 1.7.1 because this version is java …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ dependencies {
 
     testCompile 'org.ow2.asm:asm:5.0.4'
 
-    testCompile 'org.assertj:assertj-core:2.1.0'
+    testCompile 'org.assertj:assertj-core:1.7.1'
 
     testRuntime configurations.provided
 


### PR DESCRIPTION
…6 compatible (2.x requires java 7+) (see discussion of https://github.com/mockito/mockito/pull/440)