### PR TITLE
Make tests which test for timeouts with Thread#sleep more lenient.

### DIFF
--- a/src/test/java/org/mockitousage/verification/VerificationAfterDelayTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationAfterDelayTest.java
@@ -49,7 +49,7 @@ public class VerificationAfterDelayTest extends TestBase {
         t.start();
 
         // then
-        verify(mock, after(50).times(1)).clear();
+        verify(mock, after(500).times(1)).clear();
     }
 
     @Test
@@ -98,7 +98,7 @@ public class VerificationAfterDelayTest extends TestBase {
         assertTrue(System.currentTimeMillis() - startTime >= 100);
     }
     
-    @Test(timeout=100)
+    @Test(timeout=1000)
     public void shouldStopEarlyIfTestIsDefinitelyFailed() throws Exception {
         // given
         Thread t = waitAndExerciseMock(50);

--- a/src/test/java/org/mockitousage/verification/VerificationWithTimeoutTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationWithTimeoutTest.java
@@ -83,8 +83,8 @@ public class VerificationWithTimeoutTest extends TestBase {
         t2.start();
 
         //then
-        verify(mock, timeout(50).atLeast(1)).clear();
-        verify(mock, timeout(50).times(2)).clear();
+        verify(mock, timeout(500).atLeast(1)).clear();
+        verify(mock, timeout(500).times(2)).clear();
         verifyNoMoreInteractions(mock);
     }
 
@@ -99,7 +99,7 @@ public class VerificationWithTimeoutTest extends TestBase {
         t2.start();
 
         //then
-        verify(mock, timeout(50).atLeast(1)).clear();
+        verify(mock, timeout(500).atLeast(1)).clear();
         try {
             verify(mock, timeout(100).times(3)).clear();
             fail();
@@ -116,7 +116,7 @@ public class VerificationWithTimeoutTest extends TestBase {
 
         //then
         verify(mock, never()).clear();
-        verify(mock, timeout(40).only()).clear();
+        verify(mock, timeout(500).only()).clear();
     }
 
     @Test(expected=NoInteractionsWanted.class)
@@ -134,7 +134,7 @@ public class VerificationWithTimeoutTest extends TestBase {
         // expect to have received the "clear" but
         // for the call on "add" to break the "only" part
         // of the verification
-        verify(mock, timeout(50).only()).clear();
+        verify(mock, timeout(500).only()).clear();
 
         // the test should end with an exception
     }
@@ -184,7 +184,7 @@ public class VerificationWithTimeoutTest extends TestBase {
         InOrder inOrder = inOrder(mock);
         inOrder.verify(mock).add(anyString());
         inOrder.verify(mock, never()).clear();
-        inOrder.verify(mock, timeout(40)).clear();
+        inOrder.verify(mock, timeout(500)).clear();
     }
 
     @Test(expected = MockitoException.class)


### PR DESCRIPTION
I took a look at the recently builds on travis ci and noticed a lot of failed builds. These failures where mostly unrelated to the actual changes, but caused by these strict timeout tests.

This pull request will not completely fix these random failures, but it should reduce their occurrences. 

The ideal solution would be to completely remove usage of `Thread#sleep` from the test, but I have no idea how to do this.