### PR TITLE
Refactored Timeout and After concurrent test

### DIFF
--- a/src/test/java/org/mockitoutil/Stopwatch.java
+++ b/src/test/java/org/mockitoutil/Stopwatch.java
@@ -1,0 +1,65 @@
+package org.mockitoutil;
+
+import static java.lang.String.format;
+import static java.lang.System.nanoTime;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+import java.util.concurrent.TimeUnit;
+import org.mockito.exceptions.base.MockitoAssertionError;
+
+/**
+ * This class can be uses as stopwatch to assert that a given time is elapsed or not.
+ */
+public class Stopwatch {
+
+    /**
+     * The start time in nano seconds or <code>null</code> if this stop watch was not started yet
+     */
+    private Long startNanos = null;
+
+    /**
+     * To create an instance use {@link #createNotStarted()}
+     */
+    private Stopwatch() {
+    }
+
+    /**
+     * Return a new and not started {@link Stopwatch}.
+     */
+    public static Stopwatch createNotStarted() {
+        return new Stopwatch();
+    }
+
+    public void start() {
+        if (startNanos != null)
+            throw new IllegalStateException("This stop watch is already started!");
+
+        startNanos = nanoTime();
+    }
+
+    public void assertElapsedTimeIsMoreThan(long expected, TimeUnit unit) {
+        long elapsedNanos = elapsedNanos();
+        long expectedNanos = unit.toNanos(expected);
+
+        if (elapsedNanos <= expectedNanos)
+            fail("Expected that more than %dms elapsed! But was: %dms", expectedNanos, elapsedNanos);
+    }
+
+    public void assertElapsedTimeIsLessThan(long expected, TimeUnit unit) {
+        long elapsedNanos = elapsedNanos();
+        long expectedNanos = unit.toNanos(expected);
+
+        if (elapsedNanos >= expectedNanos)
+            fail("Expected that less than %dms elapsed! But was: %dms", expectedNanos, elapsedNanos);
+    }
+
+    private long elapsedNanos() {
+        if (startNanos == null)
+            throw new IllegalStateException("This stop watch is not started!");
+        return nanoTime() - startNanos;
+    }
+
+    private static void fail(String message, long expectedNanos, long elapsedNanos) {
+        throw new MockitoAssertionError(format(message, NANOSECONDS.toMillis(expectedNanos), NANOSECONDS.toMillis(elapsedNanos)));
+    }
+}


### PR DESCRIPTION
Refactored concurrent test in order to fix #433. The implementation now uses  an `Executor `to perform async calls instead of extending `Thread` and doesn't extend TestBase anymore. 

I also added a Stopwatch which can be used for further time dependent testing. In the future I want to use this class to write more tests for After/Timeout.


