### PR TITLE
Modified JavaDoc for ArgumentMatcher

### DIFF
--- a/src/main/java/org/mockito/ArgumentMatcher.java
+++ b/src/main/java/org/mockito/ArgumentMatcher.java
@@ -35,6 +35,8 @@ package org.mockito;
  *     Useful if you already have a hamcrest matcher. Reuse and win!
  *     Note that {@link org.mockito.hamcrest.MockitoHamcrest#argThat(org.hamcrest.Matcher)} demonstrates <b>NullPointerException</b> auto-unboxing caveat.
  *     </li>
+ *     <li>Java 8 only - use a lambda in place of an {@link ArgumentMatcher} since {@link ArgumentMatcher}
+ *     is effectively a functional interface. A lambda can be used with the {@link Mockito#argThat} method.</li>
  * </ul>
  *
  * <p>
@@ -44,8 +46,8 @@ package org.mockito;
  *
  * <pre class="code"><code class="java">
  * class ListOfTwoElements implements ArgumentMatcher&lt;List&gt; {
- *     public boolean matches(Object list) {
- *         return ((List) list).size() == 2;
+ *     public boolean matches(List list) {
+ *         return list.size() == 2;
  *     }
  *     public String toString() {
  *         //printed in verification errors
@@ -93,6 +95,7 @@ package org.mockito;
  * b) Use <code>org.mockito.hamcrest.MockitoHamcrest.argThat()</code> instead of <code>Mockito.argThat()</code>.
  * Ensure that there is <a href="http://hamcrest.org/JavaHamcrest/">hamcrest</a> dependency on classpath
  * (Mockito does not depend on hamcrest any more).
+ *
  * </li>
  * </ul>
  * What option is right for you? If you don't mind compile dependency to hamcrest
@@ -110,22 +113,6 @@ public interface ArgumentMatcher<T> {
      * <p>
      * The method should <b>never</b> assert if the argument doesn't match. It
      * should only return false.
-     * <p>
-     * The argument is not using the generic type in order to force explicit casting in the implementation.
-     * This way it is easier to debug when incompatible arguments are passed to the matchers.
-     * You have to trust us on this one. If we used parametrized type then <code>ClassCastException</code>
-     * would be thrown in certain scenarios.
-     * For example:
-     *
-     * <pre class="code"><code class="java">
-     *   //test, method accepts Collection argument and ArgumentMatcher&lt;List&gt; is used
-     *   when(mock.useCollection(someListMatcher())).thenDoNothing();
-     *
-     *   //production code, yields confusing ClassCastException
-     *   //although Set extends Collection but is not compatible with ArgumentMatcher&lt;List&gt;
-     *   mock.useCollection(new HashSet());
-     * </pre>
-     *
      * <p>
      * See the example in the top level javadoc for {@link ArgumentMatcher}
      *


### PR DESCRIPTION
To fix #453 - this is the amendment to the `ArgumentMatcher` JavaDoc.