### PR TITLE
Fixes #457 CompareTo compares now only agains instances of Comparable.

### DIFF
--- a/src/main/java/org/mockito/AdditionalMatchers.java
+++ b/src/main/java/org/mockito/AdditionalMatchers.java
@@ -51,7 +51,7 @@ public class AdditionalMatchers {
      *            the given value.
      * @return <code>null</code>.
      */
-    public static <T extends Comparable<T>> T geq(Comparable<T> value) {
+    public static <T extends Comparable<T>> T geq(T value) {
         reportMatcher(new GreaterOrEqual<T>(value));
         return null;
     }
@@ -149,7 +149,7 @@ public class AdditionalMatchers {
      *            the given value.
      * @return <code>null</code>.
      */
-    public static <T extends Comparable<T>> T leq(Comparable<T> value) {
+    public static <T extends Comparable<T>> T leq(T value) {
         reportMatcher(new LessOrEqual<T>(value));
         return null;
     }
@@ -247,7 +247,7 @@ public class AdditionalMatchers {
      *            the given value.
      * @return <code>null</code>.
      */
-    public static <T extends Comparable<T>> T gt(Comparable<T> value) {
+    public static <T extends Comparable<T>> T gt(T value) {
         reportMatcher(new GreaterThan<T>(value));
         return null;
     }
@@ -345,7 +345,7 @@ public class AdditionalMatchers {
      *            the given value.
      * @return <code>null</code>.
      */
-    public static <T extends Comparable<T>> T lt(Comparable<T> value) {
+    public static <T extends Comparable<T>> T lt(T value) {
         reportMatcher(new LessThan<T>(value));
         return null;
     }
@@ -444,7 +444,7 @@ public class AdditionalMatchers {
      *            the given value.
      * @return <code>null</code>.
      */
-    public static <T extends Comparable<T>> T cmpEq(Comparable<T> value) {
+    public static <T extends Comparable<T>> T cmpEq(T value) {
         reportMatcher(new CompareEqual<T>(value));
         return null;
     }

--- a/src/main/java/org/mockito/internal/invocation/ArgumentsComparator.java
+++ b/src/main/java/org/mockito/internal/invocation/ArgumentsComparator.java
@@ -4,11 +4,13 @@
  */
 package org.mockito.internal.invocation;
 
+import static java.lang.reflect.Modifier.isPublic;
+
+import java.lang.reflect.Method;
+import java.util.List;
 import org.mockito.ArgumentMatcher;
 import org.mockito.internal.matchers.VarargMatcher;
 import org.mockito.invocation.Invocation;
-
-import java.util.List;
 
 @SuppressWarnings("unchecked")
 public class ArgumentsComparator {
@@ -22,21 +24,24 @@ public class ArgumentsComparator {
             return false;
         }
         for (int i = 0; i < actualArgs.length; i++) {
-            if (!invocationMatcher.getMatchers().get(i).matches(actualArgs[i])) {
+            ArgumentMatcher<Object> argumentMatcher = invocationMatcher.getMatchers().get(i);
+            Object argument = actualArgs[i];
+
+            if (!matches(argumentMatcher, argument)) {
                 return false;
             }
         }
         return true;
     }
 
-    //ok, this method is a little bit messy but the vararg business unfortunately is messy...      
-    private boolean varArgsMatch(InvocationMatcher invocationMatcher, Invocation actual) {
+    // ok, this method is a little bit messy but the vararg business unfortunately is messy...
+    private static boolean varArgsMatch(InvocationMatcher invocationMatcher, Invocation actual) {
         if (!actual.getMethod().isVarArgs()) {
-            //if the method is not vararg forget about it
+            // if the method is not vararg forget about it
             return false;
         }
 
-        //we must use raw arguments, not arguments...
+        // we must use raw arguments, not arguments...
         Object[] rawArgs = actual.getRawArguments();
         List<ArgumentMatcher> matchers = invocationMatcher.getMatchers();
 
@@ -46,18 +51,68 @@ public class ArgumentsComparator {
 
         for (int i = 0; i < rawArgs.length; i++) {
             ArgumentMatcher m = matchers.get(i);
-            //it's a vararg because it's the last array in the arg list
-            if (rawArgs[i] != null && rawArgs[i].getClass().isArray() && i == rawArgs.length-1) {
-                //this is very important to only allow VarargMatchers here. If you're not sure why remove it and run all tests.
+            // it's a vararg because it's the last array in the arg list
+            if (rawArgs[i] != null && rawArgs[i].getClass().isArray() && i == rawArgs.length - 1) {
+                // this is very important to only allow VarargMatchers here. If
+                // you're not sure why remove it and run all tests.
                 if (!(m instanceof VarargMatcher) || !m.matches(rawArgs[i])) {
                     return false;
                 }
-            //it's not a vararg (i.e. some ordinary argument before varargs), just do the ordinary check
-            } else if (!m.matches(rawArgs[i])){
+                // it's not a vararg (i.e. some ordinary argument before
+                // varargs), just do the ordinary check
+            } else if (!m.matches(rawArgs[i])) {
                 return false;
             }
         }
 
         return true;
+    }
+
+    private static boolean matches(ArgumentMatcher<Object> argumentMatcher, Object argument) {
+        if (isCompatible(argumentMatcher, argument)) {
+            return argumentMatcher.matches(argument);
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns <code>true</code> if the given <b>argument</b> can be passed to
+     * the given <code>argumentMatcher</code> without causing a
+     * {@link ClassCastException}.
+     */
+    private static boolean isCompatible(ArgumentMatcher<?> argumentMatcher, Object argument) {
+        if (argument == null)
+            return true;
+
+        Class<?> expectedArgumentType = getArgumentType(argumentMatcher);
+
+        return expectedArgumentType.isInstance(argument);
+    }
+
+    /**
+     * Returns the type of {@link ArgumentMatcher#matches(T)} of the given
+     * {@link ArgumentMatcher} implementation.
+     */
+    private static Class<?> getArgumentType(ArgumentMatcher<?> argumentMatcher) {
+        Method[] methods = argumentMatcher.getClass().getMethods();
+        for (Method method : methods) {
+            if (isMatchesMethod(method)) {
+                return method.getParameterTypes()[0];
+            }
+        }
+        throw new NoSuchMethodError("Method 'matches(T)' not found in ArgumentMatcher: " + argumentMatcher + " !\r\n Please file a bug with this stack trace at: https://github.com/mockito/mockito/issues/new ");
+    }
+
+    /**
+     * Returns <code>true</code> if the given method is
+     * {@link ArgumentMatcher#matches(T)}
+     */
+    private static boolean isMatchesMethod(Method method) {
+        if (method.getParameterTypes().length != 1)
+            return false;
+        if (method.isBridge())
+            return false;
+        return method.getName().equals("matches");
     }
 }

--- a/src/main/java/org/mockito/internal/matchers/CompareEqual.java
+++ b/src/main/java/org/mockito/internal/matchers/CompareEqual.java
@@ -9,7 +9,7 @@ import java.io.Serializable;
 
 public class CompareEqual<T extends Comparable<T>> extends CompareTo<T> implements Serializable {
 
-    public CompareEqual(Comparable<T> value) {
+    public CompareEqual(T value) {
         super(value);
     }
 

--- a/src/main/java/org/mockito/internal/matchers/CompareTo.java
+++ b/src/main/java/org/mockito/internal/matchers/CompareTo.java
@@ -9,24 +9,32 @@ import org.mockito.ArgumentMatcher;
 
 import java.io.Serializable;
 
-
 public abstract class CompareTo<T extends Comparable<T>> implements ArgumentMatcher<T>, Serializable {
-    private final Comparable<T> wanted;
+    private final T wanted;
 
-    public CompareTo(Comparable<T> value) {
+    public CompareTo(T value) {
         this.wanted = value;
     }
 
-    @SuppressWarnings("unchecked")
-    public boolean matches(T actual) {
-        return matchResult(((Comparable)actual).compareTo(wanted));
+    @Override
+    public final boolean matches(T actual) {
+        if (actual == null) {
+            return false;
+        }
+        if (!actual.getClass().isInstance(wanted)){ 
+            return false;
+        }
+       
+        int result = actual.compareTo(wanted);
+        return matchResult(result);
     }
 
-    public String toString() {
+    @Override
+    public final String toString() {
         return getName() + "(" + wanted + ")";
     }
-    
+
     protected abstract String getName();
-    
+
     protected abstract boolean matchResult(int result);
 }

--- a/src/main/java/org/mockito/internal/matchers/GreaterOrEqual.java
+++ b/src/main/java/org/mockito/internal/matchers/GreaterOrEqual.java
@@ -9,7 +9,7 @@ import java.io.Serializable;
 
 public class GreaterOrEqual<T extends Comparable<T>> extends CompareTo<T> implements Serializable {
 
-    public GreaterOrEqual(Comparable<T> value) {
+    public GreaterOrEqual(T value) {
         super(value);
     }
 

--- a/src/main/java/org/mockito/internal/matchers/GreaterThan.java
+++ b/src/main/java/org/mockito/internal/matchers/GreaterThan.java
@@ -9,7 +9,7 @@ import java.io.Serializable;
 
 public class GreaterThan<T extends Comparable<T>> extends CompareTo<T> implements Serializable {
 
-    public GreaterThan(Comparable<T> value) {
+    public GreaterThan(T value) {
         super(value);
     }
 

--- a/src/main/java/org/mockito/internal/matchers/LessOrEqual.java
+++ b/src/main/java/org/mockito/internal/matchers/LessOrEqual.java
@@ -9,7 +9,7 @@ import java.io.Serializable;
 
 public class LessOrEqual<T extends Comparable<T>> extends CompareTo<T> implements Serializable {
 
-    public LessOrEqual(Comparable<T> value) {
+    public LessOrEqual(T value) {
         super(value);
     }
 

--- a/src/main/java/org/mockito/internal/matchers/LessThan.java
+++ b/src/main/java/org/mockito/internal/matchers/LessThan.java
@@ -9,7 +9,7 @@ import java.io.Serializable;
 
 public class LessThan<T extends Comparable<T>> extends CompareTo<T> implements Serializable {
 
-    public LessThan(Comparable<T> value) {
+    public LessThan(T value) {
         super(value);
     }
 

--- a/src/test/java/org/mockito/internal/util/collections/HashCodeAndEqualsSafeSetTest.java
+++ b/src/test/java/org/mockito/internal/util/collections/HashCodeAndEqualsSafeSetTest.java
@@ -4,41 +4,53 @@
  */
 package org.mockito.internal.util.collections;
 
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Observer;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 public class HashCodeAndEqualsSafeSetTest {
 
+    @Rule
+    public MockitoRule r = MockitoJUnit.rule();
+    @Mock
+    private UnmockableHashCodeAndEquals mock1;
+
     @Test
     public void can_add_mock_that_have_failing_hashCode_method() throws Exception {
-        new HashCodeAndEqualsSafeSet().add(mock(UnmockableHashCodeAndEquals.class));
+        new HashCodeAndEqualsSafeSet().add(mock1);
     }
 
     @Test
     public void mock_with_failing_hashCode_method_can_be_added() throws Exception {
-        new HashCodeAndEqualsSafeSet().add(mock(UnmockableHashCodeAndEquals.class));
+        new HashCodeAndEqualsSafeSet().add(mock1);
     }
 
     @Test
     public void mock_with_failing_equals_method_can_be_used() throws Exception {
         HashCodeAndEqualsSafeSet mocks = new HashCodeAndEqualsSafeSet();
-        UnmockableHashCodeAndEquals mock = mock(UnmockableHashCodeAndEquals.class);
-        mocks.add(mock);
+        mocks.add(mock1);
 
-        assertThat(mocks.contains(mock)).isTrue();
-        assertThat(mocks.contains(mock(UnmockableHashCodeAndEquals.class))).isFalse();
+        assertThat(mocks.contains(mock1)).isTrue();
+
+        UnmockableHashCodeAndEquals mock2 = mock(UnmockableHashCodeAndEquals.class);
+        assertThat(mocks.contains(mock2)).isFalse();
     }
 
     @Test
     public void can_remove() throws Exception {
         HashCodeAndEqualsSafeSet mocks = new HashCodeAndEqualsSafeSet();
-        UnmockableHashCodeAndEquals mock = mock(UnmockableHashCodeAndEquals.class);
+        UnmockableHashCodeAndEquals mock = mock1;
         mocks.add(mock);
         mocks.remove(mock);
 
@@ -49,7 +61,7 @@ public class HashCodeAndEqualsSafeSetTest {
     @Test
     public void can_add_a_collection() throws Exception {
         HashCodeAndEqualsSafeSet mocks = HashCodeAndEqualsSafeSet.of(
-                mock(UnmockableHashCodeAndEquals.class),
+                mock1,
                 mock(Observer.class));
 
         HashCodeAndEqualsSafeSet workingSet = new HashCodeAndEqualsSafeSet();
@@ -62,7 +74,7 @@ public class HashCodeAndEqualsSafeSetTest {
     @Test
     public void can_retain_a_collection() throws Exception {
         HashCodeAndEqualsSafeSet mocks = HashCodeAndEqualsSafeSet.of(
-                mock(UnmockableHashCodeAndEquals.class),
+                mock1,
                 mock(Observer.class));
 
         HashCodeAndEqualsSafeSet workingSet = new HashCodeAndEqualsSafeSet();
@@ -77,7 +89,7 @@ public class HashCodeAndEqualsSafeSetTest {
     @Test
     public void can_remove_a_collection() throws Exception {
         HashCodeAndEqualsSafeSet mocks = HashCodeAndEqualsSafeSet.of(
-                mock(UnmockableHashCodeAndEquals.class),
+                mock1,
                 mock(Observer.class));
 
         HashCodeAndEqualsSafeSet workingSet = new HashCodeAndEqualsSafeSet();
@@ -92,7 +104,7 @@ public class HashCodeAndEqualsSafeSetTest {
     @Test
     public void can_iterate() throws Exception {
         HashCodeAndEqualsSafeSet mocks = HashCodeAndEqualsSafeSet.of(
-                mock(UnmockableHashCodeAndEquals.class),
+                mock1,
                 mock(Observer.class));
 
         LinkedList<Object> accumulator = new LinkedList<Object>();
@@ -104,12 +116,65 @@ public class HashCodeAndEqualsSafeSetTest {
 
     @Test
     public void toArray_just_work() throws Exception {
-        UnmockableHashCodeAndEquals mock1 = mock(UnmockableHashCodeAndEquals.class);
         HashCodeAndEqualsSafeSet mocks = HashCodeAndEqualsSafeSet.of(mock1);
 
         assertThat(mocks.toArray()[0]).isSameAs(mock1);
 
         assertThat(mocks.toArray(new UnmockableHashCodeAndEquals[0])[0]).isSameAs(mock1);
+    }
+    
+    @Test(expected=CloneNotSupportedException.class)    
+    public void cloneIsNotSupported() throws CloneNotSupportedException{
+        HashCodeAndEqualsSafeSet.of().clone();
+    }
+    
+    @Test
+    public void isEmptyAfterClear() throws Exception {
+        HashCodeAndEqualsSafeSet set = HashCodeAndEqualsSafeSet.of(mock1);
+        set.clear();
+        
+        assertThat(set).isEmpty();
+    }
+    
+    @Test
+    public void isEqualToItself(){
+        HashCodeAndEqualsSafeSet set = HashCodeAndEqualsSafeSet.of(mock1);
+        assertThat(set).isEqualTo(set);
+    }
+    
+    @Test
+    public void isNotEqualToAnOtherTypeOfSetWithSameContent(){
+        HashCodeAndEqualsSafeSet set = HashCodeAndEqualsSafeSet.of();
+        assertThat(set).isNotEqualTo(new HashSet<Object>());
+    }
+    
+    @Test
+    public void isNotEqualWhenContentIsDifferent(){
+       
+        HashCodeAndEqualsSafeSet set = HashCodeAndEqualsSafeSet.of(mock1);
+        assertThat(set).isNotEqualTo(HashCodeAndEqualsSafeSet.of());
+    }
+    
+    @Test
+    public void hashCodeIsEqualIfContentIsEqual(){
+        HashCodeAndEqualsSafeSet set = HashCodeAndEqualsSafeSet.of(mock1);
+        assertThat(set.hashCode()).isEqualTo(HashCodeAndEqualsSafeSet.of(mock1).hashCode());
+    }
+    
+    @Test
+    public void toStringIsNotNullOrEmpty() throws Exception {
+        HashCodeAndEqualsSafeSet set = HashCodeAndEqualsSafeSet.of(mock1);
+        assertThat(set.toString()).isNotEmpty();
+    }
+    
+    @Test
+    public void removeByIterator() throws Exception {
+        HashCodeAndEqualsSafeSet set = HashCodeAndEqualsSafeSet.of(mock1);
+        Iterator<Object> iterator = set.iterator();
+        iterator.next();
+        iterator.remove();
+        
+        assertThat(set).isEmpty();
     }
 
     private static class UnmockableHashCodeAndEquals {

--- a/src/test/java/org/mockitousage/bugs/CompareMatcherTest.java
+++ b/src/test/java/org/mockitousage/bugs/CompareMatcherTest.java
@@ -1,0 +1,104 @@
+package org.mockitousage.bugs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.AdditionalMatchers.leq;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Date;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockitousage.IMethods;
+
+public class CompareMatcherTest {
+    private static final Object NOT_A_COMPARABLE = new Object();
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    public IMethods mock;
+
+    /**
+     * Should not throw an {@link NullPointerException}
+     * 
+     * @see Bug-ID https://github.com/mockito/mockito/issues/457
+     */
+    @Test
+    public void compareNullArgument() {
+        final IMethods mock = mock(IMethods.class);
+
+        when(mock.forInteger(leq(5))).thenReturn("");
+
+        assertThat(mock.forInteger(null)).isNull();// a default value must be returned
+    }
+
+    /**
+     * Should not throw an {@link ClassCastException}
+     */
+    @Test
+    public void compareToNonCompareable() {
+        when(mock.forObject(leq(5))).thenReturn("");
+
+        assertThat(mock.forObject(NOT_A_COMPARABLE)).isNull();// a default value must be returned
+    }
+
+    /**
+     * Should not throw an {@link ClassCastException}
+     */
+    @Test
+    public void compareToNull() {
+        when(mock.forInteger(leq((Integer) null))).thenReturn("");
+
+        assertThat(mock.forInteger(null)).isNull();// a default value must be returned
+    }
+
+    /**
+     * Should not throw an {@link ClassCastException}
+     */
+    @Test
+    public void compareToStringVsInt() {
+        when(mock.forObject(startsWith("Hello"))).thenReturn("");
+
+        assertThat(mock.forObject(123)).isNull();// a default value must be returned
+    }
+    
+    @Test
+    public void compareToIntVsString() throws Exception {
+        when(mock.forObject(leq(5))).thenReturn("");
+        
+        mock.forObject("abc");
+    }
+
+    @Test
+    public void matchesOverloadsMustBeIgnored() {
+        class TestMatcher implements ArgumentMatcher<Integer> {
+            @Override
+            public boolean matches(Integer arg) {
+                return false;
+            }
+
+            @SuppressWarnings("unused")
+            public boolean matches(Date arg) {
+                throw new UnsupportedOperationException();
+            }
+
+            @SuppressWarnings("unused")
+            public boolean matches(Integer arg, Void v) {
+                throw new UnsupportedOperationException();
+            }
+
+        }
+
+        when(mock.forObject(argThat(new TestMatcher()))).thenReturn("x");
+
+        assertThat(mock.forObject(123)).isNull();
+    }
+
+}


### PR DESCRIPTION
This PR...
 * fixes the NPE described in #457 
 * fixes cases were CCE were thrown if an `ArgumentMatcher `is not type-complatible with an argument to match.
 * fixes parameter types in all constructors of `CompareTo `sub classes 
 * added tests to `HashCodeAndEqualsSafeSetTest `in order to pass the codecov checks