### PR TITLE
Reference correct types for multiple parent class loader if user class and Mockito are loaded by different loaders (e.g. OSGi)

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/MockBytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/MockBytecodeGenerator.java
@@ -61,9 +61,11 @@ class MockBytecodeGenerator {
                       .load(new MultipleParentClassLoader.Builder()
                               .append(features.mockedType)
                               .append(features.interfaces)
-                              .append(MultipleParentClassLoader.class.getClassLoader())
                               .append(Thread.currentThread().getContextClassLoader())
-                              .build(), ClassLoadingStrategy.Default.INJECTION)
+                              .append(MockAccess.class, DispatcherDefaultingToRealMethod.class)
+                              .append(MockMethodInterceptor.class,
+                                      MockMethodInterceptor.ForHashCode.class,
+                                      MockMethodInterceptor.ForEquals.class).build(), ClassLoadingStrategy.Default.INJECTION)
                       .getLoaded();
     }
 


### PR DESCRIPTION
Fixes #385.