### PR TITLE
refactored ThreadSafeMockingProgress to a singleton

### DIFF
--- a/src/main/java/org/mockito/AdditionalMatchers.java
+++ b/src/main/java/org/mockito/AdditionalMatchers.java
@@ -5,6 +5,8 @@
 
 package org.mockito;
 
+import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
+
 import org.mockito.internal.matchers.ArrayEquals;
 import org.mockito.internal.matchers.CompareEqual;
 import org.mockito.internal.matchers.EqualsWithDelta;
@@ -13,8 +15,6 @@ import org.mockito.internal.matchers.GreaterOrEqual;
 import org.mockito.internal.matchers.GreaterThan;
 import org.mockito.internal.matchers.LessOrEqual;
 import org.mockito.internal.matchers.LessThan;
-import org.mockito.internal.progress.MockingProgress;
-import org.mockito.internal.progress.ThreadSafeMockingProgress;
 
 /**
  * See {@link Matchers} for general info about matchers.
@@ -41,8 +41,6 @@ import org.mockito.internal.progress.ThreadSafeMockingProgress;
 @SuppressWarnings("ALL")
 public class AdditionalMatchers {
     
-    private static final MockingProgress MOCKING_PROGRESS = new ThreadSafeMockingProgress();
-
     /**
      * argument greater than or equal the given value.
      * <p>
@@ -612,7 +610,7 @@ public class AdditionalMatchers {
      * @return <code>false</code>.
      */
     public static boolean and(boolean first, boolean second) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportAnd(); 
+        mockingProgress().getArgumentMatcherStorage().reportAnd(); 
         return false;
     }
 
@@ -628,7 +626,7 @@ public class AdditionalMatchers {
      * @return <code>0</code>.
      */
     public static byte and(byte first, byte second) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportAnd();
+        mockingProgress().getArgumentMatcherStorage().reportAnd();
         return 0;
     }
 
@@ -644,7 +642,7 @@ public class AdditionalMatchers {
      * @return <code>0</code>.
      */
     public static char and(char first, char second) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportAnd();
+        mockingProgress().getArgumentMatcherStorage().reportAnd();
         return 0;
     }
 
@@ -660,7 +658,7 @@ public class AdditionalMatchers {
      * @return <code>0</code>.
      */
     public static double and(double first, double second) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportAnd();
+        mockingProgress().getArgumentMatcherStorage().reportAnd();
         return 0;
     }
 
@@ -676,7 +674,7 @@ public class AdditionalMatchers {
      * @return <code>0</code>.
      */
     public static float and(float first, float second) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportAnd();
+        mockingProgress().getArgumentMatcherStorage().reportAnd();
         return 0;
     }
 
@@ -692,7 +690,7 @@ public class AdditionalMatchers {
      * @return <code>0</code>.
      */
     public static int and(int first, int second) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportAnd();
+        mockingProgress().getArgumentMatcherStorage().reportAnd();
         return 0;
     }
 
@@ -708,7 +706,7 @@ public class AdditionalMatchers {
      * @return <code>0</code>.
      */
     public static long and(long first, long second) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportAnd();
+        mockingProgress().getArgumentMatcherStorage().reportAnd();
         return 0;
     }
 
@@ -724,7 +722,7 @@ public class AdditionalMatchers {
      * @return <code>0</code>.
      */
     public static short and(short first, short second) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportAnd();
+        mockingProgress().getArgumentMatcherStorage().reportAnd();
         return 0;
     }
 
@@ -742,7 +740,7 @@ public class AdditionalMatchers {
      * @return <code>null</code>.
      */
     public static <T> T and(T first, T second) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportAnd();
+        mockingProgress().getArgumentMatcherStorage().reportAnd();
         return null;
     }
 
@@ -758,7 +756,7 @@ public class AdditionalMatchers {
      * @return <code>false</code>.
      */
     public static boolean or(boolean first, boolean second) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportOr();
+        mockingProgress().getArgumentMatcherStorage().reportOr();
         return false;
     }
 
@@ -776,7 +774,7 @@ public class AdditionalMatchers {
      * @return <code>null</code>.
      */
     public static <T> T or(T first, T second) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportOr();
+        mockingProgress().getArgumentMatcherStorage().reportOr();
         return null;
     }
 
@@ -792,7 +790,7 @@ public class AdditionalMatchers {
      * @return <code>0</code>.
      */
     public static short or(short first, short second) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportOr();
+        mockingProgress().getArgumentMatcherStorage().reportOr();
         return 0;
     }
 
@@ -808,7 +806,7 @@ public class AdditionalMatchers {
      * @return <code>0</code>.
      */
     public static long or(long first, long second) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportOr();
+        mockingProgress().getArgumentMatcherStorage().reportOr();
         return 0;
     }
 
@@ -824,7 +822,7 @@ public class AdditionalMatchers {
      * @return <code>0</code>.
      */
     public static int or(int first, int second) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportOr();
+        mockingProgress().getArgumentMatcherStorage().reportOr();
         return 0;
     }
 
@@ -840,7 +838,7 @@ public class AdditionalMatchers {
      * @return <code>0</code>.
      */
     public static float or(float first, float second) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportOr();
+        mockingProgress().getArgumentMatcherStorage().reportOr();
         return 0;
     }
 
@@ -856,7 +854,7 @@ public class AdditionalMatchers {
      * @return <code>0</code>.
      */
     public static double or(double first, double second) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportOr();
+        mockingProgress().getArgumentMatcherStorage().reportOr();
         return 0;
     }
 
@@ -872,7 +870,7 @@ public class AdditionalMatchers {
      * @return <code>0</code>.
      */
     public static char or(char first, char second) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportOr();
+        mockingProgress().getArgumentMatcherStorage().reportOr();
         return 0;
     }
 
@@ -888,7 +886,7 @@ public class AdditionalMatchers {
      * @return <code>0</code>.
      */
     public static byte or(byte first, byte second) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportOr();
+        mockingProgress().getArgumentMatcherStorage().reportOr();
         return 0;
     }
 
@@ -904,7 +902,7 @@ public class AdditionalMatchers {
      * @return <code>null</code>.
      */
     public static <T> T not(T first) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportNot();
+        mockingProgress().getArgumentMatcherStorage().reportNot();
         return null;
     }
 
@@ -918,7 +916,7 @@ public class AdditionalMatchers {
      * @return <code>0</code>.
      */
     public static short not(short first) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportNot();
+        mockingProgress().getArgumentMatcherStorage().reportNot();
         return 0;
     }
 
@@ -932,7 +930,7 @@ public class AdditionalMatchers {
      * @return <code>0</code>.
      */
     public static int not(int first) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportNot();
+        mockingProgress().getArgumentMatcherStorage().reportNot();
         return 0;
     }
 
@@ -946,7 +944,7 @@ public class AdditionalMatchers {
      * @return <code>0</code>.
      */
     public static long not(long first) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportNot();
+        mockingProgress().getArgumentMatcherStorage().reportNot();
         return 0;
     }
 
@@ -960,7 +958,7 @@ public class AdditionalMatchers {
      * @return <code>0</code>.
      */
     public static float not(float first) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportNot();
+        mockingProgress().getArgumentMatcherStorage().reportNot();
         return 0;
     }
 
@@ -974,7 +972,7 @@ public class AdditionalMatchers {
      * @return <code>0</code>.
      */
     public static double not(double first) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportNot();
+        mockingProgress().getArgumentMatcherStorage().reportNot();
         return 0;
     }
 
@@ -988,7 +986,7 @@ public class AdditionalMatchers {
      * @return <code>0</code>.
      */
     public static char not(char first) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportNot();
+        mockingProgress().getArgumentMatcherStorage().reportNot();
         return 0;
     }
 
@@ -1002,7 +1000,7 @@ public class AdditionalMatchers {
      * @return <code>false</code>.
      */
     public static boolean not(boolean first) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportNot(); 
+        mockingProgress().getArgumentMatcherStorage().reportNot(); 
         return false;
     }
 
@@ -1016,7 +1014,7 @@ public class AdditionalMatchers {
      * @return <code>0</code>.
      */
     public static byte not(byte first) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportNot();
+        mockingProgress().getArgumentMatcherStorage().reportNot();
         return 0;
     }
 
@@ -1055,6 +1053,6 @@ public class AdditionalMatchers {
     }
     
     private static void reportMatcher(ArgumentMatcher<?> matcher) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportMatcher(matcher);
+        mockingProgress().getArgumentMatcherStorage().reportMatcher(matcher);
     }
 }

--- a/src/main/java/org/mockito/Matchers.java
+++ b/src/main/java/org/mockito/Matchers.java
@@ -6,10 +6,10 @@ package org.mockito;
 
 import org.mockito.internal.matchers.*;
 import org.mockito.internal.matchers.apachecommons.ReflectionEquals;
-import org.mockito.internal.progress.MockingProgress;
 import org.mockito.internal.progress.ThreadSafeMockingProgress;
 import org.mockito.internal.util.Primitives;
 
+import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
 import static org.mockito.internal.util.Primitives.defaultValue;
 
 import java.util.Collection;
@@ -64,8 +64,6 @@ import java.util.Set;
 @SuppressWarnings("unchecked")
 public class Matchers {
     
-    private static final MockingProgress MOCKING_PROGRESS = new ThreadSafeMockingProgress();
-
     /**
      * Any <code>boolean</code> or non-null <code>Boolean</code>
      * <p>
@@ -840,6 +838,6 @@ public class Matchers {
     }
 
     private static void reportMatcher(ArgumentMatcher<?> matcher) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportMatcher(matcher);
+        mockingProgress().getArgumentMatcherStorage().reportMatcher(matcher);
     }
 }

--- a/src/main/java/org/mockito/hamcrest/MockitoHamcrest.java
+++ b/src/main/java/org/mockito/hamcrest/MockitoHamcrest.java
@@ -1,13 +1,12 @@
 package org.mockito.hamcrest;
 
 import static org.mockito.internal.hamcrest.MatcherGenericTypeExtractor.genericTypeOfMatcher;
+import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
 import static org.mockito.internal.util.Primitives.defaultValue;
 
 import org.hamcrest.Matcher;
 import org.mockito.ArgumentMatcher;
 import org.mockito.internal.hamcrest.HamcrestArgumentMatcher;
-import org.mockito.internal.progress.MockingProgress;
-import org.mockito.internal.progress.ThreadSafeMockingProgress;
 
 /**
  * Allows matching arguments with hamcrest matchers.
@@ -43,8 +42,6 @@ import org.mockito.internal.progress.ThreadSafeMockingProgress;
  * @since 2.0
  */
 public class MockitoHamcrest {
-
-    private static final MockingProgress MOCKING_PROGRESS = new ThreadSafeMockingProgress();
 
     /**
      * Allows matching arguments with hamcrest matchers.
@@ -174,6 +171,6 @@ public class MockitoHamcrest {
     }
 
     private static <T> void reportMatcher(Matcher<T> matcher) {
-        MOCKING_PROGRESS.getArgumentMatcherStorage().reportMatcher(new HamcrestArgumentMatcher<T>(matcher));
+        mockingProgress().getArgumentMatcherStorage().reportMatcher(new HamcrestArgumentMatcher<T>(matcher));
     }
 }

--- a/src/main/java/org/mockito/internal/debugging/WarningsCollector.java
+++ b/src/main/java/org/mockito/internal/debugging/WarningsCollector.java
@@ -4,16 +4,15 @@
  */
 package org.mockito.internal.debugging;
 
+import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
+
+import java.util.LinkedList;
+import java.util.List;
 import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockito.internal.invocation.UnusedStubsFinder;
 import org.mockito.internal.invocation.finder.AllInvocationsFinder;
 import org.mockito.internal.listeners.CollectCreatedMocks;
-import org.mockito.internal.progress.MockingProgress;
-import org.mockito.internal.progress.ThreadSafeMockingProgress;
 import org.mockito.invocation.Invocation;
-
-import java.util.LinkedList;
-import java.util.List;
 
 public class WarningsCollector {
    
@@ -21,8 +20,7 @@ public class WarningsCollector {
 
     public WarningsCollector() {
         createdMocks = new LinkedList<Object>();
-        MockingProgress progress = new ThreadSafeMockingProgress();
-        progress.setListener(new CollectCreatedMocks(createdMocks));
+        mockingProgress().setListener(new CollectCreatedMocks(createdMocks));
     }
 
     public String getWarnings() {

--- a/src/main/java/org/mockito/internal/stubbing/InvocationContainerImpl.java
+++ b/src/main/java/org/mockito/internal/stubbing/InvocationContainerImpl.java
@@ -7,6 +7,7 @@ package org.mockito.internal.stubbing;
 import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockito.internal.invocation.StubInfoImpl;
 import org.mockito.internal.progress.MockingProgress;
+import org.mockito.internal.progress.ThreadSafeMockingProgress;
 import org.mockito.internal.stubbing.answers.AnswersValidator;
 import org.mockito.internal.verification.DefaultRegisteredInvocations;
 import org.mockito.internal.verification.RegisteredInvocations;
@@ -14,6 +15,8 @@ import org.mockito.internal.verification.SingleRegisteredInvocation;
 import org.mockito.invocation.Invocation;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.stubbing.Answer;
+
+import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -25,14 +28,12 @@ public class InvocationContainerImpl implements InvocationContainer, Serializabl
 
     private static final long serialVersionUID = -5334301962749537177L;
     private final LinkedList<StubbedInvocationMatcher> stubbed = new LinkedList<StubbedInvocationMatcher>();
-    private final MockingProgress mockingProgress;
     private final List<Answer<?>> answersForStubbing = new ArrayList<Answer<?>>();
     private final RegisteredInvocations registeredInvocations;
 
     private InvocationMatcher invocationForStubbing;
 
-    public InvocationContainerImpl(MockingProgress mockingProgress, MockCreationSettings mockSettings) {
-        this.mockingProgress = mockingProgress;
+    public InvocationContainerImpl(MockCreationSettings mockSettings) {
         this.registeredInvocations = createRegisteredInvocations(mockSettings);
     }
 
@@ -56,7 +57,7 @@ public class InvocationContainerImpl implements InvocationContainer, Serializabl
 
     public void addAnswer(Answer answer, boolean isConsecutive) {
         Invocation invocation = invocationForStubbing.getInvocation();
-        mockingProgress.stubbingCompleted(invocation);
+        mockingProgress().stubbingCompleted(invocation);
         AnswersValidator answersValidator = new AnswersValidator();
         answersValidator.validate(answer, invocation);
 

--- a/src/main/java/org/mockito/junit/VerificationCollectorImpl.java
+++ b/src/main/java/org/mockito/junit/VerificationCollectorImpl.java
@@ -1,21 +1,19 @@
 package org.mockito.junit;
 
+import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
+
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.mockito.exceptions.base.MockitoAssertionError;
-import org.mockito.internal.progress.MockingProgress;
 import org.mockito.internal.progress.MockingProgressImpl;
-import org.mockito.internal.progress.ThreadSafeMockingProgress;
-import org.mockito.verification.VerificationStrategy;
 import org.mockito.internal.verification.api.VerificationData;
 import org.mockito.verification.VerificationMode;
+import org.mockito.verification.VerificationStrategy;
 
 /**
  * Mockito implementation of VerificationCollector.
  */
 class VerificationCollectorImpl implements VerificationCollector {
-
-    private final MockingProgress mockingProgress = new ThreadSafeMockingProgress();
 
     private StringBuilder builder;
     private int numberOfFailures;
@@ -35,14 +33,14 @@ class VerificationCollectorImpl implements VerificationCollector {
                 } finally {
                     // If base.evaluate() throws an error, we must explicitly reset the VerificationStrategy
                     // to prevent subsequent tests to be assert lazily
-                    mockingProgress.setVerificationStrategy(MockingProgressImpl.getDefaultVerificationStrategy());
+                    mockingProgress().setVerificationStrategy(MockingProgressImpl.getDefaultVerificationStrategy());
                 }
             }
         };
     }
 
     public void collectAndReport() throws MockitoAssertionError {
-        mockingProgress.setVerificationStrategy(MockingProgressImpl.getDefaultVerificationStrategy());
+        mockingProgress().setVerificationStrategy(MockingProgressImpl.getDefaultVerificationStrategy());
 
         if (this.numberOfFailures > 0) {
             String error = this.builder.toString();
@@ -54,7 +52,7 @@ class VerificationCollectorImpl implements VerificationCollector {
     }
 
     public VerificationCollector assertLazily() {
-        mockingProgress.setVerificationStrategy(new VerificationStrategy() {
+        mockingProgress().setVerificationStrategy(new VerificationStrategy() {
             public VerificationMode maybeVerifyLazily(VerificationMode mode) {
                 return new VerificationWrapper(mode);
             }

--- a/src/test/java/org/mockito/MockitoTest.java
+++ b/src/test/java/org/mockito/MockitoTest.java
@@ -5,29 +5,24 @@
 
 package org.mockito;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
+
+import java.util.List;
 import org.junit.Test;
 import org.mockito.exceptions.misusing.NotAMockException;
 import org.mockito.internal.creation.MockSettingsImpl;
-import org.mockito.internal.progress.ThreadSafeMockingProgress;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.times;
 
 @SuppressWarnings("unchecked")
 public class MockitoTest {
-
-	
-	
-	
 	
     @Test
     public void shouldRemoveStubbableFromProgressAfterStubbing() {
         List mock = Mockito.mock(List.class);
         Mockito.when(mock.add("test")).thenReturn(true);
         //TODO Consider to move to separate test
-        assertThat(new ThreadSafeMockingProgress().pullOngoingStubbing()).isNull();
+        assertThat(mockingProgress().pullOngoingStubbing()).isNull();
     }
     
     @Test(expected=NotAMockException.class)

--- a/src/test/java/org/mockito/StateMaster.java
+++ b/src/test/java/org/mockito/StateMaster.java
@@ -5,18 +5,16 @@
 
 package org.mockito;
 
-import org.mockito.internal.progress.ThreadSafeMockingProgress;
+import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
 
 public class StateMaster {
-    
-    private final ThreadSafeMockingProgress mockingProgress = new ThreadSafeMockingProgress();
 
     public void reset() {
-        mockingProgress.reset();
-        mockingProgress.resetOngoingStubbing();
+        mockingProgress().reset();
+        mockingProgress().resetOngoingStubbing();
     }
-    
+
     public void validate() {
-        mockingProgress.validateState();
+        mockingProgress().validateState();
     }
 }

--- a/src/test/java/org/mockito/internal/handler/MockHandlerImplTest.java
+++ b/src/test/java/org/mockito/internal/handler/MockHandlerImplTest.java
@@ -26,6 +26,7 @@ import org.mockitoutil.TestBase;
 
 import java.util.Arrays;
 
+import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
 import static junit.framework.TestCase.assertNull;
 import static junit.framework.TestCase.fail;
 import static org.mockito.BDDMockito.given;
@@ -46,7 +47,7 @@ public class MockHandlerImplTest extends TestBase {
         Invocation invocation = new InvocationBuilder().toInvocation();
         @SuppressWarnings("rawtypes")
         MockHandlerImpl<?> handler = new MockHandlerImpl(new MockSettingsImpl());
-        handler.mockingProgress.verificationStarted(VerificationModeFactory.atLeastOnce());
+        mockingProgress().verificationStarted(VerificationModeFactory.atLeastOnce());
         handler.matchersBinder = new MatchersBinder() {
             public InvocationMatcher bindMatchers(ArgumentMatcherStorage argumentMatcherStorage, Invocation invocation) {
                 throw new InvalidUseOfMatchersException();
@@ -62,7 +63,7 @@ public class MockHandlerImplTest extends TestBase {
         } catch (InvalidUseOfMatchersException ignored) {
         }
 
-        assertNull(handler.mockingProgress.pullVerificationMode());
+        assertNull(mockingProgress().pullVerificationMode());
     }
 
 

--- a/src/test/java/org/mockito/internal/progress/ThreadSafeMockingProgressTest.java
+++ b/src/test/java/org/mockito/internal/progress/ThreadSafeMockingProgressTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import static junit.framework.TestCase.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
 
 public class ThreadSafeMockingProgressTest extends TestBase {
 
@@ -25,11 +26,11 @@ public class ThreadSafeMockingProgressTest extends TestBase {
     @Test
     public void shouldShareState() throws Exception {
         //given
-        ThreadSafeMockingProgress p = new ThreadSafeMockingProgress();
+        MockingProgress p = mockingProgress();
         p.verificationStarted(new DummyVerificationMode());
 
         //then
-        p = new ThreadSafeMockingProgress();
+        p = mockingProgress();
         assertNotNull(p.pullVerificationMode());
     }
 
@@ -37,7 +38,7 @@ public class ThreadSafeMockingProgressTest extends TestBase {
     public void shouldKnowWhenVerificationHasStarted() throws Exception {
         //given
         verify(mock(List.class));
-        ThreadSafeMockingProgress p = new ThreadSafeMockingProgress();
+        MockingProgress p = mockingProgress();
 
         //then
         assertNotNull(p.pullVerificationMode());

--- a/src/test/java/org/mockito/internal/stubbing/InvocationContainerImplStubbingTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/InvocationContainerImplStubbingTest.java
@@ -5,6 +5,8 @@
 
 package org.mockito.internal.stubbing;
 
+import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.exceptions.base.MockitoException;
@@ -13,6 +15,7 @@ import org.mockito.internal.invocation.InvocationBuilder;
 import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockito.internal.progress.MockingProgress;
 import org.mockito.internal.progress.MockingProgressImpl;
+import org.mockito.internal.progress.ThreadSafeMockingProgress;
 import org.mockito.internal.stubbing.answers.Returns;
 import org.mockito.internal.stubbing.answers.ThrowsException;
 import org.mockito.invocation.Invocation;
@@ -30,13 +33,13 @@ public class InvocationContainerImplStubbingTest extends TestBase {
 
     @Before
     public void setup() {
-        state = new MockingProgressImpl();
+        state = mockingProgress();
 
-        invocationContainerImpl = new InvocationContainerImpl(state, new MockSettingsImpl());
+        invocationContainerImpl = new InvocationContainerImpl(new MockSettingsImpl());
         invocationContainerImpl.setInvocationForPotentialStubbing(new InvocationBuilder().toInvocationMatcher());
 
         invocationContainerImplStubOnly =
-          new InvocationContainerImpl(state, new MockSettingsImpl().stubOnly());
+          new InvocationContainerImpl( new MockSettingsImpl().stubOnly());
         invocationContainerImplStubOnly.setInvocationForPotentialStubbing(new InvocationBuilder().toInvocationMatcher());
 
         simpleMethod = new InvocationBuilder().simpleMethod().toInvocation();

--- a/src/test/java/org/mockito/internal/stubbing/InvocationContainerImplTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/InvocationContainerImplTest.java
@@ -4,29 +4,30 @@
  */
 package org.mockito.internal.stubbing;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
+
+import java.util.LinkedList;
+import java.util.concurrent.CountDownLatch;
 import org.junit.Test;
 import org.mockito.internal.creation.MockSettingsImpl;
 import org.mockito.internal.invocation.InvocationBuilder;
 import org.mockito.internal.invocation.InvocationMatcher;
-import org.mockito.internal.progress.ThreadSafeMockingProgress;
 import org.mockito.internal.stubbing.answers.Returns;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsEmptyValues;
 import org.mockito.invocation.Invocation;
 import org.mockito.mock.MockCreationSettings;
-
-import java.util.LinkedList;
-import java.util.concurrent.CountDownLatch;
-
-import static org.junit.Assert.*;
 
 /**
  * Author: Szczepan Faber
  */
 public class InvocationContainerImplTest {
 
-    InvocationContainerImpl container = new InvocationContainerImpl(new ThreadSafeMockingProgress(), new MockSettingsImpl());
+    InvocationContainerImpl container = new InvocationContainerImpl( new MockSettingsImpl());
     InvocationContainerImpl containerStubOnly =
-      new InvocationContainerImpl(new ThreadSafeMockingProgress(), (MockCreationSettings) new MockSettingsImpl().stubOnly());
+      new InvocationContainerImpl( (MockCreationSettings) new MockSettingsImpl().stubOnly());
     Invocation invocation = new InvocationBuilder().toInvocation();
     LinkedList<Throwable> exceptions = new LinkedList<Throwable>();
 

--- a/src/test/java/org/mockito/internal/verification/NoMoreInteractionsTest.java
+++ b/src/test/java/org/mockito/internal/verification/NoMoreInteractionsTest.java
@@ -21,6 +21,7 @@ import org.mockitoutil.TestBase;
 import static java.util.Arrays.asList;
 import static junit.framework.TestCase.*;
 import static org.mockito.Mockito.mock;
+import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
 
 public class NoMoreInteractionsTest extends TestBase {
 
@@ -90,7 +91,7 @@ public class NoMoreInteractionsTest extends TestBase {
         InvocationMatcher i = new InvocationBuilder().mock(mock).toInvocationMatcher();
 
         InvocationContainerImpl invocations =
-            new InvocationContainerImpl(new ThreadSafeMockingProgress(), new MockSettingsImpl());
+            new InvocationContainerImpl( new MockSettingsImpl());
         invocations.setInvocationForPotentialStubbing(i);
 
         try {


### PR DESCRIPTION
The actual implementation of [ThreadSafeMockingProgress](https://github.com/mockito/mockito/blob/master/src/main/java/org/mockito/internal/progress/ThreadSafeMockingProgress.java) disguise that it is effectively a singleton cause the ThreadLocal member is static. This makes it hard to see that different instances  share the same state.

This PR...
 * refactores `ThreadSafeMockingProgress `to provider of MockingProgress instances
 * uses the standard way of instantiating the initial `ThreadLocal `value this also avoids possible race conditions
 
