### PR TITLE
Exclude mockito internal packages from the Javadoc

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     //TODO SF use jcabi to edit issues after the release so that they have the milestone attached
     //compile "com.jcabi:jcabi-github:0.17"
     compile "com.googlecode.json-simple:json-simple:1.1.1@jar"
+    compile files("${System.properties['java.home']}/../lib/tools.jar")
     testCompile("org.spockframework:spock-core:0.7-groovy-2.0") {
         exclude module: "groovy-all"
     }

--- a/buildSrc/src/main/java/org/mockito/javadoc/JavadocExclude.java
+++ b/buildSrc/src/main/java/org/mockito/javadoc/JavadocExclude.java
@@ -1,0 +1,70 @@
+package org.mockito.javadoc;
+
+import com.sun.javadoc.*;
+import com.sun.tools.doclets.formats.html.HtmlDoclet;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Doclet built to exclude mockito internal packages from the outputted Javadoc.
+ * All methods except the start method are copied from {@link com.sun.tools.doclets.standard.Standard}.
+ * Inspired by https://gist.github.com/benjchristensen/1410681
+ */
+public class JavadocExclude {
+
+    public static int optionLength(String var0) {
+        return HtmlDoclet.optionLength(var0);
+    }
+
+    public static boolean start(RootDoc root) {
+        Class clz = root.getClass();
+        return HtmlDoclet.start((RootDoc) Proxy.newProxyInstance(clz.getClassLoader(), clz.getInterfaces(), new ExcludeHandler(root)));
+    }
+
+    public static boolean validOptions(String[][] var0, DocErrorReporter var1) {
+        return HtmlDoclet.validOptions(var0, var1);
+    }
+
+    public static LanguageVersion languageVersion() {
+        return HtmlDoclet.languageVersion();
+    }
+
+    /**
+     * Proxy which filters the {@link RootDoc#classes()} method to filter {@link ClassDoc} based on their package name.
+     */
+    private static class ExcludeHandler implements InvocationHandler {
+        private final RootDoc root;
+
+        private ExcludeHandler(RootDoc root) {
+            this.root = root;
+        }
+
+        @Override
+        public Object invoke(Object o, Method method, Object[] args) throws Throwable {
+            Object result = method.invoke(root, args);
+            if (result instanceof Object[]) {
+                List<ClassDoc> filteredDocs = new ArrayList<ClassDoc>();
+                Object[] array = (Object[]) result;
+                for (Object entry : array) {
+                    if (entry instanceof ClassDoc) {
+                        ClassDoc doc = (ClassDoc) entry;
+                        if (!doc.containingPackage().name().startsWith("org.mockito.internal")) {
+                            filteredDocs.add(doc);
+                        }
+                    }
+                }
+                // If no ClassDoc were found in the original array,
+                // since PackageDoc area also included in the classes array.
+                if (filteredDocs.size() > 0) {
+                    ClassDoc[] docArray = new ClassDoc[filteredDocs.size()];
+                    return filteredDocs.toArray(docArray);
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -14,6 +14,8 @@ task mockitoJavadoc(type: Javadoc) {
     title = "Mockito ${project.version} API"
     def javadocJdk6Hack = "jdk6-project-version-insert.min.js"
 
+    options.doclet "org.mockito.javadoc.JavadocExclude"
+    options.docletpath = [rootProject.file('./buildSrc/build/classes/main/')]
     options.docTitle = """<h1><a href="org/mockito/Mockito.html">Click to see examples</a>. Mockito ${project.version} API.</h1>"""
     options.windowTitle = "Mockito ${project.version} API"
     options.group("Main package", ["org.mockito"])

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Mar 09 16:13:07 CET 2016
+#Wed Jul 06 11:31:59 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.11-all.zip


### PR DESCRIPTION
This one was a toughy, but I managed to write a Doclet that post-processes the generated classes. It filters all internal classes. This way, there are no compilation failures when generating the Javadoc if you would use `exclude "**/internal/**"`.

Fixes #226 