### PR TITLE
Update version scheme to publish release candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,24 +17,34 @@ See the [release notes page](https://github.com/mockito/mockito/blob/master/doc/
 
 ## Versioning
 
-Mockito has an automated release system, which imposed some change on how the version numbers work. While this is similar to [_semver_](http://semver.org/), there's some differences. Let's look at the following versions `1.10.19` and `2.0.5-beta` and `2.0.0` (not yet released). They follow this scheme:
+Mockito has an automated release system, which imposed some change on how the version numbers work.
+They follow this scheme:
 
 ```
-major.minor.build-tag
+major.minor.patch-tag.tagVersion
 ```
 
 | number | meaning                                                                               |
 | ------ | ------------------------------------------------------------------------------------- |
-| major  | major version, with most probably incompatible change in API and behavior             |
-| minor  | minor version, important enough change to bump this number                            |
-| build  | a released build number incremented automatically when a pull request is merged       |
-| tag    | will probably be `-beta` or just nothing (during beta, breaking changes are expected) |
+| major  | major version, backwards incompatible with the previous major version                 |
+| minor  | minor version, backwards compatible with added features                               |
+| patch  | patch version, small bug fixes or stylistic improvements                              |
+| tag    | *optional* beta or RC (release candidate). See below.                                 |
 
 That means:
 
-* `2.0.0` and `2.0.5-beta` are binary incompatible with `1.10.19`.
-* `2.0.5-beta` is the fifth release beta of version `2.0.0`.
-* `2.0.5-beta` is a work in progress, api may change and may not be graduated in version `2.0.0`.
+* `2.0.0` and `2.0.0-beta.5` are binary incompatible with `1.10.19`.
+* `2.0.0-beta.5` is the fifth release beta of version `2.0.0`.
+* `2.0.0-beta.5` could be (but is not necessarily) binary incompatible with version `2.0.0`.
+* `2.0.0-RC.1` is binary compatible with release `2.0.0`.
+
+### Tags
+There are two different tags: beta or RC. Beta indicates that the version is directly generated from the master branch of the git repository.
+Beta releases are automatically published whenever we merge a pull request or push a change to the master branch.
+
+When we deem our master status worthy of a release, we publish a release candidate. The release candidate is scheduled to be officially published
+in the official release a while later. There will be no breaking changes between a release candidate and its equivalent official release.
+The only changes will include bug fixes or small updates. No additional features will be included.
 
 ## Looking for support
 

--- a/buildSrc/src/main/groovy/org/mockito/release/version/VersionBumper.java
+++ b/buildSrc/src/main/groovy/org/mockito/release/version/VersionBumper.java
@@ -9,17 +9,20 @@ class VersionBumper {
      * Increments 'patch' element of the version of provided version, e.g. 1.0.0 -> 1.0.1
      */
     String incrementVersion(String version) {
-        Pattern pattern = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)(-(\\w+)){0,1}");
+        Pattern pattern = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)(-(\\w+)\\.(\\d+))?");
         Matcher matcher = pattern.matcher(version);
         boolean m = matcher.matches();
         if (!m) {
-            throw new IllegalArgumentException("Unsupported version: '" + version + "'. Examples of supported versions: 1.0.0, 1.20.123, 1.0.10-beta");
+            throw new IllegalArgumentException("Unsupported version: '" + version + "'. Examples of supported versions: 1.0.0, 1.20.123, 1.0.10-beta.3");
         }
 
         int major = Integer.parseInt(matcher.group(1));
         int minor = Integer.parseInt(matcher.group(2));
         int patch = Integer.parseInt(matcher.group(3));
-        String postfix = matcher.group(4) != null ? matcher.group(4) : "";
-        return "" + major + "." + minor + "." + (patch + 1) + postfix;
+        if (matcher.group(4) != null) {
+            int betaVersion = Integer.parseInt(matcher.group(6));
+            return "" + major + "." + minor + "." + patch + "-" + matcher.group(5) + "." + (betaVersion + 1);
+        }
+        return "" + major + "." + minor + "." + (patch + 1);
     }
 }

--- a/buildSrc/src/test/groovy/org/mockito/release/version/VersionBumperTest.groovy
+++ b/buildSrc/src/test/groovy/org/mockito/release/version/VersionBumperTest.groovy
@@ -13,8 +13,9 @@ class VersionBumperTest extends Specification {
         v.incrementVersion("0.0.0") == "0.0.1"
         v.incrementVersion("1.10.15") == "1.10.16"
 
-        v.incrementVersion("1.0.0-beta") == "1.0.1-beta"
-        v.incrementVersion("1.10.15-beta") == "1.10.16-beta"
+        v.incrementVersion("1.0.0-beta.3") == "1.0.0-beta.4"
+        v.incrementVersion("1.10.15-beta.5") == "1.10.15-beta.6"
+        v.incrementVersion("2.0.0-RC.1") == "2.0.0-RC.2"
     }
 
     def "increments only 3 numbered versions"() {
@@ -25,6 +26,6 @@ class VersionBumperTest extends Specification {
         thrown(IllegalArgumentException)
 
         where:
-        unsupported << ["1.0", "2", "1.0.0.0", "1.0.1-beta.2"]
+        unsupported << ["1.0", "2", "1.0.0.0", "1.0.1-beta"]
     }
 }

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-version=2.0.112-beta
+version=2.0.0-beta.112
 mockito.testng.version=1.0


### PR DESCRIPTION
Beta releases now follow the official semver scheme of `MAJOR.MINOR.PATCH-beta.BETAVERSION`. This PR also updates the current version to a release candidate.

We should decide after the release candiate what the version of Mockito 2.0 should be. E.g. should it be `2.0.0`? That would mean we go down on our `PATCH` number which might confuses people. For the Mockito 3.0 beta is to set the version to `3.0.0-beta.BETAVERSION` to not confuse with the `PATCH` number, but it still leaves us with the question regarding the official release of Mockito 2.0 :cry: 

Closes #123 