### PR TITLE
Revert "Remove deprecated method"

### DIFF
--- a/src/main/java/org/mockito/Answers.java
+++ b/src/main/java/org/mockito/Answers.java
@@ -87,6 +87,15 @@ public enum Answers implements Answer<Object>{
         this.implementation = implementation;
     }
 
+    /**
+     * @deprecated as of 2.0. Use the enum-constant directly, instead of this getter. This method will be removed in a future release<br>
+     * E.g. instead of <code>Answers.CALLS_REAL_METHODS.get()</code> use <code>Answers.CALLS_REAL_METHODS</code> .
+     */
+    @Deprecated
+    public Answer<Object> get() {
+        return this;
+    }
+
     public Object answer(InvocationOnMock invocation) throws Throwable {
         return implementation.answer(invocation);
     } 


### PR DESCRIPTION
Simple git revert for an accidental removal of a deprecated api since 2.0 instead of 1.X.

Fixes #482.