### PR TITLE
Code cov on releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,9 @@ branches:
 install:
  - true
 script:
-  - ./gradlew ciBuild release
+  - TRAVIS_MESSAGE="$(git log --format=%B -n 1)"
+  - ./gradlew ciBuild
+  - if [[ $TRAVIS_MESSAGE != *"[ci skip-release]"* ]] ; then ./gradlew release; fi
 after_success:
   - ./gradlew --stacktrace coverageReport && cp build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml jacoco.xml || echo "Code coverage failed"
   - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"

--- a/dummy-commit.txt
+++ b/dummy-commit.txt
@@ -1,1 +1,1 @@
-Change this if you need a dummy commit. Push build.
+Change this if you need a dummy commit. Push build

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -86,7 +86,7 @@ release {
 
 releaseSteps {
     String currentVersion = project.version //the version loaded when Gradle build has started
-    String buildInfo = "by Travis CI build $System.env.TRAVIS_BUILD_NUMBER [ci skip]"
+    String buildInfo = "by Travis CI build $System.env.TRAVIS_BUILD_NUMBER [ci skip-release]"
     MaskedArg pushTarget = new MaskedArg(value: "https://szczepiq:${System.env.GH_TOKEN}@github.com/mockito/mockito.git")
 
     step("ensure good chunk of recent commits is pulled for release notes automation") {


### PR DESCRIPTION
Releases are now triggering CI builds to generate the code coverage reports.
An example of a normal build can be found at https://travis-ci.org/mockito/mockito/builds/143765346#L334-L374
An example of a build ignored as the commit message contained `[ci skip-release]` can be found at https://travis-ci.org/mockito/mockito/builds/143765834#L311-L314

Fixes #465