### PR TITLE
Fixes #482 : Reintroduce `Answers.ANSWER.get()` method.

### DIFF
--- a/src/main/java/org/mockito/Answers.java
+++ b/src/main/java/org/mockito/Answers.java
@@ -5,11 +5,11 @@
 package org.mockito;
 
 import org.mockito.internal.stubbing.answers.CallsRealMethods;
-import org.mockito.internal.stubbing.defaultanswers.TriesToReturnSelf;
 import org.mockito.internal.stubbing.defaultanswers.GloballyConfiguredAnswer;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsDeepStubs;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsMocks;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsSmartNulls;
+import org.mockito.internal.stubbing.defaultanswers.TriesToReturnSelf;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -24,7 +24,7 @@ import org.mockito.stubbing.Answer;
  * </code></pre>
  * <b>This is not the full list</b> of Answers available in Mockito. Some interesting answers can be found in org.mockito.stubbing.answers package.
  */
-public enum Answers implements Answer<Object>{
+public enum Answers implements Answer<Object> {
     /**
      * The default configured answer of every mock.
      *
@@ -78,8 +78,7 @@ public enum Answers implements Answer<Object>{
      *
      * @see org.mockito.Mockito#RETURNS_SELF
      */
-    RETURNS_SELF(new TriesToReturnSelf())
-    ;
+    RETURNS_SELF(new TriesToReturnSelf());
 
     private final Answer<Object> implementation;
 
@@ -87,7 +86,16 @@ public enum Answers implements Answer<Object>{
         this.implementation = implementation;
     }
 
+    /**
+     * @deprecated Use the enum-constant directly, instead of this getter. This method will be removed in a future release<br>
+     * e.g. instead of <code>Answers.CALLS_REAL_METHODS.get()</code> use <code>Answers.CALLS_REAL_METHODS</code>.
+     */
+    @Deprecated
+    public Answer<Object> get() {
+        return this;
+    }
+
     public Object answer(InvocationOnMock invocation) throws Throwable {
         return implementation.answer(invocation);
-    } 
+    }
 }


### PR DESCRIPTION
Reintroduce `Answers.ANSWER.get()` method.

Fixes #482