### PR TITLE
Moves Reporter friendly exception factory to internal package

### DIFF
--- a/src/main/java/org/mockito/internal/InOrderImpl.java
+++ b/src/main/java/org/mockito/internal/InOrderImpl.java
@@ -17,7 +17,7 @@ import org.mockito.verification.VerificationMode;
 import org.mockito.verification.VerificationWrapper;
 import org.mockito.verification.VerificationWrapperInOrderWrapper;
 
-import static org.mockito.exceptions.Reporter.inOrderRequiresFamiliarMock;
+import static org.mockito.internal.exceptions.Reporter.inOrderRequiresFamiliarMock;
 
 import java.util.LinkedList;
 import java.util.List;

--- a/src/main/java/org/mockito/internal/MockitoCore.java
+++ b/src/main/java/org/mockito/internal/MockitoCore.java
@@ -4,15 +4,15 @@
  */
 package org.mockito.internal;
 
-import static org.mockito.exceptions.Reporter.missingMethodInvocation;
-import static org.mockito.exceptions.Reporter.mocksHaveToBePassedToVerifyNoMoreInteractions;
-import static org.mockito.exceptions.Reporter.mocksHaveToBePassedWhenCreatingInOrder;
-import static org.mockito.exceptions.Reporter.notAMockPassedToVerify;
-import static org.mockito.exceptions.Reporter.notAMockPassedToVerifyNoMoreInteractions;
-import static org.mockito.exceptions.Reporter.notAMockPassedWhenCreatingInOrder;
-import static org.mockito.exceptions.Reporter.nullPassedToVerify;
-import static org.mockito.exceptions.Reporter.nullPassedToVerifyNoMoreInteractions;
-import static org.mockito.exceptions.Reporter.nullPassedWhenCreatingInOrder;
+import static org.mockito.internal.exceptions.Reporter.missingMethodInvocation;
+import static org.mockito.internal.exceptions.Reporter.mocksHaveToBePassedToVerifyNoMoreInteractions;
+import static org.mockito.internal.exceptions.Reporter.mocksHaveToBePassedWhenCreatingInOrder;
+import static org.mockito.internal.exceptions.Reporter.notAMockPassedToVerify;
+import static org.mockito.internal.exceptions.Reporter.notAMockPassedToVerifyNoMoreInteractions;
+import static org.mockito.internal.exceptions.Reporter.notAMockPassedWhenCreatingInOrder;
+import static org.mockito.internal.exceptions.Reporter.nullPassedToVerify;
+import static org.mockito.internal.exceptions.Reporter.nullPassedToVerifyNoMoreInteractions;
+import static org.mockito.internal.exceptions.Reporter.nullPassedWhenCreatingInOrder;
 import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
 import static org.mockito.internal.verification.VerificationModeFactory.noMoreInteractions;
 

--- a/src/main/java/org/mockito/internal/configuration/DefaultAnnotationEngine.java
+++ b/src/main/java/org/mockito/internal/configuration/DefaultAnnotationEngine.java
@@ -10,7 +10,7 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.configuration.AnnotationEngine;
 import org.mockito.exceptions.base.MockitoException;
 
-import static org.mockito.exceptions.Reporter.moreThanOneAnnotationNotAllowed;
+import static org.mockito.internal.exceptions.Reporter.moreThanOneAnnotationNotAllowed;
 import static org.mockito.internal.util.reflection.FieldSetter.setField;
 
 import java.lang.annotation.Annotation;

--- a/src/main/java/org/mockito/internal/configuration/SpyAnnotationEngine.java
+++ b/src/main/java/org/mockito/internal/configuration/SpyAnnotationEngine.java
@@ -5,7 +5,7 @@
 package org.mockito.internal.configuration;
 
 import static org.mockito.Mockito.withSettings;
-import static org.mockito.exceptions.Reporter.unsupportedCombinationOfAnnotations;
+import static org.mockito.internal.exceptions.Reporter.unsupportedCombinationOfAnnotations;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;

--- a/src/main/java/org/mockito/internal/configuration/injection/ConstructorInjection.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/ConstructorInjection.java
@@ -10,7 +10,7 @@ import org.mockito.internal.util.reflection.FieldInitializationReport;
 import org.mockito.internal.util.reflection.FieldInitializer;
 import org.mockito.internal.util.reflection.FieldInitializer.ConstructorArgumentResolver;
 
-import static org.mockito.exceptions.Reporter.fieldInitialisationThrewException;
+import static org.mockito.internal.exceptions.Reporter.fieldInitialisationThrewException;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;

--- a/src/main/java/org/mockito/internal/configuration/injection/PropertyAndSetterInjection.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/PropertyAndSetterInjection.java
@@ -5,8 +5,8 @@
 
 package org.mockito.internal.configuration.injection;
 
-import static org.mockito.exceptions.Reporter.cannotInitializeForInjectMocksAnnotation;
-import static org.mockito.exceptions.Reporter.fieldInitialisationThrewException;
+import static org.mockito.internal.exceptions.Reporter.cannotInitializeForInjectMocksAnnotation;
+import static org.mockito.internal.exceptions.Reporter.fieldInitialisationThrewException;
 import static org.mockito.internal.util.collections.Sets.newMockSafeHashSet;
 
 import java.lang.reflect.Field;

--- a/src/main/java/org/mockito/internal/configuration/injection/filter/TerminalMockCandidateFilter.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/filter/TerminalMockCandidateFilter.java
@@ -4,14 +4,14 @@
  */
 package org.mockito.internal.configuration.injection.filter;
 
-import static org.mockito.exceptions.Reporter.cannotInjectDependency;
-import static org.mockito.internal.util.reflection.FieldSetter.setField;
+import org.mockito.internal.util.reflection.BeanPropertySetter;
 
 import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.List;
 
-import org.mockito.internal.util.reflection.BeanPropertySetter;
+import static org.mockito.internal.exceptions.Reporter.cannotInjectDependency;
+import static org.mockito.internal.util.reflection.FieldSetter.setField;
 
 /**
  * This node returns an actual injecter which will be either :

--- a/src/main/java/org/mockito/internal/configuration/injection/scanner/InjectMocksScanner.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/scanner/InjectMocksScanner.java
@@ -8,7 +8,7 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
-import static org.mockito.exceptions.Reporter.unsupportedCombinationOfAnnotations;
+import static org.mockito.internal.exceptions.Reporter.unsupportedCombinationOfAnnotations;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;

--- a/src/main/java/org/mockito/internal/creation/MockSettingsImpl.java
+++ b/src/main/java/org/mockito/internal/creation/MockSettingsImpl.java
@@ -6,7 +6,7 @@ package org.mockito.internal.creation;
 
 import org.mockito.MockSettings;
 
-import static org.mockito.exceptions.Reporter.*;
+import static org.mockito.internal.exceptions.Reporter.*;
 import org.mockito.internal.creation.settings.CreationSettings;
 import org.mockito.internal.debugging.VerboseMockInvocationLogger;
 import org.mockito.internal.util.MockCreationValidator;

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InterceptedInvocation.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InterceptedInvocation.java
@@ -10,7 +10,7 @@ import org.mockito.invocation.Invocation;
 import org.mockito.invocation.Location;
 import org.mockito.invocation.StubInfo;
 
-import static org.mockito.exceptions.Reporter.cannotCallAbstractRealMethod;
+import static org.mockito.internal.exceptions.Reporter.cannotCallAbstractRealMethod;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;

--- a/src/main/java/org/mockito/internal/exceptions/Reporter.java
+++ b/src/main/java/org/mockito/internal/exceptions/Reporter.java
@@ -3,11 +3,20 @@
  * This program is made available under the terms of the MIT License.
  */
 
-package org.mockito.exceptions;
+package org.mockito.internal.exceptions;
 
 import org.mockito.exceptions.base.MockitoAssertionError;
 import org.mockito.exceptions.base.MockitoException;
-import org.mockito.exceptions.misusing.*;
+import org.mockito.exceptions.misusing.CannotStubVoidMethodWithReturnValue;
+import org.mockito.exceptions.misusing.CannotVerifyStubOnlyMock;
+import org.mockito.exceptions.misusing.FriendlyReminderException;
+import org.mockito.exceptions.misusing.InvalidUseOfMatchersException;
+import org.mockito.exceptions.misusing.MissingMethodInvocationException;
+import org.mockito.exceptions.misusing.NotAMockException;
+import org.mockito.exceptions.misusing.NullInsteadOfMockException;
+import org.mockito.exceptions.misusing.UnfinishedStubbingException;
+import org.mockito.exceptions.misusing.UnfinishedVerificationException;
+import org.mockito.exceptions.misusing.WrongTypeOfReturnValue;
 import org.mockito.exceptions.verification.NeverWantedButInvoked;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockito.exceptions.verification.SmartNullPointerException;
@@ -16,8 +25,6 @@ import org.mockito.exceptions.verification.TooManyActualInvocations;
 import org.mockito.exceptions.verification.VerificationInOrderFailure;
 import org.mockito.exceptions.verification.WantedButNotInvoked;
 import org.mockito.internal.debugging.LocationImpl;
-import org.mockito.internal.exceptions.MockitoLimitations;
-import org.mockito.internal.exceptions.VerificationAwareInvocation;
 import org.mockito.internal.exceptions.util.ScenarioPrinter;
 import org.mockito.internal.junit.JUnitTool;
 import org.mockito.internal.matchers.LocalizedMatcher;
@@ -53,8 +60,9 @@ import static org.mockito.internal.util.StringJoiner.join;
  */
 public class Reporter {
 
-	private Reporter(){}
-	
+    private Reporter() {
+    }
+
     public static MockitoException checkedExceptionInvalid(Throwable t) {
         return new MockitoException(join(
                 "Checked exception is invalid for this method!",
@@ -300,12 +308,12 @@ public class Reporter {
 
     public static AssertionError argumentsAreDifferent(String wanted, String actual, Location actualLocation) {
         String message = join("Argument(s) are different! Wanted:",
-                wanted,
-                new LocationImpl(),
-                "Actual invocation has different arguments:",
-                actual,
-                actualLocation,
-                ""
+                              wanted,
+                              new LocationImpl(),
+                              "Actual invocation has different arguments:",
+                              actual,
+                              actualLocation,
+                              ""
         );
 
         return JUnitTool.createArgumentsAreDifferentException(message, wanted, actual);
@@ -323,9 +331,9 @@ public class Reporter {
             StringBuilder sb = new StringBuilder("\nHowever, there were other interactions with this mock:\n");
             for (DescribedInvocation i : invocations) {
                 sb.append(i.toString())
-                        .append("\n")
-                        .append(i.getLocation())
-                        .append("\n\n");
+                  .append("\n")
+                  .append(i.getLocation())
+                  .append("\n\n");
             }
             allInvocations = sb.toString();
         }
@@ -362,7 +370,7 @@ public class Reporter {
     }
 
     private static String createTooManyInvocationsMessage(int wantedCount, int actualCount, DescribedInvocation wanted,
-                                                   Location firstUndesired) {
+                                                          Location firstUndesired) {
         return join(
                 wanted.toString(),
                 "Wanted " + pluralize(wantedCount) + ":",
@@ -392,7 +400,7 @@ public class Reporter {
     }
 
     private static String createTooLittleInvocationsMessage(org.mockito.internal.reporting.Discrepancy discrepancy, DescribedInvocation wanted,
-                                                     Location lastActualInvocation) {
+                                                            Location lastActualInvocation) {
         String ending =
                 (lastActualInvocation != null) ? lastActualInvocation + "\n" : "\n";
 
@@ -612,47 +620,47 @@ public class Reporter {
 
     public static MockitoException moreThanOneAnnotationNotAllowed(String fieldName) {
         return new MockitoException("You cannot have more than one Mockito annotation on a field!\n" +
-                "The field '" + fieldName + "' has multiple Mockito annotations.\n" +
-                "For info how to use annotations see examples in javadoc for MockitoAnnotations class.");
+                                            "The field '" + fieldName + "' has multiple Mockito annotations.\n" +
+                                            "For info how to use annotations see examples in javadoc for MockitoAnnotations class.");
     }
 
     public static MockitoException unsupportedCombinationOfAnnotations(String undesiredAnnotationOne, String undesiredAnnotationTwo) {
         return new MockitoException("This combination of annotations is not permitted on a single field:\n" +
-                "@" + undesiredAnnotationOne + " and @" + undesiredAnnotationTwo);
+                                            "@" + undesiredAnnotationOne + " and @" + undesiredAnnotationTwo);
     }
 
     public static MockitoException cannotInitializeForSpyAnnotation(String fieldName, Exception details) {
         return new MockitoException(join("Cannot instantiate a @Spy for '" + fieldName + "' field.",
-                "You haven't provided the instance for spying at field declaration so I tried to construct the instance.",
-                "However, I failed because: " + details.getMessage(),
-                "Examples of correct usage of @Spy:",
-                "   @Spy List mock = new LinkedList();",
-                "   @Spy Foo foo; //only if Foo has parameterless constructor",
-                "   //also, don't forget about MockitoAnnotations.initMocks();",
-                ""), details);
+                                         "You haven't provided the instance for spying at field declaration so I tried to construct the instance.",
+                                         "However, I failed because: " + details.getMessage(),
+                                         "Examples of correct usage of @Spy:",
+                                         "   @Spy List mock = new LinkedList();",
+                                         "   @Spy Foo foo; //only if Foo has parameterless constructor",
+                                         "   //also, don't forget about MockitoAnnotations.initMocks();",
+                                         ""), details);
     }
 
     public static MockitoException cannotInitializeForInjectMocksAnnotation(String fieldName, Exception details) {
         return new MockitoException(join("Cannot instantiate @InjectMocks field named '" + fieldName + "'.",
-                "You haven't provided the instance at field declaration so I tried to construct the instance.",
-                "However, I failed because: " + details.getMessage(),
-                "Examples of correct usage of @InjectMocks:",
-                "   @InjectMocks Service service = new Service();",
-                "   @InjectMocks Service service;",
-                "   //also, don't forget about MockitoAnnotations.initMocks();",
-                "   //and... don't forget about some @Mocks for injection :)",
-                ""), details);
+                                         "You haven't provided the instance at field declaration so I tried to construct the instance.",
+                                         "However, I failed because: " + details.getMessage(),
+                                         "Examples of correct usage of @InjectMocks:",
+                                         "   @InjectMocks Service service = new Service();",
+                                         "   @InjectMocks Service service;",
+                                         "   //also, don't forget about MockitoAnnotations.initMocks();",
+                                         "   //and... don't forget about some @Mocks for injection :)",
+                                         ""), details);
     }
 
     public static MockitoException atMostAndNeverShouldNotBeUsedWithTimeout() {
         return new FriendlyReminderException(join("",
-                "Don't panic! I'm just a friendly reminder!",
-                "timeout() should not be used with atMost() or never() because...",
-                "...it does not make much sense - the test would have passed immediately in concurency",
-                "We kept this method only to avoid compilation errors when upgrading Mockito.",
-                "In future release we will remove timeout(x).atMost(y) from the API.",
-                "If you want to find out more please refer to issue 235",
-                ""));
+                                                  "Don't panic! I'm just a friendly reminder!",
+                                                  "timeout() should not be used with atMost() or never() because...",
+                                                  "...it does not make much sense - the test would have passed immediately in concurency",
+                                                  "We kept this method only to avoid compilation errors when upgrading Mockito.",
+                                                  "In future release we will remove timeout(x).atMost(y) from the API.",
+                                                  "If you want to find out more please refer to issue 235",
+                                                  ""));
     }
 
     public static MockitoException fieldInitialisationThrewException(Field field, Throwable details) {
@@ -713,23 +721,25 @@ public class Reporter {
     }
 
     public static MockitoException invalidArgumentRangeAtIdentityAnswerCreationTime() {
-        return new MockitoException(join("Invalid argument index.",
+        return new MockitoException(join(
+                "Invalid argument index.",
                 "The index need to be a positive number that indicates the position of the argument to return.",
                 "However it is possible to use the -1 value to indicates that the last argument should be",
                 "returned."));
     }
 
     public static MockitoException invalidArgumentPositionRangeAtInvocationTime(InvocationOnMock invocation, boolean willReturnLastParameter, int argumentIndex) {
-        return new MockitoException(
-                join("Invalid argument index for the current invocation of method : ",
-                        " -> " + safelyGetMockName(invocation.getMock()) + "." + invocation.getMethod().getName() + "()",
-                        "",
-                        (willReturnLastParameter ?
-                                "Last parameter wanted" :
-                                "Wanted parameter at position " + argumentIndex) + " but " + possibleArgumentTypesOf(invocation),
-                        "The index need to be a positive number that indicates a valid position of the argument in the invocation.",
-                        "However it is possible to use the -1 value to indicates that the last argument should be returned.",
-                        ""));
+        return new MockitoException(join(
+                "Invalid argument index for the current invocation of method : ",
+                " -> " + safelyGetMockName(invocation.getMock()) + "." + invocation.getMethod().getName() + "()",
+                "",
+                (willReturnLastParameter ?
+                        "Last parameter wanted" :
+                        "Wanted parameter at position " + argumentIndex) + " but " + possibleArgumentTypesOf(invocation),
+                "The index need to be a positive number that indicates a valid position of the argument in the invocation.",
+                "However it is possible to use the -1 value to indicates that the last argument should be returned.",
+                ""
+        ));
     }
 
     private static StringBuilder possibleArgumentTypesOf(InvocationOnMock invocation) {
@@ -814,12 +824,14 @@ public class Reporter {
     }
 
     public static MockitoException cannotCreateTimerWithNegativeDurationTime(long durationMillis) {
-        return new FriendlyReminderException(join("",
+        return new FriendlyReminderException(join(
+                "",
                 "Don't panic! I'm just a friendly reminder!",
                 "It is impossible for time to go backward, therefore...",
-                "You cannot put negative value of duration: (" +  durationMillis +  ")",
+                "You cannot put negative value of duration: (" + durationMillis + ")",
                 "as argument of timer methods (after(), timeout())",
-                ""));
+                ""
+        ));
     }
 
     public static MockitoException notAnException() {

--- a/src/main/java/org/mockito/internal/handler/InvocationNotifierHandler.java
+++ b/src/main/java/org/mockito/internal/handler/InvocationNotifierHandler.java
@@ -4,7 +4,7 @@
  */
 package org.mockito.internal.handler;
 
-import static org.mockito.exceptions.Reporter.invocationListenerThrewException;
+import static org.mockito.internal.exceptions.Reporter.invocationListenerThrewException;
 
 import java.util.List;
 import org.mockito.internal.InternalMockHandler;

--- a/src/main/java/org/mockito/internal/handler/MockHandlerImpl.java
+++ b/src/main/java/org/mockito/internal/handler/MockHandlerImpl.java
@@ -4,7 +4,7 @@
  */
 package org.mockito.internal.handler;
 
-import static org.mockito.exceptions.Reporter.stubPassedToVerify;
+import static org.mockito.internal.exceptions.Reporter.stubPassedToVerify;
 import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
 
 import java.util.List;

--- a/src/main/java/org/mockito/internal/invocation/InvocationImpl.java
+++ b/src/main/java/org/mockito/internal/invocation/InvocationImpl.java
@@ -10,7 +10,7 @@ import org.mockito.internal.invocation.realmethod.RealMethod;
 import org.mockito.internal.reporting.PrintSettings;
 import org.mockito.invocation.*;
 
-import static org.mockito.exceptions.Reporter.cannotCallAbstractRealMethod;
+import static org.mockito.internal.exceptions.Reporter.cannotCallAbstractRealMethod;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;

--- a/src/main/java/org/mockito/internal/invocation/MatchersBinder.java
+++ b/src/main/java/org/mockito/internal/invocation/MatchersBinder.java
@@ -6,7 +6,7 @@
 package org.mockito.internal.invocation;
 
 
-import static org.mockito.exceptions.Reporter.invalidUseOfMatchers;
+import static org.mockito.internal.exceptions.Reporter.invalidUseOfMatchers;
 
 import java.io.Serializable;
 import java.util.LinkedList;

--- a/src/main/java/org/mockito/internal/matchers/CapturingMatcher.java
+++ b/src/main/java/org/mockito/internal/matchers/CapturingMatcher.java
@@ -6,7 +6,7 @@ package org.mockito.internal.matchers;
 
 import org.mockito.ArgumentMatcher;
 
-import static org.mockito.exceptions.Reporter.noArgumentValueWasCaptured;
+import static org.mockito.internal.exceptions.Reporter.noArgumentValueWasCaptured;
 
 import java.io.Serializable;
 import java.util.LinkedList;

--- a/src/main/java/org/mockito/internal/progress/ArgumentMatcherStorageImpl.java
+++ b/src/main/java/org/mockito/internal/progress/ArgumentMatcherStorageImpl.java
@@ -11,9 +11,9 @@ import org.mockito.internal.matchers.LocalizedMatcher;
 import org.mockito.internal.matchers.Not;
 import org.mockito.internal.matchers.Or;
 
-import static org.mockito.exceptions.Reporter.incorrectUseOfAdditionalMatchers;
-import static org.mockito.exceptions.Reporter.misplacedArgumentMatcher;
-import static org.mockito.exceptions.Reporter.reportNoSubMatchersFound;
+import static org.mockito.internal.exceptions.Reporter.incorrectUseOfAdditionalMatchers;
+import static org.mockito.internal.exceptions.Reporter.misplacedArgumentMatcher;
+import static org.mockito.internal.exceptions.Reporter.reportNoSubMatchersFound;
 
 import java.util.*;
 

--- a/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
+++ b/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
@@ -5,8 +5,8 @@
 
 package org.mockito.internal.progress;
 
-import static org.mockito.exceptions.Reporter.unfinishedStubbing;
-import static org.mockito.exceptions.Reporter.unfinishedVerificationException;
+import static org.mockito.internal.exceptions.Reporter.unfinishedStubbing;
+import static org.mockito.internal.exceptions.Reporter.unfinishedVerificationException;
 
 import org.mockito.internal.configuration.GlobalConfiguration;
 import org.mockito.internal.debugging.Localized;

--- a/src/main/java/org/mockito/internal/stubbing/OngoingStubbingImpl.java
+++ b/src/main/java/org/mockito/internal/stubbing/OngoingStubbingImpl.java
@@ -8,7 +8,7 @@ import org.mockito.invocation.Invocation;
 import org.mockito.stubbing.Answer;
 import org.mockito.stubbing.OngoingStubbing;
 
-import static org.mockito.exceptions.Reporter.incorrectUseOfApi;
+import static org.mockito.internal.exceptions.Reporter.incorrectUseOfApi;
 
 import java.util.List;
 

--- a/src/main/java/org/mockito/internal/stubbing/StubberImpl.java
+++ b/src/main/java/org/mockito/internal/stubbing/StubberImpl.java
@@ -4,8 +4,8 @@
  */
 package org.mockito.internal.stubbing;
 
-import static org.mockito.exceptions.Reporter.notAMockPassedToWhenMethod;
-import static org.mockito.exceptions.Reporter.nullPassedToWhenMethod;
+import static org.mockito.internal.exceptions.Reporter.notAMockPassedToWhenMethod;
+import static org.mockito.internal.exceptions.Reporter.nullPassedToWhenMethod;
 
 import java.util.LinkedList;
 import java.util.List;

--- a/src/main/java/org/mockito/internal/stubbing/answers/AnswersValidator.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/AnswersValidator.java
@@ -4,14 +4,14 @@
  */
 package org.mockito.internal.stubbing.answers;
 
-import static org.mockito.exceptions.Reporter.cannotCallAbstractRealMethod;
-import static org.mockito.exceptions.Reporter.cannotStubVoidMethodWithAReturnValue;
-import static org.mockito.exceptions.Reporter.cannotStubWithNullThrowable;
-import static org.mockito.exceptions.Reporter.checkedExceptionInvalid;
-import static org.mockito.exceptions.Reporter.onlyVoidMethodsCanBeSetToDoNothing;
-import static org.mockito.exceptions.Reporter.wrongTypeOfArgumentToReturn;
-import static org.mockito.exceptions.Reporter.wrongTypeOfReturnValue;
-import static org.mockito.exceptions.Reporter.wrongTypeReturnedByDefaultAnswer;
+import static org.mockito.internal.exceptions.Reporter.cannotCallAbstractRealMethod;
+import static org.mockito.internal.exceptions.Reporter.cannotStubVoidMethodWithAReturnValue;
+import static org.mockito.internal.exceptions.Reporter.cannotStubWithNullThrowable;
+import static org.mockito.internal.exceptions.Reporter.checkedExceptionInvalid;
+import static org.mockito.internal.exceptions.Reporter.onlyVoidMethodsCanBeSetToDoNothing;
+import static org.mockito.internal.exceptions.Reporter.wrongTypeOfArgumentToReturn;
+import static org.mockito.internal.exceptions.Reporter.wrongTypeOfReturnValue;
+import static org.mockito.internal.exceptions.Reporter.wrongTypeReturnedByDefaultAnswer;
 
 import org.mockito.invocation.Invocation;
 import org.mockito.stubbing.Answer;

--- a/src/main/java/org/mockito/internal/stubbing/answers/ReturnsArgumentAt.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/ReturnsArgumentAt.java
@@ -7,8 +7,8 @@ package org.mockito.internal.stubbing.answers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import static org.mockito.exceptions.Reporter.invalidArgumentPositionRangeAtInvocationTime;
-import static org.mockito.exceptions.Reporter.invalidArgumentRangeAtIdentityAnswerCreationTime;
+import static org.mockito.internal.exceptions.Reporter.invalidArgumentPositionRangeAtInvocationTime;
+import static org.mockito.internal.exceptions.Reporter.invalidArgumentRangeAtIdentityAnswerCreationTime;
 
 import java.io.Serializable;
 

--- a/src/main/java/org/mockito/internal/stubbing/answers/ThrowsExceptionClass.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/ThrowsExceptionClass.java
@@ -10,7 +10,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.objenesis.ObjenesisHelper;
 
-import static org.mockito.exceptions.Reporter.notAnException;
+import static org.mockito.internal.exceptions.Reporter.notAnException;
 
 import java.io.Serializable;
 

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ForwardsInvocations.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ForwardsInvocations.java
@@ -4,8 +4,8 @@
  */
 package org.mockito.internal.stubbing.defaultanswers;
 
-import static org.mockito.exceptions.Reporter.delegatedMethodDoesNotExistOnDelegate;
-import static org.mockito.exceptions.Reporter.delegatedMethodHasWrongReturnType;
+import static org.mockito.internal.exceptions.Reporter.delegatedMethodDoesNotExistOnDelegate;
+import static org.mockito.internal.exceptions.Reporter.delegatedMethodHasWrongReturnType;
 
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNulls.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNulls.java
@@ -4,7 +4,7 @@
  */
 package org.mockito.internal.stubbing.defaultanswers;
 
-import static org.mockito.exceptions.Reporter.smartNullPointerException;
+import static org.mockito.internal.exceptions.Reporter.smartNullPointerException;
 
 import java.io.Serializable;
 import java.lang.reflect.Modifier;

--- a/src/main/java/org/mockito/internal/util/MockCreationValidator.java
+++ b/src/main/java/org/mockito/internal/util/MockCreationValidator.java
@@ -4,11 +4,11 @@
  */
 package org.mockito.internal.util;
 
-import static org.mockito.exceptions.Reporter.cannotMockClass;
-import static org.mockito.exceptions.Reporter.extraInterfacesCannotContainMockedType;
-import static org.mockito.exceptions.Reporter.mockedTypeIsInconsistentWithDelegatedInstanceType;
-import static org.mockito.exceptions.Reporter.mockedTypeIsInconsistentWithSpiedInstanceType;
-import static org.mockito.exceptions.Reporter.usingConstructorWithFancySerializable;
+import static org.mockito.internal.exceptions.Reporter.cannotMockClass;
+import static org.mockito.internal.exceptions.Reporter.extraInterfacesCannotContainMockedType;
+import static org.mockito.internal.exceptions.Reporter.mockedTypeIsInconsistentWithDelegatedInstanceType;
+import static org.mockito.internal.exceptions.Reporter.mockedTypeIsInconsistentWithSpiedInstanceType;
+import static org.mockito.internal.exceptions.Reporter.usingConstructorWithFancySerializable;
 
 import java.util.Collection;
 

--- a/src/main/java/org/mockito/internal/util/Timer.java
+++ b/src/main/java/org/mockito/internal/util/Timer.java
@@ -1,6 +1,6 @@
 package org.mockito.internal.util;
 
-import static org.mockito.exceptions.Reporter.cannotCreateTimerWithNegativeDurationTime;
+import static org.mockito.internal.exceptions.Reporter.cannotCreateTimerWithNegativeDurationTime;
 
 public class Timer {
 

--- a/src/main/java/org/mockito/internal/verification/AtMost.java
+++ b/src/main/java/org/mockito/internal/verification/AtMost.java
@@ -5,7 +5,7 @@
 
 package org.mockito.internal.verification;
 
-import static org.mockito.exceptions.Reporter.wantedAtMostX;
+import static org.mockito.internal.exceptions.Reporter.wantedAtMostX;
 import static org.mockito.internal.invocation.InvocationMarker.markVerified;
 import static org.mockito.internal.invocation.InvocationsFinder.findInvocations;
 

--- a/src/main/java/org/mockito/internal/verification/NoMoreInteractions.java
+++ b/src/main/java/org/mockito/internal/verification/NoMoreInteractions.java
@@ -5,8 +5,8 @@
 
 package org.mockito.internal.verification;
 
-import static org.mockito.exceptions.Reporter.noMoreInteractionsWanted;
-import static org.mockito.exceptions.Reporter.noMoreInteractionsWantedInOrder;
+import static org.mockito.internal.exceptions.Reporter.noMoreInteractionsWanted;
+import static org.mockito.internal.exceptions.Reporter.noMoreInteractionsWantedInOrder;
 import static org.mockito.internal.invocation.InvocationsFinder.findFirstUnverified;
 import static org.mockito.internal.invocation.InvocationsFinder.findFirstUnverifiedInOrder;
 

--- a/src/main/java/org/mockito/internal/verification/Only.java
+++ b/src/main/java/org/mockito/internal/verification/Only.java
@@ -4,8 +4,8 @@
  */
 package org.mockito.internal.verification;
 
-import static org.mockito.exceptions.Reporter.noMoreInteractionsWanted;
-import static org.mockito.exceptions.Reporter.wantedButNotInvoked;
+import static org.mockito.internal.exceptions.Reporter.noMoreInteractionsWanted;
+import static org.mockito.internal.exceptions.Reporter.wantedButNotInvoked;
 import static org.mockito.internal.invocation.InvocationMarker.markVerified;
 import static org.mockito.internal.invocation.InvocationsFinder.findFirstUnverified;
 import static org.mockito.internal.invocation.InvocationsFinder.findInvocations;

--- a/src/main/java/org/mockito/internal/verification/VerificationDataImpl.java
+++ b/src/main/java/org/mockito/internal/verification/VerificationDataImpl.java
@@ -10,7 +10,7 @@ import org.mockito.internal.util.ObjectMethodsGuru;
 import org.mockito.internal.verification.api.VerificationData;
 import org.mockito.invocation.Invocation;
 
-import static org.mockito.exceptions.Reporter.cannotVerifyToString;
+import static org.mockito.internal.exceptions.Reporter.cannotVerifyToString;
 
 import java.util.List;
 

--- a/src/main/java/org/mockito/internal/verification/checkers/AtLeastXNumberOfInvocationsChecker.java
+++ b/src/main/java/org/mockito/internal/verification/checkers/AtLeastXNumberOfInvocationsChecker.java
@@ -5,7 +5,7 @@
 
 package org.mockito.internal.verification.checkers;
 
-import static org.mockito.exceptions.Reporter.tooLittleActualInvocations;
+import static org.mockito.internal.exceptions.Reporter.tooLittleActualInvocations;
 import static org.mockito.internal.invocation.InvocationMarker.markVerified;
 import static org.mockito.internal.invocation.InvocationsFinder.findInvocations;
 import static org.mockito.internal.invocation.InvocationsFinder.getLastLocation;

--- a/src/main/java/org/mockito/internal/verification/checkers/AtLeastXNumberOfInvocationsInOrderChecker.java
+++ b/src/main/java/org/mockito/internal/verification/checkers/AtLeastXNumberOfInvocationsInOrderChecker.java
@@ -5,7 +5,7 @@
 
 package org.mockito.internal.verification.checkers;
 
-import static org.mockito.exceptions.Reporter.tooLittleActualInvocationsInOrder;
+import static org.mockito.internal.exceptions.Reporter.tooLittleActualInvocationsInOrder;
 import static org.mockito.internal.invocation.InvocationMarker.markVerifiedInOrder;
 import static org.mockito.internal.invocation.InvocationsFinder.findAllMatchingUnverifiedChunks;
 import static org.mockito.internal.invocation.InvocationsFinder.getLastLocation;

--- a/src/main/java/org/mockito/internal/verification/checkers/MissingInvocationChecker.java
+++ b/src/main/java/org/mockito/internal/verification/checkers/MissingInvocationChecker.java
@@ -5,8 +5,8 @@
 
 package org.mockito.internal.verification.checkers;
 
-import static org.mockito.exceptions.Reporter.argumentsAreDifferent;
-import static org.mockito.exceptions.Reporter.wantedButNotInvoked;
+import static org.mockito.internal.exceptions.Reporter.argumentsAreDifferent;
+import static org.mockito.internal.exceptions.Reporter.wantedButNotInvoked;
 import static org.mockito.internal.invocation.InvocationsFinder.findInvocations;
 import static org.mockito.internal.invocation.InvocationsFinder.findSimilarInvocation;
 

--- a/src/main/java/org/mockito/internal/verification/checkers/MissingInvocationInOrderChecker.java
+++ b/src/main/java/org/mockito/internal/verification/checkers/MissingInvocationInOrderChecker.java
@@ -5,7 +5,7 @@
 
 package org.mockito.internal.verification.checkers;
 
-import static org.mockito.exceptions.Reporter.wantedButNotInvokedInOrder;
+import static org.mockito.internal.exceptions.Reporter.wantedButNotInvokedInOrder;
 import static org.mockito.internal.invocation.InvocationsFinder.findAllMatchingUnverifiedChunks;
 import static org.mockito.internal.invocation.InvocationsFinder.findPreviousVerifiedInOrder;
 

--- a/src/main/java/org/mockito/internal/verification/checkers/NonGreedyNumberOfInvocationsInOrderChecker.java
+++ b/src/main/java/org/mockito/internal/verification/checkers/NonGreedyNumberOfInvocationsInOrderChecker.java
@@ -5,7 +5,7 @@
 
 package org.mockito.internal.verification.checkers;
 
-import static org.mockito.exceptions.Reporter.tooLittleActualInvocationsInOrder;
+import static org.mockito.internal.exceptions.Reporter.tooLittleActualInvocationsInOrder;
 import static org.mockito.internal.invocation.InvocationMarker.markVerified;
 import static org.mockito.internal.invocation.InvocationsFinder.findFirstMatchingUnverifiedInvocation;
 

--- a/src/main/java/org/mockito/internal/verification/checkers/NumberOfInvocationsChecker.java
+++ b/src/main/java/org/mockito/internal/verification/checkers/NumberOfInvocationsChecker.java
@@ -5,9 +5,9 @@
 
 package org.mockito.internal.verification.checkers;
 
-import static org.mockito.exceptions.Reporter.neverWantedButInvoked;
-import static org.mockito.exceptions.Reporter.tooLittleActualInvocations;
-import static org.mockito.exceptions.Reporter.tooManyActualInvocations;
+import static org.mockito.internal.exceptions.Reporter.neverWantedButInvoked;
+import static org.mockito.internal.exceptions.Reporter.tooLittleActualInvocations;
+import static org.mockito.internal.exceptions.Reporter.tooManyActualInvocations;
 import static org.mockito.internal.invocation.InvocationMarker.markVerified;
 import static org.mockito.internal.invocation.InvocationsFinder.findInvocations;
 import static org.mockito.internal.invocation.InvocationsFinder.getLastLocation;

--- a/src/main/java/org/mockito/internal/verification/checkers/NumberOfInvocationsInOrderChecker.java
+++ b/src/main/java/org/mockito/internal/verification/checkers/NumberOfInvocationsInOrderChecker.java
@@ -5,8 +5,8 @@
 
 package org.mockito.internal.verification.checkers;
 
-import static org.mockito.exceptions.Reporter.tooLittleActualInvocationsInOrder;
-import static org.mockito.exceptions.Reporter.tooManyActualInvocationsInOrder;
+import static org.mockito.internal.exceptions.Reporter.tooLittleActualInvocationsInOrder;
+import static org.mockito.internal.exceptions.Reporter.tooManyActualInvocationsInOrder;
 import static org.mockito.internal.invocation.InvocationMarker.markVerifiedInOrder;
 import static org.mockito.internal.invocation.InvocationsFinder.findMatchingChunk;
 import static org.mockito.internal.invocation.InvocationsFinder.getLastLocation;

--- a/src/main/java/org/mockito/verification/Timeout.java
+++ b/src/main/java/org/mockito/verification/Timeout.java
@@ -4,7 +4,7 @@
  */
 package org.mockito.verification;
 
-import static org.mockito.exceptions.Reporter.atMostAndNeverShouldNotBeUsedWithTimeout;
+import static org.mockito.internal.exceptions.Reporter.atMostAndNeverShouldNotBeUsedWithTimeout;
 
 import org.mockito.internal.util.Timer;
 import org.mockito.internal.verification.VerificationModeFactory;

--- a/src/test/java/org/concurrentmockito/ThreadsRunAllTestsHalfManualTest.java
+++ b/src/test/java/org/concurrentmockito/ThreadsRunAllTestsHalfManualTest.java
@@ -9,7 +9,7 @@ import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
 import org.mockito.MockitoTest;
-import org.mockito.exceptions.ReporterTest;
+import org.mockito.internal.exceptions.ReporterTest;
 import org.mockito.exceptions.base.MockitoAssertionErrorTest;
 import org.mockito.exceptions.base.MockitoExceptionTest;
 import org.mockito.internal.AllInvocationsFinderTest;

--- a/src/test/java/org/mockito/internal/exceptions/ReporterTest.java
+++ b/src/test/java/org/mockito/internal/exceptions/ReporterTest.java
@@ -3,7 +3,7 @@
  * This program is made available under the terms of the MIT License.
  */
 
-package org.mockito.exceptions;
+package org.mockito.internal.exceptions;
 
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -11,7 +11,6 @@ import org.mockito.exceptions.base.MockitoException;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockito.exceptions.verification.TooLittleActualInvocations;
 import org.mockito.exceptions.verification.VerificationInOrderFailure;
-import org.mockito.internal.exceptions.VerificationAwareInvocation;
 import org.mockito.internal.invocation.InvocationBuilder;
 import org.mockito.internal.stubbing.answers.Returns;
 import org.mockito.invocation.Invocation;


### PR DESCRIPTION
The `Reporter` friendly exception factory class lies in `org.mockito.exceptions.Reporter`, however it's API is subject to change without really impacting user experience.

Thus, I propose to move `org.mockito.exceptions.Reporter` to `org.mockito.internal.exceptions.Reporter`.

I didn't provided a dummy class for two reasons :

1. I would like to schedule this for Mockito 2 a major version
2. This class shouldn't be used outside framework development