### PR TITLE
Fix some warnings

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyCrossClassLoaderSerializationSupport.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyCrossClassLoaderSerializationSupport.java
@@ -26,7 +26,6 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.mockito.Incubating;
 import org.mockito.exceptions.base.MockitoSerializationIssue;
 import org.mockito.internal.configuration.plugins.Plugins;
-import org.mockito.internal.creation.bytebuddy.MockMethodInterceptor.ForWriteReplace;
 import org.mockito.internal.util.MockUtil;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.mock.MockName;

--- a/src/main/java/org/mockito/internal/runners/StrictRunner.java
+++ b/src/main/java/org/mockito/internal/runners/StrictRunner.java
@@ -5,9 +5,7 @@ import org.junit.runner.manipulation.Filter;
 import org.junit.runner.manipulation.NoTestsRemainException;
 import org.junit.runner.notification.RunNotifier;
 import org.mockito.Mockito;
-import org.mockito.MockitoFramework;
 import org.mockito.internal.runners.util.FailureDetecter;
-import org.mockito.internal.runners.util.FrameworkUsageValidator;
 
 /**
  * Created by sfaber on 7/22/16.

--- a/src/main/java/org/mockito/internal/runners/util/FailureDetecter.java
+++ b/src/main/java/org/mockito/internal/runners/util/FailureDetecter.java
@@ -6,7 +6,6 @@ package org.mockito.internal.runners.util;
 
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunListener;
-import org.junit.runner.notification.RunNotifier;
 
 /**
  * Implementation of JUnit run listener that knows when any of the tests failed

--- a/src/test/java/org/mockito/internal/InvalidStateDetectionTest.java
+++ b/src/test/java/org/mockito/internal/InvalidStateDetectionTest.java
@@ -17,7 +17,6 @@ import org.mockitoutil.TestBase;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.fail;
-import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.*;
 
 /**

--- a/src/test/java/org/mockito/internal/creation/DelegatingMethodTest.java
+++ b/src/test/java/org/mockito/internal/creation/DelegatingMethodTest.java
@@ -50,8 +50,8 @@ public class DelegatingMethodTest extends TestBase {
 
     private interface Something {
 
-        public Object someMethod(Object param);
+        Object someMethod(Object param);
 
-        public Object otherMethod(Object param);
+        Object otherMethod(Object param);
     }
 }

--- a/src/test/java/org/mockito/internal/creation/bytebuddy/CachingMockBytecodeGeneratorTest.java
+++ b/src/test/java/org/mockito/internal/creation/bytebuddy/CachingMockBytecodeGeneratorTest.java
@@ -128,7 +128,7 @@ public class CachingMockBytecodeGeneratorTest {
             if (inputArgument.contains("-XX:+DisableExplicitGC")) {
                 return false;
             }
-        };
+        }
         return true;
     }
 

--- a/src/test/java/org/mockito/internal/hamcrest/MatcherGenericTypeExtractorTest.java
+++ b/src/test/java/org/mockito/internal/hamcrest/MatcherGenericTypeExtractorTest.java
@@ -75,7 +75,7 @@ public class MatcherGenericTypeExtractorTest extends TestBase {
         public void describeTo(Description description) {}
     }
 
-    private static interface IMatcher extends Matcher<Integer> {}
+    private interface IMatcher extends Matcher<Integer> {}
 
     //non-generic matcher implementing the interface
     private static class SubclassGenericMatcherFromInterface extends BaseMatcher<Integer> implements Serializable, Cloneable, IMatcher {

--- a/src/test/java/org/mockito/internal/stubbing/InvocationContainerImplStubbingTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/InvocationContainerImplStubbingTest.java
@@ -125,5 +125,5 @@ public class InvocationContainerImplStubbingTest extends TestBase {
     }
 
     @SuppressWarnings("serial")
-    class MyException extends RuntimeException {};
+    class MyException extends RuntimeException {}
 }

--- a/src/test/java/org/mockito/internal/util/reflection/LenientCopyToolTest.java
+++ b/src/test/java/org/mockito/internal/util/reflection/LenientCopyToolTest.java
@@ -12,8 +12,6 @@ import java.util.LinkedList;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertFalse;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.*;
 
 @SuppressWarnings("unchecked")

--- a/src/test/java/org/mockitousage/CompilationWarningsTest.java
+++ b/src/test/java/org/mockitousage/CompilationWarningsTest.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import static org.mockito.BDDMockito.doAnswer;
 import static org.mockito.BDDMockito.*;
 
 

--- a/src/test/java/org/mockitousage/PlaygroundWithDemoOfUnclonedParametersProblemTest.java
+++ b/src/test/java/org/mockitousage/PlaygroundWithDemoOfUnclonedParametersProblemTest.java
@@ -134,7 +134,7 @@ public class PlaygroundWithDemoOfUnclonedParametersProblemTest extends TestBase 
     }
 
     private interface ImportLogDao {
-        public boolean anyImportRunningOrRunnedToday(int importType, Date currentDate);
+        boolean anyImportRunningOrRunnedToday(int importType, Date currentDate);
 
         void include(ImportLogBean importLogBean);
 

--- a/src/test/java/org/mockitousage/annotation/CaptorAnnotationBasicTest.java
+++ b/src/test/java/org/mockitousage/annotation/CaptorAnnotationBasicTest.java
@@ -41,7 +41,7 @@ public class CaptorAnnotationBasicTest extends TestBase {
     }
 
     public interface PeopleRepository {
-        public void save(Person capture);
+        void save(Person capture);
     }
     
     @Mock PeopleRepository peopleRepository;           

--- a/src/test/java/org/mockitousage/basicapi/MocksCreationTest.java
+++ b/src/test/java/org/mockitousage/basicapi/MocksCreationTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.*;
 @SuppressWarnings("unchecked")
 public class MocksCreationTest extends TestBase {
 
-    private class HasPrivateConstructor {};
+    private class HasPrivateConstructor {}
     
     @Test
     public void shouldCreateMockWhenConstructorIsPrivate() {

--- a/src/test/java/org/mockitousage/basicapi/MocksSerializationForAnnotationTest.java
+++ b/src/test/java/org/mockitousage/basicapi/MocksSerializationForAnnotationTest.java
@@ -25,8 +25,6 @@ import java.util.List;
 import java.util.Observable;
 
 import static junit.framework.TestCase.*;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 import static org.mockitoutil.SimpleSerializationUtil.*;
 

--- a/src/test/java/org/mockitousage/basicapi/MocksSerializationTest.java
+++ b/src/test/java/org/mockitousage/basicapi/MocksSerializationTest.java
@@ -27,7 +27,6 @@ import java.util.Observable;
 
 import static junit.framework.TestCase.*;
 import static org.junit.Assume.assumeFalse;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 import static org.mockitoutil.SimpleSerializationUtil.*;
 

--- a/src/test/java/org/mockitousage/basicapi/ResetTest.java
+++ b/src/test/java/org/mockitousage/basicapi/ResetTest.java
@@ -13,7 +13,6 @@ import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
 import static junit.framework.TestCase.*;
-import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.*;
 
 public class ResetTest extends TestBase {

--- a/src/test/java/org/mockitousage/basicapi/UsingVarargsTest.java
+++ b/src/test/java/org/mockitousage/basicapi/UsingVarargsTest.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.fail;
-import static org.mockito.Matchers.anyVararg;
 import static org.mockito.Mockito.*;
 
 public class UsingVarargsTest extends TestBase {

--- a/src/test/java/org/mockitousage/bugs/AIOOBExceptionWithAtLeastTest.java
+++ b/src/test/java/org/mockitousage/bugs/AIOOBExceptionWithAtLeastTest.java
@@ -8,8 +8,6 @@ package org.mockitousage.bugs;
 import org.junit.Test;
 import org.mockitoutil.TestBase;
 
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 
 //see bug 116

--- a/src/test/java/org/mockitousage/bugs/ActualInvocationHasNullArgumentNPEBugTest.java
+++ b/src/test/java/org/mockitousage/bugs/ActualInvocationHasNullArgumentNPEBugTest.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 import org.mockitoutil.TestBase;
 
 import static junit.framework.TestCase.fail;
-import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.*;
 
 public class ActualInvocationHasNullArgumentNPEBugTest extends TestBase {

--- a/src/test/java/org/mockitousage/bugs/ConcurrentModificationExceptionOnMultiThreadedVerificationTest.java
+++ b/src/test/java/org/mockitousage/bugs/ConcurrentModificationExceptionOnMultiThreadedVerificationTest.java
@@ -79,7 +79,7 @@ public class ConcurrentModificationExceptionOnMultiThreadedVerificationTest {
     }
     
     public interface ITarget {
-        public String targetMethod(String arg);
+        String targetMethod(String arg);
     }
     
 }

--- a/src/test/java/org/mockitousage/bugs/InheritedGenericsPolimorphicCallTest.java
+++ b/src/test/java/org/mockitousage/bugs/InheritedGenericsPolimorphicCallTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.verify;
 public class InheritedGenericsPolimorphicCallTest extends TestBase {
 
     protected interface MyIterable<T> extends Iterable<T> {
-        public MyIterator<T> iterator();
+        MyIterator<T> iterator();
     }
 
     protected interface MyIterator<T> extends Iterator<T> {

--- a/src/test/java/org/mockitousage/bugs/MultithreadedStubbingHalfManualTest.java
+++ b/src/test/java/org/mockitousage/bugs/MultithreadedStubbingHalfManualTest.java
@@ -26,9 +26,9 @@ public class MultithreadedStubbingHalfManualTest {
      * Class with two methods, one of them is repeatedly mocked while another is repeatedly called.
      */
     public interface ToMock {
-        public Integer getValue(Integer param);
+        Integer getValue(Integer param);
 
-        public List<Integer> getValues(Integer param);
+        List<Integer> getValues(Integer param);
     }
 
     /**

--- a/src/test/java/org/mockitousage/bugs/varargs/VarargsNotPlayingWithAnyObjectTest.java
+++ b/src/test/java/org/mockitousage/bugs/varargs/VarargsNotPlayingWithAnyObjectTest.java
@@ -11,10 +11,6 @@ import org.mockitoutil.TestBase;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.fail;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.anyVararg;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
 //see issue 62

--- a/src/test/java/org/mockitousage/examples/use/ExampleTest.java
+++ b/src/test/java/org/mockitousage/examples/use/ExampleTest.java
@@ -15,8 +15,6 @@ import org.mockitoutil.TestBase;
 
 import java.util.Arrays;
 
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/org/mockitousage/matchers/CapturingArgumentsTest.java
+++ b/src/test/java/org/mockitousage/matchers/CapturingArgumentsTest.java
@@ -17,8 +17,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static junit.framework.TestCase.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
 public class CapturingArgumentsTest extends TestBase {

--- a/src/test/java/org/mockitousage/matchers/MatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/MatchersTest.java
@@ -21,25 +21,7 @@ import java.util.List;
 import static junit.framework.TestCase.*;
 import static org.mockito.AdditionalMatchers.*;
 import static org.mockito.AdditionalMatchers.eq;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyByte;
-import static org.mockito.Matchers.anyChar;
-import static org.mockito.Matchers.anyDouble;
-import static org.mockito.Matchers.anyFloat;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyShort;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
-import static org.mockito.Matchers.isNotNull;
-import static org.mockito.Matchers.isNull;
-import static org.mockito.Matchers.matches;
-import static org.mockito.Matchers.notNull;
-import static org.mockito.Matchers.same;
-import static org.mockito.Matchers.startsWith;
 import static org.mockito.Mockito.*;
 
 

--- a/src/test/java/org/mockitousage/matchers/NewMatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/NewMatchersTest.java
@@ -15,10 +15,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 
 import static junit.framework.TestCase.assertEquals;
-import static org.mockito.Matchers.anyCollection;
-import static org.mockito.Matchers.anyList;
-import static org.mockito.Matchers.anyMap;
-import static org.mockito.Matchers.anySet;
 import static org.mockito.Mockito.*;
 
 @SuppressWarnings("unchecked")

--- a/src/test/java/org/mockitousage/matchers/VerificationAndStubbingUsingMatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/VerificationAndStubbingUsingMatchersTest.java
@@ -13,10 +13,6 @@ import org.mockitoutil.TestBase;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.fail;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.startsWith;
 import static org.mockito.Mockito.*;
 
 public class VerificationAndStubbingUsingMatchersTest extends TestBase {

--- a/src/test/java/org/mockitousage/misuse/DetectingMisusedMatchersTest.java
+++ b/src/test/java/org/mockitousage/misuse/DetectingMisusedMatchersTest.java
@@ -15,9 +15,6 @@ import org.mockitoutil.TestBase;
 import java.util.Observer;
 
 import static junit.framework.TestCase.fail;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.*;
 
 public class DetectingMisusedMatchersTest extends TestBase {

--- a/src/test/java/org/mockitousage/packageprotected/MockingPackageProtectedTest.java
+++ b/src/test/java/org/mockitousage/packageprotected/MockingPackageProtectedTest.java
@@ -12,9 +12,9 @@ import static org.mockito.Mockito.mock;
 
 public class MockingPackageProtectedTest extends TestBase {
 
-    static class Foo {};
+    static class Foo {}
     
-    class Bar {};
+    class Bar {}
     
     @Test
     public void shouldMockPackageProtectedClasses() {

--- a/src/test/java/org/mockitousage/spies/SpyingOnRealObjectsTest.java
+++ b/src/test/java/org/mockitousage/spies/SpyingOnRealObjectsTest.java
@@ -19,7 +19,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 import static junit.framework.TestCase.*;
-import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.*;
 
 public class SpyingOnRealObjectsTest extends TestBase {

--- a/src/test/java/org/mockitousage/stacktrace/ClickableStackTracesWhenFrameworkMisusedTest.java
+++ b/src/test/java/org/mockitousage/stacktrace/ClickableStackTracesWhenFrameworkMisusedTest.java
@@ -15,7 +15,6 @@ import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
 import static junit.framework.TestCase.fail;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 
 public class ClickableStackTracesWhenFrameworkMisusedTest extends TestBase {

--- a/src/test/java/org/mockitousage/stacktrace/ModellingDescriptiveMessagesTest.java
+++ b/src/test/java/org/mockitousage/stacktrace/ModellingDescriptiveMessagesTest.java
@@ -19,7 +19,6 @@ import org.mockitoutil.TestBase;
 import java.util.LinkedList;
 import java.util.List;
 
-import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.*;
 
 @Ignore

--- a/src/test/java/org/mockitousage/stacktrace/PointingStackTraceToActualInvocationChunkInOrderTest.java
+++ b/src/test/java/org/mockitousage/stacktrace/PointingStackTraceToActualInvocationChunkInOrderTest.java
@@ -16,7 +16,6 @@ import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
 import static junit.framework.TestCase.fail;
-import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/org/mockitousage/stacktrace/PointingStackTraceToActualInvocationInOrderTest.java
+++ b/src/test/java/org/mockitousage/stacktrace/PointingStackTraceToActualInvocationInOrderTest.java
@@ -16,7 +16,6 @@ import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
 import static junit.framework.TestCase.fail;
-import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.*;
 
 //This is required to make sure stack trace is well filtered when runner is ON

--- a/src/test/java/org/mockitousage/stubbing/BasicStubbingTest.java
+++ b/src/test/java/org/mockitousage/stubbing/BasicStubbingTest.java
@@ -15,7 +15,6 @@ import org.mockitoutil.TestBase;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.fail;
-import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.*;
 
 public class BasicStubbingTest extends TestBase {

--- a/src/test/java/org/mockitousage/stubbing/CallingRealMethodTest.java
+++ b/src/test/java/org/mockitousage/stubbing/CallingRealMethodTest.java
@@ -10,7 +10,6 @@ import org.mockito.Mock;
 import org.mockitoutil.TestBase;
 
 import static junit.framework.TestCase.assertEquals;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 
 public class CallingRealMethodTest extends TestBase {

--- a/src/test/java/org/mockitousage/stubbing/DeepStubbingTest.java
+++ b/src/test/java/org/mockitousage/stubbing/DeepStubbingTest.java
@@ -18,9 +18,6 @@ import java.util.Locale;
 
 import static junit.framework.TestCase.*;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
 

--- a/src/test/java/org/mockitousage/stubbing/StubbingUsingDoReturnTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingUsingDoReturnTest.java
@@ -20,8 +20,6 @@ import org.mockitoutil.TestBase;
 import java.io.IOException;
 
 import static junit.framework.TestCase.fail;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
 @SuppressWarnings("serial")

--- a/src/test/java/org/mockitousage/stubbing/StubbingWithAdditionalAnswersTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingWithAdditionalAnswersTest.java
@@ -14,7 +14,6 @@ import org.mockitousage.IMethods;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.AdditionalAnswers.*;
 import static org.mockito.BDDMockito.*;
-import static org.mockito.Matchers.anyVararg;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StubbingWithAdditionalAnswersTest {

--- a/src/test/java/org/mockitousage/stubbing/StubbingWithCustomAnswerTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingWithCustomAnswerTest.java
@@ -15,7 +15,6 @@ import java.lang.reflect.Method;
 import java.util.Set;
 
 import static junit.framework.TestCase.*;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 
 public class StubbingWithCustomAnswerTest extends TestBase {

--- a/src/test/java/org/mockitousage/verification/AtLeastXVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/AtLeastXVerificationTest.java
@@ -13,7 +13,6 @@ import org.mockitoutil.TestBase;
 import java.util.List;
 
 import static junit.framework.TestCase.fail;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 
 public class AtLeastXVerificationTest extends TestBase {

--- a/src/test/java/org/mockitousage/verification/AtMostXVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/AtMostXVerificationTest.java
@@ -17,7 +17,6 @@ import java.util.List;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.fail;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 
 public class AtMostXVerificationTest extends TestBase {

--- a/src/test/java/org/mockitousage/verification/DescriptiveMessagesOnVerificationInOrderErrorsTest.java
+++ b/src/test/java/org/mockitousage/verification/DescriptiveMessagesOnVerificationInOrderErrorsTest.java
@@ -15,7 +15,6 @@ import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
 import static junit.framework.TestCase.fail;
-import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.*;
 
 public class DescriptiveMessagesOnVerificationInOrderErrorsTest extends TestBase {

--- a/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
+++ b/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
@@ -19,9 +19,6 @@ import org.mockitoutil.TestBase;
 
 import static junit.framework.TestCase.fail;
 import static org.mockito.AdditionalMatchers.aryEq;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.matches;
 import static org.mockito.Mockito.*;
 
 public class DescriptiveMessagesWhenVerificationFailsTest extends TestBase {

--- a/src/test/java/org/mockitousage/verification/VerificationExcludingStubsTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationExcludingStubsTest.java
@@ -34,7 +34,7 @@ public class VerificationExcludingStubsTest extends TestBase {
         verify(mock).objectArgMethod("foo");
 
         //verifyNoMoreInteractions fails:
-        try { verifyNoMoreInteractions(mock); fail(); } catch (NoInteractionsWanted e) {};
+        try { verifyNoMoreInteractions(mock); fail(); } catch (NoInteractionsWanted e) {}
         
         //but it works when stubs are ignored:
         ignoreStubs(mock);

--- a/src/test/java/org/mockitousage/verification/VerificationInOrderTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationInOrderTest.java
@@ -14,7 +14,6 @@ import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
 import static junit.framework.TestCase.fail;
-import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.*;
 
 public class VerificationInOrderTest extends TestBase {

--- a/src/test/java/org/mockitousage/verification/VerificationOnMultipleMocksUsingMatchersTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationOnMultipleMocksUsingMatchersTest.java
@@ -14,9 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
 @SuppressWarnings("unchecked")

--- a/src/test/java/org/mockitoutil/JUnitResultAssert.java
+++ b/src/test/java/org/mockitoutil/JUnitResultAssert.java
@@ -2,7 +2,6 @@ package org.mockitoutil;
 
 import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
-import org.mockito.exceptions.misusing.UnnecessaryStubbingException;
 
 import java.util.List;
 

--- a/src/test/java/org/mockitoutil/TestBase.java
+++ b/src/test/java/org/mockitoutil/TestBase.java
@@ -26,7 +26,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Collection;
-import java.util.regex.Pattern;
 
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;

--- a/subprojects/testng/src/test/java/org/mockitousage/testng/InitializeChildTestWhenParentHasListenerTest.java
+++ b/subprojects/testng/src/test/java/org/mockitousage/testng/InitializeChildTestWhenParentHasListenerTest.java
@@ -6,7 +6,6 @@ import org.testng.annotations.Test;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.fail;
 
 public class InitializeChildTestWhenParentHasListenerTest extends ParentTest {
 


### PR DESCRIPTION
Fixed various warnings, mostly unused imports, but also a couple of unnecessary semicolons and interface modifiers.

`./gradlew build` built successfully.