### PR TITLE
Make ciBuild depends also on subprojects state

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,8 @@ task wrapper(type: Wrapper) {
 
 task ciBuild {
     //validate the state of the project
-    dependsOn build, publishToMavenLocal, tasks.idea, tasks.eclipse
+    dependsOn { allprojects*.build }
+    dependsOn publishToMavenLocal, tasks.idea, tasks.eclipse
 }
 
 //Making sure that release task is only invoked after the entire ciBuild validation

--- a/subprojects/extTest/extTest.gradle
+++ b/subprojects/extTest/extTest.gradle
@@ -6,6 +6,7 @@ dependencies {
     testCompile project(path: ':', configuration: 'testUtil')
 
     testCompile ("junit:junit:4.12")
+    testCompile 'org.assertj:assertj-core:1.7.1'
 }
 
 configurations.all {

--- a/subprojects/extTest/src/test/java/org/mockitousage/plugins/stacktrace/PluginStackTraceFilteringTest.java
+++ b/subprojects/extTest/src/test/java/org/mockitousage/plugins/stacktrace/PluginStackTraceFilteringTest.java
@@ -14,6 +14,7 @@ import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
 import static junit.framework.TestCase.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 
 public class PluginStackTraceFilteringTest extends TestBase {
@@ -38,8 +39,9 @@ public class PluginStackTraceFilteringTest extends TestBase {
             fail();
         } catch (WantedButNotInvoked e) {
             String trace = getStackTrace(e);
-            assertContains("verifyMock_x", trace);
-            assertNotContains("verify_excludeMe_x", trace);
+            assertThat(trace)
+                    .contains("verifyMock_x")
+                    .doesNotContain("verify_excludeMe_x");
         }
     }
 
@@ -51,8 +53,9 @@ public class PluginStackTraceFilteringTest extends TestBase {
             fail();
         } catch (WantedButNotInvoked e) {
             String trace = getStackTrace(e);
-            assertContains("verifyMock_x", trace);
-            assertContains("verify_excludeMe_x", trace);
+            assertThat(trace)
+                    .contains("verifyMock_x")
+                    .contains("verify_excludeMe_x");
         }
     }
 

--- a/subprojects/testng/src/main/java/org/mockito/testng/MockitoBeforeTestNGMethod.java
+++ b/subprojects/testng/src/main/java/org/mockito/testng/MockitoBeforeTestNGMethod.java
@@ -15,7 +15,7 @@ import static org.mockito.internal.util.reflection.Fields.annotatedBy;
 
 public class MockitoBeforeTestNGMethod {
 
-    private final WeakHashMap<Object, Boolean> initializedInstances = new WeakHashMap<>();
+    private final WeakHashMap<Object, Boolean> initializedInstances = new WeakHashMap<Object, Boolean>();
 
     /**
      * Initialize mocks.

--- a/subprojects/testng/testng.gradle
+++ b/subprojects/testng/testng.gradle
@@ -46,7 +46,7 @@ uploadArchives {
 dependencies {
     compile project.rootProject
     compile 'org.testng:testng:6.3.1'
-    testCompile 'org.assertj:assertj-core:2.1.0'
+    testCompile 'org.assertj:assertj-core:1.7.1'
 }
 
 test {


### PR DESCRIPTION
Before those changes CI build was silently ignoring compilation erros in Mockito submodules. Because of that `gw check` was failing locally (e.g. due to missing `assertNotContainsError()`).

In addition to enable building those modules (I don't know what are the plans about testng module by the way) I fixed Java 6 compatibility in them.