### PR TITLE
Verify build on Travis also with Java 7 and 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,21 @@ before_install:
 jdk:
   - openjdk6
 
+matrix:
+  include:
+  - jdk: openjdk7
+    env: SKIP_RELEASE=true
+  - jdk: oraclejdk8
+    env: SKIP_RELEASE=true
+
 env:
-  matrix:
-  - TERM=dumb
   global:
+  - TERM=dumb
   - GRADLE_OPTS="-XX:+UseCompressedOops -Djava.awt.headless=true"
   - secure: ZjU6SpkLzTAJr9qmxKDSI0uA8eJ/r5n58/equD6ifDlCBUasxPxOwaIARuNjhH45UCFOQDO9HMmvD7IWufyYl0OpACMM6MZ/0JX5Qsd+vhmBGirl6H3rRbVpvyoSI1J2xqJXy9/yTU54IYMDv3R7suinvmKXYHCqJ3h7ke+m4Ik=
   - secure: SDwSEK8W+GU78fVLi+P0k+v5eYK1fevz1Z0Htsjta2PRr0DicL6CMTNLxi48c3vXT+GHL6W8uojmfRwnHd8yyRZu2nW4Hda5rWB3de6Nz64lOZFYUbvoZfj9TdCgDYn+u2jUkm6+C76ZlPtfQhS97uZCb9iCDSdm1JErpng5e6g=
   - secure: aRk3elhhgDvXc2RyKAOcn9UF4w5U2zgFqUEEwdZ/r5DLrlKlA0aDE3pBZhST479nHIVEjF3w/SjePmfc9K/JPp2cLE12qHBT5mp4F2MZhNkBDay4vsXLwkhWsyQLz85VrvR/QkeCbLXSQBCZsy/KI8PwwMIrcEH6rAoo+1MYTos=
+
 branches:
   except:
   - /^v\d/

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -57,8 +57,9 @@ task("releaseNeeded") {
     doLast {
         def branch = System.env.TRAVIS_BRANCH
         def pr = System.env.TRAVIS_PULL_REQUEST
-        ext.needed = dryRun || (pr == 'false' && branch == 'master' && !comparePublications.publicationsEqual)
-        logger.lifecycle("Release needed: {}, branch: {}, pull request: {}, dry run: {}, publications equal: {}.", needed, branch, pr, dryRun, comparePublications.publicationsEqual)
+        def skipped = System.env.SKIP_RELEASE
+        ext.needed = dryRun || (pr == 'false' && branch == 'master' && !comparePublications.publicationsEqual && skipped != 'true')
+        logger.lifecycle("Release needed: {}, branch: {}, pull request: {}, dry run: {}, publications equal: {}, skipped: {}.", needed, branch, pr, dryRun, comparePublications.publicationsEqual, skipped)
     }
 }
 


### PR DESCRIPTION
In addition to building with Java 6, Java 7 and 8 builds were added to verify compatibility with newest Java versions. Release task was modified to provide a way to skip releasing in specific builds.

After migration to Gradle 3.0 Java 9 EA build could be also added.