### PR TITLE
Missing generics info on collection matchers

### DIFF
--- a/src/main/java/org/mockito/ArgumentMatchers.java
+++ b/src/main/java/org/mockito/ArgumentMatchers.java
@@ -474,9 +474,9 @@ public class ArgumentMatchers {
      * @see #isNull()
      * @see #isNull(Class)
      */
-    public static List anyList() {
+    public static <T> List<T> anyList() {
         reportMatcher(new InstanceOf(List.class, "<any List>"));
-        return new ArrayList(0);
+        return new ArrayList<T>(0);
     }
 
     /**
@@ -532,9 +532,9 @@ public class ArgumentMatchers {
      * @see #isNull()
      * @see #isNull(Class)
      */
-    public static Set anySet() {
+    public static <T> Set<T> anySet() {
         reportMatcher(new InstanceOf(Set.class, "<any set>"));
-        return new HashSet(0);
+        return new HashSet<T>(0);
     }
 
     /**
@@ -592,9 +592,9 @@ public class ArgumentMatchers {
      * @see #isNull()
      * @see #isNull(Class)
      */
-    public static Map anyMap() {
+    public static <K, V> Map<K, V> anyMap() {
         reportMatcher(new InstanceOf(Map.class, "<any map>"));
-        return new HashMap(0);
+        return new HashMap<K, V>(0);
     }
 
     /**
@@ -653,9 +653,9 @@ public class ArgumentMatchers {
      * @see #isNull()
      * @see #isNull(Class)
      */
-    public static Collection anyCollection() {
+    public static <T> Collection<T> anyCollection() {
         reportMatcher(new InstanceOf(Collection.class, "<any collection>"));
-        return new ArrayList(0);
+        return new ArrayList<T>(0);
     }
 
     /**
@@ -714,9 +714,9 @@ public class ArgumentMatchers {
      * @see #isNull(Class)
      * @since 2.0.0
      */
-    public static Collection anyIterable() {
+    public static <T> Iterable<T> anyIterable() {
         reportMatcher(new InstanceOf(Iterable.class, "<any iterable>"));
-        return new ArrayList(0);
+        return new ArrayList<T>(0);
     }
 
     /**

--- a/src/test/java/org/mockitousage/bugs/DiamondInheritanceIsConfusingMockitoTest.java
+++ b/src/test/java/org/mockitousage/bugs/DiamondInheritanceIsConfusingMockitoTest.java
@@ -1,0 +1,44 @@
+package org.mockitousage.bugs;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+// see #508
+public class DiamondInheritanceIsConfusingMockitoTest {
+
+    @Test
+    public void should_work() {
+        Sub mock = Mockito.mock(Sub.class);
+        // The following line results in
+        // org.mockito.exceptions.misusing.MissingMethodInvocationException:
+        // when() requires an argument which has to be 'a method call on a mock'.
+        // Presumably confused by the interface/superclass signatures.
+        Mockito.when(mock.getFoo()).thenReturn("Hello");
+
+        Assert.assertEquals("Hello", mock.getFoo());
+    }
+
+    public class Super<T> {
+        private T value;
+
+        public Super(T value) {
+            this.value = value;
+        }
+
+        public T getFoo() { return value; }
+    }
+
+    public class Sub
+            extends Super<String>
+            implements iInterface {
+
+        public Sub(String s) {
+            super(s);
+        }
+    }
+
+    public interface iInterface {
+        String getFoo();
+    }
+}


### PR DESCRIPTION
Follow up on #510 (issue #194) following this comment https://github.com/mockito/mockito/pull/510#issuecomment-236877717

Basically it tweaks the collection matchers with generic support. It should have bee in abf9851.