### PR TITLE
Move release skipping logic to Gradle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ before_install:
   - sudo hostname "$(hostname | cut -c1-63)"
   - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
   - cat /etc/hosts # optionally check the content *after*
+  - export TRAVIS_COMMIT_MESSAGE=$(git log --format=%B -n 1 $TRAVIS_COMMIT)
+  - echo "$TRAVIS_COMMIT_MESSAGE"
 
 jdk:
   - openjdk6
@@ -46,10 +48,7 @@ branches:
 install:
  - true
 script:
-  - TRAVIS_MESSAGE="$(git log --format=%B -n 1)"
-  - ./gradlew ciBuild
-  - echo "Travis commit message is $TRAVIS_MESSAGE"
-  - if [[ "$TRAVIS_MESSAGE" != *"[ci skip-release]"* ]] ; then ./gradlew release; fi
+  - ./gradlew ciBuild release
 after_success:
   - ./gradlew --stacktrace coverageReport && cp build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml jacoco.xml || echo "Code coverage failed"
   - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -11,6 +11,8 @@ In case the release process from Travis CI fails, please try:
     - useful for recreating/merging release notes
 """
 
+def skipReleaseCommitMessage = '[ci skip-release]'
+
 import org.mockito.release.version.*
 
 assert project == rootProject
@@ -57,9 +59,12 @@ task("releaseNeeded") {
     doLast {
         def branch = System.env.TRAVIS_BRANCH
         def pr = System.env.TRAVIS_PULL_REQUEST
-        def skipped = System.env.SKIP_RELEASE
-        ext.needed = dryRun || (pr == 'false' && branch == 'master' && !comparePublications.publicationsEqual && skipped != 'true')
-        logger.lifecycle("Release needed: {}, branch: {}, pull request: {}, dry run: {}, publications equal: {}, skipped: {}.", needed, branch, pr, dryRun, comparePublications.publicationsEqual, skipped)
+        def skipEnvVariable = System.env.SKIP_RELEASE
+        def commitMessage = System.env.TRAVIS_COMMIT_MESSAGE
+        def skippedByCommitMessage = commitMessage?.contains(skipReleaseCommitMessage)
+        ext.needed = dryRun || (pr == 'false' && branch == 'master' && !comparePublications.publicationsEqual && skipEnvVariable != 'true' && !skippedByCommitMessage)
+        logger.lifecycle("Release needed: {}, branch: {}, pull request: {}, dry run: {}, publications equal: {}, skip env variable: {}, skipped by message: {}.",
+                needed, branch, pr, dryRun, comparePublications.publicationsEqual, skipEnvVariable, skippedByCommitMessage)
     }
 }
 
@@ -87,7 +92,7 @@ release {
 
 releaseSteps {
     String currentVersion = project.version //the version loaded when Gradle build has started
-    String buildInfo = "by Travis CI build $System.env.TRAVIS_BUILD_NUMBER [ci skip-release]"
+    String buildInfo = "by Travis CI build $System.env.TRAVIS_BUILD_NUMBER $skipReleaseCommitMessage"
     MaskedArg pushTarget = new MaskedArg(value: "https://szczepiq:${System.env.GH_TOKEN}@github.com/mockito/mockito.git")
 
     step("ensure good chunk of recent commits is pulled for release notes automation") {


### PR DESCRIPTION
This is an enhancement for #493. I'm not a big fan of putting build logic into bash & .travis.yml, especially that we already have it separated in `release.gradle`.
