### PR TITLE
refactored ObjectMethodsGuru to a static utility class

### DIFF
--- a/src/main/java/org/mockito/internal/matchers/text/MatcherToString.java
+++ b/src/main/java/org/mockito/internal/matchers/text/MatcherToString.java
@@ -4,6 +4,8 @@ import org.mockito.ArgumentMatcher;
 import org.mockito.internal.util.Decamelizer;
 import org.mockito.internal.util.ObjectMethodsGuru;
 
+import static org.mockito.internal.util.ObjectMethodsGuru.isToStringMethod;
+
 import java.lang.reflect.Method;
 
 /**
@@ -22,12 +24,11 @@ class MatcherToString {
      * @return
      */
     static String toString(ArgumentMatcher<?> matcher) {
-        ObjectMethodsGuru guru = new ObjectMethodsGuru();
         Class<?> cls = matcher.getClass();
         while(cls != Object.class) {
             Method[] methods = cls.getDeclaredMethods();
             for (Method m : methods) {
-                if(guru.isToString(m)) {
+                if(isToStringMethod(m)) {
                     return matcher.toString();
                 }
             }

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValues.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValues.java
@@ -8,6 +8,9 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.mock.MockName;
 import org.mockito.stubbing.Answer;
 
+import static org.mockito.internal.util.ObjectMethodsGuru.isCompareToMethod;
+import static org.mockito.internal.util.ObjectMethodsGuru.isToStringMethod;
+
 import java.io.Serializable;
 import java.util.*;
 
@@ -41,13 +44,12 @@ public class ReturnsEmptyValues implements Answer<Object>, Serializable {
 
     private static final long serialVersionUID = 1998191268711234347L;
 
-    private final ObjectMethodsGuru methodsGuru = new ObjectMethodsGuru();
 
     /* (non-Javadoc)
      * @see org.mockito.stubbing.Answer#answer(org.mockito.invocation.InvocationOnMock)
      */
     public Object answer(InvocationOnMock invocation) {
-        if (methodsGuru.isToString(invocation.getMethod())) {
+        if (isToStringMethod(invocation.getMethod())) {
             Object mock = invocation.getMock();
             MockName name = MockUtil.getMockName(mock);
             if (name.isDefault()) {
@@ -55,7 +57,7 @@ public class ReturnsEmptyValues implements Answer<Object>, Serializable {
             } else {
                 return name.toString();
             }
-        } else if (methodsGuru.isCompareToMethod(invocation.getMethod())) {
+        } else if (isCompareToMethod(invocation.getMethod())) {
             //see issue 184.
             //mocks by default should return 0 if references are the same, otherwise some other value because they are not the same. Hence we return 1 (anything but 0 is good).
             //Only for compareTo() method by the Comparable interface

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNulls.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNulls.java
@@ -5,13 +5,13 @@
 package org.mockito.internal.stubbing.defaultanswers;
 
 import static org.mockito.internal.exceptions.Reporter.smartNullPointerException;
+import static org.mockito.internal.util.ObjectMethodsGuru.isToStringMethod;
 
 import java.io.Serializable;
 import java.lang.reflect.Modifier;
 
 import org.mockito.Mockito;
 import org.mockito.internal.debugging.LocationImpl;
-import org.mockito.internal.util.ObjectMethodsGuru;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.invocation.Location;
 import org.mockito.stubbing.Answer;
@@ -63,7 +63,7 @@ public class ReturnsSmartNulls implements Answer<Object>, Serializable {
         }
 
         public Object answer(InvocationOnMock currentInvocation) throws Throwable {
-            if (new ObjectMethodsGuru().isToString(currentInvocation.getMethod())) {
+            if (isToStringMethod(currentInvocation.getMethod())) {
                 return "SmartNull returned by this unstubbed method call on a mock:\n" +
                         unstubbedInvocation.toString();
             }

--- a/src/main/java/org/mockito/internal/util/ObjectMethodsGuru.java
+++ b/src/main/java/org/mockito/internal/util/ObjectMethodsGuru.java
@@ -4,36 +4,23 @@
  */
 package org.mockito.internal.util;
 
+import java.lang.reflect.Method;
 import org.mockito.internal.creation.DelegatingMethod;
 import org.mockito.internal.invocation.MockitoMethod;
 
-import java.io.Serializable;
-import java.lang.reflect.Method;
+public class ObjectMethodsGuru{
 
-public class ObjectMethodsGuru implements Serializable {
-
-    public boolean isToString(Method method) {
-        return isToString(new DelegatingMethod(method));
+    private ObjectMethodsGuru() {
+    }
+    
+    public static boolean isToStringMethod(Method method) {
+        MockitoMethod m = new DelegatingMethod(method);
+        return m.getReturnType() == String.class && 
+               m.getParameterTypes().length == 0 && 
+               m.getName().equals("toString");
     }
 
-    public boolean isToString(MockitoMethod method) {
-        return method.getReturnType() == String.class
-                && method.getParameterTypes().length == 0
-                && method.getName().equals("toString");
-    }
-
-    public boolean isEqualsMethod(Method method) {
-        return method.getName().equals("equals")
-                && method.getParameterTypes().length == 1
-                && method.getParameterTypes()[0] == Object.class;
-    }
-
-    public boolean isHashCodeMethod(Method method) {
-        return method.getName().equals("hashCode")
-                && method.getParameterTypes().length == 0;
-    }
-
-    public boolean isCompareToMethod(Method method) {
+    public static boolean isCompareToMethod(Method method) {
         return Comparable.class.isAssignableFrom(method.getDeclaringClass())
                 && method.getName().equals("compareTo")
                 && method.getParameterTypes().length == 1

--- a/src/main/java/org/mockito/internal/verification/DefaultRegisteredInvocations.java
+++ b/src/main/java/org/mockito/internal/verification/DefaultRegisteredInvocations.java
@@ -10,6 +10,8 @@ import org.mockito.internal.util.collections.ListUtil;
 import org.mockito.internal.util.collections.ListUtil.Filter;
 import org.mockito.invocation.Invocation;
 
+import static org.mockito.internal.util.ObjectMethodsGuru.isToStringMethod;
+
 import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.List;
@@ -58,7 +60,7 @@ public class DefaultRegisteredInvocations implements RegisteredInvocations, Seri
 
     private static class RemoveToString implements Filter<Invocation> {
         public boolean isOut(Invocation invocation) {
-            return new ObjectMethodsGuru().isToString(invocation.getMethod());
+            return isToStringMethod(invocation.getMethod());
         }
     }
 

--- a/src/main/java/org/mockito/internal/verification/VerificationDataImpl.java
+++ b/src/main/java/org/mockito/internal/verification/VerificationDataImpl.java
@@ -6,11 +6,11 @@ package org.mockito.internal.verification;
 
 import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockito.internal.stubbing.InvocationContainer;
-import org.mockito.internal.util.ObjectMethodsGuru;
 import org.mockito.internal.verification.api.VerificationData;
 import org.mockito.invocation.Invocation;
 
 import static org.mockito.internal.exceptions.Reporter.cannotVerifyToString;
+import static org.mockito.internal.util.ObjectMethodsGuru.isToStringMethod;
 
 import java.util.List;
 
@@ -25,10 +25,12 @@ public class VerificationDataImpl implements VerificationData {
         this.assertWantedIsVerifiable();
     }
 
+    @Override
     public List<Invocation> getAllInvocations() {
         return invocations.getInvocations();
     }
 
+    @Override
     public InvocationMatcher getWanted() {
         return wanted;
     }
@@ -37,8 +39,7 @@ public class VerificationDataImpl implements VerificationData {
         if (wanted == null) {
             return;
         }
-        ObjectMethodsGuru o =  new ObjectMethodsGuru();
-        if (o.isToString(wanted.getMethod())) {
+        if (isToStringMethod(wanted.getMethod())) {
             throw cannotVerifyToString();
         }
     }

--- a/src/test/java/org/mockito/internal/util/ObjectMethodsGuruTest.java
+++ b/src/test/java/org/mockito/internal/util/ObjectMethodsGuruTest.java
@@ -15,49 +15,34 @@ import static junit.framework.TestCase.assertTrue;
 
 public class ObjectMethodsGuruTest extends TestBase {
 
-    private final ObjectMethodsGuru guru = new ObjectMethodsGuru();
     
-    @Test
-    public void shouldKnowToStringMethod() throws Exception {
-        assertFalse(guru.isToString(Object.class.getMethod("equals", Object.class)));
-        assertFalse(guru.isToString(IMethods.class.getMethod("toString", String.class)));
-        assertTrue(guru.isToString(IMethods.class.getMethod("toString")));
-    }
-
-    @Test
-    public void shouldKnowEqualsMethod() throws Exception {
-        assertFalse(guru.isEqualsMethod(IMethods.class.getMethod("equals", String.class)));
-        assertFalse(guru.isEqualsMethod(IMethods.class.getMethod("equals")));
-        assertFalse(guru.isEqualsMethod(Object.class.getMethod("toString")));
-        assertTrue(guru.isEqualsMethod(Object.class.getMethod("equals", Object.class)));
-    }
-
-    @Test
-    public void shouldKnowHashCodeMethod() throws Exception {
-        assertFalse(guru.isHashCodeMethod(IMethods.class.getMethod("toString")));
-        assertFalse(guru.isHashCodeMethod(IMethods.class.getMethod("hashCode", String.class)));
-        assertTrue(guru.isHashCodeMethod(Object.class.getDeclaredMethod("hashCode")));
-    }
-
-    interface HasCompareToButDoesNotImplementComparable {
+    private interface HasCompareToButDoesNotImplementComparable {
         int compareTo(HasCompareToButDoesNotImplementComparable other);
     }
 
-    interface HasCompare extends Comparable {
+    private interface HasCompare extends Comparable {
         int foo(HasCompare other);
         int compareTo(HasCompare other, String redHerring);
         int compareTo(String redHerring);
         int compareTo(HasCompare redHerring);
     }
+    
+    @Test
+    public void shouldKnowToStringMethod() throws Exception {
+        assertFalse(ObjectMethodsGuru.isToStringMethod(Object.class.getMethod("equals", Object.class)));
+        assertFalse(ObjectMethodsGuru.isToStringMethod(IMethods.class.getMethod("toString", String.class)));
+        assertTrue(ObjectMethodsGuru.isToStringMethod(IMethods.class.getMethod("toString")));
+    }
+
 
     @Test
     public void shouldKnowCompareToMethod() throws Exception {
-        assertFalse(guru.isCompareToMethod(Date.class.getMethod("toString")));
-        assertFalse(guru.isCompareToMethod(HasCompare.class.getMethod("foo", HasCompare.class)));
-        assertFalse(guru.isCompareToMethod(HasCompare.class.getMethod("compareTo", HasCompare.class, String.class)));
-        assertFalse(guru.isCompareToMethod(HasCompare.class.getMethod("compareTo", String.class)));
-        assertFalse(guru.isCompareToMethod(HasCompareToButDoesNotImplementComparable.class.getDeclaredMethod("compareTo", HasCompareToButDoesNotImplementComparable.class)));
+        assertFalse(ObjectMethodsGuru.isCompareToMethod(Date.class.getMethod("toString")));
+        assertFalse(ObjectMethodsGuru.isCompareToMethod(HasCompare.class.getMethod("foo", HasCompare.class)));
+        assertFalse(ObjectMethodsGuru.isCompareToMethod(HasCompare.class.getMethod("compareTo", HasCompare.class, String.class)));
+        assertFalse(ObjectMethodsGuru.isCompareToMethod(HasCompare.class.getMethod("compareTo", String.class)));
+        assertFalse(ObjectMethodsGuru.isCompareToMethod(HasCompareToButDoesNotImplementComparable.class.getDeclaredMethod("compareTo", HasCompareToButDoesNotImplementComparable.class)));
 
-        assertTrue(guru.isCompareToMethod(HasCompare.class.getMethod("compareTo", HasCompare.class)));
+        assertTrue(ObjectMethodsGuru.isCompareToMethod(HasCompare.class.getMethod("compareTo", HasCompare.class)));
     }
 }


### PR DESCRIPTION
* refactored `ObjectMethodsGuru` to a static utility class
* removed unused methods and associated tests:
 * `isToString(MockitoMethod method)`
 * `isEqualsMethod(Method method)`
 * `isHashCodeMethod(Method method)`
* renamed `isToString(..)` to `isToStringMethod(..)`

relates to #426 