### PR TITLE
Fully register a class' ancestry for GenericMetadataSupport.

### DIFF
--- a/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsGenericDeepStubsTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsGenericDeepStubsTest.java
@@ -19,6 +19,8 @@ import static org.mockito.Mockito.mock;
 public class ReturnsGenericDeepStubsTest {
     interface ListOfInteger extends List<Integer> {}
 
+    interface AnotherListOfInteger extends ListOfInteger {}
+
     interface GenericsNest<K extends Comparable<K> & Cloneable> extends Map<K, Set<Number>> {
         Set<Number> remove(Object key); // override with fixed ParameterizedType
         List<? super Number> returningWildcard();
@@ -93,9 +95,11 @@ public class ReturnsGenericDeepStubsTest {
     public void will_return_default_value_on_non_mockable_nested_generic() throws Exception {
         GenericsNest<?> genericsNest = mock(GenericsNest.class, RETURNS_DEEP_STUBS);
         ListOfInteger listOfInteger = mock(ListOfInteger.class, RETURNS_DEEP_STUBS);
+        AnotherListOfInteger anotherListOfInteger = mock(AnotherListOfInteger.class, RETURNS_DEEP_STUBS);
 
         assertThat(genericsNest.returningNonMockableNestedGeneric().keySet().iterator().next()).isNull();
         assertThat(listOfInteger.get(25)).isEqualTo(0);
+        assertThat(anotherListOfInteger.get(25)).isEqualTo(0);
     }
 
     @Test(expected = ClassCastException.class)

--- a/src/test/java/org/mockito/internal/util/reflection/GenericMetadataSupportTest.java
+++ b/src/test/java/org/mockito/internal/util/reflection/GenericMetadataSupportTest.java
@@ -28,6 +28,11 @@ public class GenericMetadataSupportTest {
         E get();
     }
     interface ListOfNumbers extends List<Number> {}
+    interface AnotherListOfNumbers extends ListOfNumbers {}
+
+    abstract class ListOfNumbersImpl implements ListOfNumbers {}
+    abstract class AnotherListOfNumbersImpl extends ListOfNumbersImpl {}
+
     interface ListOfAnyNumbers<N extends Number & Cloneable> extends List<N> {}
 
     interface GenericsNest<K extends Comparable<K> & Cloneable> extends Map<K, Set<Number>> {
@@ -74,6 +79,13 @@ public class GenericMetadataSupportTest {
         assertThat(inferFrom(Map.class).actualTypeArguments().keySet()).hasSize(2).extracting("name").contains("K", "V");
         assertThat(inferFrom(Serializable.class).actualTypeArguments().keySet()).isEmpty();
         assertThat(inferFrom(StringList.class).actualTypeArguments().keySet()).isEmpty();
+    }
+
+    @Test
+    public void can_resolve_type_variables_from_ancestors() throws Exception {
+        Method listGet = List.class.getMethod("get", int.class);
+        assertThat(inferFrom(AnotherListOfNumbers.class).resolveGenericReturnType(listGet).rawType()).isEqualTo(Number.class);
+        assertThat(inferFrom(AnotherListOfNumbersImpl.class).resolveGenericReturnType(listGet).rawType()).isEqualTo(Number.class);
     }
 
     @Test


### PR DESCRIPTION
The old implemention would take a class X and consider all of its superclasses
and the interfaces implemented by X and the interfaces implemented by all of
its superclasses.

The new implementation also considers the superinterfaces of the interfaces
implemented by X and the superinterfaces of the interfaces implemented by its
superclasses.

Fixes #497