### PR TITLE
Fixed #538 changed error message in case initialization for mock injection fails.

### DIFF
--- a/src/main/java/org/mockito/internal/configuration/injection/PropertyAndSetterInjection.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/PropertyAndSetterInjection.java
@@ -98,7 +98,7 @@ public class PropertyAndSetterInjection extends MockInjectionStrategy {
                 Throwable realCause = e.getCause().getCause();
                 throw fieldInitialisationThrewException(field, realCause);
             }
-            throw cannotInitializeForInjectMocksAnnotation(field.getName(), e);
+            throw cannotInitializeForInjectMocksAnnotation(field.getName(),e.getMessage());
         }
     }
 

--- a/src/main/java/org/mockito/internal/exceptions/Reporter.java
+++ b/src/main/java/org/mockito/internal/exceptions/Reporter.java
@@ -627,16 +627,14 @@ public class Reporter {
                                          ""), details);
     }
 
-    public static MockitoException cannotInitializeForInjectMocksAnnotation(String fieldName, Exception details) {
-        return new MockitoException(join("Cannot instantiate @InjectMocks field named '" + fieldName + "'.",
+    public static MockitoException cannotInitializeForInjectMocksAnnotation(String fieldName, String causeMessage) {
+        return new MockitoException(join("Cannot instantiate @InjectMocks field named '" + fieldName + "'! Cause: "+causeMessage,
                                          "You haven't provided the instance at field declaration so I tried to construct the instance.",
-                                         "However, I failed because: " + details.getMessage(),
                                          "Examples of correct usage of @InjectMocks:",
                                          "   @InjectMocks Service service = new Service();",
                                          "   @InjectMocks Service service;",
-                                         "   //also, don't forget about MockitoAnnotations.initMocks();",
                                          "   //and... don't forget about some @Mocks for injection :)",
-                                         ""), details);
+                                         ""));
     }
 
     public static MockitoException atMostAndNeverShouldNotBeUsedWithTimeout() {

--- a/src/main/java/org/mockito/internal/util/reflection/FieldInitializer.java
+++ b/src/main/java/org/mockito/internal/util/reflection/FieldInitializer.java
@@ -7,6 +7,7 @@ package org.mockito.internal.util.reflection;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.util.MockUtil;
 
+import static java.lang.reflect.Modifier.isStatic;
 import static org.mockito.internal.util.reflection.FieldSetter.setField;
 
 import java.lang.reflect.Constructor;
@@ -68,7 +69,9 @@ public class FieldInitializer {
             checkNotLocal(field);
             checkNotInner(field);
             checkNotInterface(field);
+            checkNotEnum(field);
             checkNotAbstract(field);
+            
         }
         this.fieldOwner = fieldOwner;
         this.field = field;
@@ -100,8 +103,9 @@ public class FieldInitializer {
     }
 
     private void checkNotInner(Field field) {
-        if(field.getType().isMemberClass() && !Modifier.isStatic(field.getType().getModifiers())) {
-            throw new MockitoException("the type '" + field.getType().getSimpleName() + "' is an inner class.");
+        Class<?> type = field.getType();
+        if(type.isMemberClass() && !isStatic(type.getModifiers())) {
+            throw new MockitoException("the type '" + type.getSimpleName() + "' is an inner non static class.");
         }
     }
 
@@ -113,9 +117,16 @@ public class FieldInitializer {
 
     private void checkNotAbstract(Field field) {
         if(Modifier.isAbstract(field.getType().getModifiers())) {
-            throw new MockitoException("the type '" + field.getType().getSimpleName() + " is an abstract class.");
+            throw new MockitoException("the type '" + field.getType().getSimpleName() + "' is an abstract class.");
         }
     }
+    
+    private void checkNotEnum(Field field) {
+        if(field.getType().isEnum()) {
+            throw new MockitoException("the type '" + field.getType().getSimpleName() + "' is an enum.");
+        }
+    }
+
 
     private FieldInitializationReport acquireFieldInstance() throws IllegalAccessException {
         Object fieldInstance = field.get(fieldOwner);

--- a/src/test/java/org/mockitousage/basicapi/MocksCreationTest.java
+++ b/src/test/java/org/mockitousage/basicapi/MocksCreationTest.java
@@ -6,7 +6,9 @@
 package org.mockitousage.basicapi;
 
 import org.junit.Test;
+import org.mockito.InjectMocks;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.exceptions.verification.SmartNullPointerException;
 import org.mockito.internal.debugging.LocationImpl;
@@ -16,6 +18,7 @@ import org.mockitoutil.TestBase;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static junit.framework.TestCase.*;
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
Fixed #538

If a filed is annotated with @InjectMocks and the type of a field is an enum, inner class, interface or local class the error message is now: _"Mock injection failed on field 'fieldName' cause the type 'AbstractCollection' is an abstract class._"



