### PR TITLE
Replace or remove code.google.com links in documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -27,7 +27,7 @@
 * Also, don't hesitate to ask questions on the [mailing list](https://groups.google.com/forum/#!forum/mockito) - that helps us improve javadocs/FAQ.
 * Please suggest changes to javadoc/exception messages when you find something unclear.
 * If you miss a particular feature in Mockito - browse or ask on the mailing list, show us a sample code and describe the problem.
-* Wondering what to work on? See [task/bug list](https://github.com/mockito/mockito/issues/) [(old task/bug list)](http://code.google.com/p/mockito/issues/list) and pick up something you would like to work on. Remember that some feature requests we somewhat not agree with so not everything we want to work on :)
+* Wondering what to work on? See [task/bug list](https://github.com/mockito/mockito/issues/) and pick up something you would like to work on. Remember that some feature requests we somewhat not agree with so not everything we want to work on :)
 * Mockito currently uses GitHub for versioning so you can *create a fork of Mockito in no time*. Go to the [github project](https://github.com/mockito/mockito) and "Create your own fork". Create a new branch, commit, ..., when you're ready let us know about your pull request so we can discuss it and merge the PR!
 * Note the project now uses *gradle*, when your Gradle install is ready, make your IDE project's files (for example **`gradle idea`**). Other gradle commands are listed via **`gradle tasks`**.
 
@@ -38,18 +38,18 @@ For that reason each pull request has to go through a thorough review and/or dis
 
 Things we pay attention in a PR :
 
-* On pull requests, please document the change, what it brings, what is the benefit. If the issue exists on the old issue tracker on [Google Code](https://code.google.com/p/mockito/issues/list), please add cross links. But don't create a new one there.
+* On pull requests, please document the change, what it brings, what is the benefit.
 * **Clean commit history** in the topic branch in your fork of the repository, even during review. That means that commits are _rebased_ and _squashed_ if necessary, so that each commit clearly changes one things and there are no extraneous fix-ups.
 
   For that matter it's possible to commit [_semantic_ changes](http://lemike-de.tumblr.com/post/79041908218/semantic-commits). _Tests are an asset, so is history_.
-  
+
   _Exemple gratia_:
-  
+
   ```
   Fixes #73 : The new feature
   Fixes #73 : Refactors this part of Mockito to make feature possible
   ```
-  
+
 * In the code, always test your feature / change, in unit tests and in our `acceptance test suite` located in `org.mockitousage`. Older tests will be migrated when a test is modified.
 * New test methods should follow a snake case convention (`ensure_that_stuff_is_doing_that`), this allows the test name to be fully expressive on intent while still readable.
 * When reporting errors to the users, if it's a user report report it gently and explain how a user should deal with it, see the `Reporter` class. However not all errors should go there, some unlikely technical errors don't need to be in the `Reporter` class.
@@ -58,4 +58,3 @@ Things we pay attention in a PR :
 
 
 _If you are unsure about git you can have a look on our [git tips to have a clean history](https://github.com/mockito/mockito/wiki/Using git to prepare your PR to have a clean history)._
-

--- a/src/main/java/org/mockito/AdditionalAnswers.java
+++ b/src/main/java/org/mockito/AdditionalAnswers.java
@@ -122,8 +122,7 @@ public class AdditionalAnswers {
      *     <li>Already custom proxied object</li>
      *     <li>Special objects with a finalize method, i.e. to avoid executing it 2 times</li>
      * </ul>
-     * For more details including the use cases reported by users take a look at
-     * <a link="http://code.google.com/p/mockito/issues/detail?id=145">issue 145</a>.
+     *
      * <p>
      * The difference with the regular spy:
      * <ul>

--- a/src/main/java/org/mockito/MockSettings.java
+++ b/src/main/java/org/mockito/MockSettings.java
@@ -40,7 +40,6 @@ public interface MockSettings extends Serializable {
 
     /**
      * Specifies extra interfaces the mock should implement. Might be useful for legacy code or some corner cases.
-     * For background, see issue 51 <a href="http://code.google.com/p/mockito/issues/detail?id=51">here</a>
      * <p>
      * This mysterious feature should be used very occasionally.
      * The object under test should know exactly its collaborators & dependencies.

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -674,8 +674,7 @@ import org.mockito.junit.*;
  * <p>
  * The only reason we added <code>reset()</code> method is to
  * make it possible to work with container-injected mocks.
- * See issue 55 (<a href="http://code.google.com/p/mockito/issues/detail?id=55">here</a>)
- * or FAQ (<a href="http://code.google.com/p/mockito/wiki/FAQ">here</a>).
+ * For more information see FAQ (<a href="https://github.com/mockito/mockito/wiki/FAQ">here</a>).
  * <p>
  * <b>Don't harm yourself.</b> <code>reset()</code> in the middle of the test method is a code smell (you're probably testing too much).
  * <pre class="code"><code class="java">
@@ -693,7 +692,7 @@ import org.mockito.junit.*;
  * <h3 id="18">18. <a class="meaningful_link" href="#framework_validation">Troubleshooting & validating framework usage</a> (Since 1.8.0)</h3>
  *
  * First of all, in case of any trouble, I encourage you to read the Mockito FAQ:
- * <a href="http://code.google.com/p/mockito/wiki/FAQ">http://code.google.com/p/mockito/wiki/FAQ</a>
+ * <a href="https://github.com/mockito/mockito/wiki/FAQ">https://github.com/mockito/mockito/wiki/FAQ</a>
  * <p>
  * In case of questions you may also post to mockito mailing list:
  * <a href="http://groups.google.com/group/mockito">http://groups.google.com/group/mockito</a>
@@ -1812,8 +1811,7 @@ public class Mockito extends ArgumentMatchers {
      * <p>
      * The only reason we added <code>reset()</code> method is to
      * make it possible to work with container-injected mocks.
-     * See issue 55 (<a href="http://code.google.com/p/mockito/issues/detail?id=55">here</a>)
-     * or FAQ (<a href="http://code.google.com/p/mockito/wiki/FAQ">here</a>).
+     * For more information see the FAQ (<a href="https://github.com/mockito/mockito/wiki/FAQ">here</a>).
      * <p>
      * <b>Don't harm yourself.</b> <code>reset()</code> in the middle of the test method is a code smell (you're probably testing too much).
      * <pre class="code"><code class="java">
@@ -2202,8 +2200,8 @@ public class Mockito extends ArgumentMatchers {
      * Also, you can create InOrder object passing only mocks that are relevant for in-order verification.
      * <p>
      * <code>InOrder</code> verification is 'greedy', but you will hardly ever notice it.
-     * If you want to find out more, search for 'greedy' in the Mockito
-     * <a href="http://code.google.com/p/mockito/w/list">wiki pages</a>.
+     * If you want to find out more, read
+     * <a href="https://github.com/mockito/mockito/wiki/Greedy-algorithm-of-verfication-InOrder">this wiki page</a>.
      * <p>
      * As of Mockito 1.8.4 you can verifyNoMoreInvocations() in order-sensitive way. Read more: {@link InOrder#verifyNoMoreInteractions()}
      * <p>
@@ -2485,7 +2483,7 @@ public class Mockito extends ArgumentMatchers {
     }
 
     /**
-     * First of all, in case of any trouble, I encourage you to read the Mockito FAQ: <a href="http://code.google.com/p/mockito/wiki/FAQ">http://code.google.com/p/mockito/wiki/FAQ</a>
+     * First of all, in case of any trouble, I encourage you to read the Mockito FAQ: <a href="https://github.com/mockito/mockito/wiki/FAQ">https://github.com/mockito/mockito/wiki/FAQ</a>
      * <p>
      * In case of questions you may also post to mockito mailing list: <a href="http://groups.google.com/group/mockito">http://groups.google.com/group/mockito</a>
      * <p>


### PR DESCRIPTION
Most links are replaced by their GitHub equivalent. Some links were pointing to issues on code.google.com, but given the large amount of documentation on these methods I decided to remove them.

Fixes #533