### PR TITLE
Fixes #554 : Checks.checkNotNull now throws IAE instead of NPE

### DIFF
--- a/src/main/java/org/mockito/internal/util/Checks.java
+++ b/src/main/java/org/mockito/internal/util/Checks.java
@@ -12,7 +12,7 @@ public class Checks {
 
     public static <T> T checkNotNull(T value, String checkedValue) {
         if(value == null) {
-            throw new NullPointerException(checkedValue + " should not be null");
+            throw new IllegalArgumentException(checkedValue + " should not be null");
         }
         return value;
     }

--- a/src/test/java/org/mockito/internal/configuration/MockInjectionTest.java
+++ b/src/test/java/org/mockito/internal/configuration/MockInjectionTest.java
@@ -29,22 +29,22 @@ public class MockInjectionTest {
         withoutConstructor = null;
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void should_not_allow_null_on_field() {
         MockInjection.onField((Field) null, this);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void should_not_allow_null_on_fields() {
         MockInjection.onFields((Set<Field>) null, this);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void should_not_allow_null_on_instance_owning_the_field() throws Exception {
         MockInjection.onField(field("withConstructor"), null);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void should_not_allow_null_on_mocks() throws Exception {
         MockInjection.onField(field("withConstructor"), this).withMocks(null);
     }


### PR DESCRIPTION
Changes NPE to IAE, see #554 