### PR TITLE
Make travis use OracleJDK7 instead of OpenJDK7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jdk:
 
 matrix:
   include:
-  - jdk: openjdk7
+  - jdk: oraclejdk7
     env: SKIP_RELEASE=true
   - jdk: oraclejdk8
     env: SKIP_RELEASE=true


### PR DESCRIPTION
Travis [doc](https://docs.travis-ci.com/user/ci-environment/#JDK) indicate that their distribution of the OracleJDK is more up-to-date than OpenJDK. 

> OracleJDK 7 is the default because we have a much more recent patch level compared to OpenJDK 7 from the Ubuntu repositories. Sun/Oracle JDK 6 is not provided because it reached End of Life in fall 2012.