### PR TITLE
Pretty print primitive and wrappers types in Maps

### DIFF
--- a/src/main/java/org/mockito/internal/matchers/text/ValuePrinter.java
+++ b/src/main/java/org/mockito/internal/matchers/text/ValuePrinter.java
@@ -40,7 +40,7 @@ public class ValuePrinter {
         Iterator<? extends Map.Entry<?, ?>> iterator = map.entrySet().iterator();
         while (iterator.hasNext()) {
             Map.Entry<?, ?> entry = iterator.next();
-            result.append(print(entry.getKey())).append("=").append(print(entry.getValue()));
+            result.append(print(entry.getKey())).append(" = ").append(print(entry.getValue()));
             if (iterator.hasNext()) {
                 result.append(", ");
             }

--- a/src/main/java/org/mockito/internal/matchers/text/ValuePrinter.java
+++ b/src/main/java/org/mockito/internal/matchers/text/ValuePrinter.java
@@ -28,6 +28,8 @@ public class ValuePrinter {
             return value + "d";
         } else if (value instanceof Float) {
             return value + "f";
+        } else if (value instanceof Byte) {
+            return String.format("0x%02X", (Byte) value);
         } else if (value instanceof Map) {
             return printMap((Map) value);
         } else if (value.getClass().isArray()) {

--- a/src/main/java/org/mockito/internal/matchers/text/ValuePrinter.java
+++ b/src/main/java/org/mockito/internal/matchers/text/ValuePrinter.java
@@ -24,6 +24,10 @@ public class ValuePrinter {
             return printChar((Character) value);
         } else if (value instanceof Long) {
             return value + "L";
+        } else if (value instanceof Double) {
+            return value + "d";
+        } else if (value instanceof Float) {
+            return value + "f";
         } else if (value instanceof Map) {
             return printMap((Map) value);
         } else if (value.getClass().isArray()) {

--- a/src/main/java/org/mockito/internal/matchers/text/ValuePrinter.java
+++ b/src/main/java/org/mockito/internal/matchers/text/ValuePrinter.java
@@ -1,6 +1,7 @@
 package org.mockito.internal.matchers.text;
 
 import java.util.Iterator;
+import java.util.Map;
 
 import static java.lang.String.valueOf;
 
@@ -21,6 +22,10 @@ public class ValuePrinter {
             return "\"" + value + "\"";
         } else if (value instanceof Character) {
             return printChar((Character) value);
+        } else if (value instanceof Long) {
+            return value + "L";
+        } else if (value instanceof Map) {
+            return printMap((Map) value);
         } else if (value.getClass().isArray()) {
             return printValues("[", ", ", "]", new org.mockito.internal.matchers.text.ArrayIterator(value));
         } else if (value instanceof FormattedText) {
@@ -28,6 +33,19 @@ public class ValuePrinter {
         }
 
         return descriptionOf(value);
+    }
+
+    private static String printMap(Map<?,?> map) {
+        StringBuilder result = new StringBuilder();
+        Iterator<? extends Map.Entry<?, ?>> iterator = map.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<?, ?> entry = iterator.next();
+            result.append(print(entry.getKey())).append("=").append(print(entry.getValue()));
+            if (iterator.hasNext()) {
+                result.append(", ");
+            }
+        }
+        return "{" + result.toString() + "}";
     }
 
     /**

--- a/src/test/java/org/mockito/internal/matchers/EqualsTest.java
+++ b/src/test/java/org/mockito/internal/matchers/EqualsTest.java
@@ -39,7 +39,7 @@ public class EqualsTest extends TestBase {
     public void shouldDescribeWithExtraTypeInfoOfLong() throws Exception {
         String descStr = new Equals(100L).toStringWithType();
         
-        assertEquals("(Long) 100", descStr);
+        assertEquals("(Long) 100L", descStr);
     }
 
     @Test

--- a/src/test/java/org/mockito/internal/matchers/MatchersPrinterTest.java
+++ b/src/test/java/org/mockito/internal/matchers/MatchersPrinterTest.java
@@ -36,7 +36,7 @@ public class MatchersPrinterTest extends TestBase {
         //when
         String line = printer.getArgumentsLine((List) Arrays.asList(new Equals(1L), new Equals(2)), PrintSettings.verboseMatchers(1));
         //then
-        assertEquals("(1, (Integer) 2);", line);
+        assertEquals("(1L, (Integer) 2);", line);
     }
 
     @Test
@@ -44,7 +44,7 @@ public class MatchersPrinterTest extends TestBase {
         //when
         String line = printer.getArgumentsLine((List) Arrays.asList(new Equals(1L), new Equals("x")), PrintSettings.verboseMatchers(1));
         //then
-        assertEquals("(1, (String) \"x\");", line);
+        assertEquals("(1L, (String) \"x\");", line);
     }
 
     @Test
@@ -52,7 +52,7 @@ public class MatchersPrinterTest extends TestBase {
         //when
         String line = printer.getArgumentsBlock((List) Arrays.asList(new Equals(1L), new Equals(2)), PrintSettings.verboseMatchers(0, 1));
         //then
-        assertEquals("(\n    (Long) 1,\n    (Integer) 2\n);", line);
+        assertEquals("(\n    (Long) 1L,\n    (Integer) 2\n);", line);
     }
 
     @Test
@@ -60,6 +60,6 @@ public class MatchersPrinterTest extends TestBase {
         //when
         String line = printer.getArgumentsLine((List) Arrays.asList(new Equals(1L), NotNull.NOT_NULL), PrintSettings.verboseMatchers(0));
         //then
-        assertEquals("((Long) 1, notNull());", line);
+        assertEquals("((Long) 1L, notNull());", line);
     }
 }

--- a/src/test/java/org/mockito/internal/matchers/text/ValuePrinterTest.java
+++ b/src/test/java/org/mockito/internal/matchers/text/ValuePrinterTest.java
@@ -3,6 +3,8 @@ package org.mockito.internal.matchers.text;
 
 import org.junit.Test;
 
+import java.util.HashMap;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.internal.matchers.text.ValuePrinter.print;
@@ -14,7 +16,14 @@ public class ValuePrinterTest {
         assertEquals("null", print(null));
         assertEquals("\"str\"", print("str"));
         assertEquals("\"x\ny\"", print("x\ny"));
+        assertEquals("3", print(3));
+        assertEquals("3L", print(3L));
         assertEquals("[1, 2]", print(new int[]{1, 2}));
+        assertEquals("{\"hoge\"=2L}", print(new HashMap<String, Object>() {
+            {
+                put("hoge", 2L);
+            }
+        }));
         assertTrue(print(new UnsafeToString()).contains("UnsafeToString"));
         assertEquals("ToString", print(new ToString()));
         assertEquals("formatted", print(new FormattedText("formatted")));

--- a/src/test/java/org/mockito/internal/matchers/text/ValuePrinterTest.java
+++ b/src/test/java/org/mockito/internal/matchers/text/ValuePrinterTest.java
@@ -21,15 +21,19 @@ public class ValuePrinterTest {
         assertEquals("3.14d", print(3.14d));
         assertEquals("3.14f", print(3.14f));
         assertEquals("[1, 2]", print(new int[]{1, 2}));
-        assertEquals("{\"hoge\" = 2L}", print(new LinkedHashMap<String, Object>() {
-            {
-                put("hoge", 2L);
-            }
-        }));
-        assertEquals("{\"foo\" = 2L, \"bar\" = 3L}", print(new LinkedHashMap<String, Object>() {
+        assertEquals("{\"foo\" = 2L}", print(new LinkedHashMap<String, Object>() {
             {
                 put("foo", 2L);
-                put("bar", 3L);
+            }
+        }));
+        assertEquals("{\"byte\" = 0x01, \"short\" = 2, \"int\" = 3, \"long\" = 4L, \"float\" = 2.71f, \"double\" = 3.14d}", print(new LinkedHashMap<String, Object>() {
+            {
+                put("byte", (byte)1);
+                put("short", (short)2);
+                put("int", 3);
+                put("long", 4L);
+                put("float", 2.71f);
+                put("double", 3.14d);
             }
         }));
         assertTrue(print(new UnsafeToString()).contains("UnsafeToString"));

--- a/src/test/java/org/mockito/internal/matchers/text/ValuePrinterTest.java
+++ b/src/test/java/org/mockito/internal/matchers/text/ValuePrinterTest.java
@@ -3,7 +3,7 @@ package org.mockito.internal.matchers.text;
 
 import org.junit.Test;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -19,9 +19,15 @@ public class ValuePrinterTest {
         assertEquals("3", print(3));
         assertEquals("3L", print(3L));
         assertEquals("[1, 2]", print(new int[]{1, 2}));
-        assertEquals("{\"hoge\"=2L}", print(new HashMap<String, Object>() {
+        assertEquals("{\"hoge\" = 2L}", print(new LinkedHashMap<String, Object>() {
             {
                 put("hoge", 2L);
+            }
+        }));
+        assertEquals("{\"foo\" = 2L, \"bar\" = 3L}", print(new LinkedHashMap<String, Object>() {
+            {
+                put("foo", 2L);
+                put("bar", 3L);
             }
         }));
         assertTrue(print(new UnsafeToString()).contains("UnsafeToString"));

--- a/src/test/java/org/mockito/internal/matchers/text/ValuePrinterTest.java
+++ b/src/test/java/org/mockito/internal/matchers/text/ValuePrinterTest.java
@@ -18,6 +18,8 @@ public class ValuePrinterTest {
         assertEquals("\"x\ny\"", print("x\ny"));
         assertEquals("3", print(3));
         assertEquals("3L", print(3L));
+        assertEquals("3.14d", print(3.14d));
+        assertEquals("3.14f", print(3.14f));
         assertEquals("[1, 2]", print(new int[]{1, 2}));
         assertEquals("{\"hoge\" = 2L}", print(new LinkedHashMap<String, Object>() {
             {

--- a/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
+++ b/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
@@ -374,7 +374,7 @@ public class DescriptiveMessagesWhenVerificationFailsTest extends TestBase {
             assertThat(e)
                 .hasMessageContaining("iMethods.threeArgumentMethod(12, foo, \"xx\")")
                 .hasMessageContaining("iMethods.arrayMethod([\"a\", \"b\", \"c\"])")
-                .hasMessageContaining("iMethods.forByte(25)");
+                .hasMessageContaining("iMethods.forByte(0x19)");
         }
     }
 

--- a/src/test/java/org/mockitousage/verification/PrintingVerboseTypesWithArgumentsTest.java
+++ b/src/test/java/org/mockitousage/verification/PrintingVerboseTypesWithArgumentsTest.java
@@ -42,7 +42,7 @@ public class PrintingVerboseTypesWithArgumentsTest extends TestBase {
             //then
             assertThat(e)
                 .hasMessageContaining("withLong((Integer) 100);")
-                .hasMessageContaining("withLong((Long) 100);");
+                .hasMessageContaining("withLong((Long) 100L);");
         }
     }
 
@@ -60,7 +60,7 @@ public class PrintingVerboseTypesWithArgumentsTest extends TestBase {
             //then
             assertThat(e)
                 .hasMessageContaining("withLongAndInt((Integer) 100, 200)")
-                .hasMessageContaining("withLongAndInt((Long) 100, 200)");
+                .hasMessageContaining("withLongAndInt((Long) 100L, 200)");
         }
     }
 
@@ -78,7 +78,7 @@ public class PrintingVerboseTypesWithArgumentsTest extends TestBase {
             //then
             Assertions.assertThat(e.getMessage())
                       .contains("withLongAndInt(\n" +
-                                        "    (Long) 100,\n" +
+                                        "    (Long) 100L,\n" +
                                         "    200\n" +
                                         ")")
                       .contains("withLongAndInt(\n" +
@@ -101,8 +101,8 @@ public class PrintingVerboseTypesWithArgumentsTest extends TestBase {
         } catch (ArgumentsAreDifferent e) {
             //then
             assertThat(e)
-                .hasMessageContaining("withLongAndInt(100, 200)")
-                .hasMessageContaining("withLongAndInt(100, 230)");
+                .hasMessageContaining("withLongAndInt(100L, 200)")
+                .hasMessageContaining("withLongAndInt(100L, 230)");
         }
     }
 


### PR DESCRIPTION
check list

 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/master/.github/CONTRIBUTING.md)
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_


In following case, user can't understand the difference between expected and actual.

Code:

    @Test
    public void foo() {
        Foo m = mock(Foo.class);
        m.foo(new HashMap<String, Object>(){{
            put("hoge", 4);
        }});
        verify(m).foo(new HashMap<String, Object>(){{
            put("hoge", 4L);
        }});
    }

    public static class Foo {
        void foo(Map<String, Object> map) {
        }
    }

Output:

    Argument(s) are different! Wanted:
    foo.foo(() {hoge=4});
    -> at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    Actual invocation has different arguments:
    foo.foo(() {hoge=4});
    -> at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)

If mockito outputs the "L" suffix for long values, user can understand the difference easily.

After this commit, the output will be following:

    Argument(s) are different! Wanted:
    foo.foo({"hoge"=4L});
    -> at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    Actual invocation has different arguments:
    foo.foo({"hoge"=4});
    -> at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)


This will fix #570