### PR TITLE
make VerificationWithTimeoutTest#shouldAllowMixingOnlyWithTimeout mor…

### DIFF
--- a/src/test/java/org/mockitousage/verification/VerificationWithTimeoutTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationWithTimeoutTest.java
@@ -111,11 +111,11 @@ public class VerificationWithTimeoutTest {
     @Test
     public void shouldAllowMixingOnlyWithTimeout() throws Exception {
         // given
-        callAsyncWithDelay(mock, 'c', 10, MILLISECONDS);
+        callAsyncWithDelay(mock, 'c', 20, MILLISECONDS);
 
         // then
         verify(mock, never()).oneArg('c');
-        verify(mock, timeout(30).only()).oneArg('c');
+        verify(mock, timeout(100).only()).oneArg('c');
     }
 
     @Test


### PR DESCRIPTION
…e lenient to reduce build failures on travis ci

The two recent build failures where both caused by this test:
https://travis-ci.org/mockito/mockito/jobs/154189781
https://travis-ci.org/mockito/mockito/jobs/154506554