### PR TITLE
Update version explanation with bad beta versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See the [release notes page](https://github.com/mockito/mockito/blob/master/doc/
 ## Versioning
 
 Mockito has an automated release system, which imposed some change on how the version numbers work.
-They follow this scheme:
+The versions follow this scheme:
 
 ```
 major.minor.patch-tag.tagVersion
@@ -37,6 +37,13 @@ That means:
 * `2.0.0-beta.5` is the fifth release beta of version `2.0.0`.
 * `2.0.0-beta.5` could be (but is not necessarily) binary incompatible with version `2.0.0`.
 * `2.0.0-RC.1` is binary compatible with release `2.0.0`.
+
+**Note : ** During the 2.0 beta phase we unleashed beta builds with the following version schemes, like : `2.0.111-beta`, where the _build number_ is placed beore the _tag_. The current scheme reuses the _build number_ and places it behind the _tag_. Hence those versions are to be considered as beta builds that happen either before or after a release candidate, but always before the final release.
+
+```
+2.0.111-beta < 2.0.0-beta.112 < 2.0.0-RC.1 < 2.0.0-beta.200 < 2.0.0
+```
+
 
 ### Tags
 There are two different tags: beta or RC. Beta indicates that the version is directly generated from the master branch of the git repository.


### PR DESCRIPTION
The previous versioning scheme has been changed in #483, however the previous artefacts still exists, and some pages may mention them, we should still explain what are these artefact and what they mean in regard of other versions.