### PR TITLE
Reintroduces javadoc stylesheet

### DIFF
--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -52,7 +52,7 @@ task mockitoJavadoc(type: Javadoc) {
           }
         </script>
     """.replaceAll(/\r|\n/, ""))
-//    options.stylesheetFile file("src/javadoc/stylesheet.css")
+    options.stylesheetFile file("src/javadoc/stylesheet.css")
 //    options.addStringOption('top', 'some html')
     if (JavaVersion.current().isJava8Compatible()) {
         options.addStringOption('Xdoclint:none', '-quiet')

--- a/src/javadoc/stylesheet.css
+++ b/src/javadoc/stylesheet.css
@@ -1,0 +1,63 @@
+/* Javadoc style sheet */
+
+/* Define colors, fonts and other style attributes here to override the defaults */
+
+/* Page background color */
+body { background-color: #FFFFFF; color:#333; font-size: 100%; }
+
+body { font-size: 0.875em; line-height: 1.286em; font-family:   "Helvetica", "Arial", sans-serif; }
+
+code { color: #777; line-height: 1.286em; font-family: "Consolas", "Lucida Console", "Droid Sans Mono", "Andale Mono", "Monaco", "Lucida Sans Typewriter"; }
+
+pre { color: #555; line-height: 1.0em; font-family: "Consolas", "Lucida Console", "Droid Sans Mono", "Andale Mono", "Monaco", "Lucida Sans Typewriter"; }
+
+
+a { text-decoration: none; color: #16569A; /* also try #2E85ED, #0033FF, #6C93C6, #1D7BBE, #1D8DD2 */ }
+a:hover, a:hover code { color: #EEEEEE; background-color: #16569A; }
+a:visited, a:visited code { color: #CC3300; }
+a:visited:hover, a:visited:hover code { color: #fff; background-color: #CC3300; }
+
+a.meaningful_link { text-decoration: none; color: #333333; background-color: #EAF9DD; border-bottom: 1px dashed #006400 }
+a.meaningful_link code { text-decoration: none; color: #777; border-bottom: 1px dashed #006400 }
+a.meaningful_link:hover, a.meaningful_link:hover code { background-color: #E0F9C9; }
+a.meaningful_link:visited, a.meaningful_link:visited code { color: #4B0012; }
+a.meaningful_link:visited:hover, a.meaningful_link:visited:hover code{ color: #4B0012; background-color: #ADE78B; }
+
+table[border="1"] { border: 1px solid #ddd; }
+table[border="1"] td, table[border="1"] th { border: 1px solid #ddd; }
+table[cellpadding="3"] td { padding: 0.5em; }
+
+font[size="-1"] { font-size: 0.85em; line-height: 1.5em; }
+font[size="-2"] { font-size: 0.8em; }
+font[size="+2"] { font-size: 1.4em; line-height: 1.3em; padding: 0.4em 0; }
+
+/* Headings */
+h1 { font-size: 1.5em; line-height: 1.286em;}
+
+/* Table colors */
+.TableHeadingColor     { background: #ccc; color:#444; } /* Dark mauve */
+.TableSubHeadingColor  { background: #ddd; color:#444; } /* Light mauve */
+.TableRowColor         { background: #FFFFFF; color:#666; font-size: 0.95em; } /* White */
+.TableRowColor code    { color:#000; } /* White */
+
+/* Font used in left-hand frame lists */
+.FrameTitleFont   { font-size: 100%; }
+.FrameHeadingFont { font-size:  90%; }
+.FrameItemFont { font-size:  0.9em; line-height: 1.3em;
+}
+/* Java Interfaces */
+.FrameItemFont a i {
+    font-style: normal; color: #666;
+}
+.FrameItemFont a:hover i {
+    font-style: normal; color: #fff; background-color: #666;
+}
+
+/* Navigation bar fonts and colors */
+.NavBarCell1    { background-color:#E0E6DF; } /* Light mauve */
+.NavBarCell1Rev { background-color:#16569A; color:#FFFFFF} /* Dark Blue */
+.NavBarFont1    { }
+.NavBarFont1Rev { color:#FFFFFF; }
+
+.NavBarCell2    { background-color:#FFFFFF; color:#000000}
+.NavBarCell3    { background-color:#FFFFFF; color:#000000}


### PR DESCRIPTION
Fixes #552

Since artifacts are built with openjdk6, we can reintroduce a good looking javadoc stylesheet.

