### PR TITLE
Generate service-worker after generating JavaDoc for offline access

### DIFF
--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -31,7 +31,7 @@ task mockitoJavadoc(type: Javadoc) {
     options.noNavBar = false
     options.noTree = false
     options.links('http://docs.oracle.com/javase/8/docs/api/')
-    options.header("""<em id="mockito-version-header-javadoc7-header"><strong>Mockito ${project.version} API</strong></em>""")
+    options.header("""<script>var l = window.location; if (l.protocol === "http" && l.origin.indexOf("javadoc.io") > -1) { l.protocol = "https"; }</script><em id="mockito-version-header-javadoc7-header"><strong>Mockito ${project.version} API</strong></em>""")
     options.footer("""<em id="mockito-version-header-javadoc7-footer"><strong>Mockito ${project.version} API</strong></em>""")
     options.bottom("""
         <script type="text/javascript" src="{@docRoot}/js/${javadocJdk6Hack}"></script>

--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -52,12 +52,18 @@ task mockitoJavadoc(type: Javadoc) {
             from "src/javadoc"
             into "$buildDir/javadoc"
         }
-        logger.lifecycle("Installing sw-precache globally")
-        exec {
-            commandLine "npm", "install", "-g", "sw-precache"
-        }
-        exec {
-            commandLine "sw-precache", "--config=sw-precache-config.json"
+        try {
+            logger.lifecycle("Installing sw-precache globally")
+            exec {
+                commandLine "npm", "install", "-g", "sw-precache"
+            }
+            exec {
+                commandLine "sw-precache", "--config=sw-precache-config.json"
+            }
+            // Even though there is an option ignoreExitValue for exec, exec keeps on throwing exceptions.
+            // Therefore we just have to catch them and continue on with the build.
+        } catch(Exception ignored) {
+            logger.lifecycle("NPM is not installed. Aborting generating service-worker");
         }
     }
 }

--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -37,20 +37,9 @@ task mockitoJavadoc(type: Javadoc) {
         <script type="text/javascript" src="{@docRoot}/js/${javadocJdk6Hack}"></script>
         <script type="text/javascript" src="{@docRoot}/js/jquery-1.7.min.js"></script>
         <script type="text/javascript" src="{@docRoot}/js/highlight-8.6-java/highlight.pack.js"></script>
-        <link rel="stylesheet" type="text/css" href="{@docRoot}/js/highlight-8.6-java/styles/obsidian.css"/>
 
-        <script type="text/javascript">
-          var usingOldIE = \$.browser.msie && parseInt(\$.browser.version) < 9;
-          if(!usingOldIE) {
-              \$("head").append("<link rel=\\"shortcut icon\\" href=\\"{@docRoot}/favicon.ico?v=cafebabe\\">");
-              \$("head", window.parent.document).append("<link rel=\\"shortcut icon\\" href=\\"{@docRoot}/favicon.ico?v=cafebabe\\">");
-              hljs.initHighlightingOnLoad();
-              \$("pre.code").css("font-size", "0.9em");
-              injectProjectVersionForJavadocJDK6("Mockito ${project.version} API",
-                                                 "em#mockito-version-header-javadoc7-header",
-                                                 "em#mockito-version-header-javadoc7-footer");
-          }
-        </script>
+        <link rel="stylesheet" type="text/css" href="{@docRoot}/js/highlight-8.6-java/styles/obsidian.css"/>
+        <script type="text/javascript" src="{@docRoot}/js/index.js" async defer></script>
     """.replaceAll(/\r|\n/, ""))
     options.stylesheetFile file("src/javadoc/stylesheet.css")
 //    options.addStringOption('top', 'some html')
@@ -62,6 +51,13 @@ task mockitoJavadoc(type: Javadoc) {
         copy {
             from "src/javadoc"
             into "$buildDir/javadoc"
+        }
+        logger.lifecycle("Installing sw-precache globally")
+        exec {
+            commandLine "npm", "install", "-g", "sw-precache"
+        }
+        exec {
+            commandLine "sw-precache", "--config=sw-precache-config.json"
         }
     }
 }

--- a/src/javadoc/js/index.js
+++ b/src/javadoc/js/index.js
@@ -1,0 +1,64 @@
+var usingOldIE = $.browser.msie && parseInt($.browser.version) < 9;
+if(!usingOldIE) {
+    $("head").append("<link rel=\"shortcut icon\" href=\"{@docRoot}/favicon.ico?v=cafebabe\">");
+    $("head", window.parent.document).append("<link rel=\"shortcut icon\" href=\"{@docRoot}/favicon.ico?v=cafebabe\">");
+    hljs.initHighlightingOnLoad();
+    $("pre.code").css("font-size", "0.9em");
+    injectProjectVersionForJavadocJDK6("Mockito ${project.version} API",
+        "em#mockito-version-header-javadoc7-header",
+        "em#mockito-version-header-javadoc7-footer");
+}
+
+if ('serviceWorker' in navigator) {
+    var toast = document.getElementById('sw-toast');
+    if (!toast) {
+        toast = document.createElement('div');
+        toast.id = 'sw-toast';
+        toast.show = function(message) {
+            toast.textContent = message;
+            setTimeout(function() {
+                toast.classList.remove('shown')
+            }, 3000);
+            toast.classList.add('shown');
+        };
+        document.body.appendChild(toast);
+        toast.classList.add('hidden');
+    }
+    // Show a toast with a service-worker-related update.
+    window.showToast = function(message) {
+        toast.show(message);
+    };
+
+    navigator.serviceWorker.register('service-worker.js')
+        .then(function(registration) {
+            registration.onupdatefound = function() {
+                // The updatefound event implies that registration.installing is set; see
+                // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-container-updatefound-event
+                var installingWorker = registration.installing;
+                installingWorker.onstatechange = function() {
+                    switch (installingWorker.state) {
+                        case 'installed':
+                            if (!navigator.serviceWorker.controller) {
+                                toast.show('Service Worker installed! Pages you view are cached for offline use.');
+                            }
+                            break;
+                        case 'redundant':
+                            throw Error('The installing service worker became redundant.');
+                    }
+                };
+            };
+        }).catch(function(e) {
+            console.error('Service worker registration failed:', e);
+            // toast.show('Service worker registration failed');
+        });
+}
+
+// Check to see if the service worker controlling the page at initial load
+// has become redundant, since this implies there's a new service worker with fresh content.
+if (navigator.serviceWorker && navigator.serviceWorker.controller) {
+    navigator.serviceWorker.controller.onstatechange = function(event) {
+        if (event.target.state === 'redundant') {
+            toast.show('Site updated. Refresh this page to see the latest content.');
+        }
+    };
+}

--- a/src/javadoc/js/index.js
+++ b/src/javadoc/js/index.js
@@ -9,7 +9,7 @@ if(!usingOldIE) {
         "em#mockito-version-header-javadoc7-footer");
 }
 
-if ('serviceWorker' in navigator) {
+if ('serviceWorker' in navigator && window.location.protocol === 'https') {
     var toast = document.getElementById('sw-toast');
     if (!toast) {
         toast = document.createElement('div');

--- a/src/javadoc/service-worker.js
+++ b/src/javadoc/service-worker.js
@@ -1,0 +1,1 @@
+console.log('Disabled in developer mode');

--- a/src/javadoc/stylesheet.css
+++ b/src/javadoc/stylesheet.css
@@ -427,3 +427,37 @@ Formatting effect styles
     color:green;
     padding:0 30px 0 0;
 }
+
+/*
+Service-worker toast styling.
+Taken from https://github.com/PolymerElements/paper-toast/blob/master/paper-toast.html
+*/
+#sw-toast {
+    position: fixed;
+    display: block;
+    left: 0;
+    bottom: 0;
+    background-color: #323232;
+    color: #f1f1f1;
+    min-height: 48px;
+    min-width: 288px;
+    padding: 16px 24px;
+    box-sizing: border-box;
+    box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26);
+    border-radius: 2px;
+    margin: 12px;
+    font-size: 14px;
+    cursor: default;
+    -webkit-transition: -webkit-transform 0.3s, opacity 0.3s;
+    transition: transform 0.3s, opacity 0.3s;
+}
+#sw-toast.hidden {
+    opacity: 0;
+    -webkit-transform: translateY(100px);
+    transform: translateY(100px);
+}
+#sw-toast.shown {
+    opacity: 1;
+    -webkit-transform: translateY(0px);
+    transform: translateY(0px);
+}

--- a/sw-precache-config.json
+++ b/sw-precache-config.json
@@ -1,0 +1,15 @@
+{
+  "staticFileGlobs": [
+    "build/javadoc/index-files/*.html",
+    "build/javadoc/js/*.js",
+    "build/javadoc/js/highlight-8.6-java/highlight.pack.js",
+    "build/javadoc/js/highlight-8.6-java/styles/obsidian.css",
+    "build/javadoc/org/**/*.html",
+    "build/javadoc/*.html",
+    "build/javadoc/favicon.ico",
+    "build/javadoc/script.js",
+    "build/javadoc/stylesheet.css"
+  ],
+  "stripPrefix": "build/javadoc/",
+  "swFile": "build/javadoc/service-worker.js"
+}


### PR DESCRIPTION
Service-workers intercept network calls and (if you are offline)
can serve files from the cache. The documentation of Mockito can
therefore be accessed even if you do not have internet access.

All files are pre-cached the first time you open the webpage.
Consecutive openings of the website will result in significantly
faster responses (since we poke the cache) and also work offline.

When new documentation is generated, the service-worker is updated
and a friendly toast is displayed informing the user can refresh
the page to view the new content.

Requirements for generating the service-worker is having npm
(and therefore Node.js) installed. You must also make sure the
gradle daemon has the correct permissions to write to the global
node_modules folder.

This normally is done with (on linux):

``` shell
sudo chown -R $(whoami) /usr/local/lib/node_modules
sudo chown -R $(whoami) /usr/local/bin
sudo chown -R $(whoami) ~/.npm
```

Fixes https://github.com/mockito/mockito.github.io/issues/17
