### PR TITLE
Fixes #595, going towqard 2.1.0 instead of 2.0.0

### DIFF
--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-version=2.0.0-beta.119
+version=2.1.0-beta.119
 mockito.testng.version=1.0


### PR DESCRIPTION
Following discussion in #595, about the best way to handle our non semantic versioning of 2.0 betas, we decided to release 2.1.0 instead of 2.0.0.

I'm simply bumping the versions properties from `2.0.0-beta.119` to `2.1.0-beta.119`