### PR TITLE
ArgumentCaptor and ArgumentMatchers can now mixed in varargs

### DIFF
--- a/src/main/java/org/mockito/internal/invocation/InvocationArgumentCaptor.java
+++ b/src/main/java/org/mockito/internal/invocation/InvocationArgumentCaptor.java
@@ -1,0 +1,90 @@
+package org.mockito.internal.invocation;
+
+import static java.lang.reflect.Array.get;
+import static java.lang.reflect.Array.getLength;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import org.mockito.ArgumentMatcher;
+import org.mockito.internal.matchers.CapturesArguments;
+import org.mockito.invocation.Invocation;
+
+
+/**
+ * 
+ * @author Christian Schwarz
+ *
+ */
+public class InvocationArgumentCaptor {
+
+    private InvocationArgumentCaptor() {
+    }
+    
+    public static void captureArguments(Invocation invocation,List<ArgumentMatcher<?>> matchers) {
+        captureRegularArguments(invocation,matchers);
+        if (invocation.getMethod().isVarArgs()) {
+            captureVarargsPart(invocation,matchers);
+        }
+    }
+
+    private static void captureRegularArguments(Invocation invocation,List<ArgumentMatcher<?>> matchers) {
+        for (int position = 0; position < regularArgumentsSize(invocation); position++) {
+            ArgumentMatcher<?> m = matchers.get(position);
+            if (m instanceof CapturesArguments) {
+                ((CapturesArguments) m).captureFrom(invocation.getArgument(position));
+            }
+        }
+    }
+
+    private static void captureVarargsPart(Invocation invocation,List<ArgumentMatcher<?>> matchers) {
+        int indexOfVararg = invocation.getRawArguments().length - 1;
+        
+        ArgumentMatcher<?>[] varargMatchers =varargMatchers(matchers,indexOfVararg);
+        Object varargsArray = invocation.getRawArguments()[indexOfVararg];
+        
+        if (varargMatchers.length>1){
+            captureEachWithItsDedicatedCaptor(varargsArray,varargMatchers);
+        }else if (varargMatchers.length==1){
+            captureAllWithASingleCaptor(varargsArray, varargMatchers[0]);
+            
+        }
+    }
+
+    private static void captureAllWithASingleCaptor(Object varargsArray, ArgumentMatcher<?> varargMatcher) {
+        if (!(varargMatcher instanceof CapturesArguments))
+            return;
+        CapturesArguments capturingMatcher = (CapturesArguments) varargMatcher;
+
+        for (int i = 0; i < getLength(varargsArray); i++) {
+            capturingMatcher.captureFrom(get(varargsArray, i));
+        }
+    }
+
+    private static void captureEachWithItsDedicatedCaptor(Object varargsArray , ArgumentMatcher<?>[] matchers) {
+        for (int i = 0; i < matchers.length; i++) {
+            ArgumentMatcher<?> m = matchers[i];
+            if (m instanceof CapturesArguments) {
+                ((CapturesArguments) m).captureFrom(get(varargsArray, i));
+            }
+        }
+    }
+
+    private static ArgumentMatcher<?>[] varargMatchers(List<ArgumentMatcher<?>> matchers,int indexOfVararg) {
+        int varargsSize = matchers.size()-indexOfVararg;
+        ArgumentMatcher<?>[] varargMatchers = new ArgumentMatcher[varargsSize];
+        for (int i = 0; i < varargsSize; i++) {
+            varargMatchers[i]=matchers.get(i+indexOfVararg);
+        }
+        return varargMatchers;
+    }
+    
+    private static int regularArgumentsSize(Invocation invocation) {
+        Method method = invocation.getMethod();
+        int parameterCount = method.getParameterTypes().length;
+        if (method.isVarArgs()){
+            return parameterCount - 1; // ignores vararg array
+        }
+        
+        return parameterCount;
+    }
+}

--- a/src/main/java/org/mockito/internal/invocation/InvocationMatcher.java
+++ b/src/main/java/org/mockito/internal/invocation/InvocationMatcher.java
@@ -5,43 +5,51 @@
 
 package org.mockito.internal.invocation;
 
+import static org.mockito.internal.invocation.ArgumentsComparator.argumentsMatch;
+import static org.mockito.internal.invocation.ArgumentsProcessor.argumentsToMatchers;
+import static org.mockito.internal.invocation.InvocationArgumentCaptor.captureArguments;
+
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 import org.mockito.ArgumentMatcher;
-import org.mockito.internal.matchers.CapturesArguments;
 import org.mockito.internal.reporting.PrintSettings;
 import org.mockito.invocation.DescribedInvocation;
 import org.mockito.invocation.Invocation;
 import org.mockito.invocation.Location;
 
-import static org.mockito.internal.invocation.ArgumentsComparator.argumentsMatch;
-
-import java.io.Serializable;
-import java.lang.reflect.Array;
-import java.lang.reflect.Method;
-import java.util.*;
-
-@SuppressWarnings("unchecked")
 /**
- * In addition to all content of the invocation, the invocation matcher contains the argument matchers.
- * Invocation matcher is used during verification and stubbing.
- * In those cases, the user can provide argument matchers instead of 'raw' arguments.
- * Raw arguments are converted to 'equals' matchers anyway.
+ * In addition to all content of the invocation, the invocation matcher contains the argument matchers. Invocation matcher is used during verification and stubbing. In those cases, the user can provide argument matchers instead of 'raw' arguments. Raw arguments are converted to 'equals' matchers anyway.
  */
+@SuppressWarnings("serial")
 public class InvocationMatcher implements DescribedInvocation, CapturesArgumentsFromInvocation, Serializable {
 
     private final Invocation invocation;
-    private final List<ArgumentMatcher> matchers;
+    private final List<ArgumentMatcher<?>> matchers;
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public InvocationMatcher(Invocation invocation, List<ArgumentMatcher> matchers) {
         this.invocation = invocation;
         if (matchers.isEmpty()) {
-            this.matchers = ArgumentsProcessor.argumentsToMatchers(invocation.getArguments());
+            this.matchers = (List) argumentsToMatchers(invocation.getArguments());
         } else {
-            this.matchers = matchers;
+            this.matchers = (List) matchers;
         }
     }
 
+    @SuppressWarnings("rawtypes")
     public InvocationMatcher(Invocation invocation) {
-        this(invocation, Collections.<ArgumentMatcher>emptyList());
+        this(invocation, Collections.<ArgumentMatcher> emptyList());
+    }
+
+    public static List<InvocationMatcher> createFrom(List<Invocation> invocations) {
+        LinkedList<InvocationMatcher> out = new LinkedList<InvocationMatcher>();
+        for (Invocation i : invocations) {
+            out.add(new InvocationMatcher(i));
+        }
+        return out;
     }
 
     public Method getMethod() {
@@ -49,54 +57,50 @@ public class InvocationMatcher implements DescribedInvocation, CapturesArguments
     }
 
     public Invocation getInvocation() {
-        return this.invocation;
+        return invocation;
     }
 
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public List<ArgumentMatcher> getMatchers() {
-        return this.matchers;
+        return (List) matchers;
     }
 
+    @Override
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public String toString() {
-        return new PrintSettings().print(matchers, invocation);
+        return new PrintSettings().print((List) matchers, invocation);
     }
 
     public boolean matches(Invocation actual) {
-        return invocation.getMock().equals(actual.getMock())
-                && hasSameMethod(actual)
-                && argumentsMatch(this, actual);
-    }
-
-    private boolean safelyArgumentsMatch(Object[] actualArgs) {
-        try {
-            return argumentsMatch(this, actualArgs);
-        } catch (Throwable t) {
-            return false;
-        }
+        return invocation.getMock().equals(actual.getMock()) && hasSameMethod(actual) && argumentsMatch(this, actual);
     }
 
     /**
-     * similar means the same method name, same mock, unverified
-     * and: if arguments are the same cannot be overloaded
+     * similar means the same method name, same mock, unverified and: if arguments are the same cannot be overloaded
      */
     public boolean hasSimilarMethod(Invocation candidate) {
         String wantedMethodName = getMethod().getName();
-        String currentMethodName = candidate.getMethod().getName();
+        String candidateMethodName = candidate.getMethod().getName();
 
-        final boolean methodNameEquals = wantedMethodName.equals(currentMethodName);
-        final boolean isUnverified = !candidate.isVerified();
-        final boolean mockIsTheSame = getInvocation().getMock() == candidate.getMock();
-        final boolean methodEquals = hasSameMethod(candidate);
-
-        if (!methodNameEquals || !isUnverified || !mockIsTheSame) {
+        if (!wantedMethodName.equals(candidateMethodName)) {
             return false;
         }
+        if (candidate.isVerified()) {
+            return false;
+        }
+        if (getInvocation().getMock() != candidate.getMock()) {
+            return false;
+        }
+        if (hasSameMethod(candidate)) {
+            return true;
+        }
 
-        final boolean overloadedButSameArgs = !methodEquals && safelyArgumentsMatch(candidate.getArguments());
-
-        return !overloadedButSameArgs;
+        return !safelyArgumentsMatch(candidate.getArguments());
     }
 
     public boolean hasSameMethod(Invocation candidate) {
+        // not using method.equals() for 1 good reason:
+        // sometimes java generates forwarding methods when generics are in play see JavaGenericsForwardingMethodsTest
         Method m1 = invocation.getMethod();
         Method m2 = candidate.getMethod();
 
@@ -115,59 +119,22 @@ public class InvocationMatcher implements DescribedInvocation, CapturesArguments
         return false;
     }
 
+    @Override
     public Location getLocation() {
         return invocation.getLocation();
     }
 
+    @Override
     public void captureArgumentsFrom(Invocation invocation) {
-        captureRegularArguments(invocation);
-        captureVarargsPart(invocation);
+        captureArguments(invocation, matchers);
     }
 
-    private void captureRegularArguments(Invocation invocation) {
-        for (int position = 0; position < regularArgumentsSize(invocation); position++) {
-            ArgumentMatcher m = matchers.get(position);
-            if (m instanceof CapturesArguments) {
-                ((CapturesArguments) m).captureFrom(invocation.getArgument(position));
-            }
+    private boolean safelyArgumentsMatch(Object[] actualArgs) {
+        try {
+            return argumentsMatch(this, actualArgs);
+        } catch (Throwable t) {
+            return false;
         }
     }
 
-    private void captureVarargsPart(Invocation invocation) {
-        if (!invocation.getMethod().isVarArgs()) {
-            return;
-        }
-        int indexOfVararg = invocation.getRawArguments().length - 1;
-        for (ArgumentMatcher m : uniqueMatcherSet(indexOfVararg)) {
-            if (m instanceof CapturesArguments) {
-                Object rawArgument = invocation.getRawArguments()[indexOfVararg];
-                for (int i = 0; i < Array.getLength(rawArgument); i++) {
-                    ((CapturesArguments) m).captureFrom(Array.get(rawArgument, i));
-                }
-            }
-        }
-    }
-
-    private int regularArgumentsSize(Invocation invocation) {
-        return invocation.getMethod().isVarArgs() ?
-                invocation.getRawArguments().length - 1 // ignores vararg holder array
-                : matchers.size();
-    }
-
-    private Set<ArgumentMatcher> uniqueMatcherSet(int indexOfVararg) {
-        HashSet<ArgumentMatcher> set = new HashSet<ArgumentMatcher>();
-        for (int position = indexOfVararg; position < matchers.size(); position++) {
-            ArgumentMatcher matcher = matchers.get(position);
-            set.add(matcher);
-        }
-        return set;
-    }
-
-    public static List<InvocationMatcher> createFrom(List<Invocation> invocations) {
-        LinkedList<InvocationMatcher> out = new LinkedList<InvocationMatcher>();
-        for (Invocation i : invocations) {
-            out.add(new InvocationMatcher(i));
-        }
-        return out;
-    }
 }

--- a/src/test/java/org/mockitousage/matchers/VarargsTest.java
+++ b/src/test/java/org/mockitousage/matchers/VarargsTest.java
@@ -1,0 +1,259 @@
+package org.mockitousage.matchers;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNotNull;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.AbstractListAssert;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Condition;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockitousage.IMethods;
+
+public class VarargsTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+    @Captor
+    private ArgumentCaptor<String> captor;
+    @Mock
+    private IMethods mock;
+
+    private static final Condition<Object> NULL = new Condition<Object>() {
+
+        @Override
+        public boolean matches(Object value) {
+            return value == null;
+        }
+    };
+
+    @Test
+    public void shouldMatchVarArgs_noArgs() {
+        mock.varargs();
+
+        verify(mock).varargs();
+    }
+
+    @Test
+    @Ignore
+    public void shouldMatchVarArgs_noArgsIsNotNull() {
+        mock.varargs();
+
+        verify(mock).varargs(isNotNull());
+    }
+
+    @Test
+    @Ignore
+    public void shouldMatchVarArgs_noArgsIsNull() {
+        mock.varargs();
+
+        verify(mock).varargs(isNull());
+    }
+
+    @Test
+    @Ignore
+    public void shouldMatchVarArgs_noArgsIsNotNullArray() {
+        mock.varargs();
+
+        verify(mock).varargs((String[]) isNotNull());
+    }
+
+    @Test
+    public void shouldMatchVarArgs_oneNullArg_eqNull() {
+        Object arg = null;
+        mock.varargs(arg);
+
+        verify(mock).varargs(eq(null));
+    }
+
+    @Test
+    public void shouldMatchVarArgs_oneNullArg_isNull() {
+        Object arg = null;
+        mock.varargs(arg);
+
+        verify(mock).varargs(isNull());
+    }
+
+    @Test
+    public void shouldMatchVarArgs_nullArrayArg() {
+        Object[] argArray = null;
+        mock.varargs(argArray);
+
+        verify(mock).varargs(isNull());
+    }
+
+    @Test
+    public void shouldMatchVarArgs_twoArgsOneMatcher() {
+        mock.varargs("1", "1");
+
+        exception.expectMessage("Argument(s) are different");
+
+        verify(mock).varargs(eq("1"));
+    }
+
+    @Test
+    public void shouldMatchVarArgs_oneNullArgument() {
+        mock.varargs("1", null);
+
+        verify(mock).varargs(eq("1"), (String) isNull());
+    }
+
+    @Test
+    public void shouldMatchVarArgs_onebyte() {
+        mock.varargsbyte((byte) 1);
+
+        verify(mock).varargsbyte(eq((byte) 1));
+    }
+
+    @Test
+    public void shouldMatchVarArgs_nullByteArray() {
+        mock.varargsbyte(null);
+
+        verify(mock).varargsbyte((byte[]) isNull());
+    }
+
+    @Test
+    public void shouldMatchVarArgs_emptyByteArray() {
+        mock.varargsbyte();
+
+        verify(mock).varargsbyte();
+    }
+
+    @Test
+    @Ignore
+    public void shouldMatchVarArgs_emptyArrayIsNotNull() {
+        mock.varargsbyte();
+
+        verify(mock).varargsbyte((byte[]) isNotNull());
+    }
+
+    @Test
+    public void shouldMatchVarArgs_oneArgIsNotNull() {
+        mock.varargsbyte((byte) 1);
+
+        verify(mock).varargsbyte((byte[]) isNotNull());
+    }
+
+    @Test
+    public void shouldCaptureVarArgs_noArgs() {
+        mock.varargs();
+
+        verify(mock).varargs(captor.capture());
+
+        assertThat(captor).isEmpty();
+    }
+
+    @Test
+    public void shouldCaptureVarArgs_oneNullArg_eqNull() {
+        String arg = null;
+        mock.varargs(arg);
+
+        verify(mock).varargs(captor.capture());
+
+        assertThat(captor).areExactly(1, NULL);
+    }
+
+    @Test
+    @Ignore
+    public void shouldCaptureVarArgs_nullArrayArg() {
+        String[] argArray = null;
+        mock.varargs(argArray);
+
+        verify(mock).varargs(captor.capture());
+        assertThat(captor).areExactly(1, NULL);
+    }
+
+    @Test
+    public void shouldCaptureVarArgs_twoArgsOneCapture() {
+        mock.varargs("1", "2");
+
+        verify(mock).varargs(captor.capture());
+
+        assertThat(captor).contains("1", "2");
+    }
+
+    @Test
+    public void shouldCaptureVarArgs_twoArgsTwoCaptures() {
+        mock.varargs("1", "2");
+
+        verify(mock).varargs(captor.capture(), captor.capture());
+
+        assertThat(captor).contains("1", "2");
+    }
+
+    @Test
+    public void shouldCaptureVarArgs_oneNullArgument() {
+        mock.varargs("1", null);
+
+        verify(mock).varargs(captor.capture());
+
+        assertThat(captor).contains("1", (String) null);
+    }
+
+    @Test
+    public void shouldCaptureVarArgs_oneNullArgument2() {
+        mock.varargs("1", null);
+
+        verify(mock).varargs(captor.capture(), captor.capture());
+
+        assertThat(captor).contains("1", (String) null);
+    }
+
+    @Test
+    public void shouldCaptureVarArgs_3args2captures() {
+        mock.varargs("1", "2", "3");
+
+        exception.expect(ArgumentsAreDifferent.class);
+
+        verify(mock).varargs(captor.capture(), captor.capture());
+
+    }
+
+    @Test
+    public void shouldCaptureVarArgs_3argsCaptorMatcherMix() {
+        mock.varargs("1", "2", "3");
+
+        verify(mock).varargs(captor.capture(), eq("2"), captor.capture());
+
+        assertThat(captor).containsExactly("1", "3");
+
+    }
+
+    @Test
+    public void shouldCaptureVarArgs_1args2captures() {
+        mock.varargs("1");
+
+        exception.expect(ArgumentsAreDifferent.class);
+
+        verify(mock).varargs(captor.capture(), captor.capture());
+
+    }
+
+    @Test
+    @Ignore
+    public void shouldCaptureVarArgsAsArray() throws Exception {
+        mock.varargs("1", "2");
+
+        ArgumentCaptor<String[]> varargCaptor = ArgumentCaptor.forClass(String[].class);
+
+        verify(mock).varargs(varargCaptor.capture());
+
+        assertThat(varargCaptor).containsExactly(new String[] { "1", "2" });
+    }
+    
+    private <T> AbstractListAssert<?, ?, T> assertThat(ArgumentCaptor<T> captor) {
+        return Assertions.assertThat(captor.getAllValues());
+    }
+}


### PR DESCRIPTION
fixes #439 
 * ArgumentCaptor and ArgumentMatchers can now mixed in varargs
 * added 25 regression tests in VarargsTest (5 are ignored cause they belong to other issues and fail currently)
 * refactored InvocationMatcher:
  * removed duplicates and unneccesary code
  * simplified the logic as much as possible
  * moved caputing logic to InvocationArgumentCaptor (if you have a better name let me know)