### PR TITLE
Fixes #497 : RETURNS_DEEP_STUBS may try to mock final classes

### DIFF
--- a/src/main/java/org/mockito/internal/util/reflection/GenericMetadataSupport.java
+++ b/src/main/java/org/mockito/internal/util/reflection/GenericMetadataSupport.java
@@ -251,7 +251,7 @@ public abstract class GenericMetadataSupport {
     private GenericMetadataSupport resolveGenericType(Type type, Method method) {
 
         if (type instanceof Class) {
-            return new NotGenericReturnTypeSupport(type);
+            return new NotGenericReturnTypeSupport(this, type);
         }
         if (type instanceof ParameterizedType) {
             return new ParameterizedReturnType(this, method.getTypeParameters(), (ParameterizedType) type);
@@ -494,8 +494,11 @@ public abstract class GenericMetadataSupport {
     private static class NotGenericReturnTypeSupport extends GenericMetadataSupport {
         private final Class<?> returnType;
 
-        public NotGenericReturnTypeSupport(Type genericReturnType) {
+        public NotGenericReturnTypeSupport(GenericMetadataSupport source, Type genericReturnType) {
             returnType = (Class<?>) genericReturnType;
+            this.contextualActualTypeParameters = source.contextualActualTypeParameters;
+
+            registerAllTypeVariables(returnType);
         }
 
         @Override

--- a/src/test/java/org/mockitousage/stubbing/DeepStubbingTest.java
+++ b/src/test/java/org/mockitousage/stubbing/DeepStubbingTest.java
@@ -14,6 +14,7 @@ import javax.net.SocketFactory;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.net.Socket;
+import java.util.List;
 import java.util.Locale;
 
 import static junit.framework.TestCase.*;
@@ -64,7 +65,15 @@ public class DeepStubbingTest extends TestBase {
     }    
     
     static final class FinalClass {}
-    
+
+    interface First {
+        Second getSecond();
+
+        String getString();
+    }
+
+    interface Second extends List<String> {}
+
     @Test
     public void myTest() throws Exception {
         SocketFactory sf = mock(SocketFactory.class, RETURNS_DEEP_STUBS);
@@ -309,5 +318,12 @@ public class DeepStubbingTest extends TestBase {
         
         //then
         assertEquals(value, person.getFinalClass());
+    }
+
+    @Test
+    public void deep_stub_does_not_try_to_mock_generic_final_classes() {
+        First first = mock(First.class, RETURNS_DEEP_STUBS);
+        assertNull(first.getString());
+        assertNull(first.getSecond().get(0));
     }
 }


### PR DESCRIPTION
Fixes #497

With deep stubs, it was possible for generic metadata to be lost/unused
through nested invocations on non generic types. This could cause `RETURNS_DEEP_STUBS` to try mocking final classes which would result in a `ClassCastException`.

Apparently my other PR (#549) wasn't quite enough to fully fix this problem.

---------------------------------
**EDITED by mockito team**