### PR TITLE
Moves arity interfaces of java8 helper answers to public API

### DIFF
--- a/src/main/java/org/mockito/AdditionalAnswers.java
+++ b/src/main/java/org/mockito/AdditionalAnswers.java
@@ -216,6 +216,7 @@ public class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.0.0
      */
+    @Incubating
     public static <T, A> Answer<T> answer(Answer1<T, A> answer) {
         return toAnswer(answer);
     }
@@ -228,6 +229,7 @@ public class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.0.0
      */
+    @Incubating
     public static <A> Answer<Void> answerVoid(VoidAnswer1<A> answer) {
         return toAnswer(answer);
     }
@@ -242,6 +244,7 @@ public class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.0.0
      */
+    @Incubating
     public static <T, A, B> Answer<T> answer(Answer2<T, A, B> answer) {
         return toAnswer(answer);
     }
@@ -255,6 +258,7 @@ public class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.0.0
      */
+    @Incubating
     public static <A, B> Answer<Void> answerVoid(VoidAnswer2<A, B> answer) {
         return toAnswer(answer);
     }
@@ -270,6 +274,7 @@ public class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.0.0
      */
+    @Incubating
     public static <T, A, B, C> Answer<T> answer(Answer3<T, A, B, C> answer) {
         return toAnswer(answer);
     }
@@ -284,6 +289,7 @@ public class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.0.0
      */
+    @Incubating
     public static <A, B, C> Answer<Void> answerVoid(VoidAnswer3<A, B, C> answer) {
         return toAnswer(answer);
     }
@@ -300,6 +306,7 @@ public class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.0.0
      */
+    @Incubating
     public static <T, A, B, C, D> Answer<T> answer(Answer4<T, A, B, C, D> answer) {
         return toAnswer(answer);
     }
@@ -315,6 +322,7 @@ public class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.0.0
      */
+    @Incubating
     public static <A, B, C, D> Answer<Void> answerVoid(VoidAnswer4<A, B, C, D> answer) {
         return toAnswer(answer);
     }
@@ -332,6 +340,7 @@ public class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.0.0
      */
+    @Incubating
     public static <T, A, B, C, D, E> Answer<T> answer(Answer5<T, A, B, C, D, E> answer) {
         return toAnswer(answer);
     }
@@ -349,6 +358,7 @@ public class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.0.0
      */
+    @Incubating
     public static <A, B, C, D, E> Answer<Void> answerVoid(VoidAnswer5<A, B, C, D, E> answer) {
         return toAnswer(answer);
     }

--- a/src/main/java/org/mockito/AdditionalAnswers.java
+++ b/src/main/java/org/mockito/AdditionalAnswers.java
@@ -4,19 +4,28 @@
  */
 package org.mockito;
 
-import org.mockito.internal.stubbing.answers.AnswerFunctionalInterfaces;
+import static org.mockito.internal.stubbing.answers.AnswerFunctionalInterfaces.toAnswer;
+import java.util.Collection;
 import org.mockito.internal.stubbing.answers.ReturnsArgumentAt;
 import org.mockito.internal.stubbing.answers.ReturnsElementsOf;
 import org.mockito.internal.stubbing.defaultanswers.ForwardsInvocations;
 import org.mockito.stubbing.Answer;
-
-import java.util.Collection;
+import org.mockito.stubbing.Answer1;
+import org.mockito.stubbing.Answer2;
+import org.mockito.stubbing.Answer3;
+import org.mockito.stubbing.Answer4;
+import org.mockito.stubbing.Answer5;
+import org.mockito.stubbing.VoidAnswer1;
+import org.mockito.stubbing.VoidAnswer2;
+import org.mockito.stubbing.VoidAnswer3;
+import org.mockito.stubbing.VoidAnswer4;
+import org.mockito.stubbing.VoidAnswer5;
 
 /**
  * Additional answers provides factory methods for answers.
  *
  * <p>Currently offer answers that can return the parameter of an invocation at a certain position,
- * along with answers that draw on a strongly typed interface from {@link AnswerFunctionalInterfaces}
+ * along with answers that draw on a strongly typed interface from {@link org.mockito.internal.stubbing.answers.AnswerFunctionalInterfaces}
  * to provide a neater way to write custom answers that either return a value or are void.
  *
  * <p>See factory methods for more information : {@link #returnsFirstArg}, {@link #returnsSecondArg},
@@ -207,8 +216,8 @@ public class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.0.0
      */
-    public static <T, A, B> Answer<T> answer(AnswerFunctionalInterfaces.Answer1<T, A> answer) {
-        return AnswerFunctionalInterfaces.toAnswer(answer);
+    public static <T, A> Answer<T> answer(Answer1<T, A> answer) {
+        return toAnswer(answer);
     }
 
     /**
@@ -219,8 +228,8 @@ public class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.0.0
      */
-    public static <A, B> Answer<Void> answerVoid(AnswerFunctionalInterfaces.VoidAnswer1<A> answer) {
-        return AnswerFunctionalInterfaces.toAnswer(answer);
+    public static <A> Answer<Void> answerVoid(VoidAnswer1<A> answer) {
+        return toAnswer(answer);
     }
 
     /**
@@ -233,8 +242,8 @@ public class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.0.0
      */
-    public static <T, A, B> Answer<T> answer(AnswerFunctionalInterfaces.Answer2<T, A, B> answer) {
-        return AnswerFunctionalInterfaces.toAnswer(answer);
+    public static <T, A, B> Answer<T> answer(Answer2<T, A, B> answer) {
+        return toAnswer(answer);
     }
 
     /**
@@ -246,8 +255,8 @@ public class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.0.0
      */
-    public static <A, B> Answer<Void> answerVoid(AnswerFunctionalInterfaces.VoidAnswer2<A, B> answer) {
-        return AnswerFunctionalInterfaces.toAnswer(answer);
+    public static <A, B> Answer<Void> answerVoid(VoidAnswer2<A, B> answer) {
+        return toAnswer(answer);
     }
 
     /**
@@ -261,8 +270,8 @@ public class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.0.0
      */
-    public static <T, A, B, C> Answer<T> answer(AnswerFunctionalInterfaces.Answer3<T, A, B, C> answer) {
-        return AnswerFunctionalInterfaces.toAnswer(answer);
+    public static <T, A, B, C> Answer<T> answer(Answer3<T, A, B, C> answer) {
+        return toAnswer(answer);
     }
 
     /**
@@ -275,8 +284,8 @@ public class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.0.0
      */
-    public static <A, B, C> Answer<Void> answerVoid(AnswerFunctionalInterfaces.VoidAnswer3<A, B, C> answer) {
-        return AnswerFunctionalInterfaces.toAnswer(answer);
+    public static <A, B, C> Answer<Void> answerVoid(VoidAnswer3<A, B, C> answer) {
+        return toAnswer(answer);
     }
 
     /**
@@ -291,8 +300,8 @@ public class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.0.0
      */
-    public static <T, A, B, C, D> Answer<T> answer(AnswerFunctionalInterfaces.Answer4<T, A, B, C, D> answer) {
-        return AnswerFunctionalInterfaces.toAnswer(answer);
+    public static <T, A, B, C, D> Answer<T> answer(Answer4<T, A, B, C, D> answer) {
+        return toAnswer(answer);
     }
 
     /**
@@ -306,8 +315,8 @@ public class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.0.0
      */
-    public static <A, B, C, D> Answer<Void> answerVoid(AnswerFunctionalInterfaces.VoidAnswer4<A, B, C, D> answer) {
-        return AnswerFunctionalInterfaces.toAnswer(answer);
+    public static <A, B, C, D> Answer<Void> answerVoid(VoidAnswer4<A, B, C, D> answer) {
+        return toAnswer(answer);
     }
 
     /**
@@ -323,8 +332,8 @@ public class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.0.0
      */
-    public static <T, A, B, C, D, E> Answer<T> answer(AnswerFunctionalInterfaces.Answer5<T, A, B, C, D, E> answer) {
-        return AnswerFunctionalInterfaces.toAnswer(answer);
+    public static <T, A, B, C, D, E> Answer<T> answer(Answer5<T, A, B, C, D, E> answer) {
+        return toAnswer(answer);
     }
 
     /**
@@ -340,7 +349,7 @@ public class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.0.0
      */
-    public static <A, B, C, D, E> Answer<Void> answerVoid(AnswerFunctionalInterfaces.VoidAnswer5<A, B, C, D, E> answer) {
-        return AnswerFunctionalInterfaces.toAnswer(answer);
+    public static <A, B, C, D, E> Answer<Void> answerVoid(VoidAnswer5<A, B, C, D, E> answer) {
+        return toAnswer(answer);
     }
 }

--- a/src/main/java/org/mockito/Answers.java
+++ b/src/main/java/org/mockito/Answers.java
@@ -88,7 +88,7 @@ public enum Answers implements Answer<Object>{
     }
 
     /**
-     * @deprecated as of 2.0. Use the enum-constant directly, instead of this getter. This method will be removed in a future release<br>
+     * @deprecated as of 2.0.0 Use the enum-constant directly, instead of this getter. This method will be removed in a future release<br>
      * E.g. instead of <code>Answers.CALLS_REAL_METHODS.get()</code> use <code>Answers.CALLS_REAL_METHODS</code> .
      */
     @Deprecated

--- a/src/main/java/org/mockito/BDDMockito.java
+++ b/src/main/java/org/mockito/BDDMockito.java
@@ -336,9 +336,12 @@ public class BDDMockito extends Mockito {
         BDDStubber will(Answer<?> answer);
 
         /**
-         * See original {@link Stubber#doNothing()}
+         * See original {@link Stubber#doNothing()}.
+         *
+         * This method will be removed in version 3.0.0
+         *
          * @since 1.8.0
-         * @deprecated please use {@link #willDoNothing()} instead
+         * @deprecated as of 2.0.0 please use {@link #willDoNothing()} instead
          */
         @Deprecated
         BDDStubber willNothing();

--- a/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java
@@ -2,6 +2,16 @@ package org.mockito.internal.stubbing.answers;
 
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.mockito.stubbing.Answer1;
+import org.mockito.stubbing.Answer2;
+import org.mockito.stubbing.Answer3;
+import org.mockito.stubbing.Answer4;
+import org.mockito.stubbing.Answer5;
+import org.mockito.stubbing.VoidAnswer1;
+import org.mockito.stubbing.VoidAnswer2;
+import org.mockito.stubbing.VoidAnswer3;
+import org.mockito.stubbing.VoidAnswer4;
+import org.mockito.stubbing.VoidAnswer5;
 
 /**
  * Functional interfaces to make it easy to implement answers in Java 8
@@ -221,111 +231,5 @@ public class AnswerFunctionalInterfaces {
                 return null;
             }
         };
-    }
-
-
-    /**
-     * One parameter function which returns something
-     * @param <T> return type
-     * @param <A> input parameter 1 type
-     */
-    public interface Answer1<T, A> {
-        T answer(A a);
-    }
-
-    /**
-     * One parameter void function
-     * @param <A> input parameter 1 type
-     */
-    public interface VoidAnswer1<A> {
-        void answer(A a);
-    }
-
-    /**
-     * Two parameter function which returns something
-     * @param <T> return type
-     * @param <A> input parameter 1 type
-     * @param <B> input parameter 2 type
-     */
-    public interface Answer2<T, A, B> {
-        T answer(A a, B b);
-    }
-
-    /**
-     * Two parameter void function
-     * @param <A> input parameter 1 type
-     * @param <B> input parameter 2 type
-     */
-    public interface VoidAnswer2< A, B> {
-        void answer(A a, B b);
-    }
-
-    /**
-     * Three parameter function which returns something
-     * @param <T> return type
-     * @param <A> input parameter 1 type
-     * @param <B> input parameter 2 type
-     * @param <C> input parameter 3 type
-     */
-    public interface Answer3<T, A, B, C> {
-        T answer(A a, B b, C c);
-    }
-
-    /**
-     * Two parameter void function
-     * @param <A> input parameter 1 type
-     * @param <B> input parameter 2 type
-     * @param <C> input parameter 3 type
-     */
-    public interface VoidAnswer3< A, B, C> {
-        void answer(A a, B b, C c);
-    }
-
-    /**
-     * Three parameter function which returns something
-     * @param <T> return type
-     * @param <A> input parameter 1 type
-     * @param <B> input parameter 2 type
-     * @param <C> input parameter 3 type
-     * @param <D> input parameter 4 type
-     */
-    public interface Answer4<T, A, B, C, D> {
-        T answer(A a, B b, C c, D d);
-    }
-
-    /**
-     * Two parameter void function
-     * @param <A> input parameter 1 type
-     * @param <B> input parameter 2 type
-     * @param <C> input parameter 3 type
-     * @param <D> input parameter 4 type
-     */
-    public interface VoidAnswer4<A, B, C, D> {
-        void answer(A a, B b, C c, D d);
-    }
-
-    /**
-     * Three parameter function which returns something
-     * @param <T> return type
-     * @param <A> input parameter 1 type
-     * @param <B> input parameter 2 type
-     * @param <C> input parameter 3 type
-     * @param <D> input parameter 4 type
-     * @param <E> input parameter 5 type
-     */
-    public interface Answer5<T, A, B, C, D, E> {
-        T answer(A a, B b, C c, D d, E e);
-    }
-
-    /**
-     * Two parameter void function
-     * @param <A> input parameter 1 type
-     * @param <B> input parameter 2 type
-     * @param <C> input parameter 3 type
-     * @param <D> input parameter 4 type
-     * @param <E> input parameter 5 type
-     */
-    public interface VoidAnswer5< A, B, C, D, E> {
-        void answer(A a, B b, C c, D d, E e);
     }
 }

--- a/src/main/java/org/mockito/stubbing/Answer1.java
+++ b/src/main/java/org/mockito/stubbing/Answer1.java
@@ -1,11 +1,14 @@
 package org.mockito.stubbing;
 
+import org.mockito.Incubating;
+
 /**
  * One parameter function which returns something
  *
  * @param <T> return type
  * @param <A> input parameter 1 type
  */
+@Incubating
 public interface Answer1<T, A> {
     T answer(A a);
 }

--- a/src/main/java/org/mockito/stubbing/Answer1.java
+++ b/src/main/java/org/mockito/stubbing/Answer1.java
@@ -1,0 +1,12 @@
+package org.mockito.stubbing;
+
+/**
+ * One parameter function which returns something
+ *
+ * @param <T> return type
+ * @param <A> input parameter 1 type
+ */
+public interface Answer1<T, A> {
+    T answer(A a);
+}
+

--- a/src/main/java/org/mockito/stubbing/Answer2.java
+++ b/src/main/java/org/mockito/stubbing/Answer2.java
@@ -1,5 +1,7 @@
 package org.mockito.stubbing;
 
+import org.mockito.Incubating;
+
 /**
  * Two parameter function which returns something
  *
@@ -7,6 +9,7 @@ package org.mockito.stubbing;
  * @param <A> input parameter 1 type
  * @param <B> input parameter 2 type
  */
+@Incubating
 public interface Answer2<T, A, B> {
     T answer(A a, B b);
 }

--- a/src/main/java/org/mockito/stubbing/Answer2.java
+++ b/src/main/java/org/mockito/stubbing/Answer2.java
@@ -1,0 +1,12 @@
+package org.mockito.stubbing;
+
+/**
+ * Two parameter function which returns something
+ *
+ * @param <T> return type
+ * @param <A> input parameter 1 type
+ * @param <B> input parameter 2 type
+ */
+public interface Answer2<T, A, B> {
+    T answer(A a, B b);
+}

--- a/src/main/java/org/mockito/stubbing/Answer3.java
+++ b/src/main/java/org/mockito/stubbing/Answer3.java
@@ -1,0 +1,13 @@
+package org.mockito.stubbing;
+
+/**
+ * Three parameter function which returns something
+ *
+ * @param <T> return type
+ * @param <A> input parameter 1 type
+ * @param <B> input parameter 2 type
+ * @param <C> input parameter 3 type
+ */
+public interface Answer3<T, A, B, C> {
+    T answer(A a, B b, C c);
+}

--- a/src/main/java/org/mockito/stubbing/Answer3.java
+++ b/src/main/java/org/mockito/stubbing/Answer3.java
@@ -1,5 +1,7 @@
 package org.mockito.stubbing;
 
+import org.mockito.Incubating;
+
 /**
  * Three parameter function which returns something
  *
@@ -8,6 +10,7 @@ package org.mockito.stubbing;
  * @param <B> input parameter 2 type
  * @param <C> input parameter 3 type
  */
+@Incubating
 public interface Answer3<T, A, B, C> {
     T answer(A a, B b, C c);
 }

--- a/src/main/java/org/mockito/stubbing/Answer4.java
+++ b/src/main/java/org/mockito/stubbing/Answer4.java
@@ -1,0 +1,14 @@
+package org.mockito.stubbing;
+
+/**
+ * Three parameter function which returns something
+ *
+ * @param <T> return type
+ * @param <A> input parameter 1 type
+ * @param <B> input parameter 2 type
+ * @param <C> input parameter 3 type
+ * @param <D> input parameter 4 type
+ */
+public interface Answer4<T, A, B, C, D> {
+    T answer(A a, B b, C c, D d);
+}

--- a/src/main/java/org/mockito/stubbing/Answer4.java
+++ b/src/main/java/org/mockito/stubbing/Answer4.java
@@ -1,5 +1,7 @@
 package org.mockito.stubbing;
 
+import org.mockito.Incubating;
+
 /**
  * Three parameter function which returns something
  *
@@ -9,6 +11,7 @@ package org.mockito.stubbing;
  * @param <C> input parameter 3 type
  * @param <D> input parameter 4 type
  */
+@Incubating
 public interface Answer4<T, A, B, C, D> {
     T answer(A a, B b, C c, D d);
 }

--- a/src/main/java/org/mockito/stubbing/Answer5.java
+++ b/src/main/java/org/mockito/stubbing/Answer5.java
@@ -1,5 +1,7 @@
 package org.mockito.stubbing;
 
+import org.mockito.Incubating;
+
 /**
  * Three parameter function which returns something
  *
@@ -10,6 +12,7 @@ package org.mockito.stubbing;
  * @param <D> input parameter 4 type
  * @param <E> input parameter 5 type
  */
+@Incubating
 public interface Answer5<T, A, B, C, D, E> {
     T answer(A a, B b, C c, D d, E e);
 }

--- a/src/main/java/org/mockito/stubbing/Answer5.java
+++ b/src/main/java/org/mockito/stubbing/Answer5.java
@@ -1,0 +1,15 @@
+package org.mockito.stubbing;
+
+/**
+ * Three parameter function which returns something
+ *
+ * @param <T> return type
+ * @param <A> input parameter 1 type
+ * @param <B> input parameter 2 type
+ * @param <C> input parameter 3 type
+ * @param <D> input parameter 4 type
+ * @param <E> input parameter 5 type
+ */
+public interface Answer5<T, A, B, C, D, E> {
+    T answer(A a, B b, C c, D d, E e);
+}

--- a/src/main/java/org/mockito/stubbing/VoidAnswer1.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer1.java
@@ -1,0 +1,10 @@
+package org.mockito.stubbing;
+
+/**
+ * One parameter void function
+ *
+ * @param <A> input parameter 1 type
+ */
+public interface VoidAnswer1<A> {
+    void answer(A a);
+}

--- a/src/main/java/org/mockito/stubbing/VoidAnswer1.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer1.java
@@ -1,10 +1,13 @@
 package org.mockito.stubbing;
 
+import org.mockito.Incubating;
+
 /**
  * One parameter void function
  *
  * @param <A> input parameter 1 type
  */
+@Incubating
 public interface VoidAnswer1<A> {
     void answer(A a);
 }

--- a/src/main/java/org/mockito/stubbing/VoidAnswer2.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer2.java
@@ -1,11 +1,14 @@
 package org.mockito.stubbing;
 
+import org.mockito.Incubating;
+
 /**
  * Two parameter void function
  *
  * @param <A> input parameter 1 type
  * @param <B> input parameter 2 type
  */
+@Incubating
 public interface VoidAnswer2<A, B> {
     void answer(A a, B b);
 }

--- a/src/main/java/org/mockito/stubbing/VoidAnswer2.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer2.java
@@ -1,0 +1,11 @@
+package org.mockito.stubbing;
+
+/**
+ * Two parameter void function
+ *
+ * @param <A> input parameter 1 type
+ * @param <B> input parameter 2 type
+ */
+public interface VoidAnswer2<A, B> {
+    void answer(A a, B b);
+}

--- a/src/main/java/org/mockito/stubbing/VoidAnswer3.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer3.java
@@ -1,0 +1,12 @@
+package org.mockito.stubbing;
+
+/**
+ * Two parameter void function
+ *
+ * @param <A> input parameter 1 type
+ * @param <B> input parameter 2 type
+ * @param <C> input parameter 3 type
+ */
+public interface VoidAnswer3<A, B, C> {
+    void answer(A a, B b, C c);
+}

--- a/src/main/java/org/mockito/stubbing/VoidAnswer3.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer3.java
@@ -1,5 +1,7 @@
 package org.mockito.stubbing;
 
+import org.mockito.Incubating;
+
 /**
  * Two parameter void function
  *
@@ -7,6 +9,7 @@ package org.mockito.stubbing;
  * @param <B> input parameter 2 type
  * @param <C> input parameter 3 type
  */
+@Incubating
 public interface VoidAnswer3<A, B, C> {
     void answer(A a, B b, C c);
 }

--- a/src/main/java/org/mockito/stubbing/VoidAnswer4.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer4.java
@@ -1,0 +1,13 @@
+package org.mockito.stubbing;
+
+/**
+ * Two parameter void function
+ *
+ * @param <A> input parameter 1 type
+ * @param <B> input parameter 2 type
+ * @param <C> input parameter 3 type
+ * @param <D> input parameter 4 type
+ */
+public interface VoidAnswer4<A, B, C, D> {
+    void answer(A a, B b, C c, D d);
+}

--- a/src/main/java/org/mockito/stubbing/VoidAnswer4.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer4.java
@@ -1,5 +1,7 @@
 package org.mockito.stubbing;
 
+import org.mockito.Incubating;
+
 /**
  * Two parameter void function
  *
@@ -8,6 +10,7 @@ package org.mockito.stubbing;
  * @param <C> input parameter 3 type
  * @param <D> input parameter 4 type
  */
+@Incubating
 public interface VoidAnswer4<A, B, C, D> {
     void answer(A a, B b, C c, D d);
 }

--- a/src/main/java/org/mockito/stubbing/VoidAnswer5.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer5.java
@@ -1,0 +1,14 @@
+package org.mockito.stubbing;
+
+/**
+ * Two parameter void function
+ *
+ * @param <A> input parameter 1 type
+ * @param <B> input parameter 2 type
+ * @param <C> input parameter 3 type
+ * @param <D> input parameter 4 type
+ * @param <E> input parameter 5 type
+ */
+public interface VoidAnswer5<A, B, C, D, E> {
+    void answer(A a, B b, C c, D d, E e);
+}

--- a/src/main/java/org/mockito/stubbing/VoidAnswer5.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer5.java
@@ -1,5 +1,7 @@
 package org.mockito.stubbing;
 
+import org.mockito.Incubating;
+
 /**
  * Two parameter void function
  *
@@ -9,6 +11,7 @@ package org.mockito.stubbing;
  * @param <D> input parameter 4 type
  * @param <E> input parameter 5 type
  */
+@Incubating
 public interface VoidAnswer5<A, B, C, D, E> {
     void answer(A a, B b, C c, D d, E e);
 }

--- a/src/test/java/org/mockitousage/stubbing/StubbingWithAdditionalAnswersTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingWithAdditionalAnswersTest.java
@@ -4,16 +4,38 @@
  */
 package org.mockitousage.stubbing;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.AdditionalAnswers.answer;
+import static org.mockito.AdditionalAnswers.answerVoid;
+import static org.mockito.AdditionalAnswers.returnsArgAt;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.AdditionalAnswers.returnsLastArg;
+import static org.mockito.AdditionalAnswers.returnsSecondArg;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.anyInt;
+import static org.mockito.BDDMockito.anyObject;
+import static org.mockito.BDDMockito.anyString;
+import static org.mockito.BDDMockito.anyVararg;
+import static org.mockito.BDDMockito.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.times;
+import static org.mockito.BDDMockito.verify;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.internal.stubbing.answers.AnswerFunctionalInterfaces;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer1;
+import org.mockito.stubbing.Answer2;
+import org.mockito.stubbing.Answer3;
+import org.mockito.stubbing.Answer4;
+import org.mockito.stubbing.Answer5;
+import org.mockito.stubbing.VoidAnswer1;
+import org.mockito.stubbing.VoidAnswer2;
+import org.mockito.stubbing.VoidAnswer3;
+import org.mockito.stubbing.VoidAnswer4;
+import org.mockito.stubbing.VoidAnswer5;
 import org.mockitousage.IMethods;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.AdditionalAnswers.*;
-import static org.mockito.BDDMockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StubbingWithAdditionalAnswersTest {
@@ -50,7 +72,7 @@ public class StubbingWithAdditionalAnswersTest {
     @Test
     public void can_return_based_on_strongly_types_one_parameter_function() throws Exception {
         given(iMethods.simpleMethod(anyString()))
-                .will(answer(new AnswerFunctionalInterfaces.Answer1<String, String>() {
+                .will(answer(new Answer1<String, String>() {
                     public String answer(String s) {
                         return s;
                     }
@@ -64,7 +86,7 @@ public class StubbingWithAdditionalAnswersTest {
         final IMethods target = mock(IMethods.class);
 
         given(iMethods.simpleMethod(anyString()))
-                .will(answerVoid(new AnswerFunctionalInterfaces.VoidAnswer1<String>() {
+                .will(answerVoid(new VoidAnswer1<String>() {
                     public void answer(String s) {
                         target.simpleMethod(s);
                     }
@@ -80,7 +102,7 @@ public class StubbingWithAdditionalAnswersTest {
     @Test
     public void can_return_based_on_strongly_typed_two_parameter_function() throws Exception {
         given(iMethods.simpleMethod(anyString(), anyInt()))
-            .will(answer(new AnswerFunctionalInterfaces.Answer2<String, String, Integer>() {
+            .will(answer(new Answer2<String, String, Integer>() {
                 public String answer(String s, Integer i) {
                     return s + "-" + i;
                 }
@@ -94,7 +116,7 @@ public class StubbingWithAdditionalAnswersTest {
         final IMethods target = mock(IMethods.class);
 
         given(iMethods.simpleMethod(anyString(), anyInt()))
-            .will(answerVoid(new AnswerFunctionalInterfaces.VoidAnswer2<String, Integer>() {
+            .will(answerVoid(new VoidAnswer2<String, Integer>() {
                 public void answer(String s, Integer i) {
                     target.simpleMethod(s, i);
                 }
@@ -111,7 +133,7 @@ public class StubbingWithAdditionalAnswersTest {
     public void can_return_based_on_strongly_typed_three_parameter_function() throws Exception {
         final IMethods target = mock(IMethods.class);
         given(iMethods.threeArgumentMethodWithStrings(anyInt(), anyString(), anyString()))
-                .will(answer(new AnswerFunctionalInterfaces.Answer3<String, Integer, String, String>() {
+                .will(answer(new Answer3<String, Integer, String, String>() {
                     public String answer(Integer i, String s1, String s2) {
                         target.threeArgumentMethodWithStrings(i, s1, s2);
                         return "answered";
@@ -127,7 +149,7 @@ public class StubbingWithAdditionalAnswersTest {
         final IMethods target = mock(IMethods.class);
 
         given(iMethods.threeArgumentMethodWithStrings(anyInt(), anyString(), anyString()))
-                .will(answerVoid(new AnswerFunctionalInterfaces.VoidAnswer3<Integer, String, String>() {
+                .will(answerVoid(new VoidAnswer3<Integer, String, String>() {
                     public void answer(Integer i, String s1, String s2) {
                         target.threeArgumentMethodWithStrings(i, s1, s2);
                     }
@@ -144,7 +166,7 @@ public class StubbingWithAdditionalAnswersTest {
         public void can_return_based_on_strongly_typed_four_parameter_function() throws Exception {
         final IMethods target = mock(IMethods.class);
         given(iMethods.fourArgumentMethod(anyInt(), anyString(), anyString(), any(boolean[].class)))
-                .will(answer(new AnswerFunctionalInterfaces.Answer4<String, Integer, String, String, boolean[]>() {
+                .will(answer(new Answer4<String, Integer, String, String, boolean[]>() {
                     public String answer(Integer i, String s1, String s2, boolean[] a) {
                         target.fourArgumentMethod(i, s1, s2, a);
                         return "answered";
@@ -161,7 +183,7 @@ public class StubbingWithAdditionalAnswersTest {
         final IMethods target = mock(IMethods.class);
 
         given(iMethods.fourArgumentMethod(anyInt(), anyString(), anyString(), any(boolean[].class)))
-                .will(answerVoid(new AnswerFunctionalInterfaces.VoidAnswer4<Integer, String, String, boolean[]>() {
+                .will(answerVoid(new VoidAnswer4<Integer, String, String, boolean[]>() {
                     public void answer(Integer i, String s1, String s2, boolean[] a) {
                         target.fourArgumentMethod(i, s1, s2, a);
                     }
@@ -179,7 +201,7 @@ public class StubbingWithAdditionalAnswersTest {
     public void can_return_based_on_strongly_typed_five_parameter_function() throws Exception {
         final IMethods target = mock(IMethods.class);
         given(iMethods.simpleMethod(anyString(), anyInt(), anyInt(), anyInt(), anyInt()))
-                .will(answer(new AnswerFunctionalInterfaces.Answer5<String, String, Integer, Integer, Integer, Integer>() {
+                .will(answer(new Answer5<String, String, Integer, Integer, Integer, Integer>() {
                     public String answer(String s1, Integer i1, Integer i2, Integer i3, Integer i4) {
                         target.simpleMethod(s1, i1, i2, i3, i4);
                         return "answered";
@@ -195,7 +217,7 @@ public class StubbingWithAdditionalAnswersTest {
         final IMethods target = mock(IMethods.class);
 
         given(iMethods.simpleMethod(anyString(), anyInt(), anyInt(), anyInt(), anyInt()))
-                .will(answerVoid(new AnswerFunctionalInterfaces.VoidAnswer5<String, Integer, Integer, Integer, Integer>() {
+                .will(answerVoid(new VoidAnswer5<String, Integer, Integer, Integer, Integer>() {
                     public void  answer(String s1, Integer i1, Integer i2, Integer i3, Integer i4) {
                         target.simpleMethod(s1, i1, i2, i3, i4);
                     }


### PR DESCRIPTION
The Java 8 helper interfaces have been introduced in #338. However the public `AdditionalAnswers.answer` family leak the functional interfaces.

These _parameter arity_ interfaces can be public, hence they are moved next to `Answer` in the `org.mockito.stubbing` package.

I'm however in favor of adding the `@Incubating` annotation on those APIs and related objects. Thoughts ?

Fixes #614