### PR TITLE
Updated the javadocs

### DIFF
--- a/src/main/java/org/mockito/AdditionalAnswers.java
+++ b/src/main/java/org/mockito/AdditionalAnswers.java
@@ -214,7 +214,7 @@ public class AdditionalAnswers {
      * @param <T> return type
      * @param <A> input parameter type 1
      * @return the answer object to use
-     * @since 2.0.0
+     * @since 2.1.0
      */
     @Incubating
     public static <T, A> Answer<T> answer(Answer1<T, A> answer) {
@@ -227,7 +227,7 @@ public class AdditionalAnswers {
      * @param answer interface to the answer - a void method
      * @param <A> input parameter type 1
      * @return the answer object to use
-     * @since 2.0.0
+     * @since 2.1.0
      */
     @Incubating
     public static <A> Answer<Void> answerVoid(VoidAnswer1<A> answer) {
@@ -242,7 +242,7 @@ public class AdditionalAnswers {
      * @param <A> input parameter type 1
      * @param <B> input parameter type 2
      * @return the answer object to use
-     * @since 2.0.0
+     * @since 2.1.0
      */
     @Incubating
     public static <T, A, B> Answer<T> answer(Answer2<T, A, B> answer) {
@@ -256,7 +256,7 @@ public class AdditionalAnswers {
      * @param <A> input parameter type 1
      * @param <B> input parameter type 2
      * @return the answer object to use
-     * @since 2.0.0
+     * @since 2.1.0
      */
     @Incubating
     public static <A, B> Answer<Void> answerVoid(VoidAnswer2<A, B> answer) {
@@ -272,7 +272,7 @@ public class AdditionalAnswers {
      * @param <B> input parameter type 2
      * @param <C> input parameter type 3
      * @return the answer object to use
-     * @since 2.0.0
+     * @since 2.1.0
      */
     @Incubating
     public static <T, A, B, C> Answer<T> answer(Answer3<T, A, B, C> answer) {
@@ -287,7 +287,7 @@ public class AdditionalAnswers {
      * @param <B> input parameter type 2
      * @param <C> input parameter type 3
      * @return the answer object to use
-     * @since 2.0.0
+     * @since 2.1.0
      */
     @Incubating
     public static <A, B, C> Answer<Void> answerVoid(VoidAnswer3<A, B, C> answer) {
@@ -304,7 +304,7 @@ public class AdditionalAnswers {
      * @param <C> input parameter type 3
      * @param <D> input parameter type 4
      * @return the answer object to use
-     * @since 2.0.0
+     * @since 2.1.0
      */
     @Incubating
     public static <T, A, B, C, D> Answer<T> answer(Answer4<T, A, B, C, D> answer) {
@@ -320,7 +320,7 @@ public class AdditionalAnswers {
      * @param <C> input parameter type 3
      * @param <D> input parameter type 4
      * @return the answer object to use
-     * @since 2.0.0
+     * @since 2.1.0
      */
     @Incubating
     public static <A, B, C, D> Answer<Void> answerVoid(VoidAnswer4<A, B, C, D> answer) {
@@ -338,7 +338,7 @@ public class AdditionalAnswers {
      * @param <D> input parameter type 4
      * @param <E> input parameter type 5
      * @return the answer object to use
-     * @since 2.0.0
+     * @since 2.1.0
      */
     @Incubating
     public static <T, A, B, C, D, E> Answer<T> answer(Answer5<T, A, B, C, D, E> answer) {
@@ -356,7 +356,7 @@ public class AdditionalAnswers {
      * @param <D> input parameter type 4
      * @param <E> input parameter type 5
      * @return the answer object to use
-     * @since 2.0.0
+     * @since 2.1.0
      */
     @Incubating
     public static <A, B, C, D, E> Answer<Void> answerVoid(VoidAnswer5<A, B, C, D, E> answer) {

--- a/src/main/java/org/mockito/Answers.java
+++ b/src/main/java/org/mockito/Answers.java
@@ -88,7 +88,7 @@ public enum Answers implements Answer<Object>{
     }
 
     /**
-     * @deprecated as of 2.0.0 Use the enum-constant directly, instead of this getter. This method will be removed in a future release<br>
+     * @deprecated as of 2.1.0 Use the enum-constant directly, instead of this getter. This method will be removed in a future release<br>
      * E.g. instead of <code>Answers.CALLS_REAL_METHODS.get()</code> use <code>Answers.CALLS_REAL_METHODS</code> .
      */
     @Deprecated

--- a/src/main/java/org/mockito/ArgumentMatcher.java
+++ b/src/main/java/org/mockito/ArgumentMatcher.java
@@ -2,7 +2,7 @@ package org.mockito;
 
 /**
  * Allows creating customized argument matchers.
- * This API was changed in Mockito 2.0.0 in an effort to decouple Mockito from Hamcrest
+ * This API was changed in Mockito 2.1.0 in an effort to decouple Mockito from Hamcrest
  * and reduce the risk of version incompatibility.
  * Migration guide is included close to the bottom of this javadoc.
  * <p>
@@ -81,7 +81,7 @@ package org.mockito;
  *
  * <p>
  * Read more about other matchers in javadoc for {@link Matchers} class.
- * <h2>2.0.0 migration guide</h2>
+ * <h2>2.1.0 migration guide</h2>
  *
  * All existing custom implementations of <code>ArgumentMatcher</code> will no longer compile.
  * All locations where hamcrest matchers are passed to <code>argThat()</code> will no longer compile.
@@ -104,7 +104,7 @@ package org.mockito;
  * you can choose different option in future (and refactor the code)
  *
  * @param <T> type of argument
- * @since 2.0.0
+ * @since 2.1.0
  */
 public interface ArgumentMatcher<T> {
 

--- a/src/main/java/org/mockito/ArgumentMatchers.java
+++ b/src/main/java/org/mockito/ArgumentMatchers.java
@@ -115,7 +115,7 @@ public class ArgumentMatchers {
      * <strong>Notes : </strong><br/>
      * <ul>
      *     <li>For primitive types use {@link #anyChar()} family or {@link #isA(Class)} or {@link #any(Class)}.</li>
-     *     <li>Since mockito 2.0.0 {@link #any(Class)} is not anymore an alias of this method.</li>
+     *     <li>Since mockito 2.1.0 {@link #any(Class)} is not anymore an alias of this method.</li>
      * </ul>
      * </p>
      *
@@ -165,7 +165,7 @@ public class ArgumentMatchers {
      * </p>
      *
      * <p>
-     * Since Mockito 2.0.0, only allow non-null instance of <code></code>, thus <code>null</code> is not anymore a valid value.
+     * Since Mockito 2.1.0, only allow non-null instance of <code></code>, thus <code>null</code> is not anymore a valid value.
      * As reference are nullable, the suggested API to <strong>match</strong> <code>null</code>
      * would be {@link #isNull()}. We felt this change would make tests harness much safer that it was with Mockito
      * 1.x.
@@ -174,8 +174,8 @@ public class ArgumentMatchers {
      * <p><strong>Notes : </strong><br/>
      * <ul>
      *     <li>For primitive types use {@link #anyChar()} family.</li>
-     *     <li>Since Mockito 2.0.0 this method will perform a type check thus <code>null</code> values are not authorized.</li>
-     *     <li>Since mockito 2.0.0 {@link #any()} and {@link #anyObject()} are not anymore aliases of this method.</li>
+     *     <li>Since Mockito 2.1.0 this method will perform a type check thus <code>null</code> values are not authorized.</li>
+     *     <li>Since mockito 2.1.0 {@link #any()} and {@link #anyObject()} are not anymore aliases of this method.</li>
      * </ul>
      * </p>
      *
@@ -240,7 +240,7 @@ public class ArgumentMatchers {
      * @return <code>null</code>.
      * @see #any()
      * @see #any(Class)
-     * @deprecated as of 2.0.0 use {@link #any()}
+     * @deprecated as of 2.1.0 use {@link #any()}
      */
     @Deprecated
     public static <T> T anyVararg() {
@@ -252,7 +252,7 @@ public class ArgumentMatchers {
      * Any <code>boolean</code> or <strong>non-null</strong> <code>Boolean</code>
      *
      * <p>
-     * Since Mockito 2.0.0, only allow valued <code>Boolean</code>, thus <code>null</code> is not anymore a valid value.
+     * Since Mockito 2.1.0, only allow valued <code>Boolean</code>, thus <code>null</code> is not anymore a valid value.
      * As primitive wrappers are nullable, the suggested API to <strong>match</strong> <code>null</code> wrapper
      * would be {@link #isNull()}. We felt this change would make tests harness much safer that it was with Mockito
      * 1.x.
@@ -275,7 +275,7 @@ public class ArgumentMatchers {
      * Any <code>byte</code> or <strong>non-null</strong> <code>Byte</code>.
      *
      * <p>
-     * Since Mockito 2.0.0, only allow valued <code>Byte</code>, thus <code>null</code> is not anymore a valid value.
+     * Since Mockito 2.1.0, only allow valued <code>Byte</code>, thus <code>null</code> is not anymore a valid value.
      * As primitive wrappers are nullable, the suggested API to <strong>match</strong> <code>null</code> wrapper
      * would be {@link #isNull()}. We felt this change would make tests harness much safer that it was with Mockito
      * 1.x.
@@ -298,7 +298,7 @@ public class ArgumentMatchers {
      * Any <code>char</code> or <strong>non-null</strong> <code>Character</code>.
      *
      * <p>
-     * Since Mockito 2.0.0, only allow valued <code>Character</code>, thus <code>null</code> is not anymore a valid value.
+     * Since Mockito 2.1.0, only allow valued <code>Character</code>, thus <code>null</code> is not anymore a valid value.
      * As primitive wrappers are nullable, the suggested API to <strong>match</strong> <code>null</code> wrapper
      * would be {@link #isNull()}. We felt this change would make tests harness much safer that it was with Mockito
      * 1.x.
@@ -321,7 +321,7 @@ public class ArgumentMatchers {
      * Any int or <strong>non-null</strong> <code>Integer</code>.
      *
      * <p>
-     * Since Mockito 2.0.0, only allow valued <code>Integer</code>, thus <code>null</code> is not anymore a valid value.
+     * Since Mockito 2.1.0, only allow valued <code>Integer</code>, thus <code>null</code> is not anymore a valid value.
      * As primitive wrappers are nullable, the suggested API to <strong>match</strong> <code>null</code> wrapper
      * would be {@link #isNull()}. We felt this change would make tests harness much safer that it was with Mockito
      * 1.x.
@@ -344,7 +344,7 @@ public class ArgumentMatchers {
      * Any <code>long</code> or <strong>non-null</strong> <code>Long</code>.
      *
      * <p>
-     * Since Mockito 2.0.0, only allow valued <code>Long</code>, thus <code>null</code> is not anymore a valid value.
+     * Since Mockito 2.1.0, only allow valued <code>Long</code>, thus <code>null</code> is not anymore a valid value.
      * As primitive wrappers are nullable, the suggested API to <strong>match</strong> <code>null</code> wrapper
      * would be {@link #isNull()}. We felt this change would make tests harness much safer that it was with Mockito
      * 1.x.
@@ -367,7 +367,7 @@ public class ArgumentMatchers {
      * Any <code>float</code> or <strong>non-null</strong> <code>Float</code>.
      *
      * <p>
-     * Since Mockito 2.0.0, only allow valued <code>Float</code>, thus <code>null</code> is not anymore a valid value.
+     * Since Mockito 2.1.0, only allow valued <code>Float</code>, thus <code>null</code> is not anymore a valid value.
      * As primitive wrappers are nullable, the suggested API to <strong>match</strong> <code>null</code> wrapper
      * would be {@link #isNull()}. We felt this change would make tests harness much safer that it was with Mockito
      * 1.x.
@@ -390,7 +390,7 @@ public class ArgumentMatchers {
      * Any <code>double</code> or <strong>non-null</strong> <code>Double</code>.
      *
      * <p>
-     * Since Mockito 2.0.0, only allow valued <code>Double</code>, thus <code>null</code> is not anymore a valid value.
+     * Since Mockito 2.1.0, only allow valued <code>Double</code>, thus <code>null</code> is not anymore a valid value.
      * As primitive wrappers are nullable, the suggested API to <strong>match</strong> <code>null</code> wrapper
      * would be {@link #isNull()}. We felt this change would make tests harness much safer that it was with Mockito
      * 1.x.
@@ -413,7 +413,7 @@ public class ArgumentMatchers {
      * Any <code>short</code> or <strong>non-null</strong> <code>Short</code>.
      *
      * <p>
-     * Since Mockito 2.0.0, only allow valued <code>Short</code>, thus <code>null</code> is not anymore a valid value.
+     * Since Mockito 2.1.0, only allow valued <code>Short</code>, thus <code>null</code> is not anymore a valid value.
      * As primitive wrappers are nullable, the suggested API to <strong>match</strong> <code>null</code> wrapper
      * would be {@link #isNull()}. We felt this change would make tests harness much safer that it was with Mockito
      * 1.x.
@@ -436,7 +436,7 @@ public class ArgumentMatchers {
      * Any <strong>non-null</strong> <code>String</code>
      *
      * <p>
-     * Since Mockito 2.0.0, only allow non-null <code>String</code>.
+     * Since Mockito 2.1.0, only allow non-null <code>String</code>.
      * As this is a nullable reference, the suggested API to <strong>match</strong> <code>null</code> wrapper
      * would be {@link #isNull()}. We felt this change would make tests harness much safer that it was with Mockito
      * 1.x.
@@ -459,7 +459,7 @@ public class ArgumentMatchers {
      * Any <strong>non-null</strong> <code>List</code>.
      *
      * <p>
-     * Since Mockito 2.0.0, only allow non-null <code>List</code>.
+     * Since Mockito 2.1.0, only allow non-null <code>List</code>.
      * As this is a nullable reference, the suggested API to <strong>match</strong> <code>null</code> wrapper
      * would be {@link #isNull()}. We felt this change would make tests harness much safer that it was with Mockito
      * 1.x.
@@ -491,7 +491,7 @@ public class ArgumentMatchers {
      * </p>
      *
      * <p>
-     * Since Mockito 2.0.0, only allow non-null <code>List</code>.
+     * Since Mockito 2.1.0, only allow non-null <code>List</code>.
      * As this is a nullable reference, the suggested API to <strong>match</strong> <code>null</code> wrapper
      * would be {@link #isNull()}. We felt this change would make tests harness much safer that it was with Mockito
      * 1.x.
@@ -517,7 +517,7 @@ public class ArgumentMatchers {
      * Any <strong>non-null</strong> <code>Set</code>.
      *
      * <p>
-     * Since Mockito 2.0.0, only allow non-null <code>Set</code>.
+     * Since Mockito 2.1.0, only allow non-null <code>Set</code>.
      * As this is a nullable reference, the suggested API to <strong>match</strong> <code>null</code> wrapper
      * would be {@link #isNull()}. We felt this change would make tests harness much safer that it was with Mockito
      * 1.x.
@@ -551,7 +551,7 @@ public class ArgumentMatchers {
      * </p>
      *
      * <p>
-     * Since Mockito 2.0.0, only allow non-null <code>Set</code>.
+     * Since Mockito 2.1.0, only allow non-null <code>Set</code>.
      * As this is a nullable reference, the suggested API to <strong>match</strong> <code>null</code> wrapper
      * would be {@link #isNull()}. We felt this change would make tests harness much safer that it was with Mockito
      * 1.x.
@@ -577,7 +577,7 @@ public class ArgumentMatchers {
      * Any <strong>non-null</strong> <code>Map</code>.
      *
      * <p>
-     * Since Mockito 2.0.0, only allow non-null <code>Map</code>.
+     * Since Mockito 2.1.0, only allow non-null <code>Map</code>.
      * As this is a nullable reference, the suggested API to <strong>match</strong> <code>null</code> wrapper
      * would be {@link #isNull()}. We felt this change would make tests harness much safer that it was with Mockito
      * 1.x.
@@ -611,7 +611,7 @@ public class ArgumentMatchers {
      * </p>
      *
      * <p>
-     * Since Mockito 2.0.0, only allow non-null <code>Map</code>.
+     * Since Mockito 2.1.0, only allow non-null <code>Map</code>.
      * As this is a nullable reference, the suggested API to <strong>match</strong> <code>null</code> wrapper
      * would be {@link #isNull()}. We felt this change would make tests harness much safer that it was with Mockito
      * 1.x.
@@ -638,7 +638,7 @@ public class ArgumentMatchers {
      * Any <strong>non-null</strong> <code>Collection</code>.
      *
      * <p>
-     * Since Mockito 2.0.0, only allow non-null <code>Collection</code>.
+     * Since Mockito 2.1.0, only allow non-null <code>Collection</code>.
      * As this is a nullable reference, the suggested API to <strong>match</strong> <code>null</code>
      * would be {@link #isNull()}. We felt this change would make tests harness much safer that it was with Mockito
      * 1.x.
@@ -672,7 +672,7 @@ public class ArgumentMatchers {
      * </p>
      *
      * <p>
-     * Since Mockito 2.0.0, only allow non-null <code>Collection</code>.
+     * Since Mockito 2.1.0, only allow non-null <code>Collection</code>.
      * As this is a nullable reference, the suggested API to <strong>match</strong> <code>null</code>
      * would be {@link #isNull()}. We felt this change would make tests harness much safer that it was with Mockito
      * 1.x.
@@ -698,7 +698,7 @@ public class ArgumentMatchers {
      * Any <strong>non-null</strong> <code>Iterable</code>.
      *
      * <p>
-     * Since Mockito 2.0.0, only allow non-null <code>Iterable</code>.
+     * Since Mockito 2.1.0, only allow non-null <code>Iterable</code>.
      * As this is a nullable reference, the suggested API to <strong>match</strong> <code>null</code>
      * would be {@link #isNull()}. We felt this change would make tests harness much safer that it was with Mockito
      * 1.x.
@@ -712,7 +712,7 @@ public class ArgumentMatchers {
      * @see #anyIterableOf(Class)
      * @see #isNull()
      * @see #isNull(Class)
-     * @since 2.0.0
+     * @since 2.1.0
      */
     public static <T> Iterable<T> anyIterable() {
         reportMatcher(new InstanceOf(Iterable.class, "<any iterable>"));
@@ -733,7 +733,7 @@ public class ArgumentMatchers {
      * </p>
      *
      * <p>
-     * Since Mockito 2.0.0, only allow non-null <code>String</code>.
+     * Since Mockito 2.1.0, only allow non-null <code>String</code>.
      * As strings are nullable reference, the suggested API to <strong>match</strong> <code>null</code> wrapper
      * would be {@link #isNull()}. We felt this change would make tests harness much safer that it was with Mockito
      * 1.x.
@@ -748,7 +748,7 @@ public class ArgumentMatchers {
      * @see #anyIterable()
      * @see #isNull()
      * @see #isNull(Class)
-     * @since 2.0.0
+     * @since 2.1.0
      * @deprecated With Java 8 this method will be removed in Mockito 3.0. This method is only used for generic
      * friendliness to avoid casting, this is not anymore needed in Java 8.
      */
@@ -1120,7 +1120,7 @@ public class ArgumentMatchers {
      * Allows creating custom argument matchers.
      *
      * <p>
-     * This API has changed in 2.0.0, please read {@link ArgumentMatcher} for rationale and migration guide.
+     * This API has changed in 2.1.0, please read {@link ArgumentMatcher} for rationale and migration guide.
      * <b>NullPointerException</b> auto-unboxing caveat is described below.
      * </p>
      *

--- a/src/main/java/org/mockito/BDDMockito.java
+++ b/src/main/java/org/mockito/BDDMockito.java
@@ -119,13 +119,13 @@ public class BDDMockito extends Mockito {
 
         /**
          * See original {@link OngoingStubbing#thenThrow(Class)}
-         * @since 2.0.0
+         * @since 2.1.0
          */
         BDDMyOngoingStubbing<T> willThrow(Class<? extends Throwable> throwableType);
 
         /**
          * See original {@link OngoingStubbing#thenThrow(Class, Class[])}
-         * @since 2.0.0
+         * @since 2.1.0
          */
         // Additional method helps users of JDK7+ to hide heap pollution / unchecked generics array creation
         @SuppressWarnings ({"unchecked", "varargs"})
@@ -238,25 +238,25 @@ public class BDDMockito extends Mockito {
 
         /**
          * @see InOrder#verify(Object)
-         * @since 2.0.0
+         * @since 2.1.0
          */
         T should(InOrder inOrder);
 
         /**
          * @see InOrder#verify(Object, VerificationMode)
-         * @since 2.0.0
+         * @since 2.1.0
          */
         T should(InOrder inOrder, VerificationMode mode);
 
         /**
          * @see #verifyZeroInteractions(Object...)
-         * @since 2.0.0
+         * @since 2.1.0
          */
         void shouldHaveZeroInteractions();
 
         /**
          * @see #verifyNoMoreInteractions(Object...)
-         * @since 2.0.0
+         * @since 2.1.0
          */
         void shouldHaveNoMoreInteractions();
     }
@@ -287,7 +287,7 @@ public class BDDMockito extends Mockito {
 
         /**
          * @see InOrder#verify(Object)
-         * @since 2.0.0
+         * @since 2.1.0
          */
         public T should(InOrder inOrder) {
             return inOrder.verify(mock);
@@ -295,7 +295,7 @@ public class BDDMockito extends Mockito {
 
         /**
          * @see InOrder#verify(Object, VerificationMode)
-         * @since 2.0.0
+         * @since 2.1.0
          */
         public T should(InOrder inOrder, VerificationMode mode) {
             return inOrder.verify(mock, mode);
@@ -303,7 +303,7 @@ public class BDDMockito extends Mockito {
 
         /**
          * @see #verifyZeroInteractions(Object...)
-         * @since 2.0.0
+         * @since 2.1.0
          */
         public void shouldHaveZeroInteractions() {
             verifyZeroInteractions(mock);
@@ -311,7 +311,7 @@ public class BDDMockito extends Mockito {
 
         /**
          * @see #verifyNoMoreInteractions(Object...)
-         * @since 2.0.0
+         * @since 2.1.0
          */
         public void shouldHaveNoMoreInteractions() {
             verifyNoMoreInteractions(mock);
@@ -341,7 +341,7 @@ public class BDDMockito extends Mockito {
          * This method will be removed in version 3.0.0
          *
          * @since 1.8.0
-         * @deprecated as of 2.0.0 please use {@link #willDoNothing()} instead
+         * @deprecated as of 2.1.0 please use {@link #willDoNothing()} instead
          */
         @Deprecated
         BDDStubber willNothing();
@@ -354,13 +354,13 @@ public class BDDMockito extends Mockito {
 
         /**
          * See original {@link Stubber#doReturn(Object)}
-         * @since 2.0.0
+         * @since 2.1.0
          */
         BDDStubber willReturn(Object toBeReturned);
 
         /**
          * See original {@link Stubber#doReturn(Object)}
-         * @since 2.0.0
+         * @since 2.1.0
          */
         @SuppressWarnings({"unchecked", "varargs"})
         BDDStubber willReturn(Object toBeReturned, Object... nextToBeReturned);
@@ -373,13 +373,13 @@ public class BDDMockito extends Mockito {
 
         /**
          * See original {@link Stubber#doThrow(Class)}
-         * @since 2.0.0
+         * @since 2.1.0
          */
         BDDStubber willThrow(Class<? extends Throwable> toBeThrown);
 
         /**
          * See original {@link Stubber#doThrow(Class, Class[])}
-         * @since 2.0.0
+         * @since 2.1.0
          */
         @SuppressWarnings ({"unchecked", "varargs"})
         BDDStubber willThrow(Class<? extends Throwable> toBeThrown, Class<? extends Throwable>... nextToBeThrown);
@@ -456,7 +456,7 @@ public class BDDMockito extends Mockito {
 
     /**
      * see original {@link Mockito#doThrow(Throwable[])}
-     * @since 2.0.0
+     * @since 2.1.0
      */
     public static BDDStubber willThrow(Throwable... toBeThrown) {
         return new BDDStubberImpl(Mockito.doThrow(toBeThrown));
@@ -488,7 +488,7 @@ public class BDDMockito extends Mockito {
 
     /**
      * see original {@link Mockito#doAnswer(Answer)}
-     * @since 2.0.0
+     * @since 2.1.0
      */
     public static BDDStubber will(Answer<?> answer) {
         return new BDDStubberImpl(Mockito.doAnswer(answer));
@@ -512,7 +512,7 @@ public class BDDMockito extends Mockito {
 
     /**
      * see original {@link Mockito#doReturn(Object, Object...)}
-     * @since 2.0.0
+     * @since 2.1.0
      */
     @SuppressWarnings({"unchecked", "varargs"})
     public static BDDStubber willReturn(Object toBeReturned, Object... toBeReturnedNext) {

--- a/src/main/java/org/mockito/MockingDetails.java
+++ b/src/main/java/org/mockito/MockingDetails.java
@@ -53,7 +53,7 @@ public interface MockingDetails {
      * If <code>null</code> or non-mock was passed to {@link Mockito#mockingDetails(Object)}
      * then this method will throw with an appropriate exception.
      * After all, non-mock objects do not have any mock creation settings.
-     * @since 2.0.0
+     * @since 2.1.0
      */
     MockCreationSettings<?> getMockCreationSettings();
 }

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -30,7 +30,7 @@ import org.mockito.junit.*;
  * <h1>Contents</h1>
  *
  * <b>
- *      <a href="#0">0. Migrating to 2.0.0</a><br/>
+ *      <a href="#0">0. Migrating to 2.1.0</a><br/>
  *      <a href="#1">1. Let's verify some behaviour! </a><br/>
  *      <a href="#2">2. How about some stubbing? </a><br/>
  *      <a href="#3">3. Argument matchers </a><br/>
@@ -65,20 +65,20 @@ import org.mockito.junit.*;
  *      <a href="#32">32. (new) Better generic support with deep stubs (Since 1.10.0)</a></h3><br/>
  *      <a href="#32">33. (new) Mockito JUnit rule (Since 1.10.17)</a><br/>
  *      <a href="#34">34. (new) Switch <em>on</em> or <em>off</em> plugins (Since 1.10.15)</a><br/>
- *      <a href="#35">35. (new) Custom verification failure message (Since 2.0.0)</a><br/>
- *      <a href="#36">36. (new) Java 8 Lambda Matcher Support (Since 2.0.0)</a><br/>
- *      <a href="#37">37. (new) Java 8 Custom Answer Support (Since 2.0.0)</a><br/>
+ *      <a href="#35">35. (new) Custom verification failure message (Since 2.1.0)</a><br/>
+ *      <a href="#36">36. (new) Java 8 Lambda Matcher Support (Since 2.1.0)</a><br/>
+ *      <a href="#37">37. (new) Java 8 Custom Answer Support (Since 2.1.0)</a><br/>
  *
  * </b>
  *
- * <h3 id="0">0. <a class="meaningful_link" href="#verification">Migrating to 2.0.0</a></h3>
+ * <h3 id="0">0. <a class="meaningful_link" href="#verification">Migrating to 2.1.0</a></h3>
  *
  * In order to continue improving Mockito and further improve the unit testing experience, we want you to upgrade to 2.0.
  * Mockito follows <a href="http://semver.org/">semantic versioning</a>
  * and contains breaking changes only on major version upgrades.
  * In the lifecycle of a library, breaking changes are necessary
  * to roll out a set of brand new features that alter the existing behavior or even change the API.
- * We hope that you enjoy Mockito 2.0.0!
+ * We hope that you enjoy Mockito 2.1.0!
  * <p>
  * List of breaking changes:
  * <ul>
@@ -1077,7 +1077,7 @@ import org.mockito.junit.*;
  * More information here {@link org.mockito.plugins.PluginSwitch}.
  *
  *
- * <h3 id="35">35. <a class="meaningful_link" href="#BDD_behavior_verification">Custom verification failure message</a> (Since 2.0.0)</h3>
+ * <h3 id="35">35. <a class="meaningful_link" href="#BDD_behavior_verification">Custom verification failure message</a> (Since 2.1.0)</h3>
  * <p>
  * Allows specifying a custom message to be printed if verification fails.
  * <p>
@@ -1092,7 +1092,7 @@ import org.mockito.junit.*;
  * verify(mock, times(2).description("someMethod should be called twice")).someMethod();
  * </code></pre>
  *
- * <h3 id="36">36. <a class="meaningful_link" href="#Java_8_Lambda_Matching">Java 8 Lambda Matcher Support</a> (Since 2.0.0)</h3>
+ * <h3 id="36">36. <a class="meaningful_link" href="#Java_8_Lambda_Matching">Java 8 Lambda Matcher Support</a> (Since 2.1.0)</h3>
  * <p>
  * You can use Java 8 lambda expressions with {@link ArgumentMatcher} to reduce the dependency on {@link ArgumentCaptor}.
  * If you need to verify that the input to a function call on a mock was correct, then you would normally
@@ -1125,7 +1125,7 @@ import org.mockito.junit.*;
  * when(mock.someMethod(argThat(list -> list.size()<3))).willReturn(null);
  * </code></pre>
  *
- * <h3 id="37">37. <a class="meaningful_link" href="#Java_8_Custom_Answers">Java 8 Custom Answer Support</a> (Since 2.0.0)</h3>
+ * <h3 id="37">37. <a class="meaningful_link" href="#Java_8_Custom_Answers">Java 8 Custom Answer Support</a> (Since 2.1.0)</h3>
  * <p>
  * As the {@link Answer} interface has just one method it is already possible to implement it in Java 8 using
  * a lambda expression for very simple situations. The more you need to use the parameters of the method call,
@@ -1941,7 +1941,7 @@ public class Mockito extends ArgumentMatchers {
      *
      * @param toBeThrown to be thrown when the stubbed method is called
      * @return stubber - to select a method for stubbing
-     * @since 2.0.0
+     * @since 2.1.0
      */
     public static Stubber doThrow(Class<? extends Throwable> toBeThrown) {
         return MOCKITO_CORE.stubber().doThrow(toBeThrown);
@@ -1965,7 +1965,7 @@ public class Mockito extends ArgumentMatchers {
      * @param toBeThrown to be thrown when the stubbed method is called
      * @param toBeThrownNext next to be thrown when the stubbed method is called
      * @return stubber - to select a method for stubbing
-     * @since 2.0.0
+     * @since 2.1.0
      */
     // Additional method helps users of JDK7+ to hide heap pollution / unchecked generics array creation
     @SuppressWarnings ({"unchecked", "varargs"})
@@ -2174,7 +2174,7 @@ public class Mockito extends ArgumentMatchers {
      * @param toBeReturned to be returned when the stubbed method is called
      * @param toBeReturnedNext to be returned in consecutive calls when the stubbed method is called
      * @return stubber - to select a method for stubbing
-     * @since 2.0.0
+     * @since 2.1.0
      */
     @SuppressWarnings({"unchecked", "varargs"})
     public static Stubber doReturn(Object toBeReturned, Object... toBeReturnedNext) {
@@ -2569,7 +2569,7 @@ public class Mockito extends ArgumentMatchers {
      * </code></pre>
      * @param description The description to print on failure.
      * @return verification mode
-     * @since 2.0.0
+     * @since 2.1.0
      */
     public static VerificationMode description(String description) {
         return times(1).description(description);
@@ -2587,7 +2587,7 @@ public class Mockito extends ArgumentMatchers {
     /**
      * For advanced users or framework integrators. See {@link MockitoFramework} class.
      *
-     * @since 2.0.0
+     * @since 2.1.0
      */
     @Incubating
     public static MockitoFramework framework() {

--- a/src/main/java/org/mockito/MockitoFramework.java
+++ b/src/main/java/org/mockito/MockitoFramework.java
@@ -9,7 +9,7 @@ import org.mockito.listeners.MockitoListener;
  * <p>
  * For more info on listeners see {@link #addListener(MockitoListener)}.
  *
- * @since 2.0.0
+ * @since 2.1.0
  */
 @Incubating
 public interface MockitoFramework {

--- a/src/main/java/org/mockito/exceptions/base/MockitoAssertionError.java
+++ b/src/main/java/org/mockito/exceptions/base/MockitoAssertionError.java
@@ -27,7 +27,7 @@ public class MockitoAssertionError extends AssertionError {
      * Creates a copy of the given assertion error with the custom failure message prepended.
      * @param error The assertion error to copy
      * @param message The custom message to prepend
-     * @since 2.0.0
+     * @since 2.1.0
      */
     public MockitoAssertionError(MockitoAssertionError error, String message) {
         super(message + "\n" + error.getMessage());

--- a/src/main/java/org/mockito/hamcrest/MockitoHamcrest.java
+++ b/src/main/java/org/mockito/hamcrest/MockitoHamcrest.java
@@ -17,7 +17,7 @@ import static org.mockito.internal.util.Primitives.defaultValue;
  * Before implementing or reusing an existing hamcrest matcher please read
  * how to deal with sophisticated argument matching in {@link ArgumentMatcher}.
  * <p/>
- * Mockito 2.0.0 was decoupled from Hamcrest to avoid version incompatibilities
+ * Mockito 2.1.0 was decoupled from Hamcrest to avoid version incompatibilities
  * that have impacted our users in past. Mockito offers a dedicated API to match arguments
  * via {@link ArgumentMatcher}.
  * Hamcrest integration is provided so that users can take advantage of existing Hamcrest matchers.
@@ -39,7 +39,7 @@ import static org.mockito.internal.util.Primitives.defaultValue;
  * Hopefully, the javadoc describes the problem and solution well.
  * If you have an idea how to fix the problem, let us know via the mailing list or the issue tracker.
  *
- * @since 2.0.0
+ * @since 2.1.0
  */
 public class MockitoHamcrest {
 
@@ -50,7 +50,7 @@ public class MockitoHamcrest {
      *
      * @param matcher decides whether argument matches
      * @return <code>null</code> or default value for primitive (0, false, etc.)
-     * @since 2.0.0
+     * @since 2.1.0
      */
     @SuppressWarnings("unchecked")
     public static <T> T argThat(Matcher<T> matcher) {

--- a/src/main/java/org/mockito/internal/matchers/apachecommons/EqualsBuilder.java
+++ b/src/main/java/org/mockito/internal/matchers/apachecommons/EqualsBuilder.java
@@ -186,7 +186,7 @@ class EqualsBuilder {
      * @param reflectUpToClass  the superclass to reflect up to (inclusive),
      *  may be <code>null</code>
      * @return <code>true</code> if the two Objects have tested equals.
-     * @since 2.0.0
+     * @since 2.1.0
      */
     public static boolean reflectionEquals(Object lhs, Object rhs, boolean testTransients, Class<?> reflectUpToClass) {
         return reflectionEquals(lhs, rhs, testTransients, reflectUpToClass, null);
@@ -216,7 +216,7 @@ class EqualsBuilder {
      *  may be <code>null</code>
      * @param excludeFields  array of field names to exclude from testing
      * @return <code>true</code> if the two Objects have tested equals.
-     * @since 2.0.0
+     * @since 2.1.0
      */
     public static boolean reflectionEquals(Object lhs, Object rhs, boolean testTransients, Class<?> reflectUpToClass,
             String[] excludeFields) {
@@ -312,7 +312,7 @@ class EqualsBuilder {
      *
      * @param superEquals  the result of calling <code>super.equals()</code>
      * @return EqualsBuilder - used to chain calls.
-     * @since 2.0.0
+     * @since 2.1.0
      */
     public EqualsBuilder appendSuper(boolean superEquals) {
         isEquals &= superEquals;

--- a/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java
@@ -16,7 +16,7 @@ import org.mockito.stubbing.VoidAnswer5;
 /**
  * Functional interfaces to make it easy to implement answers in Java 8
  * 
- * @since 2.0.0
+ * @since 2.1.0
  */
 public class AnswerFunctionalInterfaces {
 	/**

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsMoreEmptyValues.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsMoreEmptyValues.java
@@ -13,7 +13,7 @@ import java.io.Serializable;
 import java.lang.reflect.Array;
 
 /**
- * It's likely this implementation will be used by default by every Mockito 2.0.0 mock.
+ * It's likely this implementation will be used by default by every Mockito 2.1.0 mock.
  * <p>
  * Currently <b>used only</b> by {@link Mockito#RETURNS_SMART_NULLS}
  * <p>

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNulls.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNulls.java
@@ -32,7 +32,7 @@ import org.mockito.stubbing.Answer;
  * return type is not mockable (e.g. final) then ordinary null is returned.
  * <p>
  * ReturnsSmartNulls will be probably the default return values strategy in
- * Mockito 2.0.0
+ * Mockito 2.1.0
  */
 public class ReturnsSmartNulls implements Answer<Object>, Serializable {
 

--- a/src/main/java/org/mockito/internal/verification/Description.java
+++ b/src/main/java/org/mockito/internal/verification/Description.java
@@ -8,7 +8,7 @@ import org.mockito.verification.VerificationMode;
  * Description verification mode wraps an existing verification mode and prepends
  * a custom message to the assertion error if verification fails.
  * @author Geoff.Schoeman
- * @since 2.0.0
+ * @since 2.1.0
  */
 public class Description implements VerificationMode {
 

--- a/src/main/java/org/mockito/internal/verification/VerificationModeFactory.java
+++ b/src/main/java/org/mockito/internal/verification/VerificationModeFactory.java
@@ -42,7 +42,7 @@ public class VerificationModeFactory {
      * @param mode Implementation used for verification
      * @param description The custom failure message
      * @return VerificationMode
-     * @since 2.0.0
+     * @since 2.1.0
      */
     public static VerificationMode description(VerificationMode mode, String description) {
         return new Description(mode, description);

--- a/src/main/java/org/mockito/invocation/InvocationOnMock.java
+++ b/src/main/java/org/mockito/invocation/InvocationOnMock.java
@@ -40,7 +40,7 @@ public interface InvocationOnMock extends Serializable {
      * Returns casted argument at the given index
      * @param index argument index
      * @return casted argument at the given index
-     * @since 2.0.0
+     * @since 2.1.0
      */
     <T> T getArgument(int index);
 

--- a/src/main/java/org/mockito/junit/MockitoJUnit.java
+++ b/src/main/java/org/mockito/junit/MockitoJUnit.java
@@ -28,7 +28,7 @@ public class MockitoJUnit {
      *
      * @see VerificationCollector
      * @return the rule instance
-     * @since 2.0.0
+     * @since 2.1.0
      */
     @Incubating
     public static VerificationCollector collector() {

--- a/src/main/java/org/mockito/junit/MockitoRule.java
+++ b/src/main/java/org/mockito/junit/MockitoRule.java
@@ -3,7 +3,7 @@ package org.mockito.junit;
 import org.junit.rules.MethodRule;
 
 /**
- * Since 2.0.0, JUnit rule emits stubbing warnings and hints to System output
+ * Since 2.1.0, JUnit rule emits stubbing warnings and hints to System output
  * (see also {@link org.mockito.quality.MockitoHint}).
  * The JUnit rule can be used instead of {@link org.mockito.runners.MockitoJUnitRunner}.
  * It requires JUnit at least 4.7.
@@ -11,11 +11,11 @@ import org.junit.rules.MethodRule;
  * This rule adds following behavior:
  * <ul>
  *   <li>
- *      Since 2.0.0, stubbing warnings and hints are printed to System output.
+ *      Since 2.1.0, stubbing warnings and hints are printed to System output.
  *      Hints contain clickable links that take you right to the line of code that contains a possible problem.
  *      <strong>Please</strong> give us feedback about the stubbing warnings of JUnit rules in the issue tracker
  *      (<a href="https://github.com/mockito/mockito/issues/384">issue 384</a>).
- *      It's a new feature of Mockito 2.0.0. It aims to help debugging tests.
+ *      It's a new feature of Mockito 2.1.0. It aims to help debugging tests.
  *      If you wish the previous behavior, see {@link MockitoRule#silent()}.
  *      However, we would really like to know why do you wish to silence the warnings!
  *      See also {@link org.mockito.quality.MockitoHint}.
@@ -53,7 +53,7 @@ public interface MockitoRule extends MethodRule {
      * By default, stubbing warnings are printed to Standard output to help debugging.
      * <p>
      * <strong>Please</strong> give us feedback about the stubbing warnings of JUnit rules.
-     * It's a new feature of Mockito 2.0.0. It aims to help debugging tests.
+     * It's a new feature of Mockito 2.1.0. It aims to help debugging tests.
      * We want to make sure the feature is useful.
      * We would really like to know why do you wish to silence the warnings!
      * See also {@link org.mockito.quality.MockitoHint}.
@@ -69,7 +69,7 @@ public interface MockitoRule extends MethodRule {
      * }
      * </code></pre>
      *
-     * @since 2.0.0
+     * @since 2.1.0
      */
     MockitoRule silent();
 }

--- a/src/main/java/org/mockito/junit/VerificationCollector.java
+++ b/src/main/java/org/mockito/junit/VerificationCollector.java
@@ -7,7 +7,12 @@ import org.mockito.verification.VerificationMode;
 
 /**
  * Use this rule in order to collect multiple verification failures and report at once.
- *
+ * This new API in incubating - let us know if you find this feature useful.
+ * Should it be turned on by default with Mockito JUnit Rule?
+ * <p>
+ * Although {@code VerificationCollector} is a JUnit Rule, it does not necessarily have to be used as a Test Rule
+ * - see {@link #collectAndReport()}.
+ * <p>
  * In the example below, the verification failure thrown by {@code byteReturningMethod()} does not block
  * verifying against the {@code simpleMethod()}. After the test is run, a report is generated stating all
  * collect verification failures.
@@ -35,6 +40,29 @@ public interface VerificationCollector extends TestRule {
     /**
      * Collect all lazily verified behaviour. If there were failed verifications, it will
      * throw a MockitoAssertionError containing all messages indicating the failed verifications.
+     * <p>
+     * Normally, users don't need to call this method because it is automatically invoked when test finishes
+     * (part of the JUnit Rule behavior).
+     * However, in some circumstances and edge cases, it might be useful to collect and report verification
+     * errors in the middle of the test (for example: some scenario tests or during debugging).
+     *
+     * <pre class="code"><code class="java">
+     *   &#064;Rule
+     *   public VerificationCollector collector = MockitoJUnit.collector();
+     *
+     *   &#064;Test
+     *   public void should_fail() {
+     *       IMethods methods = mock(IMethods.class);
+     *
+     *       verify(methods).byteReturningMethod();
+     *       verify(methods).simpleMethod();
+     *
+     *       //report all verification errors now:
+     *       collector.collectAndReport();
+     *
+     *       //some other test code
+     *   }
+     * </code></pre>
      *
      * @throws MockitoAssertionError If there were failed verifications
      * @since 2.1.0
@@ -44,11 +72,23 @@ public interface VerificationCollector extends TestRule {
 
     /**
      * Enforce all verifications are performed lazily. This method is automatically called when
-     * used as JUnitRule.
-     *
+     * used as JUnitRule and normally users don't need to use it.
+     * <p>
      * You should only use this method if you are using a VerificationCollector
      * inside a method where only this method should be verified lazily. The other methods can
      * still be verified directly.
+     *
+     * <pre class="code"><code class="java">
+     *   &#064;Test
+     *   public void should_verify_lazily() {
+     *       VerificationCollector collector = MockitoJUnit.collector().assertLazily();
+     *
+     *       verify(methods).byteReturningMethod();
+     *       verify(methods).simpleMethod();
+     *
+     *       collector.collectAndReport();
+     *   }
+     * </code></pre>
      *
      * @return this
      * @since 2.1.0

--- a/src/main/java/org/mockito/junit/VerificationCollector.java
+++ b/src/main/java/org/mockito/junit/VerificationCollector.java
@@ -27,7 +27,7 @@ import org.mockito.verification.VerificationMode;
  *
  * @see org.mockito.Mockito#verify(Object)
  * @see org.mockito.Mockito#verify(Object, VerificationMode)
- * @since 2.0.0
+ * @since 2.1.0
  */
 @Incubating
 public interface VerificationCollector extends TestRule {
@@ -37,7 +37,7 @@ public interface VerificationCollector extends TestRule {
      * throw a MockitoAssertionError containing all messages indicating the failed verifications.
      *
      * @throws MockitoAssertionError If there were failed verifications
-     * @since 2.0.0
+     * @since 2.1.0
      */
     @Incubating
     void collectAndReport() throws MockitoAssertionError;
@@ -51,7 +51,7 @@ public interface VerificationCollector extends TestRule {
      * still be verified directly.
      *
      * @return this
-     * @since 2.0.0
+     * @since 2.1.0
      */
     @Incubating
     VerificationCollector assertLazily();

--- a/src/main/java/org/mockito/plugins/MockMaker.java
+++ b/src/main/java/org/mockito/plugins/MockMaker.java
@@ -110,7 +110,7 @@ public interface MockMaker {
      *
      * @param type The type inspected for mockability.
      * @return object that carries the information about mockability of given type.
-     * @since 2.0.0
+     * @since 2.1.0
      */
     @Incubating
     TypeMockability isTypeMockable(Class<?> type);
@@ -118,7 +118,7 @@ public interface MockMaker {
     /**
      * Carries the mockability information
      *
-     * @since 2.0.0
+     * @since 2.1.0
      */
     @Incubating
     interface TypeMockability {

--- a/src/main/java/org/mockito/quality/MockitoHint.java
+++ b/src/main/java/org/mockito/quality/MockitoHint.java
@@ -1,7 +1,7 @@
 package org.mockito.quality;
 
 /**
- * Starting with 2.0.0 of Mockito stubbing hints / warnings are printed to standard output.
+ * Starting with 2.1.0 of Mockito stubbing hints / warnings are printed to standard output.
  * Hints contain clickable links that take you right to the line of code that contains a possible problem.
  * Those are hints - they not necessarily indicate real problems 100% of the time.
  * This way the developer can:
@@ -60,7 +60,7 @@ package org.mockito.quality;
  * <p>
  * Feedback very welcome at <a href="https://github.com/mockito/mockito/issues/384">issue 384</a>.
  *
- * @since 2.0.0
+ * @since 2.1.0
  */
 public interface MockitoHint {
 }

--- a/src/main/java/org/mockito/runners/ConsoleSpammingMockitoJUnitRunner.java
+++ b/src/main/java/org/mockito/runners/ConsoleSpammingMockitoJUnitRunner.java
@@ -21,7 +21,7 @@ import org.mockito.internal.util.MockitoLogger;
 import java.lang.reflect.InvocationTargetException;
 
 /**
- * @deprecated as of 2.0.0. Use the {@link org.mockito.runners.MockitoJUnitRunner} runner instead
+ * @deprecated as of 2.1.0. Use the {@link org.mockito.runners.MockitoJUnitRunner} runner instead
  * which contains support for detecting unused stubs.
  * <p>
  * If you still prefer using this runner, tell us why (create ticket in our issue tracker).

--- a/src/main/java/org/mockito/runners/MockitoJUnitRunner.java
+++ b/src/main/java/org/mockito/runners/MockitoJUnitRunner.java
@@ -24,7 +24,7 @@ import java.lang.reflect.InvocationTargetException;
  * Compatible with <b>JUnit 4.4 and higher</b>, this runner adds following behavior:
  * <ul>
  *   <li>
- *       (new since Mockito 2.0.0) Detects unused stubs in the test code.
+ *       (new since Mockito 2.1.0) Detects unused stubs in the test code.
  *       See {@link org.mockito.exceptions.misusing.UnnecessaryStubbingException}.
  *       To opt-out from this feature, use {@code}&#064;RunWith(MockitoJUnitRunner.Silent.class){@code}
  *   <li>
@@ -68,7 +68,7 @@ public class MockitoJUnitRunner extends Runner implements Filterable {
      *
      * See also {@link org.mockito.exceptions.misusing.UnnecessaryStubbingException}
      *
-     * @since 2.0.0
+     * @since 2.1.0
      */
     public static class Silent extends MockitoJUnitRunner {
         public Silent(Class<?> klass) throws InvocationTargetException {
@@ -80,7 +80,7 @@ public class MockitoJUnitRunner extends Runner implements Filterable {
      * Detects unused stubs and reports them as failures. Default behavior.
      * See {@link org.mockito.exceptions.misusing.UnnecessaryStubbingException}
      *
-     * @since 2.0.0
+     * @since 2.1.0
      */
     public static class Strict extends MockitoJUnitRunner {
         public Strict(Class<?> klass) throws InvocationTargetException {

--- a/src/main/java/org/mockito/runners/VerboseMockitoJUnitRunner.java
+++ b/src/main/java/org/mockito/runners/VerboseMockitoJUnitRunner.java
@@ -20,7 +20,7 @@ import org.mockito.internal.util.junit.JUnitFailureHacker;
 import java.lang.reflect.InvocationTargetException;
 
 /**
- * @deprecated as of 2.0.0. Use the {@link org.mockito.runners.MockitoJUnitRunner} runner instead
+ * @deprecated as of 2.1.0. Use the {@link org.mockito.runners.MockitoJUnitRunner} runner instead
  * which contains support for detecting unused stubs.
  * <p>
  * If you still prefer using this runner, tell us why (create ticket in our issue tracker).

--- a/src/main/java/org/mockito/stubbing/OngoingStubbing.java
+++ b/src/main/java/org/mockito/stubbing/OngoingStubbing.java
@@ -109,7 +109,7 @@ public interface OngoingStubbing<T> {
      * @param throwableType to be thrown on method invocation
      *
      * @return iOngoingStubbing object that allows stubbing consecutive calls
-     * @since 2.0.0
+     * @since 2.1.0
      */
     OngoingStubbing<T> thenThrow(Class<? extends Throwable> throwableType);
 
@@ -142,7 +142,7 @@ public interface OngoingStubbing<T> {
      * @param nextToBeThrown next to be thrown on method invocation
      *
      * @return iOngoingStubbing object that allows stubbing consecutive calls
-     * @since 2.0.0
+     * @since 2.1.0
      */
     // Additional method helps users of JDK7+ to hide heap pollution / unchecked generics array creation warnings (on call site)
     @SuppressWarnings ({"unchecked", "varargs"})

--- a/src/main/java/org/mockito/stubbing/Stubber.java
+++ b/src/main/java/org/mockito/stubbing/Stubber.java
@@ -97,7 +97,7 @@ public interface Stubber {
      * @param toBeThrown exception class to be thrown when the stubbed method is called
      * @return stubber - to select a method for stubbing
      *
-     * @since 2.0.0
+     * @since 2.1.0
      */
     Stubber doThrow(Class<? extends Throwable> toBeThrown);
 
@@ -114,7 +114,7 @@ public interface Stubber {
      * @param nextToBeThrown exception class next to be thrown when the stubbed method is called
      * @return stubber - to select a method for stubbing
      *
-     * @since 2.0.0
+     * @since 2.1.0
      */
     // Additional method helps users of JDK7+ to hide heap pollution / unchecked generics array creation
     @SuppressWarnings ({"unchecked", "varargs"})

--- a/src/main/java/org/mockito/verification/VerificationMode.java
+++ b/src/main/java/org/mockito/verification/VerificationMode.java
@@ -37,7 +37,7 @@ public interface VerificationMode {
      * Description will be prepended to the assertion error if verification fails.
      * @param description The custom failure message
      * @return VerificationMode
-     * @since 2.0.0
+     * @since 2.1.0
      */
     VerificationMode description(String description);
 }


### PR DESCRIPTION
Polishing the javadocs, starting with this small PR:

Issue #596
- updated @since to 2.1.0 (instead 2.0.0)
- added more docs around the verification collector