### PR TITLE
Update AssertJ to 3.5.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ dependencies {
 
     testCompile 'org.ow2.asm:asm:5.1'
 
-    testCompile 'org.assertj:assertj-core:1.7.1'
+    testCompile 'org.assertj:assertj-core:3.5.2'
 
     testRuntime configurations.provided
 


### PR DESCRIPTION
AssertJ 3 requires Java 8 and was therefore a breaking change,
but there are no other changes breaking our test suite.

Fixes #650 