### PR TITLE
Fixing the typo in JUnitDetecter class name

### DIFF
--- a/src/main/java/org/mockito/internal/junit/FriendlyExceptionMaker.java
+++ b/src/main/java/org/mockito/internal/junit/FriendlyExceptionMaker.java
@@ -8,15 +8,15 @@ import org.mockito.exceptions.verification.ArgumentsAreDifferent;
  */
 class FriendlyExceptionMaker {
 
-    private final JUnitDetecter detecter;
+    private final JUnitDetector detector;
 
-    FriendlyExceptionMaker(JUnitDetecter detecter) {
-        this.detecter = detecter;
+    FriendlyExceptionMaker(JUnitDetector detector) {
+        this.detector = detector;
     }
 
     //TODO SF this can be now unit tested
     public AssertionError createArgumentsAreDifferentException(String message, String wanted, String actual)  {
-        if (!detecter.hasJUnit()) {
+        if (!detector.hasJUnit()) {
             return new ArgumentsAreDifferent(message);
         }
 

--- a/src/main/java/org/mockito/internal/junit/JUnitDetector.java
+++ b/src/main/java/org/mockito/internal/junit/JUnitDetector.java
@@ -1,10 +1,10 @@
 package org.mockito.internal.junit;
 
-class JUnitDetecter {
+class JUnitDetector {
 
     private boolean hasJUnit;
 
-    JUnitDetecter() {
+    JUnitDetector() {
         try {
             Class.forName("junit.framework.ComparisonFailure");
             hasJUnit = true;

--- a/src/main/java/org/mockito/internal/junit/JUnitTool.java
+++ b/src/main/java/org/mockito/internal/junit/JUnitTool.java
@@ -6,13 +6,13 @@ package org.mockito.internal.junit;
 
 public class JUnitTool {
 
-    private static final JUnitDetecter detecter = new JUnitDetecter();
+    private static final JUnitDetector detector = new JUnitDetector();
 
     public static boolean hasJUnit() {
-        return detecter.hasJUnit();
+        return detector.hasJUnit();
     }
 
     public static AssertionError createArgumentsAreDifferentException(String message, String wanted, String actual)  {
-        return new FriendlyExceptionMaker(detecter).createArgumentsAreDifferentException(message, wanted, actual);
+        return new FriendlyExceptionMaker(detector).createArgumentsAreDifferentException(message, wanted, actual);
     }
 }


### PR DESCRIPTION
`JUnitDetecter` class has been renamed to `JUnitDetector`. The variables in `FriendlyExceptionMaker` and `JUniTool` have been renamed accordingly.

Fixes https://github.com/mockito/mockito/issues/655