### PR TITLE
Correct version specification syntax for bytebuddy

### DIFF
--- a/gradle/osgi.gradle
+++ b/gradle/osgi.gradle
@@ -16,7 +16,7 @@ afterEvaluate {
                     "org.mockito.*;version=${version}"
 
             instruction 'Import-Package',
-                    'net.bytebuddy.*;version=[1.4.26,2.0)',
+                    'net.bytebuddy.*;version="[1.4.26,2.0)"',
                     'junit.*;resolution:=optional',
                     'org.junit.*;resolution:=optional',
                     'org.hamcrest;resolution:=optional',


### PR DESCRIPTION
Proposed fix for #678: 
Use double quotes around version specification for Byte Buddy dependencies. 
The version for Objenesis dependencies is already specified correctly.