### PR TITLE
Updated release process so that Mockito can continuously deliver high quality features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ branches:
 install:
  - true
 script:
-  - ./gradlew ciBuild -Dscan
+  - ./gradlew ciBuild release -Dscan
 after_success:
   - ./gradlew --stacktrace coverageReport && cp build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml jacoco.xml || echo "Code coverage failed"
   - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -41,10 +41,12 @@ bintray {
                sign = true
             }
 
-            mavenCentralSync {
-                user = 'mockito'
-                password = System.env.NEXUS_PWD
-            }
+//          Temporarily disable maven central sync until the release procedure is sorted out
+//
+//            mavenCentralSync {
+//                user = 'mockito'
+//                password = System.env.NEXUS_PWD
+//            }
         }
     }
 }

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -137,7 +137,7 @@ releaseSteps {
     step("ensure good chunk of recent commits is pulled for release notes automation") {
         //Travis default clone is pretty shallow
         //Loading extra 1K commits (1.x -> 2.x had ~700 commits)
-        run "git", "pull", "--depth", "1000"
+        run "git", "pull", "--depth", "1000", "origin", System.env.TRAVIS_BRANCH
     }
 
     def gitAuthor

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -44,7 +44,8 @@ def dryRun = project.hasProperty('dryRun')
 if (dryRun) {
     //TODO SF lets not use excludedTaskNames to model this
     logger.lifecycle "Automatically scheduling 'rollbackRelease' task"
-    rollbackRelease.dependsOn release
+    //mustRun instead of dependsOn to avoid running 'release' task every time use 'dryRun' property
+    rollbackRelease.mustRunAfter release
     gradle.startParameter.taskNames += "rollbackRelease"
 }
 

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -9,6 +9,11 @@ In case the release process from Travis CI fails, please try:
     preventing version.properties to be bumped.
   3. delete top release notes paragraph(s) so that they are recreated
     - useful for recreating/merging release notes
+
+Testing release locally:
+  (this section of docs is in progress)
+  1. Configure env TRAVIS_BRANCH, GH_TOKEN, MOCKITO_BINTRAY_API_KEY
+  2. run './gradlew release -PdryRun'
 """
 
 def skipReleaseCommitMessage = '[ci skip-release]'
@@ -129,14 +134,10 @@ releaseSteps {
     String buildInfo = "by Travis CI build $System.env.TRAVIS_BUILD_NUMBER"
     MaskedArg pushTarget = new MaskedArg(value: "https://szczepiq:${System.env.GH_TOKEN}@github.com/mockito/mockito.git")
 
-    if (!dryRun) {
-        //git pull will fail when testing release from the release branch
-        //the simplest way is to avoid this step in dry run
-        step("ensure good chunk of recent commits is pulled for release notes automation") {
-            //Travis default clone is pretty shallow
-            //Loading extra 1K commits (1.x -> 2.x had ~700 commits)
-            run "git", "pull", "--depth", "1000"
-        }
+    step("ensure good chunk of recent commits is pulled for release notes automation") {
+        //Travis default clone is pretty shallow
+        //Loading extra 1K commits (1.x -> 2.x had ~700 commits)
+        run "git", "pull", "--depth", "1000"
     }
 
     def gitAuthor

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -98,6 +98,9 @@ task("releaseNeeded") {
         } else if (pr == 'false' && isReleasableBranch(branch) && !comparePublications.publicationsEqual) {
             logger.lifecycle("All criteria are met, the release will be initiated")
             ext.needed = true //standard, continuous delivery scenario
+        } else {
+            logger.lifecycle("Criteria are not met, the release will NOT be initiated")
+            ext.needed = false
         }
 
         logger.lifecycle("Release need evaluation - needed: ${ext.needed}, " +

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -13,8 +13,6 @@ In case the release process from Travis CI fails, please try:
 
 def skipReleaseCommitMessage = '[ci skip-release]'
 
-def customReleaseVersionPattern = /.*\[ci-release ([^\]]+)\].*/
-
 import org.mockito.release.version.*
 
 assert project == rootProject
@@ -50,12 +48,8 @@ if (dryRun) {
 }
 
 def isReleasableBranch(String branch) {
-    if (!branch) {
-        logger.lifecycle "Branch env variable not found. Assuming release outside Travis CI."
-        return true
-    }
     // matches 'master', 'release/2.x', 'release/3.x', etc.
-    branch.matches("master|release/.+")
+    branch?.matches("master|release/.+")
 }
 
 configurations {
@@ -86,14 +80,25 @@ task("releaseNeeded") {
         def skipEnvVariable = System.env.SKIP_RELEASE
         def commitMessage = System.env.TRAVIS_COMMIT_MESSAGE
         def skippedByCommitMessage = commitMessage?.contains(skipReleaseCommitMessage)
-        def customVersion = (commitMessage =~ customReleaseVersionPattern)
 
         //Useful for testing bintrayUpload task, makes "releaseNeeded" answer "yes"
         def forceBintrayUpload = project.hasProperty("forceBintrayUpload")
 
-        ext.needed = forceBintrayUpload || dryRun || customVersion.matches() || (pr == 'false' && isReleasableBranch(branch) && !comparePublications.publicationsEqual && skipEnvVariable != 'true' && !skippedByCommitMessage)
-        logger.lifecycle("Release needed: {}, releasable branch: {}, pull request: {}, dry run: {}, force bintray upload: {}, publications equal: {}, skip env variable: {}, skipped by message: {}, customVersion: {}.",
-                needed, isReleasableBranch(branch), pr, dryRun, forceBintrayUpload, comparePublications.publicationsEqual, skipEnvVariable, skippedByCommitMessage, customVersion.matches())
+        if (skippedByCommitMessage || skipEnvVariable) {
+            logger.lifecycle("Release is skipped on request")
+            ext.needed = false //we really don't want the release
+        } else if (forceBintrayUpload || dryRun) {
+            logger.lifecycle("Release will be initiated for testing purposes")
+            ext.needed = true //testing purposes, dry run
+        } else if (pr == 'false' && isReleasableBranch(branch) && !comparePublications.publicationsEqual) {
+            logger.lifecycle("All criteria are met, the release will be initiated")
+            ext.needed = true //standard, continuous delivery scenario
+        }
+
+        logger.lifecycle("Release need evaluation - needed: ${ext.needed}, " +
+                "releasable branch: ${isReleasableBranch(branch)}, pull request: $pr, dry run: $dryRun, " +
+                "force bintray upload: $forceBintrayUpload, publications equal: $comparePublications.publicationsEqual, " +
+                "skip env variable: $skipEnvVariable, skipped by message: $skippedByCommitMessage")
     }
 }
 
@@ -120,9 +125,8 @@ release {
 }
 
 releaseSteps {
-    def customVersion = (System.env.TRAVIS_COMMIT_MESSAGE =~ customReleaseVersionPattern)
-    String currentVersion = (customVersion.matches() ? customVersion[0][1] : project.version)
-    String buildInfo = "by Travis CI build $System.env.TRAVIS_BUILD_NUMBER $skipReleaseCommitMessage"
+    String currentVersion = project.version
+    String buildInfo = "by Travis CI build $System.env.TRAVIS_BUILD_NUMBER"
     MaskedArg pushTarget = new MaskedArg(value: "https://szczepiq:${System.env.GH_TOKEN}@github.com/mockito/mockito.git")
 
     step("ensure good chunk of recent commits is pulled for release notes automation") {

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -129,10 +129,14 @@ releaseSteps {
     String buildInfo = "by Travis CI build $System.env.TRAVIS_BUILD_NUMBER"
     MaskedArg pushTarget = new MaskedArg(value: "https://szczepiq:${System.env.GH_TOKEN}@github.com/mockito/mockito.git")
 
-    step("ensure good chunk of recent commits is pulled for release notes automation") {
-        //Travis default clone is pretty shallow
-        //Loading extra 1K commits (1.x -> 2.x had ~700 commits)
-        run "git", "pull", "--depth", "1000"
+    if (!dryRun) {
+        //git pull will fail when testing release from the release branch
+        //the simplest way is to avoid this step in dry run
+        step("ensure good chunk of recent commits is pulled for release notes automation") {
+            //Travis default clone is pretty shallow
+            //Loading extra 1K commits (1.x -> 2.x had ~700 commits)
+            run "git", "pull", "--depth", "1000"
+        }
     }
 
     def gitAuthor

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -2642,6 +2642,7 @@ public class Mockito extends ArgumentMatchers {
     /**
      * This API will move soon to a different place.
      * See <a href="https://github.com/mockito/mockito/issues/577">issue 577</a>.
+     * See also <a href="https://github.com/mockito/mockito/issues/542">issue 542</a>.
      */
     @Deprecated
     static MockitoDebugger debug() {

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-version=2.2.0-beta.2
+version=2.2.0
 mockito.testng.version=1.0


### PR DESCRIPTION
When merged, this will produce new version 2.2.0 and set release/2.x to continuously publish 2.2.1, 2.2.2, ... as new high quality features and enhancements are merged. Hurray!

Highlights:

- set next version to 2.2.0 (arbitrary number)
- reworked the conditional complexity to avoid accidental releases
- removed custom release version logic because it does not work (not opposed to this feature, just cleaned up the code. This feature should be implemented in version.gradle file)
 - for the time being, custom version can be achieved by using Gradle env variable: ORG_GRADLE_PROJECT_version=2.3.0 (it looks like magic but it is a real feature from the Gradle book ;)
- added basic docs around testing the release process (it's way too hard now)