### PR TITLE
Improved the format of arguments in verification failures when describing short and byte values

### DIFF
--- a/src/main/java/org/mockito/internal/matchers/text/ValuePrinter.java
+++ b/src/main/java/org/mockito/internal/matchers/text/ValuePrinter.java
@@ -28,8 +28,10 @@ public class ValuePrinter {
             return value + "d";
         } else if (value instanceof Float) {
             return value + "f";
+        } else if (value instanceof Short) {
+            return "(short) " + value;
         } else if (value instanceof Byte) {
-            return String.format("0x%02X", (Byte) value);
+            return String.format("(byte) 0x%02X", (Byte) value);
         } else if (value instanceof Map) {
             return printMap((Map) value);
         } else if (value.getClass().isArray()) {

--- a/src/test/java/org/mockito/internal/matchers/text/ValuePrinterTest.java
+++ b/src/test/java/org/mockito/internal/matchers/text/ValuePrinterTest.java
@@ -1,63 +1,60 @@
 package org.mockito.internal.matchers.text;
 
 
+import java.util.LinkedHashMap;
 import org.junit.Test;
 
-import java.util.LinkedHashMap;
-
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.internal.matchers.text.ValuePrinter.print;
 
 public class ValuePrinterTest {
 
     @Test
-    public void prints_values() throws Exception {
-        assertEquals("null", print(null));
-        assertEquals("\"str\"", print("str"));
-        assertEquals("\"x\ny\"", print("x\ny"));
-        assertEquals("3", print(3));
-        assertEquals("3L", print(3L));
-        assertEquals("3.14d", print(3.14d));
-        assertEquals("3.14f", print(3.14f));
-        assertEquals("[1, 2]", print(new int[]{1, 2}));
-        assertEquals("{\"foo\" = 2L}", print(new LinkedHashMap<String, Object>() {
-            {
-                put("foo", 2L);
-            }
-        }));
-        assertEquals("{\"byte\" = 0x01, \"short\" = 2, \"int\" = 3, \"long\" = 4L, \"float\" = 2.71f, \"double\" = 3.14d}", print(new LinkedHashMap<String, Object>() {
-            {
-                put("byte", (byte)1);
-                put("short", (short)2);
-                put("int", 3);
-                put("long", 4L);
-                put("float", 2.71f);
-                put("double", 3.14d);
-            }
-        }));
+    public void prints_values() {
+        assertThat(print(null)).isEqualTo("null");
+        assertThat(print("str")).isEqualTo("\"str\"");
+        assertThat(print("x\ny")).isEqualTo("\"x\ny\"");
+        assertThat(print(3)).isEqualTo("3");
+        assertThat(print(3L)).isEqualTo("3L");
+        assertThat(print(3.14d)).isEqualTo("3.14d");
+        assertThat(print(3.14f)).isEqualTo("3.14f");
+        assertThat(print(new int[]{1, 2})).isEqualTo("[1, 2]");
+        assertThat(print(new LinkedHashMap<String, Object>() {{
+            put("foo", 2L);
+        }})).isEqualTo("{\"foo\" = 2L}");
+        assertThat(print(new LinkedHashMap<String, Object>() {{
+            put("int passed as hex", 0x01);
+            put("byte", (byte) 0x01);
+            put("short", (short) 2);
+            put("int", 3);
+            put("long", 4L);
+            put("float", 2.71f);
+            put("double", 3.14d);
+        }})).isEqualTo("{\"int passed as hex\" = 1, \"byte\" = (byte) 0x01, \"short\" = (short) 2, \"int\" = 3, \"long\" = 4L, \"float\" = 2.71f, \"double\" = 3.14d}");
         assertTrue(print(new UnsafeToString()).contains("UnsafeToString"));
-        assertEquals("ToString", print(new ToString()));
-        assertEquals("formatted", print(new FormattedText("formatted")));
+        assertThat(print(new ToString())).isEqualTo("ToString");
+        assertThat(print(new FormattedText("formatted"))).isEqualTo("formatted");
+    }
+
+    @Test
+    public void prints_chars() {
+        assertThat(print('a')).isEqualTo("'a'");
+        assertThat(print('\n')).isEqualTo("'\\n'");
+        assertThat(print('\t')).isEqualTo("'\\t'");
+        assertThat(print('\r')).isEqualTo("'\\r'");
     }
 
     static class ToString {
         public String toString() {
             return "ToString";
         }
-    }
 
+    }
     static class UnsafeToString {
         public String toString() {
             throw new RuntimeException("ka-boom!");
         }
-    }
 
-    @Test
-    public void prints_chars() throws Exception {
-        assertEquals("'a'", print('a'));
-        assertEquals("'\\n'", print('\n'));
-        assertEquals("'\\t'", print('\t'));
-        assertEquals("'\\r'", print('\r'));
     }
 }

--- a/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
+++ b/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
@@ -374,7 +374,7 @@ public class DescriptiveMessagesWhenVerificationFailsTest extends TestBase {
             assertThat(e)
                 .hasMessageContaining("iMethods.threeArgumentMethod(12, foo, \"xx\")")
                 .hasMessageContaining("iMethods.arrayMethod([\"a\", \"b\", \"c\"])")
-                .hasMessageContaining("iMethods.forByte(0x19)");
+                .hasMessageContaining("iMethods.forByte((byte) 0x19)");
         }
     }
 


### PR DESCRIPTION
Currently the code can print some arguments without necessary casts, see https://github.com/mockito/mockito/pull/571#issuecomment-241357864.

Before the exception message contained : 

```
iMethods.forByte(0x19)
```

Which is actually not valid java. So the exception message now prints 

```
iMethods.forByte((byte) 0x19)
```

This PR intends to fix it, this especially affects short and byte values.