### PR TITLE
Simplified release process by hosting javadoc on javadoc.io

### DIFF
--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -188,7 +188,7 @@ TODO:
 private void commitReleaseNotes(String buildInfo) {
     def notesFile = project.file("doc/release-notes/official.md")
     run "git", "add", "$notesFile" as String
-    run "git", "commit", "-m", '"Update release notes ' + buildInfo + '"', "$notesFile" as String
+    run "git", "commit", "-m", "Update release notes $buildInfo" as String, "$notesFile" as String
 }
 
 private void createTag(String buildInfo, String tag) {

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -147,8 +147,6 @@ releaseSteps {
     step("configure generic git user") { gitAuthor = gitTool.setAuthor("Continuous Delivery Drone", "continuous.delivery.drone@gmail.com") }
     .cleanup { gitAuthor.restoreOriginal() }
 
-    step("commit updated javadoc into gh-pages branch") { commitUpdatedJavadoc(buildInfo) }
-
     /*
             Now we'll start operating on branch that we want to release.
             This introduces a problem - someone might have pushed changes *after* release process has started
@@ -158,8 +156,6 @@ releaseSteps {
             Resolutions:
              - see 'TROUBLESHOOTING' section at the top of this file
     */
-
-    step("start operating on $System.env.TRAVIS_BRANCH") { run "git", "checkout",  System.env.TRAVIS_BRANCH }
 
     step("update release notes") { project.notes.updateReleaseNotes() }
 
@@ -173,7 +169,7 @@ releaseSteps {
             .rollback { run "git", "reset", "--hard", "HEAD^" }
 
     step("push changes to all involved branches") {
-        def pushCommandLine = ["git", "push", pushTarget, System.env.TRAVIS_BRANCH, "gh-pages", "v$currentVersion", "-q"]
+        def pushCommandLine = ["git", "push", pushTarget, System.env.TRAVIS_BRANCH, "v$currentVersion", "-q"]
         if (dryRun) {
             pushCommandLine << '--dry-run'
         }
@@ -204,22 +200,6 @@ private void commitIncrementedVersion(String currentVersion, String buildInfo, V
     String nextVersion = versionFile.incrementVersion()
     String message = "Increment version '$currentVersion' -> '$nextVersion' $buildInfo"
     run "git", "commit", "-m", "$message" as String, "version.properties"
-}
-
-private void commitUpdatedJavadoc(String buildInfo) {
-    run "git", "fetch", "origin", "+gh-pages:gh-pages"
-    run "git", "checkout", "gh-pages"
-    run "git", "rm", "-r", "docs/current", "-q"
-    project.copy {
-        from "build/javadoc"
-        into "docs/$project.version"
-    }
-    project.copy {
-        from "build/javadoc"
-        into "docs/current"
-    }
-    run "git", "add", "docs"
-    run "git", "commit", "-m", '"Refresh javadoc ' + buildInfo + '"', "-q"
 }
 
 void run(Object ... args) {

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -160,13 +160,13 @@ releaseSteps {
     step("update release notes") { project.notes.updateReleaseNotes() }
 
     step("commit release notes") { commitReleaseNotes(buildInfo) }
-            .rollback { run "git", "reset", "--hard", "HEAD^" }
+            .rollback { run "git", "reset", "--hard", "HEAD~1" }
 
     step("create new version tag") { createTag(buildInfo, "v${currentVersion}".toString()) }
             .rollback { run "git", "tag", "-d", "v${currentVersion}".toString()}
 
     step("commit incremented version on $System.env.TRAVIS_BRANCH") { commitIncrementedVersion(currentVersion, buildInfo, project.versionFile) }
-            .rollback { run "git", "reset", "--hard", "HEAD^" }
+            .rollback { run "git", "reset", "--hard", "HEAD~1" }
 
     step("push changes to all involved branches") {
         def pushCommandLine = ["git", "push", pushTarget, System.env.TRAVIS_BRANCH, "v$currentVersion", "-q"]

--- a/src/test/java/org/mockitousage/debugging/InvocationsPrinterTest.java
+++ b/src/test/java/org/mockitousage/debugging/InvocationsPrinterTest.java
@@ -1,6 +1,5 @@
 package org.mockitousage.debugging;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -9,7 +8,6 @@ import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 public class InvocationsPrinterTest extends TestBase {
@@ -17,28 +15,28 @@ public class InvocationsPrinterTest extends TestBase {
     @Mock IMethods mock;
 
     @Test public void no_invocations() {
-        Assert.assertEquals("No interactions and stubbings found for mock: mock", new InvocationsPrinter().printInvocations(mock));
+        assertThat(new InvocationsPrinter().printInvocations(mock)).isEqualTo("No interactions and stubbings found for mock: mock");
     }
 
     @Test public void prints_invocations() {
         mock.simpleMethod(100);
         triggerInteraction();
 
-        assertThat(filterLineNo("[Mockito] Interactions of: mock\n" +
+        assertThat(filterLineNo(new InvocationsPrinter().printInvocations(mock)))
+                .isEqualTo(filterLineNo("[Mockito] Interactions of: mock\n" +
                         " 1. mock.simpleMethod(100);\n" +
                         "  -> at org.mockitousage.debugging.InvocationsPrinterTest.prints_invocations(InvocationsPrinterTest.java:0)\n" +
                         " 2. mock.otherMethod();\n" +
-                        "  -> at org.mockitousage.debugging.InvocationsPrinterTest.triggerInteraction(InvocationsPrinterTest.java:0)\n"))
-                .isEqualTo(filterLineNo(new InvocationsPrinter().printInvocations(mock)));
+                        "  -> at org.mockitousage.debugging.InvocationsPrinterTest.triggerInteraction(InvocationsPrinterTest.java:0)\n"));
     }
 
     @Test public void prints_stubbings() {
         triggerStubbing();
 
-        assertThat(filterLineNo("[Mockito] Unused stubbings of: mock\n" +
-                " 1. mock.simpleMethod(\"a\");\n" +
-                "  - stubbed -> at org.mockitousage.debugging.InvocationsPrinterTest.triggerStubbing(InvocationsPrinterTest.java:70)\n"))
-                .isEqualTo(filterLineNo(new InvocationsPrinter().printInvocations(mock)));
+        assertThat(filterLineNo(new InvocationsPrinter().printInvocations(mock)))
+                .isEqualTo(filterLineNo("[Mockito] Unused stubbings of: mock\n" +
+                        " 1. mock.simpleMethod(\"a\");\n" +
+                        "  - stubbed -> at org.mockitousage.debugging.InvocationsPrinterTest.triggerStubbing(InvocationsPrinterTest.java:70)\n"));
     }
 
     @Test public void prints_invocations_and_stubbings() {
@@ -47,13 +45,13 @@ public class InvocationsPrinterTest extends TestBase {
         mock.simpleMethod("a");
         triggerInteraction();
 
-        assertThat(filterLineNo("[Mockito] Interactions of: mock\n" +
+        assertThat(filterLineNo(new InvocationsPrinter().printInvocations(mock)))
+                .isEqualTo(filterLineNo("[Mockito] Interactions of: mock\n" +
                         " 1. mock.simpleMethod(\"a\");\n" +
                         "  -> at org.mockitousage.debugging.InvocationsPrinterTest.prints_invocations_and_stubbings(InvocationsPrinterTest.java:49)\n" +
                         "   - stubbed -> at org.mockitousage.debugging.InvocationsPrinterTest.triggerStubbing(InvocationsPrinterTest.java:73)\n" +
                         " 2. mock.otherMethod();\n" +
-                        "  -> at org.mockitousage.debugging.InvocationsPrinterTest.triggerInteraction(InvocationsPrinterTest.java:34)\n"))
-                .isEqualTo(filterLineNo(new InvocationsPrinter().printInvocations(mock)));
+                        "  -> at org.mockitousage.debugging.InvocationsPrinterTest.triggerInteraction(InvocationsPrinterTest.java:34)\n"));
     }
 
     @Test public void prints_invocations_and_unused_stubbings() {
@@ -62,15 +60,15 @@ public class InvocationsPrinterTest extends TestBase {
         mock.simpleMethod("b");
         triggerInteraction();
 
-        assertThat(filterLineNo("[Mockito] Interactions of: mock\n" +
-                " 1. mock.simpleMethod(\"b\");\n" +
-                "  -> at org.mockitousage.debugging.InvocationsPrinterTest.prints_invocations_and_unused_stubbings(InvocationsPrinterTest.java:55)\n" +
-                " 2. mock.otherMethod();\n" +
-                "  -> at org.mockitousage.debugging.InvocationsPrinterTest.triggerInteraction(InvocationsPrinterTest.java:34)\n" +
-                "[Mockito] Unused stubbings of: mock\n" +
-                " 1. mock.simpleMethod(\"a\");\n" +
-                "  - stubbed -> at org.mockitousage.debugging.InvocationsPrinterTest.triggerStubbing(InvocationsPrinterTest.java:62)\n"))
-                .isEqualTo(filterLineNo(new InvocationsPrinter().printInvocations(mock)));
+        assertThat(filterLineNo(new InvocationsPrinter().printInvocations(mock)))
+                .isEqualTo(filterLineNo("[Mockito] Interactions of: mock\n" +
+                        " 1. mock.simpleMethod(\"b\");\n" +
+                        "  -> at org.mockitousage.debugging.InvocationsPrinterTest.prints_invocations_and_unused_stubbings(InvocationsPrinterTest.java:55)\n" +
+                        " 2. mock.otherMethod();\n" +
+                        "  -> at org.mockitousage.debugging.InvocationsPrinterTest.triggerInteraction(InvocationsPrinterTest.java:34)\n" +
+                        "[Mockito] Unused stubbings of: mock\n" +
+                        " 1. mock.simpleMethod(\"a\");\n" +
+                        "  - stubbed -> at org.mockitousage.debugging.InvocationsPrinterTest.triggerStubbing(InvocationsPrinterTest.java:62)\n"));
     }
 
     private void triggerInteraction() {


### PR DESCRIPTION
1. As we started hosting javadoc on javadoc.io (see #692) we don't need to push javadoc to gh-pages any more. This makes the releases simpler and faster.
2. I sneaked in test fixes after Brice caught a problem in my previous change :). Thanks!!!

Tested by dry-running the release locally:
```
Dry-running the release
Performing 7 release steps
Step 1: ensure good chunk of recent commits is pulled for release notes automation
--- Executing: git pull --depth 1000 origin release/2.x
From https://github.com/mockito/mockito
 * branch            release/2.x -> FETCH_HEAD
Already up-to-date.
--- Completed!
Step 2: configure generic git user
Step 3: update release notes
Building new release notes based on /Users/sfaber/mockito/src/doc/release-notes/official.md
Building notes for revisions: v2.2.7 -> HEAD
Successfully updated release notes!
Step 4: commit release notes
--- Executing: git add /Users/sfaber/mockito/src/doc/release-notes/official.md
--- Completed!
--- Executing: git commit -m "Update release notes by Travis CI build null [ci skip]" /Users/sfaber/mockito/src/doc/release-notes/official.md
[issue-692 1b12082] "Update release notes by Travis CI build null [ci skip]"
 1 file changed, 7 insertions(+)
--- Completed!
Step 5: create new version tag
--- Executing: git tag -a v2.2.8 -m Create tag v2.2.8 by Travis CI build null [ci skip]
--- Completed!
Step 6: commit incremented version on release/2.x
--- Executing: git commit -m Increment version '2.2.8' -> '2.2.9' by Travis CI build null [ci skip] version.properties
[issue-692 df2d903] Increment version '2.2.8' -> '2.2.9' by Travis CI build null [ci skip]
 1 file changed, 1 insertion(+), 1 deletion(-)
--- Completed!
Step 7: push changes to all involved branches
--- Executing: git push <masked> release/2.x v2.2.8 -q --dry-run
--- Completed!
No cleanup found for step 'push changes to all involved branches'
No cleanup found for step 'commit incremented version on release/2.x'
No cleanup found for step 'create new version tag'
No cleanup found for step 'commit release notes'
No cleanup found for step 'update release notes'
Cleaning up after step 'configure generic git user'
No cleanup found for step 'ensure good chunk of recent commits is pulled for release notes automation'
:rollbackRelease
Release failed. Rolling back 7 release steps.
Attempting to roll back step 7 (push changes to all involved branches)
No rollback or cleanup operation found for step 'push changes to all involved branches'
Attempting to roll back step 6 (commit incremented version on release/2.x)
--- Executing: git reset --hard HEAD~1
HEAD is now at 1b12082 "Update release notes by Travis CI build null [ci skip]"
--- Completed!
Attempting to roll back step 5 (create new version tag)
--- Executing: git tag -d v2.2.8
Deleted tag 'v2.2.8' (was f05a82e)
--- Completed!
Attempting to roll back step 4 (commit release notes)
--- Executing: git reset --hard HEAD~1
HEAD is now at d2e1b4b Made release easier to test
--- Completed!
Attempting to roll back step 3 (update release notes)
No rollback or cleanup operation found for step 'update release notes'
Attempting to roll back step 2 (configure generic git user)
Attempting to roll back step 1 (ensure good chunk of recent commits is pulled for release notes automation)
No rollback or cleanup operation found for step 'ensure good chunk of recent commits is pulled for release notes automation'
```