### PR TITLE
New nullable(Class<T>) matcher for convenient matching of nullable arguments

### DIFF
--- a/src/main/java/org/mockito/ArgumentMatchers.java
+++ b/src/main/java/org/mockito/ArgumentMatchers.java
@@ -1,5 +1,14 @@
 package org.mockito;
 
+import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
+import static org.mockito.internal.util.Primitives.defaultValue;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.mockito.internal.matchers.Any;
 import org.mockito.internal.matchers.Contains;
 import org.mockito.internal.matchers.EndsWith;
@@ -12,17 +21,6 @@ import org.mockito.internal.matchers.Same;
 import org.mockito.internal.matchers.StartsWith;
 import org.mockito.internal.matchers.apachecommons.ReflectionEquals;
 import org.mockito.internal.util.Primitives;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
-import static org.mockito.internal.util.Primitives.defaultValue;
 
 /**
  * Allow flexible verification or stubbing. See also {@link AdditionalMatchers}.
@@ -98,6 +96,8 @@ import static org.mockito.internal.util.Primitives.defaultValue;
  * for given scenario and produce highest quality test (clean and maintainable).
  * Please read on in the javadoc for {@link ArgumentMatcher} to learn about approaches and see the examples.
  * </p>
+ *
+ * @see AdditionalMatchers
  */
 @SuppressWarnings("unchecked")
 public class ArgumentMatchers {
@@ -1062,6 +1062,22 @@ public class ArgumentMatchers {
      */
     public static <T> T isNotNull(Class<T> clazz) {
         return notNull(clazz);
+    }
+
+
+    /**
+     * Argument that is either <code>null</code> or of the given type.
+     *
+     * <p>
+     * See examples in javadoc for {@link ArgumentMatchers} class
+     * </p>
+     *
+     * @param clazz Type to avoid casting
+     * @return <code>null</code>.
+     */
+    public static <T> T nullable(Class<T> clazz) {
+        AdditionalMatchers.or(isNull(), isA(clazz));
+        return  (T) Primitives.defaultValue(clazz);
     }
 
     /**

--- a/src/test/java/org/mockitousage/matchers/MatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/MatchersTest.java
@@ -5,38 +5,64 @@
 
 package org.mockitousage.matchers;
 
-import org.junit.Before;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.AdditionalMatchers.and;
+import static org.mockito.AdditionalMatchers.aryEq;
+import static org.mockito.AdditionalMatchers.cmpEq;
+import static org.mockito.AdditionalMatchers.eq;
+import static org.mockito.AdditionalMatchers.find;
+import static org.mockito.AdditionalMatchers.geq;
+import static org.mockito.AdditionalMatchers.gt;
+import static org.mockito.AdditionalMatchers.leq;
+import static org.mockito.AdditionalMatchers.lt;
+import static org.mockito.AdditionalMatchers.not;
+import static org.mockito.AdditionalMatchers.or;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyByte;
+import static org.mockito.Mockito.anyChar;
+import static org.mockito.Mockito.anyDouble;
+import static org.mockito.Mockito.anyFloat;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyObject;
+import static org.mockito.Mockito.anyShort;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.contains;
+import static org.mockito.Mockito.endsWith;
+import static org.mockito.Mockito.isA;
+import static org.mockito.Mockito.isNotNull;
+import static org.mockito.Mockito.isNull;
+import static org.mockito.Mockito.matches;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.notNull;
+import static org.mockito.Mockito.same;
+import static org.mockito.Mockito.startsWith;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotSame;
+import static junit.framework.TestCase.fail;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.RandomAccess;
 import org.junit.Test;
-import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.mockito.exceptions.verification.WantedButNotInvoked;
 import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import java.math.BigDecimal;
-import java.util.HashMap;
-import java.util.List;
-
-import static junit.framework.TestCase.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.AdditionalMatchers.*;
-import static org.mockito.AdditionalMatchers.eq;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
-
 
 @SuppressWarnings("unchecked")
 public class MatchersTest extends TestBase {
-    private IMethods mock;
-
-    @Before
-    public void setUp() {
-        mock = Mockito.mock(IMethods.class);
-    }
+    private IMethods mock = Mockito.mock(IMethods.class);
 
     @Test
-    public void andOverloaded() {
+    public void and_overloaded() {
         when(mock.oneArg(and(eq(false), eq(false)))).thenReturn("0");
         when(mock.oneArg(and(eq((byte) 1), eq((byte) 1)))).thenReturn("1");
         when(mock.oneArg(and(eq('a'), eq('a')))).thenReturn("2");
@@ -45,7 +71,7 @@ public class MatchersTest extends TestBase {
         when(mock.oneArg(and(eq((int) 1), eq((int) 1)))).thenReturn("5");
         when(mock.oneArg(and(eq((long) 1), eq((long) 1)))).thenReturn("6");
         when(mock.oneArg(and(eq((short) 1), eq((short) 1)))).thenReturn("7");
-        when(mock.oneArg(and(Matchers.contains("a"), Matchers.contains("d")))).thenReturn("8");
+        when(mock.oneArg(and(contains("a"), contains("d")))).thenReturn("8");
         when(mock.oneArg(and(isA(Class.class), eq(Object.class)))).thenReturn("9");
 
         assertEquals("0", mock.oneArg(false));
@@ -64,9 +90,9 @@ public class MatchersTest extends TestBase {
 
         assertEquals("9", mock.oneArg(Object.class));
     }
-    
+
     @Test
-    public void orOverloaded() {
+    public void or_overloaded() {
         when(mock.oneArg(or(eq(false), eq(true)))).thenReturn("0");
         when(mock.oneArg(or(eq((byte) 1), eq((byte) 2)))).thenReturn("1");
         when(mock.oneArg(or(eq((char) 1), eq((char) 2)))).thenReturn("2");
@@ -98,7 +124,7 @@ public class MatchersTest extends TestBase {
     }
 
     @Test
-    public void notOverloaded() {
+    public void not_overloaded() {
         when(mock.oneArg(not(eq(false)))).thenReturn("0");
         when(mock.oneArg(not(eq((byte) 1)))).thenReturn("1");
         when(mock.oneArg(not(eq('a')))).thenReturn("2");
@@ -107,7 +133,7 @@ public class MatchersTest extends TestBase {
         when(mock.oneArg(not(eq((int) 1)))).thenReturn("5");
         when(mock.oneArg(not(eq((long) 1)))).thenReturn("6");
         when(mock.oneArg(not(eq((short) 1)))).thenReturn("7");
-        when(mock.oneArg(not(Matchers.contains("a")))).thenReturn("8");
+        when(mock.oneArg(not(contains("a")))).thenReturn("8");
         when(mock.oneArg(not(isA(Class.class)))).thenReturn("9");
 
         assertEquals("0", mock.oneArg(true));
@@ -127,7 +153,7 @@ public class MatchersTest extends TestBase {
     }
 
     @Test
-    public void lessOrEqualOverloaded() {
+    public void less_or_equal_overloaded() {
         when(mock.oneArg(leq((byte) 1))).thenReturn("1");
         when(mock.oneArg(leq((double) 1))).thenReturn("3");
         when(mock.oneArg(leq((float) 1))).thenReturn("4");
@@ -150,7 +176,7 @@ public class MatchersTest extends TestBase {
     }
 
     @Test
-    public void lessThanOverloaded() {
+    public void less_than_overloaded() {
         when(mock.oneArg(lt((byte) 1))).thenReturn("1");
         when(mock.oneArg(lt((double) 1))).thenReturn("3");
         when(mock.oneArg(lt((float) 1))).thenReturn("4");
@@ -173,7 +199,7 @@ public class MatchersTest extends TestBase {
     }
 
     @Test
-    public void greaterOrEqualMatcherOverloaded() {
+    public void greater_or_equal_matcher_overloaded() {
         when(mock.oneArg(geq((byte) 1))).thenReturn("1");
         when(mock.oneArg(geq((double) 1))).thenReturn("3");
         when(mock.oneArg(geq((float) 1))).thenReturn("4");
@@ -196,7 +222,7 @@ public class MatchersTest extends TestBase {
     }
 
     @Test
-    public void greaterThanMatcherOverloaded() {
+    public void greater_than_matcher_overloaded() {
         when(mock.oneArg(gt((byte) 1))).thenReturn("1");
         when(mock.oneArg(gt((double) 1))).thenReturn("3");
         when(mock.oneArg(gt((float) 1))).thenReturn("4");
@@ -219,24 +245,24 @@ public class MatchersTest extends TestBase {
     }
 
     @Test
-    public void compareToMatcher() {
+    public void compare_to_matcher() {
         when(mock.oneArg(cmpEq(new BigDecimal("1.5")))).thenReturn("0");
 
         assertEquals("0", mock.oneArg(new BigDecimal("1.50")));
         assertEquals(null, mock.oneArg(new BigDecimal("1.51")));
     }
-    
+
     @Test
-    public void anyStringMatcher() {
+    public void any_String_matcher() {
         when(mock.oneArg(anyString())).thenReturn("matched");
-        
+
         assertEquals("matched", mock.oneArg(""));
         assertEquals("matched", mock.oneArg("any string"));
         assertEquals(null, mock.oneArg((String) null));
     }
 
     @Test
-    public void anyMatcher() {
+    public void any_matcher() {
         when(mock.forObject(any())).thenReturn("matched");
 
         assertEquals("matched", mock.forObject(123));
@@ -246,7 +272,7 @@ public class MatchersTest extends TestBase {
     }
 
     @Test
-    public void anyXMatcher() {
+    public void any_T_matcher() {
         when(mock.oneArg(anyBoolean())).thenReturn("0");
         when(mock.oneArg(anyByte())).thenReturn("1");
         when(mock.oneArg(anyChar())).thenReturn("2");
@@ -257,7 +283,8 @@ public class MatchersTest extends TestBase {
         when(mock.oneArg(anyShort())).thenReturn("7");
         when(mock.oneArg((String) anyObject())).thenReturn("8");
         when(mock.oneArg((Object) anyObject())).thenReturn("9");
-        
+        when(mock.oneArg(any(RandomAccess.class))).thenReturn("10");
+
         assertEquals("0", mock.oneArg(true));
         assertEquals("0", mock.oneArg(false));
 
@@ -272,10 +299,12 @@ public class MatchersTest extends TestBase {
 
         assertEquals("9", mock.oneArg(new Object()));
         assertEquals("9", mock.oneArg(new HashMap()));
+
+        assertEquals("10", mock.oneArg(new ArrayList()));
     }
 
     @Test
-    public void shouldArrayEqualsDealWithNullArray() throws Exception {
+    public void should_array_equals_deal_with_null_array() throws Exception {
         Object[] nullArray = null;
         when(mock.oneArray(aryEq(nullArray))).thenReturn("null");
 
@@ -292,64 +321,64 @@ public class MatchersTest extends TestBase {
     }
 
     @Test
-    public void shouldUseSmartEqualsForArrays() throws Exception {
+    public void should_use_smart_equals_for_arrays() throws Exception {
         //issue 143
-        mock.arrayMethod(new String[] {"one"});
-        verify(mock).arrayMethod(eq(new String[] {"one"}));
-        verify(mock).arrayMethod(new String[] {"one"});
+        mock.arrayMethod(new String[]{"one"});
+        verify(mock).arrayMethod(eq(new String[]{"one"}));
+        verify(mock).arrayMethod(new String[]{"one"});
     }
 
     @Test
-    public void shouldUseSmartEqualsForPrimitiveArrays() throws Exception {
+    public void should_use_smart_equals_for_primitive_arrays() throws Exception {
         //issue 143
-        mock.objectArgMethod(new int[] {1, 2});
-        verify(mock).objectArgMethod(eq(new int[] {1, 2}));
-        verify(mock).objectArgMethod(new int[] {1, 2});
+        mock.objectArgMethod(new int[]{1, 2});
+        verify(mock).objectArgMethod(eq(new int[]{1, 2}));
+        verify(mock).objectArgMethod(new int[]{1, 2});
     }
-    
-    @Test(expected=ArgumentsAreDifferent.class)
-    public void arrayEqualsShouldThrowArgumentsAreDifferentExceptionForNonMatchingArguments() {        
+
+    @Test(expected = ArgumentsAreDifferent.class)
+    public void array_equals_should_throw_ArgumentsAreDifferentException_for_non_matching_arguments() {
         List<Object> list = Mockito.mock(List.class);
-        
+
         list.add("test"); // testing fix for issue 20
-        list.contains(new Object[] {"1"});
-        
-        Mockito.verify(list).contains(new Object[] {"1", "2", "3"});    
+        list.contains(new Object[]{"1"});
+
+        Mockito.verify(list).contains(new Object[]{"1", "2", "3"});
     }
 
     @Test
-    public void arrayEqualsMatcher() {
-        when(mock.oneArray(aryEq(new boolean[] { true, false, false }))).thenReturn("0");
-        when(mock.oneArray(aryEq(new byte[] { 1 }))).thenReturn("1");
-        when(mock.oneArray(aryEq(new char[] { 1 }))).thenReturn("2");
-        when(mock.oneArray(aryEq(new double[] { 1 }))).thenReturn("3");
-        when(mock.oneArray(aryEq(new float[] { 1 }))).thenReturn("4");
-        when(mock.oneArray(aryEq(new int[] { 1 }))).thenReturn("5");
-        when(mock.oneArray(aryEq(new long[] { 1 }))).thenReturn("6");
-        when(mock.oneArray(aryEq(new short[] { 1 }))).thenReturn("7");
-        when(mock.oneArray(aryEq(new String[] { "Test" }))).thenReturn("8");
-        when(mock.oneArray(aryEq(new Object[] { "Test", new Integer(4) }))).thenReturn("9");
+    public void array_equals_matcher() {
+        when(mock.oneArray(aryEq(new boolean[]{true, false, false}))).thenReturn("0");
+        when(mock.oneArray(aryEq(new byte[]{1}))).thenReturn("1");
+        when(mock.oneArray(aryEq(new char[]{1}))).thenReturn("2");
+        when(mock.oneArray(aryEq(new double[]{1}))).thenReturn("3");
+        when(mock.oneArray(aryEq(new float[]{1}))).thenReturn("4");
+        when(mock.oneArray(aryEq(new int[]{1}))).thenReturn("5");
+        when(mock.oneArray(aryEq(new long[]{1}))).thenReturn("6");
+        when(mock.oneArray(aryEq(new short[]{1}))).thenReturn("7");
+        when(mock.oneArray(aryEq(new String[]{"Test"}))).thenReturn("8");
+        when(mock.oneArray(aryEq(new Object[]{"Test", new Integer(4)}))).thenReturn("9");
 
-        assertEquals("0", mock.oneArray(new boolean[] { true, false, false }));
-        assertEquals("1", mock.oneArray(new byte[] { 1 }));
-        assertEquals("2", mock.oneArray(new char[] { 1 }));
-        assertEquals("3", mock.oneArray(new double[] { 1 }));
-        assertEquals("4", mock.oneArray(new float[] { 1 }));
-        assertEquals("5", mock.oneArray(new int[] { 1 }));
-        assertEquals("6", mock.oneArray(new long[] { 1 }));
-        assertEquals("7", mock.oneArray(new short[] { 1 }));
-        assertEquals("8", mock.oneArray(new String[] { "Test" }));
-        assertEquals("9", mock.oneArray(new Object[] { "Test", new Integer(4) }));
+        assertEquals("0", mock.oneArray(new boolean[]{true, false, false}));
+        assertEquals("1", mock.oneArray(new byte[]{1}));
+        assertEquals("2", mock.oneArray(new char[]{1}));
+        assertEquals("3", mock.oneArray(new double[]{1}));
+        assertEquals("4", mock.oneArray(new float[]{1}));
+        assertEquals("5", mock.oneArray(new int[]{1}));
+        assertEquals("6", mock.oneArray(new long[]{1}));
+        assertEquals("7", mock.oneArray(new short[]{1}));
+        assertEquals("8", mock.oneArray(new String[]{"Test"}));
+        assertEquals("9", mock.oneArray(new Object[]{"Test", new Integer(4)}));
 
-        assertEquals(null, mock.oneArray(new Object[] { "Test", new Integer(999) }));
-        assertEquals(null, mock.oneArray(new Object[] { "Test", new Integer(4), "x" }));
+        assertEquals(null, mock.oneArray(new Object[]{"Test", new Integer(999)}));
+        assertEquals(null, mock.oneArray(new Object[]{"Test", new Integer(4), "x"}));
 
-        assertEquals(null, mock.oneArray(new boolean[] { true, false }));
-        assertEquals(null, mock.oneArray(new boolean[] { true, true, false }));
+        assertEquals(null, mock.oneArray(new boolean[]{true, false}));
+        assertEquals(null, mock.oneArray(new boolean[]{true, true, false}));
     }
 
     @Test
-    public void greaterOrEqualMatcher() {
+    public void greater_or_equal_matcher() {
         when(mock.oneArg(geq(7))).thenReturn(">= 7");
         when(mock.oneArg(lt(7))).thenReturn("< 7");
 
@@ -362,7 +391,7 @@ public class MatchersTest extends TestBase {
     }
 
     @Test
-    public void greaterThanMatcher() {
+    public void greater_than_matcher() {
         when(mock.oneArg(gt(7))).thenReturn("> 7");
         when(mock.oneArg(leq(7))).thenReturn("<= 7");
 
@@ -375,7 +404,7 @@ public class MatchersTest extends TestBase {
     }
 
     @Test
-    public void lessOrEqualMatcher() {
+    public void less_or_equal_matcher() {
         when(mock.oneArg(leq(7))).thenReturn("<= 7");
         when(mock.oneArg(gt(7))).thenReturn("> 7");
 
@@ -388,7 +417,7 @@ public class MatchersTest extends TestBase {
     }
 
     @Test
-    public void lessThanMatcher() {
+    public void less_than_matcher() {
         when(mock.oneArg(lt(7))).thenReturn("< 7");
         when(mock.oneArg(geq(7))).thenReturn(">= 7");
 
@@ -401,7 +430,7 @@ public class MatchersTest extends TestBase {
     }
 
     @Test
-    public void orMatcher() {
+    public void or_matcher() {
         when(mock.oneArg(anyInt())).thenReturn("other");
         when(mock.oneArg(or(eq(7), eq(9)))).thenReturn("7 or 9");
 
@@ -411,7 +440,7 @@ public class MatchersTest extends TestBase {
     }
 
     @Test
-    public void nullMatcher() {
+    public void null_matcher() {
         when(mock.threeArgumentMethod(eq(1), isNull(), eq(""))).thenReturn("1");
         when(mock.threeArgumentMethod(eq(1), not(isNull()), eq(""))).thenReturn("2");
 
@@ -420,7 +449,7 @@ public class MatchersTest extends TestBase {
     }
 
     @Test
-    public void nullMatcherForPrimitiveWrappers() {
+    public void null_matcher_for_primitive_wrappers() {
         when(mock.forBoolean(isNull(Boolean.class))).thenReturn("ok");
         when(mock.forInteger(isNull(Integer.class))).thenReturn("ok");
         when(mock.forLong(isNull(Long.class))).thenReturn("ok");
@@ -441,7 +470,7 @@ public class MatchersTest extends TestBase {
     }
 
     @Test
-    public void notNullMatcher() {
+    public void not_null_matcher() {
         when(mock.threeArgumentMethod(eq(1), notNull(), eq(""))).thenReturn("1");
         when(mock.threeArgumentMethod(eq(1), not(isNotNull()), eq(""))).thenReturn("2");
 
@@ -450,7 +479,7 @@ public class MatchersTest extends TestBase {
     }
 
     @Test
-    public void findMatcher() {
+    public void find_matcher() {
         when(mock.oneArg(find("([a-z]+)\\d"))).thenReturn("1");
 
         assertEquals("1", mock.oneArg("ab12"));
@@ -459,7 +488,7 @@ public class MatchersTest extends TestBase {
     }
 
     @Test
-    public void matchesMatcher() {
+    public void matches_matcher() {
         when(mock.oneArg(matches("[a-z]+\\d\\d"))).thenReturn("1");
         when(mock.oneArg(matches("\\d\\d\\d"))).thenReturn("2");
 
@@ -469,9 +498,9 @@ public class MatchersTest extends TestBase {
     }
 
     @Test
-    public void containsMatcher() {
-        when(mock.oneArg(Matchers.contains("ell"))).thenReturn("1");
-        when(mock.oneArg(Matchers.contains("ld"))).thenReturn("2");
+    public void contains_matcher() {
+        when(mock.oneArg(contains("ell"))).thenReturn("1");
+        when(mock.oneArg(contains("ld"))).thenReturn("2");
 
         assertEquals("1", mock.oneArg("hello"));
         assertEquals("2", mock.oneArg("world"));
@@ -479,7 +508,7 @@ public class MatchersTest extends TestBase {
     }
 
     @Test
-    public void startsWithMatcher() {
+    public void starts_with_matcher() {
         when(mock.oneArg(startsWith("ab"))).thenReturn("1");
         when(mock.oneArg(startsWith("bc"))).thenReturn("2");
 
@@ -489,9 +518,9 @@ public class MatchersTest extends TestBase {
     }
 
     @Test
-    public void endsWithMatcher() {
-        when(mock.oneArg(Matchers.endsWith("ab"))).thenReturn("1");
-        when(mock.oneArg(Matchers.endsWith("bc"))).thenReturn("2");
+    public void ends_with_matcher() {
+        when(mock.oneArg(endsWith("ab"))).thenReturn("1");
+        when(mock.oneArg(endsWith("bc"))).thenReturn("2");
 
         assertEquals("1", mock.oneArg("xab"));
         assertEquals("2", mock.oneArg("xbc"));
@@ -499,7 +528,7 @@ public class MatchersTest extends TestBase {
     }
 
     @Test
-    public void deltaMatcher() {
+    public void delta_matcher() {
         when(mock.oneArg(eq(1.0D, 0.1D))).thenReturn("1");
         when(mock.oneArg(eq(2.0D, 0.1D))).thenReturn("2");
         when(mock.oneArg(eq(1.0F, 0.1F))).thenReturn("3");
@@ -518,9 +547,9 @@ public class MatchersTest extends TestBase {
 
         assertEquals(null, mock.oneArg(2.2F));
     }
-    
+
     @Test
-    public void deltaMatcherPrintsItself() {
+    public void delta_matcher_prints_itself() {
         try {
             verify(mock).oneArg(eq(1.0D, 0.1D));
             fail();
@@ -528,9 +557,9 @@ public class MatchersTest extends TestBase {
             assertThat(e).hasMessageContaining("eq(1.0, 0.1)");
         }
     }
-    
+
     @Test
-    public void sameMatcher() {
+    public void same_matcher() {
         Object one = new String("1243");
         Object two = new String("1243");
         Object three = new String("1243");
@@ -548,14 +577,14 @@ public class MatchersTest extends TestBase {
     }
 
     @Test
-    public void eqMatcherAndNulls() {
+    public void eq_matcher_and_nulls() {
         mock.simpleMethod((Object) null);
 
         verify(mock).simpleMethod((Object) eq(null));
     }
 
     @Test
-    public void sameMatcherAndNulls() {
+    public void same_matcher_and_nulls() {
         mock.simpleMethod((Object) null);
 
         verify(mock).simpleMethod((Object) same(null));

--- a/src/test/java/org/mockitousage/matchers/MatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/MatchersTest.java
@@ -17,6 +17,7 @@ import static org.mockito.AdditionalMatchers.leq;
 import static org.mockito.AdditionalMatchers.lt;
 import static org.mockito.AdditionalMatchers.not;
 import static org.mockito.AdditionalMatchers.or;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
@@ -39,6 +40,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.notNull;
 import static org.mockito.Mockito.same;
 import static org.mockito.Mockito.startsWith;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static junit.framework.TestCase.assertEquals;
@@ -588,5 +590,14 @@ public class MatchersTest extends TestBase {
         mock.simpleMethod((Object) null);
 
         verify(mock).simpleMethod((Object) same(null));
+    }
+
+    @Test
+    public void nullable_matcher() throws Exception {
+        // imagine a Stream.of(...).map(c -> mock.oneArg(c))...
+        mock.oneArg((Character) null);
+        mock.oneArg(Character.valueOf('€'));
+
+        verify(mock, times(2)).oneArg(nullable(Character.class));
     }
 }


### PR DESCRIPTION
After using mockito, I have found that the new behaviors of matcher are good and indeed show problems in the test code or in the production code. However I have found that I miss an easy way to express a matcher for `nullable` argument when the production code may produce either `null` or value types, typically `Stream.of(<mixed values>).map(o -> mapper.map(c))...`, the current options are :

* `<T> T any()` is nice but don't check the type.
* there's always `AdditionalMatchers.or()` but this feel more heavy to use.

I'm proposing the introduction of the argument matcher `<T> nullable(Class<T>)` which is a combination of `isA` and `isNull`. I'm not adding `<T> T nullable()` because this would have the same meaning as `<T> T any()`