### PR TITLE
fixes #732 allow user to override configuration class name

### DIFF
--- a/src/main/java/org/mockito/configuration/IMockitoConfiguration.java
+++ b/src/main/java/org/mockito/configuration/IMockitoConfiguration.java
@@ -14,7 +14,8 @@ import org.mockito.stubbing.Answer;
  * when you might want to have different 'mocking style' this interface might be helpful. 
  * A reason of configuring Mockito might be if you disagree with the {@link ReturnsEmptyValues} unstubbed mocks return.
  * <p>
- * To configure Mockito create exactly <b>org.mockito.configuration.MockitoConfiguration</b> class that implements this interface.
+ * To configure Mockito create exactly <b>org.mockito.configuration.MockitoConfiguration</b> class that implements this interface. You can also specify another target class by setting the
+ * <b>org.mockito.configuration.className</b> system property.
  * <p>
  * Configuring Mockito is completely <b>optional</b> - nothing happens if there isn't any <b>org.mockito.configuration.MockitoConfiguration</b> on the classpath. 
  * <p>

--- a/src/main/java/org/mockito/internal/configuration/ClassPathLoader.java
+++ b/src/main/java/org/mockito/internal/configuration/ClassPathLoader.java
@@ -29,6 +29,8 @@ import org.mockito.plugins.MockMaker;
  *     // ...
  * }
  *     </code></pre>
+ *         The user can change the name of the class by setting the system property org.mockito.configuration.className
+ *         to the name of the IMockitoConfiguration implementation.
  *     </li>
  *     <li>
  *         Can load available mockito extensions. Currently Mockito only have one extension point the
@@ -47,7 +49,9 @@ import org.mockito.plugins.MockMaker;
  */
 public class ClassPathLoader {
 
-    public static final String MOCKITO_CONFIGURATION_CLASS_NAME = "org.mockito.configuration.MockitoConfiguration";
+    public static final String MOCKITO_CONFIGURATION_CLASS_NAME_PROPERTY = "org.mockito.configuration.className";
+
+    public static final String DEFAULT_MOCKITO_CONFIGURATION_CLASS_NAME = "org.mockito.configuration.MockitoConfiguration";
 
     /**
      * @return configuration loaded from classpath or null
@@ -55,9 +59,10 @@ public class ClassPathLoader {
     @SuppressWarnings({"unchecked"})
     public IMockitoConfiguration loadConfiguration() {
         // Trying to get config from classpath
+        final String mockitoConfigurationClassName = getMockitoConfigurationClassName();
         Class<?> configClass;
         try {
-            configClass = Class.forName(MOCKITO_CONFIGURATION_CLASS_NAME);
+            configClass = Class.forName(mockitoConfigurationClassName);
         } catch (ClassNotFoundException e) {
             //that's ok, it means there is no global config, using default one.
             return null;
@@ -68,7 +73,11 @@ public class ClassPathLoader {
         } catch (ClassCastException e) {
             throw new MockitoConfigurationException("MockitoConfiguration class must implement " + IMockitoConfiguration.class.getName() + " interface.", e);
         } catch (Exception e) {
-            throw new MockitoConfigurationException("Unable to instantiate " + MOCKITO_CONFIGURATION_CLASS_NAME +" class. Does it have a safe, no-arg constructor?", e);
+            throw new MockitoConfigurationException("Unable to instantiate " + mockitoConfigurationClassName +" class. Does it have a safe, no-arg constructor?", e);
         }
+    }
+
+    private String getMockitoConfigurationClassName() {
+        return System.getProperty(MOCKITO_CONFIGURATION_CLASS_NAME_PROPERTY, DEFAULT_MOCKITO_CONFIGURATION_CLASS_NAME);
     }
 }


### PR DESCRIPTION
The changes allow one to add a System property to change the configuration class from 
org.mockito.configuration.MockitoConfiguration to your own named class

-Dorg.mockito.configuration.className=my.package.MyMockitoClass

The issue with java9 module is that you can export a package that already contained in another module, the unamed mockito module here. With that change you can have the config in your own package that will not conflict.



check list

 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [ ] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/master/.github/CONTRIBUTING.md)
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_


