### PR TITLE
[Heavy WIP] Lambda when

### DIFF
--- a/src/main/java/org/mockito/ArgumentMatcher.java
+++ b/src/main/java/org/mockito/ArgumentMatcher.java
@@ -125,4 +125,5 @@ public interface ArgumentMatcher<T> {
      * @return true if this matcher accepts the given argument.
      */
     boolean matches(T argument);
+
 }

--- a/src/main/java/org/mockito/MockitoLambda.java
+++ b/src/main/java/org/mockito/MockitoLambda.java
@@ -1,0 +1,30 @@
+package org.mockito;
+
+import org.mockito.internal.MockitoCore;
+import org.mockito.stubbing.OngoingStubbing;
+
+public class MockitoLambda {
+
+    static final MockitoCore MOCKITO_CORE = new MockitoCore();
+
+    public static <A, B, C, R> OngoingLambdaStubbing<A, B, C, R> when(TriFunction<A, B, C, R> method) {
+        return new OngoingLambdaStubbing<>(method);
+    }
+
+    @FunctionalInterface
+    public interface TriFunction<A, B, C, R> {
+        R apply(A var1, B var2, C var3);
+    }
+
+    public static class OngoingLambdaStubbing<A, B, C, R> {
+        private final TriFunction<A, B, C, R> method;
+
+        public OngoingLambdaStubbing(TriFunction<A, B, C, R> method) {
+            this.method = method;
+        }
+
+        public OngoingStubbing<R> isInvokedWith(ArgumentMatcher<A> var1, ArgumentMatcher<B> var2, ArgumentMatcher<C> var3) {
+            return MOCKITO_CORE.when(method.apply(var1, var2, var3));
+        }
+    }
+}

--- a/src/main/java/org/mockito/MockitoLambda.java
+++ b/src/main/java/org/mockito/MockitoLambda.java
@@ -1,14 +1,21 @@
 package org.mockito;
 
 import org.mockito.internal.MockitoCore;
+import org.mockito.stubbing.Answer2;
+import org.mockito.stubbing.Answer3;
 import org.mockito.stubbing.OngoingStubbing;
+import org.mockito.stubbing.VoidAnswer2;
 
 public class MockitoLambda {
 
     static final MockitoCore MOCKITO_CORE = new MockitoCore();
 
-    public static <A, B, C, R> OngoingLambdaStubbing<A, B, C, R> when(TriFunction<A, B, C, R> method) {
-        return new OngoingLambdaStubbing<>(method);
+    public static <A, B, C, R> OngoingLambdaStubbingReturn3<A, B, C, R> when(TriFunction<A, B, C, R> method) {
+        return new OngoingLambdaStubbingReturn3<>(method);
+    }
+
+    public static <A, B> OngoingLambdaStubbingVoid2<A, B> when(DuoConsumer<A, B> method) {
+        return new OngoingLambdaStubbingVoid2<>(method);
     }
 
     @FunctionalInterface
@@ -16,15 +23,57 @@ public class MockitoLambda {
         R apply(A var1, B var2, C var3);
     }
 
-    public static class OngoingLambdaStubbing<A, B, C, R> {
+    @FunctionalInterface
+    public interface DuoConsumer<A, B> {
+        void apply(A var1, B var2);
+    }
+
+    public static class OngoingLambdaStubbingReturn3<A, B, C, R> {
         private final TriFunction<A, B, C, R> method;
 
-        public OngoingLambdaStubbing(TriFunction<A, B, C, R> method) {
+        public OngoingLambdaStubbingReturn3(TriFunction<A, B, C, R> method) {
             this.method = method;
         }
 
-        public OngoingStubbing<R> isInvokedWith(ArgumentMatcher<A> var1, ArgumentMatcher<B> var2, ArgumentMatcher<C> var3) {
+        public FinishableStubbing3<A, B, C, R> isInvokedWith(ArgumentMatcher<A> var1, ArgumentMatcher<B> var2, ArgumentMatcher<C> var3) {
             return MOCKITO_CORE.when(method.apply(var1, var2, var3));
+        }
+
+        public FinishableStubbing3<A, B, C, R> isInvokedWith(A var1, B var2, C var3) {
+            return MOCKITO_CORE.when(method.apply(var1, var2, var3));
+        }
+    }
+
+    public static class FinishableStubbing3<A, B, C, R> {
+
+        public void thenReturn(R foo) {
+
+        }
+
+        public void thenAnswer(Answer3<A, B, C, R> answer) {
+
+        }
+    }
+
+    public static class OngoingLambdaStubbingVoid2<A, B> {
+        private final DuoConsumer<A, B> method;
+
+        public OngoingLambdaStubbingVoid2(DuoConsumer<A, B> method) {
+            this.method = method;
+        }
+
+        public FinishableAnswer2<A, B> isInvokedWith(ArgumentMatcher<A> var1, ArgumentMatcher<B> var2) {
+            return MOCKITO_CORE.when(method.apply(var1, var2););
+        }
+
+        public FinishableAnswer2<A, B> isInvokedWith(A var1, B var2) {
+            return MOCKITO_CORE.when(method.apply(var1, var2));
+        }
+    }
+
+    public static class FinishableAnswer2<A, B> {
+        public void thenAnswer(VoidAnswer2<A, B> answer) {
+
         }
     }
 }

--- a/src/main/java/org/mockito/internal/MockitoCore.java
+++ b/src/main/java/org/mockito/internal/MockitoCore.java
@@ -34,7 +34,6 @@ import org.mockito.internal.stubbing.InvocationContainer;
 import org.mockito.internal.stubbing.OngoingStubbingImpl;
 import org.mockito.internal.stubbing.StubberImpl;
 import org.mockito.internal.util.DefaultMockingDetails;
-import org.mockito.internal.util.MockUtil;
 import org.mockito.internal.verification.MockAwareVerificationMode;
 import org.mockito.internal.verification.VerificationDataImpl;
 import org.mockito.internal.verification.VerificationModeFactory;
@@ -94,7 +93,7 @@ public class MockitoCore {
         MockingProgress mockingProgress = mockingProgress();
         mockingProgress.validateState();
         mockingProgress.reset();
-        mockingProgress.resetOngoingStubbing();
+        mockingProgress.resetInvocationContainer();
 
         for (T m : mocks) {
             resetMock(m);
@@ -105,7 +104,7 @@ public class MockitoCore {
         MockingProgress mockingProgress = mockingProgress();
         mockingProgress.validateState();
         mockingProgress.reset();
-        mockingProgress.resetOngoingStubbing();
+        mockingProgress.resetInvocationContainer();
 
         for (T m : mocks) {
             getMockHandler(m).getInvocationContainer().clearInvocations();
@@ -159,7 +158,7 @@ public class MockitoCore {
     public Stubber stubber() {
         MockingProgress mockingProgress = mockingProgress();
         mockingProgress.stubbingStarted();
-        mockingProgress.resetOngoingStubbing();
+        mockingProgress.resetInvocationContainer();
         return new StubberImpl();
     }
 

--- a/src/main/java/org/mockito/internal/handler/MockHandlerImpl.java
+++ b/src/main/java/org/mockito/internal/handler/MockHandlerImpl.java
@@ -81,8 +81,7 @@ public class MockHandlerImpl<T> implements InternalMockHandler<T> {
 
         // prepare invocation for stubbing
         invocationContainerImpl.setInvocationForPotentialStubbing(invocationMatcher);
-        OngoingStubbingImpl<T> ongoingStubbing = new OngoingStubbingImpl<T>(invocationContainerImpl);
-        mockingProgress().reportOngoingStubbing(ongoingStubbing);
+        mockingProgress().reportInvocation(invocationContainerImpl);
 
         // look for existing answer for this invocation
         StubbedInvocationMatcher stubbedInvocation = invocationContainerImpl.findAnswerFor(invocation);

--- a/src/main/java/org/mockito/internal/progress/MockingProgress.java
+++ b/src/main/java/org/mockito/internal/progress/MockingProgress.java
@@ -5,6 +5,8 @@
 
 package org.mockito.internal.progress;
 
+import org.mockito.MockitoLambda;
+import org.mockito.internal.stubbing.InvocationContainerImpl;
 import org.mockito.listeners.MockitoListener;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.stubbing.OngoingStubbing;
@@ -13,8 +15,6 @@ import org.mockito.verification.VerificationStrategy;
 
 public interface MockingProgress {
     
-    void reportOngoingStubbing(OngoingStubbing<?> ongoingStubbing);
-
     OngoingStubbing<?> pullOngoingStubbing();
 
     void verificationStarted(VerificationMode verificationMode);
@@ -33,7 +33,7 @@ public interface MockingProgress {
      * Removes ongoing stubbing so that in case the framework is misused
      * state validation errors are more accurate
      */
-    void resetOngoingStubbing();
+    void resetInvocationContainer();
 
     ArgumentMatcherStorage getArgumentMatcherStorage();
     
@@ -46,4 +46,10 @@ public interface MockingProgress {
     void setVerificationStrategy(VerificationStrategy strategy);
 
     VerificationMode maybeVerifyLazily(VerificationMode mode);
+
+    <R, A extends MockitoLambda.Answer<R>> MockitoLambda.FinishableStubbing<R,A> pullFinishableStubbing();
+
+    <R, A extends MockitoLambda.Answer<R>> MockitoLambda.FinishableAnswer<R,A> finishableAnswer();
+
+    void reportInvocation(InvocationContainerImpl invocationContainer);
 }

--- a/src/main/java/org/mockito/internal/stubbing/InvocationContainerImpl.java
+++ b/src/main/java/org/mockito/internal/stubbing/InvocationContainerImpl.java
@@ -4,6 +4,7 @@
  */
 package org.mockito.internal.stubbing;
 
+import org.mockito.MockitoLambda;
 import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockito.internal.invocation.StubInfoImpl;
 import org.mockito.internal.stubbing.answers.AnswersValidator;
@@ -140,5 +141,9 @@ public class InvocationContainerImpl implements InvocationContainer, Serializabl
         return mockSettings.isStubOnly()
           ? new SingleRegisteredInvocation()
           : new DefaultRegisteredInvocations();
+    }
+
+    public <R, A extends MockitoLambda.Answer<R>> void addAnswer(A answer) {
+        // TODO
     }
 }

--- a/src/test/java/org/mockito/StateMaster.java
+++ b/src/test/java/org/mockito/StateMaster.java
@@ -11,7 +11,7 @@ public class StateMaster {
 
     public void reset() {
         mockingProgress().reset();
-        mockingProgress().resetOngoingStubbing();
+        mockingProgress().resetInvocationContainer();
     }
 
     public void validate() {

--- a/src/test/java/org/mockitousage/stubbing/LambdaStubbingTest.java
+++ b/src/test/java/org/mockitousage/stubbing/LambdaStubbingTest.java
@@ -15,4 +15,12 @@ public class LambdaStubbingTest {
         IMethods mock = Mockito.mock(IMethods.class);
         MockitoLambda.when(mock::threeArgumentMethodWithStrings).isInvokedWith(anyInt(), anyString(), anyString()).thenReturn("foo");
     }
+
+    @Test
+    public void stubs_void_method_as_lambda() {
+        IMethods mock = Mockito.mock(IMethods.class);
+        MockitoLambda.when(mock::twoArgumentMethod).isInvokedWith(anyInt(), anyInt()).thenAnswer((a, b) -> {
+            System.out.println("Answered " + (a * b) + " is type-safe!");
+        });
+    }
 }

--- a/src/test/java/org/mockitousage/stubbing/LambdaStubbingTest.java
+++ b/src/test/java/org/mockitousage/stubbing/LambdaStubbingTest.java
@@ -1,0 +1,18 @@
+package org.mockitousage.stubbing;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.MockitoLambda;
+import org.mockitousage.IMethods;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+
+public class LambdaStubbingTest {
+
+    @Test
+    public void stubs_method_as_lambda() {
+        IMethods mock = Mockito.mock(IMethods.class);
+        MockitoLambda.when(mock::threeArgumentMethodWithStrings).isInvokedWith(anyInt(), anyString(), anyString()).thenReturn("foo");
+    }
+}

--- a/src/test/java/org/mockitousage/stubbing/LambdaStubbingTest.java
+++ b/src/test/java/org/mockitousage/stubbing/LambdaStubbingTest.java
@@ -5,8 +5,11 @@ import org.mockito.Mockito;
 import org.mockito.MockitoLambda;
 import org.mockitousage.IMethods;
 
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.MockitoLambda.anyInt;
+import static org.mockito.MockitoLambda.anyString;
 
 public class LambdaStubbingTest {
 
@@ -14,13 +17,17 @@ public class LambdaStubbingTest {
     public void stubs_method_as_lambda() {
         IMethods mock = Mockito.mock(IMethods.class);
         MockitoLambda.when(mock::threeArgumentMethodWithStrings).isInvokedWith(anyInt(), anyString(), anyString()).thenReturn("foo");
+        assertThat(mock.threeArgumentMethodWithStrings(5, "foo", "bar")).isEqualTo("foo");
     }
 
     @Test
     public void stubs_void_method_as_lambda() {
         IMethods mock = Mockito.mock(IMethods.class);
+        AtomicBoolean atomicBoolean = new AtomicBoolean(false);
         MockitoLambda.when(mock::twoArgumentMethod).isInvokedWith(anyInt(), anyInt()).thenAnswer((a, b) -> {
-            System.out.println("Answered " + (a * b) + " is type-safe!");
+            atomicBoolean.set(true);
         });
+        mock.twoArgumentMethod(0, 1);
+        assertThat(atomicBoolean.get()).isEqualTo(true);
     }
 }


### PR DESCRIPTION
This is a prototyping PR to investigate the feasibility of stubbing with lambda's.

### Motivation

There are several reasons for using lambda's as stubs, including but not limited to:
1. Full type-safety when stubbing. This includes
    1. Type-safety when using answers. You can now pass a normal lambda as answer instead of (internally) relying on `getArgumentAt`.
    2. Type-safety for using `ArgumentMatcher` vs literal values. When you are mixing `ArgumentMatcher` with literal values, an exception on run-time is thrown. This now brings it to compile-time
2. Unifying way to handle consumers and functions. In Mockito 2 void methods are handled with `doReturn` and `doAnswer`. In my experience teaching developers starting with Mockito this brings quite some confusion. Instead, Mockito should internally handle the way to process consumers.
    1. In essence we can remove all previous ways to stub a method. That would include `doReturn()`, `doThrow()`, `doAnswer()`, `doNothing()`, `doCallRealMethod()`. These APIs are in my experience very confusing and that was also feedback I got from Mockito starters.
3. Fix issues with unwanted side-effects when re-stubbing already stubbed methods. In the current engine it is hard to fix these issues, since the invocation is performed before the actual stubbing is done. Since the "invocation" is now delayed, these issue can actually be dealt with.
    1. This probably effects Spies the most where calling of methods is expected, but not when stubbing.

In a very similar fashion to `MockitoLambda.when`, `MockitoLambda.given` can also be implemented. The naming of the methods will be different, but the implementation is equal.

I am convinced that we can fix more use-cases and bugs using this syntax as we have full control over the actual method and corresponding invocation. Moreover we can upgrade the backing engine for full type-safety instead of relying on Reflection to trace back the corresponding stubbed answer.

### Syntax
```java
public class LambdaStubbingTest {

    @Test
    public void stubs_method_as_lambda() {
        IMethods mock = Mockito.mock(IMethods.class);
        MockitoLambda.when(mock::threeArgumentMethodWithStrings).isInvokedWith(anyInt(), anyString(), anyString()).thenReturn("foo");
        assertThat(mock.threeArgumentMethodWithStrings(5, "foo", "bar")).isEqualTo("foo");
    }

    @Test
    public void stubs_void_method_as_lambda() {
        IMethods mock = Mockito.mock(IMethods.class);
        AtomicBoolean atomicBoolean = new AtomicBoolean(false);
        MockitoLambda.when(mock::twoArgumentMethod).isInvokedWith(anyInt(), anyInt()).thenAnswer((a, b) -> {
            atomicBoolean.set(true);
        });
        mock.twoArgumentMethod(0, 1);
        assertThat(atomicBoolean.get()).isEqualTo(true);
    }
}
```

The difference boils down to:
```java
when(mock::threeArgumentMethodWithStrings).isInvokedWith(anyInt(), anyString(), anyString()).thenReturn("foo");
```
vs
```java
when(mock.threeArgumentMethodWithStrings(anyInt(), anyString(), anyString())).thenReturn("foo");
```
Note that `isInvokedWith` is a bit wordy, but happy to bike-shed on the naming. Could also just be `with`:

```java
when(mock::threeArgumentMethodWithStrings).with(anyInt(), anyString(), anyString()).thenReturn("foo");
```

The difference between the two is a total of 6 characters, which I don't think is too bad.

There were some initial concerns regarding the syntax. The syntax is of course different from the "old" syntax, but I do not think the difference harms users. I would actually argue that the lambda syntax is easier to grasp for starters and in my opinion it makes more sense.

It might be a good idea to, if the prototype appears to be working, ask users whether they like the new syntax.