### PR TITLE
Add missing copyright headers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
 
     dependencies {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.2' //publishing to bintray
+        classpath'nl.javadude.gradle.plugins:license-gradle-plugin:0.11.0' // later versions don't work on JDK6
     }
 }
 
@@ -25,6 +26,7 @@ apply from: "gradle/ide.gradle"
 apply from: 'gradle/coverage.gradle'
 apply from: 'gradle/osgi.gradle'
 apply from: 'gradle/gradle-fix.gradle'
+apply from: 'gradle/license.gradle'
 
 allprojects {
     repositories {

--- a/doc/licenses/HEADER.txt
+++ b/doc/licenses/HEADER.txt
@@ -1,0 +1,2 @@
+Copyright (c) ${year} ${name}
+This program is made available under the terms of the MIT License.

--- a/gradle/license.gradle
+++ b/gradle/license.gradle
@@ -1,0 +1,14 @@
+apply plugin: 'com.github.hierynomus.license'
+
+license {
+    header = rootProject.file('doc/licenses/HEADER.txt')
+    strictCheck = true
+    ignoreFailures = true
+    skipExistingHeaders = true
+    mapping {
+        java = 'SLASHSTAR_STYLE'
+        groovy = 'SLASHSTAR_STYLE'
+    }
+    ext.year = Calendar.getInstance().get(Calendar.YEAR)
+    ext.name = 'Mockito contributors'
+}

--- a/src/main/java/org/mockito/ArgumentMatcher.java
+++ b/src/main/java/org/mockito/ArgumentMatcher.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito;
 
 /**

--- a/src/main/java/org/mockito/ArgumentMatchers.java
+++ b/src/main/java/org/mockito/ArgumentMatchers.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito;
 
 import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;

--- a/src/main/java/org/mockito/MockitoFramework.java
+++ b/src/main/java/org/mockito/MockitoFramework.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito;
 
 import org.mockito.listeners.MockitoListener;

--- a/src/main/java/org/mockito/exceptions/misusing/CannotStubVoidMethodWithReturnValue.java
+++ b/src/main/java/org/mockito/exceptions/misusing/CannotStubVoidMethodWithReturnValue.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.exceptions.misusing;
 
 import org.mockito.exceptions.base.MockitoException;

--- a/src/main/java/org/mockito/exceptions/misusing/UnnecessaryStubbingException.java
+++ b/src/main/java/org/mockito/exceptions/misusing/UnnecessaryStubbingException.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.exceptions.misusing;
 
 /**

--- a/src/main/java/org/mockito/exceptions/stacktrace/StackTraceCleaner.java
+++ b/src/main/java/org/mockito/exceptions/stacktrace/StackTraceCleaner.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.exceptions.stacktrace;
 
 /**

--- a/src/main/java/org/mockito/hamcrest/MockitoHamcrest.java
+++ b/src/main/java/org/mockito/hamcrest/MockitoHamcrest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.hamcrest;
 
 import org.hamcrest.Matcher;

--- a/src/main/java/org/mockito/internal/configuration/plugins/DefaultPluginSwitch.java
+++ b/src/main/java/org/mockito/internal/configuration/plugins/DefaultPluginSwitch.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.configuration.plugins;
 
 import org.mockito.plugins.PluginSwitch;

--- a/src/main/java/org/mockito/internal/configuration/plugins/PluginFileReader.java
+++ b/src/main/java/org/mockito/internal/configuration/plugins/PluginFileReader.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.configuration.plugins;
 
 import org.mockito.internal.util.io.IOUtil;

--- a/src/main/java/org/mockito/internal/configuration/plugins/PluginFinder.java
+++ b/src/main/java/org/mockito/internal/configuration/plugins/PluginFinder.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.configuration.plugins;
 
 import org.mockito.exceptions.base.MockitoException;

--- a/src/main/java/org/mockito/internal/configuration/plugins/PluginLoader.java
+++ b/src/main/java/org/mockito/internal/configuration/plugins/PluginLoader.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.configuration.plugins;
 
 import org.mockito.internal.util.collections.Iterables;

--- a/src/main/java/org/mockito/internal/configuration/plugins/PluginRegistry.java
+++ b/src/main/java/org/mockito/internal/configuration/plugins/PluginRegistry.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.configuration.plugins;
 
 import org.mockito.plugins.InstantiatorProvider;

--- a/src/main/java/org/mockito/internal/configuration/plugins/Plugins.java
+++ b/src/main/java/org/mockito/internal/configuration/plugins/Plugins.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.configuration.plugins;
 
 import org.mockito.plugins.InstantiatorProvider;

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMaker.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.creation.bytebuddy;
 
 import org.mockito.Incubating;

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/BytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/BytecodeGenerator.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.creation.bytebuddy;
 
 public interface BytecodeGenerator {

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/ClassCreatingMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/ClassCreatingMockMaker.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.creation.bytebuddy;
 
 import org.mockito.mock.MockCreationSettings;

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.creation.bytebuddy;
 
 import net.bytebuddy.agent.ByteBuddyAgent;

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.creation.bytebuddy;
 
 import net.bytebuddy.ByteBuddy;

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InterceptedInvocation.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InterceptedInvocation.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.creation.bytebuddy;
 
 import org.mockito.internal.debugging.LocationImpl;

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/MockAccess.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/MockAccess.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.creation.bytebuddy;
 
 public interface MockAccess {

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/MockFeatures.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/MockFeatures.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.creation.bytebuddy;
 
 import org.mockito.mock.SerializableMode;

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.creation.bytebuddy;
 
 import net.bytebuddy.asm.Advice;

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodDispatcher.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodDispatcher.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.creation.bytebuddy;
 
 import java.lang.reflect.Method;

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodInterceptor.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodInterceptor.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.creation.bytebuddy;
 
 import net.bytebuddy.implementation.bind.annotation.*;

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassByteBuddyMockMaker.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.creation.bytebuddy;
 
 import org.mockito.exceptions.base.MockitoException;

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassBytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassBytecodeGenerator.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.creation.bytebuddy;
 
 import net.bytebuddy.ByteBuddy;

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/TypeCachingBytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/TypeCachingBytecodeGenerator.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.creation.bytebuddy;
 
 import java.lang.ref.Reference;

--- a/src/main/java/org/mockito/internal/creation/instance/ConstructorInstantiator.java
+++ b/src/main/java/org/mockito/internal/creation/instance/ConstructorInstantiator.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.creation.instance;
 
 import static org.mockito.internal.util.StringJoiner.join;

--- a/src/main/java/org/mockito/internal/creation/instance/DefaultInstantiatorProvider.java
+++ b/src/main/java/org/mockito/internal/creation/instance/DefaultInstantiatorProvider.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.creation.instance;
 
 import org.mockito.mock.MockCreationSettings;

--- a/src/main/java/org/mockito/internal/creation/instance/InstantiationException.java
+++ b/src/main/java/org/mockito/internal/creation/instance/InstantiationException.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.creation.instance;
 
 import org.mockito.exceptions.base.MockitoException;

--- a/src/main/java/org/mockito/internal/creation/instance/Instantiator.java
+++ b/src/main/java/org/mockito/internal/creation/instance/Instantiator.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.creation.instance;
 
 /**

--- a/src/main/java/org/mockito/internal/creation/instance/ObjenesisInstantiator.java
+++ b/src/main/java/org/mockito/internal/creation/instance/ObjenesisInstantiator.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.creation.instance;
 
 import org.mockito.internal.configuration.GlobalConfiguration;

--- a/src/main/java/org/mockito/internal/debugging/InvocationsPrinter.java
+++ b/src/main/java/org/mockito/internal/debugging/InvocationsPrinter.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.debugging;
 
 import org.mockito.Mockito;

--- a/src/main/java/org/mockito/internal/exceptions/MockitoLimitations.java
+++ b/src/main/java/org/mockito/internal/exceptions/MockitoLimitations.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.exceptions;
 
 public class MockitoLimitations {

--- a/src/main/java/org/mockito/internal/exceptions/stacktrace/DefaultStackTraceCleaner.java
+++ b/src/main/java/org/mockito/internal/exceptions/stacktrace/DefaultStackTraceCleaner.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.exceptions.stacktrace;
 
 import org.mockito.exceptions.stacktrace.StackTraceCleaner;

--- a/src/main/java/org/mockito/internal/exceptions/stacktrace/DefaultStackTraceCleanerProvider.java
+++ b/src/main/java/org/mockito/internal/exceptions/stacktrace/DefaultStackTraceCleanerProvider.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.exceptions.stacktrace;
 
 import org.mockito.exceptions.stacktrace.StackTraceCleaner;

--- a/src/main/java/org/mockito/internal/framework/DefaultMockitoFramework.java
+++ b/src/main/java/org/mockito/internal/framework/DefaultMockitoFramework.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.framework;
 
 import org.mockito.MockitoFramework;

--- a/src/main/java/org/mockito/internal/hamcrest/HamcrestArgumentMatcher.java
+++ b/src/main/java/org/mockito/internal/hamcrest/HamcrestArgumentMatcher.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.hamcrest;
 
 import org.hamcrest.Matcher;

--- a/src/main/java/org/mockito/internal/hamcrest/MatcherGenericTypeExtractor.java
+++ b/src/main/java/org/mockito/internal/hamcrest/MatcherGenericTypeExtractor.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.hamcrest;
 
 import org.hamcrest.BaseMatcher;

--- a/src/main/java/org/mockito/internal/invocation/ArgumentMatcherAction.java
+++ b/src/main/java/org/mockito/internal/invocation/ArgumentMatcherAction.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.invocation;
 
 import org.mockito.ArgumentMatcher;

--- a/src/main/java/org/mockito/internal/invocation/InvocationComparator.java
+++ b/src/main/java/org/mockito/internal/invocation/InvocationComparator.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.invocation;
 
 import org.mockito.invocation.Invocation;

--- a/src/main/java/org/mockito/internal/invocation/MatcherApplicationStrategy.java
+++ b/src/main/java/org/mockito/internal/invocation/MatcherApplicationStrategy.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.invocation;
 
 import static org.mockito.internal.invocation.MatcherApplicationStrategy.MatcherApplicationType.ERROR_UNSUPPORTED_NUMBER_OF_MATCHERS;

--- a/src/main/java/org/mockito/internal/junit/ArgMismatchFinder.java
+++ b/src/main/java/org/mockito/internal/junit/ArgMismatchFinder.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.junit;
 
 import org.mockito.internal.invocation.finder.AllInvocationsFinder;

--- a/src/main/java/org/mockito/internal/junit/FriendlyExceptionMaker.java
+++ b/src/main/java/org/mockito/internal/junit/FriendlyExceptionMaker.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.junit;
 
 import org.mockito.exceptions.verification.ArgumentsAreDifferent;

--- a/src/main/java/org/mockito/internal/junit/JUnitDetecter.java
+++ b/src/main/java/org/mockito/internal/junit/JUnitDetecter.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.junit;
 
 class JUnitDetecter {

--- a/src/main/java/org/mockito/internal/junit/JUnitRule.java
+++ b/src/main/java/org/mockito/internal/junit/JUnitRule.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.junit;
 
 import org.junit.runners.model.FrameworkMethod;

--- a/src/main/java/org/mockito/internal/junit/RuleStubbingHintsReporter.java
+++ b/src/main/java/org/mockito/internal/junit/RuleStubbingHintsReporter.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.junit;
 
 import org.mockito.listeners.MockCreationListener;

--- a/src/main/java/org/mockito/internal/junit/StubbingArgMismatches.java
+++ b/src/main/java/org/mockito/internal/junit/StubbingArgMismatches.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.junit;
 
 import org.mockito.internal.util.MockitoLogger;

--- a/src/main/java/org/mockito/internal/junit/StubbingHint.java
+++ b/src/main/java/org/mockito/internal/junit/StubbingHint.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.junit;
 
 /**

--- a/src/main/java/org/mockito/internal/junit/UnnecessaryStubbingsReporter.java
+++ b/src/main/java/org/mockito/internal/junit/UnnecessaryStubbingsReporter.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.junit;
 
 import org.junit.runner.Description;

--- a/src/main/java/org/mockito/internal/junit/UnusedStubbings.java
+++ b/src/main/java/org/mockito/internal/junit/UnusedStubbings.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.junit;
 
 import org.mockito.internal.util.MockitoLogger;

--- a/src/main/java/org/mockito/internal/junit/UnusedStubbingsFinder.java
+++ b/src/main/java/org/mockito/internal/junit/UnusedStubbingsFinder.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.junit;
 
 import org.mockito.stubbing.Stubbing;

--- a/src/main/java/org/mockito/internal/junit/VerificationCollectorImpl.java
+++ b/src/main/java/org/mockito/internal/junit/VerificationCollectorImpl.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.junit;
 
 import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;

--- a/src/main/java/org/mockito/internal/matchers/apachecommons/commons-lang-license.txt
+++ b/src/main/java/org/mockito/internal/matchers/apachecommons/commons-lang-license.txt
@@ -1,3 +1,8 @@
+====
+    Copyright (c) 2016 Mockito contributors
+    This program is made available under the terms of the MIT License.
+====
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/src/main/java/org/mockito/internal/matchers/text/ArrayIterator.java
+++ b/src/main/java/org/mockito/internal/matchers/text/ArrayIterator.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.matchers.text;
 
 import java.lang.reflect.Array;

--- a/src/main/java/org/mockito/internal/matchers/text/FormattedText.java
+++ b/src/main/java/org/mockito/internal/matchers/text/FormattedText.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.matchers.text;
 
 /**

--- a/src/main/java/org/mockito/internal/matchers/text/MatcherToString.java
+++ b/src/main/java/org/mockito/internal/matchers/text/MatcherToString.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.matchers.text;
 
 import org.mockito.ArgumentMatcher;

--- a/src/main/java/org/mockito/internal/matchers/text/ValuePrinter.java
+++ b/src/main/java/org/mockito/internal/matchers/text/ValuePrinter.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.matchers.text;
 
 import java.util.Iterator;

--- a/src/main/java/org/mockito/internal/runners/StrictRunner.java
+++ b/src/main/java/org/mockito/internal/runners/StrictRunner.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.runners;
 
 import org.junit.runner.Description;

--- a/src/main/java/org/mockito/internal/stubbing/StubbingComparator.java
+++ b/src/main/java/org/mockito/internal/stubbing/StubbingComparator.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.stubbing;
 
 import org.mockito.internal.invocation.InvocationComparator;

--- a/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.stubbing.answers;
 
 import org.mockito.invocation.InvocationOnMock;

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValues.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValues.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.stubbing.defaultanswers;
 
 import org.mockito.internal.util.JavaEightUtil;

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/TriesToReturnSelf.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/TriesToReturnSelf.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.stubbing.defaultanswers;
 
 import org.mockito.internal.util.MockUtil;

--- a/src/main/java/org/mockito/internal/util/JavaEightUtil.java
+++ b/src/main/java/org/mockito/internal/util/JavaEightUtil.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.util;
 
 import org.mockito.internal.creation.instance.InstantiationException;

--- a/src/main/java/org/mockito/internal/util/Platform.java
+++ b/src/main/java/org/mockito/internal/util/Platform.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.util;
 
 import java.util.regex.Matcher;

--- a/src/main/java/org/mockito/internal/util/Timer.java
+++ b/src/main/java/org/mockito/internal/util/Timer.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.util;
 
 import static org.mockito.internal.exceptions.Reporter.cannotCreateTimerWithNegativeDurationTime;

--- a/src/main/java/org/mockito/internal/util/collections/Iterables.java
+++ b/src/main/java/org/mockito/internal/util/collections/Iterables.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.util.collections;
 
 import java.util.Enumeration;

--- a/src/main/java/org/mockito/internal/util/concurrent/DetachedThreadLocal.java
+++ b/src/main/java/org/mockito/internal/util/concurrent/DetachedThreadLocal.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.util.concurrent;
 
 /**

--- a/src/main/java/org/mockito/internal/util/concurrent/WeakConcurrentMap.java
+++ b/src/main/java/org/mockito/internal/util/concurrent/WeakConcurrentMap.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.util.concurrent;
 
 import java.lang.ref.Reference;

--- a/src/main/java/org/mockito/internal/util/concurrent/WeakConcurrentSet.java
+++ b/src/main/java/org/mockito/internal/util/concurrent/WeakConcurrentSet.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.util.concurrent;
 
 import java.util.Iterator;

--- a/src/main/java/org/mockito/internal/util/io/IOUtil.java
+++ b/src/main/java/org/mockito/internal/util/io/IOUtil.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.util.io;
 
 import org.mockito.exceptions.base.MockitoException;

--- a/src/main/java/org/mockito/internal/util/reflection/Constructors.java
+++ b/src/main/java/org/mockito/internal/util/reflection/Constructors.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.util.reflection;
 
 import java.lang.reflect.Constructor;

--- a/src/main/java/org/mockito/internal/util/reflection/GenericTypeExtractor.java
+++ b/src/main/java/org/mockito/internal/util/reflection/GenericTypeExtractor.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.util.reflection;
 
 import java.lang.reflect.ParameterizedType;

--- a/src/main/java/org/mockito/internal/verification/Description.java
+++ b/src/main/java/org/mockito/internal/verification/Description.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.verification;
 
 import org.mockito.exceptions.base.MockitoAssertionError;

--- a/src/main/java/org/mockito/internal/verification/VerificationWrapper.java
+++ b/src/main/java/org/mockito/internal/verification/VerificationWrapper.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.verification;
 
 import org.mockito.internal.verification.api.VerificationData;

--- a/src/main/java/org/mockito/internal/verification/VerificationWrapperInOrderWrapper.java
+++ b/src/main/java/org/mockito/internal/verification/VerificationWrapperInOrderWrapper.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.verification;
 
 import org.mockito.exceptions.base.MockitoException;

--- a/src/main/java/org/mockito/invocation/MatchableInvocation.java
+++ b/src/main/java/org/mockito/invocation/MatchableInvocation.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.invocation;
 
 import org.mockito.ArgumentMatcher;

--- a/src/main/java/org/mockito/junit/MockitoJUnit.java
+++ b/src/main/java/org/mockito/junit/MockitoJUnit.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.junit;
 
 import org.mockito.Incubating;

--- a/src/main/java/org/mockito/junit/MockitoRule.java
+++ b/src/main/java/org/mockito/junit/MockitoRule.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.junit;
 
 import org.junit.rules.MethodRule;

--- a/src/main/java/org/mockito/junit/VerificationCollector.java
+++ b/src/main/java/org/mockito/junit/VerificationCollector.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.junit;
 
 import org.junit.rules.TestRule;

--- a/src/main/java/org/mockito/listeners/MockCreationListener.java
+++ b/src/main/java/org/mockito/listeners/MockCreationListener.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.listeners;
 
 import org.mockito.mock.MockCreationSettings;

--- a/src/main/java/org/mockito/listeners/MockitoListener.java
+++ b/src/main/java/org/mockito/listeners/MockitoListener.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.listeners;
 
 /**

--- a/src/main/java/org/mockito/mock/SerializableMode.java
+++ b/src/main/java/org/mockito/mock/SerializableMode.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.mock;
 
 import org.mockito.Incubating;

--- a/src/main/java/org/mockito/plugins/PluginSwitch.java
+++ b/src/main/java/org/mockito/plugins/PluginSwitch.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.plugins;
 
 import org.mockito.Incubating;

--- a/src/main/java/org/mockito/plugins/StackTraceCleanerProvider.java
+++ b/src/main/java/org/mockito/plugins/StackTraceCleanerProvider.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.plugins;
 
 import org.mockito.exceptions.stacktrace.StackTraceCleaner;

--- a/src/main/java/org/mockito/quality/MockitoHint.java
+++ b/src/main/java/org/mockito/quality/MockitoHint.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.quality;
 
 /**

--- a/src/main/java/org/mockito/stubbing/Answer1.java
+++ b/src/main/java/org/mockito/stubbing/Answer1.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.stubbing;
 
 import org.mockito.Incubating;

--- a/src/main/java/org/mockito/stubbing/Answer2.java
+++ b/src/main/java/org/mockito/stubbing/Answer2.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.stubbing;
 
 import org.mockito.Incubating;

--- a/src/main/java/org/mockito/stubbing/Answer3.java
+++ b/src/main/java/org/mockito/stubbing/Answer3.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.stubbing;
 
 import org.mockito.Incubating;

--- a/src/main/java/org/mockito/stubbing/Answer4.java
+++ b/src/main/java/org/mockito/stubbing/Answer4.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.stubbing;
 
 import org.mockito.Incubating;

--- a/src/main/java/org/mockito/stubbing/Answer5.java
+++ b/src/main/java/org/mockito/stubbing/Answer5.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.stubbing;
 
 import org.mockito.Incubating;

--- a/src/main/java/org/mockito/stubbing/Stubbing.java
+++ b/src/main/java/org/mockito/stubbing/Stubbing.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.stubbing;
 
 import org.mockito.MockingDetails;

--- a/src/main/java/org/mockito/stubbing/VoidAnswer1.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer1.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.stubbing;
 
 import org.mockito.Incubating;

--- a/src/main/java/org/mockito/stubbing/VoidAnswer2.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer2.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.stubbing;
 
 import org.mockito.Incubating;

--- a/src/main/java/org/mockito/stubbing/VoidAnswer3.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer3.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.stubbing;
 
 import org.mockito.Incubating;

--- a/src/main/java/org/mockito/stubbing/VoidAnswer4.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer4.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.stubbing;
 
 import org.mockito.Incubating;

--- a/src/main/java/org/mockito/stubbing/VoidAnswer5.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer5.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.stubbing;
 
 import org.mockito.Incubating;

--- a/src/main/java/org/mockito/verification/After.java
+++ b/src/main/java/org/mockito/verification/After.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.verification;
 
 import org.mockito.internal.verification.VerificationModeFactory;

--- a/src/main/java/org/mockito/verification/VerificationStrategy.java
+++ b/src/main/java/org/mockito/verification/VerificationStrategy.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.verification;
 
 /**


### PR DESCRIPTION
- [x] Fixes #727 
- [x] Add missing copyrights using [license-gradle-plugin](https://github.com/hierynomus/license-gradle-plugin).
- [x] Updated only source files. Test files were skipped. Existing copyright headers were not modified.