### PR TITLE
Allow fluent usage of Mockito.framework() listeners methods

### DIFF
--- a/src/main/java/org/mockito/MockitoFramework.java
+++ b/src/main/java/org/mockito/MockitoFramework.java
@@ -37,7 +37,7 @@ public interface MockitoFramework {
      * @param listener to add
      */
     @Incubating
-    void addListener(MockitoListener listener);
+    MockitoFramework addListener(MockitoListener listener);
 
     /**
      * When you add listener using {@link #addListener(MockitoListener)} make sure to remove it.
@@ -52,5 +52,5 @@ public interface MockitoFramework {
      * @param listener to remove
      */
     @Incubating
-    void removeListener(MockitoListener listener);
+    MockitoFramework removeListener(MockitoListener listener);
 }

--- a/src/main/java/org/mockito/MockitoFramework.java
+++ b/src/main/java/org/mockito/MockitoFramework.java
@@ -35,6 +35,7 @@ public interface MockitoFramework {
      * </code></pre>
      *
      * @param listener to add
+     * @since 2.1.0
      */
     @Incubating
     MockitoFramework addListener(MockitoListener listener);
@@ -50,6 +51,7 @@ public interface MockitoFramework {
      * we are very happy to hear about it via our issue tracker or mailing list.
      *
      * @param listener to remove
+     * @since 2.1.0
      */
     @Incubating
     MockitoFramework removeListener(MockitoListener listener);

--- a/src/main/java/org/mockito/internal/framework/DefaultMockitoFramework.java
+++ b/src/main/java/org/mockito/internal/framework/DefaultMockitoFramework.java
@@ -7,14 +7,16 @@ import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingPro
 
 public class DefaultMockitoFramework implements MockitoFramework {
 
-    public void addListener(MockitoListener listener) {
+    public MockitoFramework addListener(MockitoListener listener) {
         assertNotNull(listener);
         mockingProgress().addListener(listener);
+        return this;
     }
 
-    public void removeListener(MockitoListener listener) {
+    public MockitoFramework removeListener(MockitoListener listener) {
         assertNotNull(listener);
         mockingProgress().removeListener(listener);
+        return this;
     }
 
     private void assertNotNull(MockitoListener listener) {

--- a/src/main/java/org/mockito/internal/framework/DefaultMockitoFramework.java
+++ b/src/main/java/org/mockito/internal/framework/DefaultMockitoFramework.java
@@ -1,6 +1,7 @@
 package org.mockito.internal.framework;
 
 import org.mockito.MockitoFramework;
+import org.mockito.internal.util.Checks;
 import org.mockito.listeners.MockitoListener;
 
 import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
@@ -8,20 +9,14 @@ import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingPro
 public class DefaultMockitoFramework implements MockitoFramework {
 
     public MockitoFramework addListener(MockitoListener listener) {
-        assertNotNull(listener);
+        Checks.checkNotNull(listener, "listener");
         mockingProgress().addListener(listener);
         return this;
     }
 
     public MockitoFramework removeListener(MockitoListener listener) {
-        assertNotNull(listener);
+        Checks.checkNotNull(listener, "listener");
         mockingProgress().removeListener(listener);
         return this;
-    }
-
-    private void assertNotNull(MockitoListener listener) {
-        if (listener == null) {
-            throw new IllegalArgumentException("listener cannot be null");
-        }
     }
 }


### PR DESCRIPTION
Currently `addListener` and `removeListener` returns `void` which makes it repetitive to add or remove these :

```java
Mockito.framework().addListener(...);
Mockito.framework().addListener(...);
Mockito.framework().addListener(...);
```

The main change of this PR is to return `MockitoFramework` instead, thus allowing to chain invocations :

```java
Mockito.framework().addListener(...)
                   .addListener(...)
                   .addListener(...);
```

This improvements is a breaking change, however the API is still **incubating** and should be expected to break, source wise there's no problem since nothing could be done before due to the `void` return.