### PR TITLE
Create and remove test resources based on proper task

### DIFF
--- a/gradle/mockito-core/testing.gradle
+++ b/gradle/mockito-core/testing.gradle
@@ -17,5 +17,5 @@ task removeTestResources << {
     }
 }
 
-compileTestJava.dependsOn createTestResources
-compileTestJava.finalizedBy removeTestResources
+test.dependsOn createTestResources
+test.finalizedBy removeTestResources


### PR DESCRIPTION
Currently the test resource for the inline mock maker is removed _before_ the test executes, which results in the fact that the inline tests are never really executed properly.
This PR changes the task dependencies to the `test` task.

Unfortunately, a lot of tests fail currently when `mock-maker-inline` is enabled.