### PR TITLE
Updated the verification documentation to correctly use argThat with Java8 lambdas

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -179,7 +179,7 @@ import org.mockito.verification.*;
  * verify(mockedList).get(anyInt());
  *
  * //<b>argument matchers can also be written as Java 8 Lambdas</b>
- * verify(mockedList).add(someString -> someString.length() > 5);
+ * verify(mockedList).add(argThat(someString -> someString.length() > 5));
  *
  * </code></pre>
  *


### PR DESCRIPTION
The example for custom argument matchers using a lambda in the main mockito documentation is missing a call to argThat.

This pr fixes the docs to correctly use argThat.