### PR TITLE
Fixes #731 Implements retry rule for flaky tests

### DIFF
--- a/src/test/java/org/mockitousage/verification/VerificationAfterDelayTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationAfterDelayTest.java
@@ -4,17 +4,6 @@
 
 package org.mockitousage.verification;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static junit.framework.TestCase.assertEquals;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.rules.ExpectedException.none;
-import static org.mockito.Mockito.after;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.junit.MockitoJUnit.rule;
-import static org.mockitoutil.Stopwatch.createNotStarted;
-
-import java.util.concurrent.ScheduledExecutorService;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -27,12 +16,26 @@ import org.mockito.Mock;
 import org.mockito.exceptions.base.MockitoAssertionError;
 import org.mockito.junit.MockitoRule;
 import org.mockitousage.IMethods;
+import org.mockitoutil.RetryRule;
 import org.mockitoutil.Stopwatch;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static junit.framework.TestCase.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.rules.ExpectedException.none;
+import static org.mockito.Mockito.after;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.junit.MockitoJUnit.rule;
+import static org.mockitoutil.Stopwatch.createNotStarted;
 
 public class VerificationAfterDelayTest {
 
     @Rule
     public MockitoRule mockito = rule();
+
+    @Rule
+    public RetryRule retryRule = RetryRule.attempts(4);
 
     @Rule
     public ExpectedException exception = none();

--- a/src/test/java/org/mockitousage/verification/VerificationWithTimeoutTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationWithTimeoutTest.java
@@ -5,20 +5,6 @@
 
 package org.mockitousage.verification;
 
-import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.rules.ExpectedException.none;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.junit.MockitoJUnit.rule;
-
-import java.util.concurrent.ScheduledExecutorService;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -31,6 +17,17 @@ import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockito.exceptions.verification.TooLittleActualInvocations;
 import org.mockito.junit.MockitoRule;
 import org.mockitousage.IMethods;
+import org.mockitoutil.RetryRule;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.junit.rules.ExpectedException.none;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.junit.MockitoJUnit.rule;
 
 public class VerificationWithTimeoutTest {
 
@@ -38,15 +35,16 @@ public class VerificationWithTimeoutTest {
     public MockitoRule mockito = rule();
 
     @Rule
+    public RetryRule retryRule = RetryRule.attempts(4);
+
+    @Rule
     public ExpectedException exception = none();
 
     @Mock
     private IMethods mock;
 
-    private ScheduledExecutorService executor;
-
     private DelayedExecution delayedExecution;
-    
+
     @Before
     public void setUp() {
         delayedExecution = new DelayedExecution();
@@ -60,7 +58,7 @@ public class VerificationWithTimeoutTest {
     @Test
     public void shouldVerifyWithTimeout() throws Exception {
         // when
-        delayedExecution.callAsync(30, MILLISECONDS, callMock('c') );
+        delayedExecution.callAsync(30, MILLISECONDS, callMock('c'));
 
         // then
         verify(mock, timeout(100)).oneArg('c');
@@ -73,7 +71,7 @@ public class VerificationWithTimeoutTest {
     @Test
     public void shouldFailVerificationWithTimeout() throws Exception {
         // when
-        delayedExecution.callAsync(30, MILLISECONDS, callMock('c') );
+        delayedExecution.callAsync(30, MILLISECONDS, callMock('c'));
 
         // then
         verify(mock, never()).oneArg('c');
@@ -84,8 +82,8 @@ public class VerificationWithTimeoutTest {
     @Test
     public void shouldAllowMixingOtherModesWithTimeout() throws Exception {
         // when
-        delayedExecution.callAsync(10, MILLISECONDS, callMock('c') );
-        delayedExecution.callAsync(10, MILLISECONDS, callMock('c') );
+        delayedExecution.callAsync(10, MILLISECONDS, callMock('c'));
+        delayedExecution.callAsync(10, MILLISECONDS, callMock('c'));
 
         // then
         verify(mock, timeout(100).atLeast(1)).oneArg('c');
@@ -96,8 +94,8 @@ public class VerificationWithTimeoutTest {
     @Test
     public void shouldAllowMixingOtherModesWithTimeoutAndFail() throws Exception {
         // when
-        delayedExecution.callAsync(10, MILLISECONDS, callMock('c') );
-        delayedExecution.callAsync(10, MILLISECONDS, callMock('c') );
+        delayedExecution.callAsync(10, MILLISECONDS, callMock('c'));
+        delayedExecution.callAsync(10, MILLISECONDS, callMock('c'));
 
         // then
         verify(mock, timeout(100).atLeast(1)).oneArg('c');
@@ -108,7 +106,7 @@ public class VerificationWithTimeoutTest {
     @Test
     public void shouldAllowMixingOnlyWithTimeout() throws Exception {
         // when
-        delayedExecution.callAsync(30, MILLISECONDS, callMock('c') );
+        delayedExecution.callAsync(30, MILLISECONDS, callMock('c'));
 
         // then
         verify(mock, never()).oneArg('c');
@@ -118,7 +116,7 @@ public class VerificationWithTimeoutTest {
     @Test
     public void shouldAllowMixingOnlyWithTimeoutAndFail() throws Exception {
         // when
-        delayedExecution.callAsync(30, MILLISECONDS, callMock('c') );
+        delayedExecution.callAsync(30, MILLISECONDS, callMock('c'));
 
         // and when
         mock.oneArg('x');

--- a/src/test/java/org/mockitoutil/RetryRule.java
+++ b/src/test/java/org/mockitoutil/RetryRule.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockitoutil;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class RetryRule implements TestRule {
+    private final TestRule innerRule;
+
+    public static RetryRule attempts(final int attempts) {
+        return new RetryRule(new NumberedAttempts(attempts));
+    }
+
+    private RetryRule(TestRule innerRule) {
+        this.innerRule = innerRule;
+    }
+
+    public Statement apply(final Statement base, final Description description) {
+        return innerRule.apply(base, description);
+    }
+
+    private static class NumberedAttempts implements TestRule {
+        private final int attempts;
+
+        NumberedAttempts(int attempts) {
+            assert attempts > 1;
+            this.attempts = attempts;
+        }
+
+        @Override
+        public Statement apply(final Statement base, final Description description) {
+            return new Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                    for (int remainingAttempts = attempts; remainingAttempts > 0 ; remainingAttempts--) {
+                        try {
+                            base.evaluate();
+                        } catch (Throwable throwable) {
+                            if (remainingAttempts > 0) {
+                                throw throwable;
+                            }
+                        }
+                    }
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
Previous attempts at fixing the time related tests failed. Indeed the previous attempts are not bullet proof when the CI can run schedule some threads slower than _expected_.

A proper harness should be implemented, but in the meantime, I implemented the retry rule as proposed in #731 to gain back stability on the build.