### PR TITLE
InvocationMatcher internal improvements

### DIFF
--- a/src/main/java/org/mockito/internal/invocation/InvocationMatcher.java
+++ b/src/main/java/org/mockito/internal/invocation/InvocationMatcher.java
@@ -11,6 +11,7 @@ import static org.mockito.internal.invocation.TypeSafeMatching.matchesTypeSafe;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -58,10 +59,12 @@ public class InvocationMatcher implements MatchableInvocation, DescribedInvocati
         return invocation.getMethod();
     }
 
+    @Override
     public Invocation getInvocation() {
         return invocation;
     }
 
+    @Override
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public List<ArgumentMatcher> getMatchers() {
         return (List) matchers;
@@ -73,6 +76,7 @@ public class InvocationMatcher implements MatchableInvocation, DescribedInvocati
         return new PrintSettings().print((List) matchers, invocation);
     }
 
+    @Override
     public boolean matches(Invocation candidate) {
         return invocation.getMock().equals(candidate.getMock()) && hasSameMethod(candidate) && argumentsMatch(candidate);
     }
@@ -80,6 +84,7 @@ public class InvocationMatcher implements MatchableInvocation, DescribedInvocati
     /**
      * similar means the same method name, same mock, unverified and: if arguments are the same cannot be overloaded
      */
+    @Override
     public boolean hasSimilarMethod(Invocation candidate) {
         String wantedMethodName = getMethod().getName();
         String candidateMethodName = candidate.getMethod().getName();
@@ -100,6 +105,7 @@ public class InvocationMatcher implements MatchableInvocation, DescribedInvocati
         return !argumentsMatch(candidate);
     }
 
+    @Override
     public boolean hasSameMethod(Invocation candidate) {
         // not using method.equals() for 1 good reason:
         // sometimes java generates forwarding methods when generics are in play see JavaGenericsForwardingMethodsTest
@@ -110,13 +116,7 @@ public class InvocationMatcher implements MatchableInvocation, DescribedInvocati
             /* Avoid unnecessary cloning */
             Class<?>[] params1 = m1.getParameterTypes();
             Class<?>[] params2 = m2.getParameterTypes();
-            if (params1.length == params2.length) {
-                for (int i = 0; i < params1.length; i++) {
-                    if (params1[i] != params2[i])
-                        return false;
-                }
-                return true;
-            }
+            return Arrays.equals(params1, params2);
         }
         return false;
     }


### PR DESCRIPTION
InvocationMatcher internal improvements
 * Added missing @Override annotations to reduce warning count.
 * Simplified parameter comparison in hasSameMethod(..)
 * Fixed compile error due to char conversion in MatchersTest
