### PR TITLE
Fixes #765: Set files encoding to UTF-8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ allprojects {
     tasks.withType(JavaCompile) {
         //I don't believe those warnings add value given modern IDEs
         options.warnings = false
+        options.encoding = 'UTF-8'
     }
 }
 


### PR DESCRIPTION
to avoid build failures on systems with different default encoding