### PR TITLE
Introduce default answers for primitive Optionals/Streams

### DIFF
--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValues.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValues.java
@@ -37,7 +37,10 @@ import java.util.*;
  * Returns zero if references are equals otherwise non-zero for Comparable#compareTo(T other) method (see issue 184)
  * </li>
  * <li>
- * Returns an {@code java.util.Optional#empty() empty Optional} for Optional (see issue 191).
+ * Returns an {@code java.util.Optional#empty() empty Optional} for Optional. Similarly for primitive optional variants.
+ * </li>
+ * <li>
+ * Returns an {@code java.util.stream.Stream#empty() empty Stream} for Stream. Similarly for primitive stream variants.
  * </li>
  * <li>
  * Returns null for everything else
@@ -109,8 +112,20 @@ public class ReturnsEmptyValues implements Answer<Object>, Serializable {
             return new LinkedHashMap<Object, Object>();
         } else if ("java.util.Optional".equals(type.getName())) {
             return JavaEightUtil.emptyOptional();
+        } else if ("java.util.OptionalDouble".equals(type.getName())) {
+            return JavaEightUtil.emptyOptionalDouble();
+        } else if ("java.util.OptionalInt".equals(type.getName())) {
+            return JavaEightUtil.emptyOptionalInt();
+        } else if ("java.util.OptionalLong".equals(type.getName())) {
+            return JavaEightUtil.emptyOptionalLong();
         } else if ("java.util.stream.Stream".equals(type.getName())) {
             return JavaEightUtil.emptyStream();
+        } else if ("java.util.stream.DoubleStream".equals(type.getName())) {
+            return JavaEightUtil.emptyDoubleStream();
+        } else if ("java.util.stream.IntStream".equals(type.getName())) {
+            return JavaEightUtil.emptyIntStream();
+        } else if ("java.util.stream.LongStream".equals(type.getName())) {
+            return JavaEightUtil.emptyLongStream();
         }
 
         //Let's not care about the rest of collections.

--- a/src/main/java/org/mockito/internal/util/JavaEightUtil.java
+++ b/src/main/java/org/mockito/internal/util/JavaEightUtil.java
@@ -14,16 +14,18 @@ import java.lang.reflect.Method;
  */
 public final class JavaEightUtil {
 
-    // No need for volatile, Optional#empty() is already a safe singleton.
+    // No need for volatile, these optionals are already safe singletons.
     private static Object emptyOptional;
+    private static Object emptyOptionalDouble;
+    private static Object emptyOptionalInt;
+    private static Object emptyOptionalLong;
 
     private JavaEightUtil() {
         // utility class
     }
 
     /**
-     * Creates an empty Optional using reflection to stay backwards-compatible with older
-     * JDKs (see issue 191).
+     * Creates an empty Optional using reflection to stay backwards-compatible with older JDKs.
      *
      * @return an empty Optional.
      */
@@ -33,35 +35,110 @@ public final class JavaEightUtil {
             return emptyOptional;
         }
 
-        try {
-            final Class<?> optionalClass = Class.forName("java.util.Optional");
-            final Method emptyMethod = optionalClass.getMethod("empty");
+        return emptyOptional = invokeNullaryFactoryMethod("java.util.Optional", "empty");
+    }
 
-            return emptyOptional = emptyMethod.invoke(null);
-            // any exception is really unexpected since the type name has
-            // already been verified to be java.util.Optional
-        } catch (Exception e) {
-            throw new InstantiationException("Could not create java.util.Optional#empty(): " + e, e);
+
+    /**
+     * Creates an empty OptionalDouble using reflection to stay backwards-compatible with older JDKs.
+     *
+     * @return an empty OptionalDouble.
+     */
+    public static Object emptyOptionalDouble() {
+        // no need for double-checked locking
+        if (emptyOptionalDouble != null) {
+            return emptyOptionalDouble;
         }
+
+        return emptyOptionalDouble = invokeNullaryFactoryMethod("java.util.OptionalDouble", "empty");
     }
 
     /**
-     * Creates an empty Stream using reflection to stay backwards-compatible with older
-     * JDKs.
+     * Creates an empty OptionalInt using reflection to stay backwards-compatible with older JDKs.
+     *
+     * @return an empty OptionalInt.
+     */
+    public static Object emptyOptionalInt() {
+        // no need for double-checked locking
+        if (emptyOptionalInt != null) {
+            return emptyOptionalInt;
+        }
+
+        return emptyOptionalInt = invokeNullaryFactoryMethod("java.util.OptionalInt", "empty");
+    }
+
+    /**
+     * Creates an empty OptionalLong using reflection to stay backwards-compatible with older JDKs.
+     *
+     * @return an empty OptionalLong.
+     */
+    public static Object emptyOptionalLong() {
+        // no need for double-checked locking
+        if (emptyOptionalLong != null) {
+            return emptyOptionalLong;
+        }
+
+        return emptyOptionalLong = invokeNullaryFactoryMethod("java.util.OptionalLong", "empty");
+    }
+
+    /**
+     * Creates an empty Stream using reflection to stay backwards-compatible with older JDKs.
      *
      * @return an empty Stream.
      */
     public static Object emptyStream() {
         // note: the empty stream can not be stored as a singleton.
-        try {
-            final Class<?> optionalClass = Class.forName("java.util.stream.Stream");
-            final Method emptyMethod = optionalClass.getMethod("empty");
+        return invokeNullaryFactoryMethod("java.util.stream.Stream", "empty");
+    }
 
-            return emptyMethod.invoke(null);
+    /**
+     * Creates an empty DoubleStream using reflection to stay backwards-compatible with older JDKs.
+     *
+     * @return an empty DoubleStream.
+     */
+    public static Object emptyDoubleStream() {
+        // note: the empty stream can not be stored as a singleton.
+        return invokeNullaryFactoryMethod("java.util.stream.DoubleStream", "empty");
+    }
+
+    /**
+     * Creates an empty IntStream using reflection to stay backwards-compatible with older JDKs.
+     *
+     * @return an empty IntStream.
+     */
+    public static Object emptyIntStream() {
+        // note: the empty stream can not be stored as a singleton.
+        return invokeNullaryFactoryMethod("java.util.stream.IntStream", "empty");
+    }
+
+    /**
+     * Creates an empty LongStream using reflection to stay backwards-compatible with older JDKs.
+     *
+     * @return an empty LongStream.
+     */
+    public static Object emptyLongStream() {
+        // note: the empty stream can not be stored as a singleton.
+        return invokeNullaryFactoryMethod("java.util.stream.LongStream", "empty");
+    }
+
+    /**
+     * Invokes a nullary static factory method using reflection to stay backwards-compatible with older JDKs.
+     *
+     * @param fqcn The fully qualified class name of the type to be produced.
+     * @param methodName The name of the factory method.
+     * @return the object produced.
+     */
+    private static Object invokeNullaryFactoryMethod(final String fqcn, final String methodName) {
+        try {
+            final Class<?> type = Class.forName(fqcn);
+            final Method method = type.getMethod(methodName);
+
+            return method.invoke(null);
             // any exception is really unexpected since the type name has
             // already been verified
-        } catch (Exception e) {
-            throw new InstantiationException("Could not create java.util.stream.Stream#empty(): " + e, e);
+        } catch (final Exception e) {
+            throw new InstantiationException(
+                    String.format("Could not create %s#%s(): %s", fqcn, methodName, e), e);
         }
     }
 }

--- a/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValuesTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValuesTest.java
@@ -89,7 +89,7 @@ public class ReturnsEmptyValuesTest extends TestBase {
     }
 
     @Test
-    public void should_return_empty_optional() throws Exception {
+    public void should_return_empty_Optional() throws Exception {
         Class<?> streamType = getClassOrSkipTest("java.util.stream.Stream");
 
         //given
@@ -108,7 +108,64 @@ public class ReturnsEmptyValuesTest extends TestBase {
     }
 
     @Test
-    public void should_return_empty_stream() throws Exception {
+    public void should_return_empty_OptionalDouble() throws Exception {
+        Class<?> streamType = getClassOrSkipTest("java.util.stream.DoubleStream");
+
+        //given
+        Object stream = mock(streamType);
+        Object optional = streamType.getMethod("findAny").invoke(stream);
+        assertNotNull(optional);
+        assertFalse((Boolean) Class.forName("java.util.OptionalDouble").getMethod("isPresent").invoke(optional));
+
+        Invocation findAny = this.getLastInvocation();
+
+        //when
+        Object result = values.answer(findAny);
+
+        //then
+        assertEquals(optional, result);
+    }
+
+    @Test
+    public void should_return_empty_OptionalInt() throws Exception {
+        Class<?> streamType = getClassOrSkipTest("java.util.stream.IntStream");
+
+        //given
+        Object stream = mock(streamType);
+        Object optional = streamType.getMethod("findAny").invoke(stream);
+        assertNotNull(optional);
+        assertFalse((Boolean) Class.forName("java.util.OptionalInt").getMethod("isPresent").invoke(optional));
+
+        Invocation findAny = this.getLastInvocation();
+
+        //when
+        Object result = values.answer(findAny);
+
+        //then
+        assertEquals(optional, result);
+    }
+
+    @Test
+    public void should_return_empty_OptionalLong() throws Exception {
+        Class<?> streamType = getClassOrSkipTest("java.util.stream.LongStream");
+
+        //given
+        Object stream = mock(streamType);
+        Object optional = streamType.getMethod("findAny").invoke(stream);
+        assertNotNull(optional);
+        assertFalse((Boolean) Class.forName("java.util.OptionalLong").getMethod("isPresent").invoke(optional));
+
+        Invocation findAny = this.getLastInvocation();
+
+        //when
+        Object result = values.answer(findAny);
+
+        //then
+        assertEquals(optional, result);
+    }
+
+    @Test
+    public void should_return_empty_Stream() throws Exception {
         // given
         Class<?> streamType = getClassOrSkipTest("java.util.stream.Stream");
 
@@ -118,6 +175,45 @@ public class ReturnsEmptyValuesTest extends TestBase {
 
         // then
         assertEquals("count of empty Stream", 0L, count);
+    }
+
+    @Test
+    public void should_return_empty_DoubleStream() throws Exception {
+        // given
+        Class<?> streamType = getClassOrSkipTest("java.util.stream.DoubleStream");
+
+        // when
+        Object stream = values.returnValueFor(streamType);
+        long count = (Long) streamType.getMethod("count").invoke(stream);
+
+        // then
+        assertEquals("count of empty DoubleStream", 0L, count);
+    }
+
+    @Test
+    public void should_return_empty_IntStream() throws Exception {
+        // given
+        Class<?> streamType = getClassOrSkipTest("java.util.stream.IntStream");
+
+        // when
+        Object stream = values.returnValueFor(streamType);
+        long count = (Long) streamType.getMethod("count").invoke(stream);
+
+        // then
+        assertEquals("count of empty IntStream", 0L, count);
+    }
+
+    @Test
+    public void should_return_empty_LongStream() throws Exception {
+        // given
+        Class<?> streamType = getClassOrSkipTest("java.util.stream.LongStream");
+
+        // when
+        Object stream = values.returnValueFor(streamType);
+        long count = (Long) streamType.getMethod("count").invoke(stream);
+
+        // then
+        assertEquals("count of empty LongStream", 0L, count);
     }
 
     /**


### PR DESCRIPTION
I introduced `#invokeNullaryFactoryMethod` to remove some of the existing code duplication, but am unhappy about the _new_ duplication, especially in the test code. What's your view on introducing deduplicating logic in test code? Also, the singleton fields in `JavaEightUtil` could be replaced with a `ConcurrentMap<String, Object>` (i.e. a map from FQCNs to singletons). If you agree, I'd love to reduce the size of this PR.