### PR TITLE
Simplify `ReturnsEmptyValuesTest`

### DIFF
--- a/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValuesTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValuesTest.java
@@ -90,70 +90,32 @@ public class ReturnsEmptyValuesTest extends TestBase {
 
     @Test
     public void should_return_empty_Optional() throws Exception {
-        Class<?> streamType = getClassOrSkipTest("java.util.stream.Stream");
-
-        //given
-        Object stream = mock(streamType);
-        Object optional = streamType.getMethod("findAny").invoke(stream);
-        assertNotNull(optional);
-        assertFalse((Boolean) Class.forName("java.util.Optional").getMethod("isPresent").invoke(optional));
-
-        Invocation findAny = this.getLastInvocation();
-
-        //when
-        Object result = values.answer(findAny);
-
-        //then
-        assertEquals(optional, result);
+        verify_empty_Optional_is_returned("java.util.stream.Stream", "java.util.Optional");
     }
 
     @Test
     public void should_return_empty_OptionalDouble() throws Exception {
-        Class<?> streamType = getClassOrSkipTest("java.util.stream.DoubleStream");
-
-        //given
-        Object stream = mock(streamType);
-        Object optional = streamType.getMethod("findAny").invoke(stream);
-        assertNotNull(optional);
-        assertFalse((Boolean) Class.forName("java.util.OptionalDouble").getMethod("isPresent").invoke(optional));
-
-        Invocation findAny = this.getLastInvocation();
-
-        //when
-        Object result = values.answer(findAny);
-
-        //then
-        assertEquals(optional, result);
+        verify_empty_Optional_is_returned("java.util.stream.DoubleStream", "java.util.OptionalDouble");
     }
 
     @Test
     public void should_return_empty_OptionalInt() throws Exception {
-        Class<?> streamType = getClassOrSkipTest("java.util.stream.IntStream");
-
-        //given
-        Object stream = mock(streamType);
-        Object optional = streamType.getMethod("findAny").invoke(stream);
-        assertNotNull(optional);
-        assertFalse((Boolean) Class.forName("java.util.OptionalInt").getMethod("isPresent").invoke(optional));
-
-        Invocation findAny = this.getLastInvocation();
-
-        //when
-        Object result = values.answer(findAny);
-
-        //then
-        assertEquals(optional, result);
+        verify_empty_Optional_is_returned("java.util.stream.IntStream", "java.util.OptionalInt");
     }
 
     @Test
     public void should_return_empty_OptionalLong() throws Exception {
-        Class<?> streamType = getClassOrSkipTest("java.util.stream.LongStream");
+        verify_empty_Optional_is_returned("java.util.stream.LongStream", "java.util.OptionalLong");
+    }
+
+    private void verify_empty_Optional_is_returned(String streamFqcn, String optionalFqcn) throws Exception {
+        Class<?> streamType = getClassOrSkipTest(streamFqcn);
 
         //given
         Object stream = mock(streamType);
         Object optional = streamType.getMethod("findAny").invoke(stream);
         assertNotNull(optional);
-        assertFalse((Boolean) Class.forName("java.util.OptionalLong").getMethod("isPresent").invoke(optional));
+        assertFalse((Boolean) Class.forName(optionalFqcn).getMethod("isPresent").invoke(optional));
 
         Invocation findAny = this.getLastInvocation();
 
@@ -166,54 +128,34 @@ public class ReturnsEmptyValuesTest extends TestBase {
 
     @Test
     public void should_return_empty_Stream() throws Exception {
-        // given
-        Class<?> streamType = getClassOrSkipTest("java.util.stream.Stream");
-
-        // when
-        Object stream = values.returnValueFor(streamType);
-        long count = (Long) streamType.getMethod("count").invoke(stream);
-
-        // then
-        assertEquals("count of empty Stream", 0L, count);
+        verify_empty_Stream_is_returned("java.util.stream.Stream");
     }
 
     @Test
     public void should_return_empty_DoubleStream() throws Exception {
-        // given
-        Class<?> streamType = getClassOrSkipTest("java.util.stream.DoubleStream");
-
-        // when
-        Object stream = values.returnValueFor(streamType);
-        long count = (Long) streamType.getMethod("count").invoke(stream);
-
-        // then
-        assertEquals("count of empty DoubleStream", 0L, count);
+        verify_empty_Stream_is_returned("java.util.stream.DoubleStream");
     }
 
     @Test
     public void should_return_empty_IntStream() throws Exception {
-        // given
-        Class<?> streamType = getClassOrSkipTest("java.util.stream.IntStream");
-
-        // when
-        Object stream = values.returnValueFor(streamType);
-        long count = (Long) streamType.getMethod("count").invoke(stream);
-
-        // then
-        assertEquals("count of empty IntStream", 0L, count);
+        verify_empty_Stream_is_returned("java.util.stream.IntStream");
     }
 
     @Test
     public void should_return_empty_LongStream() throws Exception {
+        verify_empty_Stream_is_returned("java.util.stream.LongStream");
+    }
+
+    private void verify_empty_Stream_is_returned(String streamFqcn) throws Exception {
         // given
-        Class<?> streamType = getClassOrSkipTest("java.util.stream.LongStream");
+        Class<?> streamType = getClassOrSkipTest(streamFqcn);
 
         // when
         Object stream = values.returnValueFor(streamType);
         long count = (Long) streamType.getMethod("count").invoke(stream);
 
         // then
-        assertEquals("count of empty LongStream", 0L, count);
+        assertEquals("count of empty " + streamFqcn, 0L, count);
     }
 
     /**


### PR DESCRIPTION
As [discussed](https://github.com/mockito/mockito/pull/782#discussion_r89658266) in the comments under #782. Longer term this approach could be replaced with a proper test parametrization framework, but then at least the foundation has been laid.
