### PR TITLE
Deep stubs no longer cause unnecessary stubbing exception with JUnit runner

### DIFF
--- a/src/main/java/org/mockito/internal/stubbing/InvocationContainerImpl.java
+++ b/src/main/java/org/mockito/internal/stubbing/InvocationContainerImpl.java
@@ -53,7 +53,10 @@ public class InvocationContainerImpl implements InvocationContainer, Serializabl
         addAnswer(answer, true);
     }
 
-    public void addAnswer(Answer answer, boolean isConsecutive) {
+    /**
+     * Adds new stubbed answer and returns the invocation matcher the answer was added to.
+     */
+    public StubbedInvocationMatcher addAnswer(Answer answer, boolean isConsecutive) {
         Invocation invocation = invocationForStubbing.getInvocation();
         mockingProgress().stubbingCompleted();
         AnswersValidator answersValidator = new AnswersValidator();
@@ -65,6 +68,7 @@ public class InvocationContainerImpl implements InvocationContainer, Serializabl
             } else {
                 stubbed.addFirst(new StubbedInvocationMatcher(invocationForStubbing, answer));
             }
+            return stubbed.getFirst();
         }
     }
 

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsDeepStubs.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsDeepStubs.java
@@ -68,10 +68,16 @@ public class ReturnsDeepStubs implements Answer<Object>, Serializable {
         }
 
         // record deep stub answer
-        return recordDeepStubAnswer(
+        StubbedInvocationMatcher stubbing = recordDeepStubAnswer(
                 newDeepStubMock(returnTypeGenericMetadata, invocation.getMock()),
                 container
         );
+
+        // deep stubbing creates a stubbing and immediately uses it
+        // so the stubbing is actually used by the same invocation
+        stubbing.markStubUsed(stubbing.getInvocation());
+
+        return stubbing.answer(invocation);
     }
 
     /**
@@ -110,9 +116,9 @@ public class ReturnsDeepStubs implements Answer<Object>, Serializable {
         return new ReturnsDeepStubsSerializationFallback(returnTypeGenericMetadata);
     }
 
-    private Object recordDeepStubAnswer(final Object mock, InvocationContainerImpl container) {
-        container.addAnswer(new DeeplyStubbedAnswer(mock), false);
-        return mock;
+    private StubbedInvocationMatcher recordDeepStubAnswer(final Object mock, InvocationContainerImpl container) {
+        DeeplyStubbedAnswer answer = new DeeplyStubbedAnswer(mock);
+        return container.addAnswer(answer, false);
     }
 
     protected GenericMetadataSupport actualParameterizedType(Object mock) {

--- a/src/test/java/org/mockitousage/junitrunner/DeepStubbingWithJUnitRunnerTest.java
+++ b/src/test/java/org/mockitousage/junitrunner/DeepStubbingWithJUnitRunnerTest.java
@@ -23,7 +23,7 @@ public class DeepStubbingWithJUnitRunnerTest {
 
     public static class SomeClass {
         void someMethod(Root root) {
-            root.getFoo();
+            root.getFoo().getBar();
         }
     }
 
@@ -32,5 +32,10 @@ public class DeepStubbingWithJUnitRunnerTest {
     }
 
     interface Foo {
+        Bar getBar();
+    }
+
+    interface Bar {
+
     }
 }

--- a/src/test/java/org/mockitousage/junitrunner/DeepStubbingWithJUnitRunnerTest.java
+++ b/src/test/java/org/mockitousage/junitrunner/DeepStubbingWithJUnitRunnerTest.java
@@ -1,0 +1,36 @@
+package org.mockitousage.junitrunner;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DeepStubbingWithJUnitRunnerTest {
+
+    private final SomeClass someClass = new SomeClass();
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS) private Root root;
+
+    @Test
+    public void deep_stubs_dont_trigger_unnecessary_stubbing_exception() {
+        //when
+        someClass.someMethod(root);
+
+        //then unnecessary stubbing exception is not thrown
+    }
+
+    public static class SomeClass {
+        void someMethod(Root root) {
+            root.getFoo();
+        }
+    }
+
+    interface Root {
+        Foo getFoo();
+    }
+
+    interface Foo {
+    }
+}


### PR DESCRIPTION
Fixes #756