### PR TITLE
Adds a warning for IBM J9 VMs if mock generation fails

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
@@ -4,6 +4,14 @@
  */
 package org.mockito.internal.creation.bytebuddy;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.lang.instrument.Instrumentation;
+import java.lang.reflect.Modifier;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.JarOutputStream;
 import net.bytebuddy.agent.ByteBuddyAgent;
 import net.bytebuddy.dynamic.ClassFileLocator;
 import org.mockito.Incubating;
@@ -15,15 +23,6 @@ import org.mockito.internal.util.Platform;
 import org.mockito.internal.util.concurrent.WeakConcurrentMap;
 import org.mockito.invocation.MockHandler;
 import org.mockito.mock.MockCreationSettings;
-
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.lang.instrument.Instrumentation;
-import java.lang.reflect.Modifier;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
-import java.util.jar.JarOutputStream;
 
 import static org.mockito.internal.creation.bytebuddy.InlineBytecodeGenerator.EXCLUDES;
 import static org.mockito.internal.util.StringJoiner.join;
@@ -210,7 +209,10 @@ public class InlineByteBuddyMockMaker implements ClassCreatingMockMaker {
                 "",
                 "If you're not sure why you're getting this error, please report to the mailing list.",
                 "",
-                Platform.isJava8BelowUpdate45() ? "Java 8 early builds have bugs that were addressed in Java 1.8.0_45, please update your JDK!\n" : "",
+                Platform.warnForVM(
+                        "IBM J9 VM", "Early IBM virtual machine are known to have issues with Mockito, please upgrade to an up-to-date version.\n",
+                        "Hotspot", Platform.isJava8BelowUpdate45() ? "Java 8 early builds have bugs that were addressed in Java 1.8.0_45, please update your JDK!\n" : ""
+                ),
                 Platform.describe(),
                 "",
                 "You are seeing this disclaimer because Mockito is configured to create inlined mocks.",

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassByteBuddyMockMaker.java
@@ -4,6 +4,7 @@
  */
 package org.mockito.internal.creation.bytebuddy;
 
+import java.lang.reflect.Modifier;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.InternalMockHandler;
 import org.mockito.internal.configuration.plugins.Plugins;
@@ -11,8 +12,6 @@ import org.mockito.internal.creation.instance.Instantiator;
 import org.mockito.internal.util.Platform;
 import org.mockito.invocation.MockHandler;
 import org.mockito.mock.MockCreationSettings;
-
-import java.lang.reflect.Modifier;
 
 import static org.mockito.internal.util.StringJoiner.join;
 
@@ -103,7 +102,10 @@ public class SubclassByteBuddyMockMaker implements ClassCreatingMockMaker {
                 "Mockito can only mock non-private & non-final classes.",
                 "If you're not sure why you're getting this error, please report to the mailing list.",
                 "",
-                Platform.isJava8BelowUpdate45() ? "Java 8 early builds have bugs that were addressed in Java 1.8.0_45, please update your JDK!\n" : "",
+                Platform.warnForVM(
+                        "IBM J9 VM", "Early IBM virtual machine are known to have issues with Mockito, please upgrade to an up-to-date version.\n",
+                        "Hotspot", Platform.isJava8BelowUpdate45() ? "Java 8 early builds have bugs that were addressed in Java 1.8.0_45, please update your JDK!\n" : ""
+                ),
                 Platform.describe(),
                 "",
                 "Underlying exception : " + generationFailed

--- a/src/main/java/org/mockito/internal/util/Platform.java
+++ b/src/main/java/org/mockito/internal/util/Platform.java
@@ -20,7 +20,8 @@ public abstract class Platform {
     public static final String OS_NAME = System.getProperty("os.name");
     public static final String OS_VERSION = System.getProperty("os.version");
 
-    private Platform() {}
+    private Platform() {
+    }
 
     public static String describe() {
         return String.format("Java               : %s\n" +
@@ -59,10 +60,26 @@ public abstract class Platform {
         }
 
         matcher = Pattern.compile("1\\.8\\.0-b\\d+").matcher(jvmVersion);
-        if (matcher.matches()) {
-            return true;
-        }
+        return matcher.matches();
 
-        return false;
+    }
+
+    public static String warnForVM(String vmName1, String warnMessage1,
+                                   String vmName2, String warnMessage2) {
+        return warnForVM(JVM_NAME,
+                         vmName1, warnMessage1,
+                         vmName2, warnMessage2);
+    }
+
+    static String warnForVM(String current,
+                            String vmName1, String warnMessage1,
+                            String vmName2, String warnMessage2) {
+        if (vmName1 != null && current.contains(vmName1)) {
+            return warnMessage1;
+        }
+        if (vmName2 != null && current.contains(vmName2)) {
+            return warnMessage2;
+        }
+        return "";
     }
 }


### PR DESCRIPTION
Related to #801, this PR simply adds a warning for IBM J9 VMs if the mock maker fails.
