### PR TITLE
Never throw mockito exceptions from a plugin type's constructor

### DIFF
--- a/src/main/java/org/mockito/exceptions/base/MockitoInitializationException.java
+++ b/src/main/java/org/mockito/exceptions/base/MockitoInitializationException.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito.exceptions.base;
+
+public class MockitoInitializationException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public MockitoInitializationException(String message) {
+        super(message);
+    }
+
+    public MockitoInitializationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
@@ -4,6 +4,19 @@
  */
 package org.mockito.internal.creation.bytebuddy;
 
+import net.bytebuddy.agent.ByteBuddyAgent;
+import net.bytebuddy.dynamic.ClassFileLocator;
+import org.mockito.Incubating;
+import org.mockito.exceptions.base.MockitoException;
+import org.mockito.exceptions.base.MockitoInitializationException;
+import org.mockito.internal.InternalMockHandler;
+import org.mockito.internal.configuration.plugins.Plugins;
+import org.mockito.internal.creation.instance.Instantiator;
+import org.mockito.internal.util.Platform;
+import org.mockito.internal.util.concurrent.WeakConcurrentMap;
+import org.mockito.invocation.MockHandler;
+import org.mockito.mock.MockCreationSettings;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -12,17 +25,6 @@ import java.lang.reflect.Modifier;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.JarOutputStream;
-import net.bytebuddy.agent.ByteBuddyAgent;
-import net.bytebuddy.dynamic.ClassFileLocator;
-import org.mockito.Incubating;
-import org.mockito.exceptions.base.MockitoException;
-import org.mockito.internal.InternalMockHandler;
-import org.mockito.internal.configuration.plugins.Plugins;
-import org.mockito.internal.creation.instance.Instantiator;
-import org.mockito.internal.util.Platform;
-import org.mockito.internal.util.concurrent.WeakConcurrentMap;
-import org.mockito.invocation.MockHandler;
-import org.mockito.mock.MockCreationSettings;
 
 import static org.mockito.internal.creation.bytebuddy.InlineBytecodeGenerator.EXCLUDES;
 import static org.mockito.internal.util.StringJoiner.join;
@@ -98,7 +100,7 @@ public class InlineByteBuddyMockMaker implements ClassCreatingMockMaker {
         try {
             instrumentation = ByteBuddyAgent.install();
             if (!instrumentation.isRetransformClassesSupported()) {
-                throw new MockitoException(join(
+                throw new MockitoInitializationException(join(
                         "Byte Buddy requires retransformation for creating inline mocks. This feature is unavailable on the current VM.",
                         "",
                         "You cannot use this mock maker on this VM:",
@@ -120,13 +122,13 @@ public class InlineByteBuddyMockMaker implements ClassCreatingMockMaker {
             try {
                 Class<?> dispatcher = Class.forName("org.mockito.internal.creation.bytebuddy.MockMethodDispatcher");
                 if (dispatcher.getClassLoader() != null) {
-                    throw new MockitoException(join(
+                    throw new MockitoInitializationException(join(
                             "The MockMethodDispatcher must not be loaded manually but must be injected into the bootstrap class loader.",
                             "",
                             "The dispatcher class was already loaded by: " + dispatcher.getClassLoader()));
                 }
             } catch (ClassNotFoundException cnfe) {
-                throw new MockitoException(join(
+                throw new MockitoInitializationException(join(
                         "Mockito failed to inject the MockMethodDispatcher class into the bootstrap class loader",
                         "",
                         "It seems like your current VM does not support the instrumentation API correctly:",
@@ -134,7 +136,7 @@ public class InlineByteBuddyMockMaker implements ClassCreatingMockMaker {
             }
             bytecodeGenerator = new TypeCachingBytecodeGenerator(new InlineBytecodeGenerator(instrumentation, mocks), true);
         } catch (IOException ioe) {
-            throw new MockitoException(join(
+            throw new MockitoInitializationException(join(
                     "Mockito could not self-attach a Java agent to the current VM. This feature is required for inline mocking.",
                     "This error occured due to an I/O error during the creation of this agent: " + ioe,
                     "",


### PR DESCRIPTION
Throwing a `MockitoException` from a mock maker constructor will cause the stack trace cleaning to be applied which itself relies on the plugin registry which is not yet initialized during the mock maker plugin's creation.