### PR TITLE
Fixes #810 : inconsistency_with_spy_and_injectmocks

### DIFF
--- a/src/main/java/org/mockito/internal/configuration/injection/scanner/InjectMocksScanner.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/scanner/InjectMocksScanner.java
@@ -7,13 +7,14 @@ package org.mockito.internal.configuration.injection.scanner;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-
-import static org.mockito.internal.exceptions.Reporter.unsupportedCombinationOfAnnotations;
+import org.mockito.Spy;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.util.HashSet;
 import java.util.Set;
+
+import static org.mockito.internal.exceptions.Reporter.unsupportedCombinationOfAnnotations;
 
 /**
  * Scan field for injection.
@@ -24,7 +25,7 @@ public class InjectMocksScanner {
     /**
      * Create a new InjectMocksScanner for the given clazz on the given instance
      *
-     * @param clazz    Current class in the hierarchy of the test
+     * @param clazz Current class in the hierarchy of the test
      */
     public InjectMocksScanner(Class<?> clazz) {
         this.clazz = clazz;
@@ -50,7 +51,9 @@ public class InjectMocksScanner {
         Set<Field> mockDependentFields = new HashSet<Field>();
         Field[] fields = clazz.getDeclaredFields();
         for (Field field : fields) {
-            if (null != field.getAnnotation(InjectMocks.class)) {
+            if (null != field.getAnnotation(InjectMocks.class)
+                    && null == field.getAnnotation(Spy.class)
+                    && null == field.getAnnotation(Mock.class)) {
                 assertNoAnnotations(field, Mock.class, Captor.class);
                 mockDependentFields.add(field);
             }


### PR DESCRIPTION
Based on a lot of discussions I found:
https://code.google.com/archive/p/mockito/issues/489
https://groups.google.com/forum/#!msg/mockito-dev/YFqTPm8yJSc/Y-ty81kLKI4J
and a few threads on SO, it seems mockito doesn't have an intention to support multiple-layer injection. I would like to see it work, but as many justified the decision: "Mockito was never intended to be a fully-fledged injection framework, it serves a different purpose". It's a shame, but I understand and respect that.

Now, it doesn't look consistent in the situation I'm facing:
This test will run successfully:
```
public class PaymentHelperTest  extends WhatEverClassYouWant {

    @Mock
    private DateUtil dateUtil;

    @InjectMocks
    private PaymentHelper paymentHelper;
```

But the exact same test without inheritance will fail:
```
public class PaymentHelperTest {

    @Mock
    private DateUtil dateUtil;

    @InjectMocks
    private PaymentHelper paymentHelper;
```
It happens because of the tricky loops like:
`        while (clazz != Object.class) {
          .....
            clazz = clazz.getSuperclass();
        }`
And a check in InjectMocksScanner.scan():
            `if (null != field.getAnnotation(InjectMocks.class)) `

I am planning to add another check in there:
