### PR TITLE
Fixes bug were previously verified invocations could not capture argu…

### DIFF
--- a/src/main/java/org/mockito/internal/verification/checkers/AtLeastXNumberOfInvocationsChecker.java
+++ b/src/main/java/org/mockito/internal/verification/checkers/AtLeastXNumberOfInvocationsChecker.java
@@ -5,7 +5,12 @@
 
 package org.mockito.internal.verification.checkers;
 
-import java.util.Iterator;
+import java.util.List;
+import org.mockito.internal.verification.api.InOrderContext;
+import org.mockito.invocation.Invocation;
+import org.mockito.invocation.Location;
+import org.mockito.invocation.MatchableInvocation;
+
 import static org.mockito.internal.exceptions.Reporter.tooLittleActualInvocations;
 import static org.mockito.internal.exceptions.Reporter.tooLittleActualInvocationsInOrder;
 import static org.mockito.internal.invocation.InvocationMarker.markVerified;
@@ -13,13 +18,6 @@ import static org.mockito.internal.invocation.InvocationMarker.markVerifiedInOrd
 import static org.mockito.internal.invocation.InvocationsFinder.findAllMatchingUnverifiedChunks;
 import static org.mockito.internal.invocation.InvocationsFinder.findInvocations;
 import static org.mockito.internal.invocation.InvocationsFinder.getLastLocation;
-
-import java.util.List;
-import org.mockito.internal.invocation.InvocationMatcher;
-import org.mockito.internal.verification.api.InOrderContext;
-import org.mockito.invocation.Invocation;
-import org.mockito.invocation.Location;
-import org.mockito.invocation.MatchableInvocation;
 
 public class AtLeastXNumberOfInvocationsChecker {
     
@@ -32,17 +30,7 @@ public class AtLeastXNumberOfInvocationsChecker {
             throw tooLittleActualInvocations(new AtLeastDiscrepancy(wantedCount, actualCount), wanted, lastLocation);
         }
 
-        removeAlreadyVerified(actualInvocations);
         markVerified(actualInvocations, wanted);
-    }
-
-    private static void removeAlreadyVerified(List<Invocation> invocations) {
-        for (Iterator<Invocation> iterator = invocations.iterator(); iterator.hasNext(); ) {
-            Invocation i = iterator.next();
-            if (i.isVerified()) {
-                iterator.remove();
-            }
-        }
     }
 
     public static void checkAtLeastNumberOfInvocations(List<Invocation> invocations, MatchableInvocation wanted, int wantedCount,InOrderContext orderingContext) {

--- a/src/main/java/org/mockito/internal/verification/checkers/NumberOfInvocationsChecker.java
+++ b/src/main/java/org/mockito/internal/verification/checkers/NumberOfInvocationsChecker.java
@@ -5,21 +5,18 @@
 
 package org.mockito.internal.verification.checkers;
 
+import java.util.List;
+import org.mockito.internal.reporting.Discrepancy;
+import org.mockito.invocation.Invocation;
+import org.mockito.invocation.Location;
+import org.mockito.invocation.MatchableInvocation;
+
 import static org.mockito.internal.exceptions.Reporter.neverWantedButInvoked;
 import static org.mockito.internal.exceptions.Reporter.tooLittleActualInvocations;
 import static org.mockito.internal.exceptions.Reporter.tooManyActualInvocations;
 import static org.mockito.internal.invocation.InvocationMarker.markVerified;
 import static org.mockito.internal.invocation.InvocationsFinder.findInvocations;
 import static org.mockito.internal.invocation.InvocationsFinder.getLastLocation;
-
-import java.util.Iterator;
-import java.util.List;
-
-import org.mockito.internal.invocation.InvocationMatcher;
-import org.mockito.internal.reporting.Discrepancy;
-import org.mockito.invocation.Invocation;
-import org.mockito.invocation.Location;
-import org.mockito.invocation.MatchableInvocation;
 
 public class NumberOfInvocationsChecker {
 
@@ -40,16 +37,6 @@ public class NumberOfInvocationsChecker {
             throw tooManyActualInvocations(wantedCount, actualCount, wanted, firstUndesired);
         }
 
-        removeAlreadyVerified(actualInvocations);
         markVerified(actualInvocations, wanted);
-    }
-
-    private void removeAlreadyVerified(List<Invocation> invocations) {
-        for (Iterator<Invocation> iterator = invocations.iterator(); iterator.hasNext(); ) {
-            Invocation i = iterator.next();
-            if (i.isVerified()) {
-                iterator.remove();
-            }
-        }
     }
 }

--- a/src/test/java/org/mockitousage/bugs/ArgumentCaptorDontCapturePreviouslyVerifiedTest.java
+++ b/src/test/java/org/mockitousage/bugs/ArgumentCaptorDontCapturePreviouslyVerifiedTest.java
@@ -1,0 +1,28 @@
+package org.mockitousage.bugs;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockitousage.IMethods;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class ArgumentCaptorDontCapturePreviouslyVerifiedTest {
+    @Test
+    public void previous_verified_invocation_should_still_capture_args() {
+        IMethods mock = mock(IMethods.class);
+
+        mock.oneArg("first");
+        ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+        verify(mock, times(1)).oneArg(argument.capture());
+        assertThat(argument.getAllValues()).hasSize(1);
+
+        // additional interactions
+        mock.oneArg("second");
+        argument = ArgumentCaptor.forClass(String.class);
+        verify(mock, times(2)).oneArg(argument.capture());
+        assertThat(argument.getAllValues()).hasSize(2);
+    }
+}


### PR DESCRIPTION
Since Mockito 2 / #380 captured arguments is not anymore done for already verified interactions.

```java
IMethods mock = mock(IMethods.class);
mock.oneArg("first");
ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
verify(mock, times(1)).oneArg(argument.capture());
assertThat(argument.getAllValues()).isEqualTo(1);

// additional interactions
mock.oneArg("second");
argument = ArgumentCaptor.forClass(String.class);
verify(mock, times(2)).oneArg(argument.capture());
assertThat(argument.getAllValues()).isEqualTo(2); // fail with mockito 2
```

The current behavior (Mockito 2.1 - 2.3.3) of `NumberedInvocationChecker` clears already verified interactions, before verifying the remaining interactions so the new argument captor is not populated with previous values. Which is akward if the times value is different that the lit size.