### PR TITLE
Only resolve instrumented method after validating that an instance is…

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
@@ -43,7 +43,7 @@ public class MockMethodAdvice extends MockMethodDispatcher {
                                      @Advice.Origin Method origin,
                                      @Advice.AllArguments Object[] arguments) throws Throwable {
         MockMethodDispatcher dispatcher = MockMethodDispatcher.get(identifier, mock);
-        if (dispatcher == null || !dispatcher.isMocked(mock, origin)) {
+        if (dispatcher == null || !dispatcher.isMocked(mock) || !dispatcher.isOverridden(mock, origin)) {
             return null;
         } else {
             return dispatcher.handle(mock, origin, arguments);
@@ -83,15 +83,16 @@ public class MockMethodAdvice extends MockMethodDispatcher {
     }
 
     @Override
-    public boolean isMocked(Object instance, Method origin) {
-        return selfCallInfo.checkSuperCall(instance) && isMock(instance) && isNotOverridden(instance.getClass(), origin);
+    public boolean isMocked(Object instance) {
+        return selfCallInfo.checkSuperCall(instance) && isMock(instance);
     }
 
-    private static boolean isNotOverridden(Class<?> type, Method origin) {
-        Class<?> currentType = type;
+    @Override
+    public boolean isOverridden(Object instance, Method origin) {
+        Class<?> currentType = instance.getClass();
         do {
             try {
-                return origin.equals(type.getDeclaredMethod(origin.getName(), origin.getParameterTypes()));
+                return origin.equals(currentType.getDeclaredMethod(origin.getName(), origin.getParameterTypes()));
             } catch (NoSuchMethodException ignored) {
                 currentType = currentType.getSuperclass();
             }

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodDispatcher.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodDispatcher.java
@@ -29,5 +29,7 @@ public abstract class MockMethodDispatcher {
 
     public abstract boolean isMock(Object instance);
 
-    public abstract boolean isMocked(Object instance, Method origin);
+    public abstract boolean isMocked(Object instance);
+
+    public abstract boolean isOverridden(Object instance, Method origin);
 }

--- a/src/test/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMakerTest.java
+++ b/src/test/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMakerTest.java
@@ -1,5 +1,6 @@
 package org.mockito.internal.creation.bytebuddy;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Observable;
 import java.util.Observer;
@@ -68,6 +69,13 @@ public class InlineByteBuddyMockMakerTest extends AbstractByteBuddyMockMakerTest
         FinalMethod proxy = mockMaker.createMock(settings, new MockHandlerImpl<FinalMethod>(settings));
         assertThat(proxy.foo()).isEqualTo("bar");
         assertThat(((SampleInterface) proxy).bar()).isEqualTo("bar");
+    }
+
+    @Test
+    public void should_create_mock_from_hashmap() throws Exception {
+        MockCreationSettings<HashMap> settings = settingsFor(HashMap.class);
+        HashMap proxy = mockMaker.createMock(settings, new MockHandlerImpl<HashMap>(settings));
+        assertThat(proxy.get(null)).isEqualTo("bar");
     }
 
     @Test


### PR DESCRIPTION
This is both a performance improvement and a way of ensuring that no stack overflow error occurs upon looking up a `Method` instance which requires using a `HashMap` which causes an infitite loop upon mocking the hash map type. Fixes #818.