### PR TITLE
Test for verification listeners test can introduces bogus erro in other test cases.

### DIFF
--- a/src/test/java/org/mockitousage/debugging/VerificationListenerCallBackTest.java
+++ b/src/test/java/org/mockitousage/debugging/VerificationListenerCallBackTest.java
@@ -1,24 +1,28 @@
 package org.mockitousage.debugging;
 
+import java.lang.reflect.Method;
 import org.assertj.core.api.Condition;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.JUnitCore;
 import org.mockito.Mockito;
 import org.mockito.MockitoFramework;
+import org.mockito.StateMaster;
 import org.mockito.exceptions.base.MockitoAssertionError;
 import org.mockito.internal.verification.api.VerificationData;
 import org.mockito.listeners.VerificationListener;
 import org.mockito.verification.VerificationEvent;
 import org.mockito.verification.VerificationMode;
 
-
-import java.lang.reflect.Method;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.framework;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class VerificationListenerCallBackTest {
     private Method invocationWanted;
@@ -31,6 +35,13 @@ public class VerificationListenerCallBackTest {
         mockitoFramework = Mockito.framework();
         mockitoFramework.addListener(listener);
         invocationWanted = Foo.class.getDeclaredMethod("doSomething", String.class);
+    }
+
+    @After
+    public void reset_mockito() {
+        StateMaster stateMaster = new StateMaster();
+        stateMaster.reset();
+        stateMaster.clearMockitoListeners();
     }
 
     @Test


### PR DESCRIPTION
The following test (org.mockitousage.debugging.VerificationListenerCallBackTest#should_not_call_listener_when_verify_was_called_incorrectly) was causing non wanted exception in mockito

```
org.mockitousage.misuse.CleaningUpPotentialStubbingTest > shouldResetOngoingStubbingOnInOrder FAILED
    org.mockito.exceptions.misusing.CannotStubVoidMethodWithReturnValue: 
    'onVerification' is a *void method* and it *cannot* be stubbed with a *return value*!
    Voids are usually stubbed with Throwables:
        doThrow(exception).when(mock).someVoidMethod();
    ***
    If you're unsure why you're getting above error read on.
    Due to the nature of the syntax above problem might occur because:
    1. The method you are trying to stub is *overloaded*. Make sure you are calling the right overloaded version.
    2. Somewhere in your test you are stubbing *final methods*. Sorry, Mockito does not verify/stub final methods.
    3. A spy is stubbed using when(spy.foo()).then() syntax. It is safer to stub spies - 
       - with doReturn|Throw() family of methods. More in javadocs for Mockito.spy() method.
    4. Mocking methods declared on non-public parent classes is not supported.
        at org.mockito.internal.exceptions.Reporter.cannotStubVoidMethodWithAReturnValue(Reporter.java:448)
        at org.mockito.internal.stubbing.answers.AnswersValidator.validateReturnValue(AnswersValidator.java:72)
        at org.mockito.internal.stubbing.answers.AnswersValidator.validate(AnswersValidator.java:29)
        at org.mockito.internal.stubbing.InvocationContainerImpl.addAnswer(InvocationContainerImpl.java:63)
        at org.mockito.internal.stubbing.InvocationContainerImpl.addAnswer(InvocationContainerImpl.java:49)
        at org.mockito.internal.stubbing.OngoingStubbingImpl.thenAnswer(OngoingStubbingImpl.java:28)
        at org.mockito.internal.stubbing.BaseStubbing.thenReturn(BaseStubbing.java:16)
        at org.mockitousage.misuse.CleaningUpPotentialStubbingTest.assertOngoingStubbingIsReset(CleaningUpPotentialStubbingTest.java:50)
        at org.mockitousage.misuse.CleaningUpPotentialStubbingTest.shouldResetOngoingStubbingOnInOrder(CleaningUpPotentialStubbingTest.java:36)
org.mockitousage.misuse.CleaningUpPotentialStubbingTest > shouldResetOngoingStubbingOnVerify FAILED
    org.mockito.exceptions.misusing.CannotStubVoidMethodWithReturnValue: 
    'onVerification' is a *void method* and it *cannot* be stubbed with a *return value*!
    Voids are usually stubbed with Throwables:
        doThrow(exception).when(mock).someVoidMethod();
    ***
    If you're unsure why you're getting above error read on.
    Due to the nature of the syntax above problem might occur because:
    1. The method you are trying to stub is *overloaded*. Make sure you are calling the right overloaded version.
    2. Somewhere in your test you are stubbing *final methods*. Sorry, Mockito does not verify/stub final methods.
    3. A spy is stubbed using when(spy.foo()).then() syntax. It is safer to stub spies - 
       - with doReturn|Throw() family of methods. More in javadocs for Mockito.spy() method.
    4. Mocking methods declared on non-public parent classes is not supported.
        at org.mockito.internal.exceptions.Reporter.cannotStubVoidMethodWithAReturnValue(Reporter.java:448)
        at org.mockito.internal.stubbing.answers.AnswersValidator.validateReturnValue(AnswersValidator.java:72)
        at org.mockito.internal.stubbing.answers.AnswersValidator.validate(AnswersValidator.java:29)
        at org.mockito.internal.stubbing.InvocationContainerImpl.addAnswer(InvocationContainerImpl.java:63)
        at org.mockito.internal.stubbing.InvocationContainerImpl.addAnswer(InvocationContainerImpl.java:49)
        at org.mockito.internal.stubbing.OngoingStubbingImpl.thenAnswer(OngoingStubbingImpl.java:28)
        at org.mockito.internal.stubbing.BaseStubbing.thenReturn(BaseStubbing.java:16)
        at org.mockitousage.misuse.CleaningUpPotentialStubbingTest.assertOngoingStubbingIsReset(CleaningUpPotentialStubbingTest.java:50)
        at org.mockitousage.misuse.CleaningUpPotentialStubbingTest.shouldResetOngoingStubbingOnVerify(CleaningUpPotentialStubbingTest.java:28)

```


The issue is that the mentionned test used a mock to create a listener for a test, but forgot to remove it. So on a next interaction with a mock, the listener was called, as such the last interaction is `void onVerification`, so the answer could not be validated.

The case is easy to reproduce :

```java
interface Foo {
    String nonVoid(String param);
    void doSomething(String param);
}
@Test
public void should_not_call_listener_when_verify_was_called_incorrectly() {
    //when
    Foo foo = null;
    VerificationListener mockListener = mock(VerificationListener.class);
    Mockito.framework().addListener(mockListener);
    try {
        verify(foo).nonVoid("");
        fail("Exception expected.");
    } catch (NullInsteadOfMockException expected) {
        //then
        verify(mockListener, never()).onVerification(any(VerificationEvent.class))
    }
    // Mockito.framework().removeListener(mockListener); // fix

    // done in CleaningUpPotentialStubbingTest
    try {
        when(null).thenReturn("anything"); // throws instead CannotStubVoidMethodWithReturnValue
        Assertions.fail("expected");
    } catch (MissingMethodInvocationException e) {} 
}
```

Given the conditions to reproduce the bug I'd say we can keep the code that way.