### PR TITLE
Prototype implementation of when syntax for void methods

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -8,6 +8,7 @@ import org.mockito.internal.MockitoCore;
 import org.mockito.internal.creation.MockSettingsImpl;
 import org.mockito.internal.debugging.MockitoDebuggerImpl;
 import org.mockito.internal.framework.DefaultMockitoFramework;
+import org.mockito.internal.stubbing.OngoingVoidStubbingImpl;
 import org.mockito.internal.verification.VerificationModeFactory;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -16,6 +17,7 @@ import org.mockito.mock.SerializableMode;
 import org.mockito.stubbing.Answer;
 import org.mockito.stubbing.Answer1;
 import org.mockito.stubbing.OngoingStubbing;
+import org.mockito.stubbing.OngoingVoidStubbing;
 import org.mockito.stubbing.Stubber;
 import org.mockito.stubbing.VoidAnswer1;
 import org.mockito.verification.After;
@@ -1819,6 +1821,10 @@ public class Mockito extends ArgumentMatchers {
      */
     public static <T> OngoingStubbing<T> when(T methodCall) {
         return MOCKITO_CORE.when(methodCall);
+    }
+    
+    public static OngoingVoidStubbing when(VoidCall methodCall){
+        return new OngoingVoidStubbingImpl(methodCall);
     }
 
     /**

--- a/src/main/java/org/mockito/VoidCall.java
+++ b/src/main/java/org/mockito/VoidCall.java
@@ -1,0 +1,7 @@
+package org.mockito;
+
+@FunctionalInterface
+public interface VoidCall {
+
+    void run() throws Throwable;
+}

--- a/src/main/java/org/mockito/internal/stubbing/OngoingVoidStubbingImpl.java
+++ b/src/main/java/org/mockito/internal/stubbing/OngoingVoidStubbingImpl.java
@@ -1,0 +1,127 @@
+package org.mockito.internal.stubbing;
+
+import static org.mockito.AdditionalAnswers.answerVoid;
+import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
+
+import java.util.List;
+
+import org.mockito.VoidCall;
+import org.mockito.exceptions.base.MockitoException;
+import org.mockito.invocation.Invocation;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.mockito.stubbing.OngoingStubbing;
+import org.mockito.stubbing.OngoingVoidStubbing;
+import org.mockito.stubbing.VoidAnswer;
+import org.mockito.stubbing.VoidAnswer0;
+import org.mockito.stubbing.VoidAnswer1;
+import org.mockito.stubbing.VoidAnswer2;
+import org.mockito.stubbing.VoidAnswer3;
+import org.mockito.stubbing.VoidAnswer4;
+import org.mockito.stubbing.VoidAnswer5;
+
+public class OngoingVoidStubbingImpl implements OngoingVoidStubbing {
+    private OngoingStubbing<Object> ongoingStubbing;
+
+    public OngoingVoidStubbingImpl(VoidCall methodCall) {
+        ongoingStubbing = execute(methodCall);
+
+        checkExactlyOneCallOnMockWasMade(ongoingStubbing);
+    }
+
+    @Override
+    public OngoingVoidStubbing thenThrow(Throwable... throwables) {
+        ongoingStubbing = ongoingStubbing.thenThrow(throwables);
+        return this;
+    }
+
+    @Override
+    public OngoingVoidStubbing thenThrow(Class<? extends Throwable> throwableType) {
+        ongoingStubbing = ongoingStubbing.thenThrow(throwableType);
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public OngoingVoidStubbing thenThrow(Class<? extends Throwable> toBeThrown, Class<? extends Throwable>... nextToBeThrown) {
+        ongoingStubbing = ongoingStubbing.thenThrow(toBeThrown, nextToBeThrown);
+        return this;
+    }
+
+    @Override
+    public OngoingVoidStubbing thenCallRealMethod() {
+        ongoingStubbing = ongoingStubbing.thenCallRealMethod();
+        return this;
+    }
+
+    @Override
+    public OngoingVoidStubbing thenDoNothing() {
+        return then(() -> {});
+    }
+
+    @Override
+    public OngoingVoidStubbing thenAnswer(VoidAnswer answer) {
+        return then((InvocationOnMock i)->{answer.answer(i);return null;});
+
+    }
+
+    @Override
+    public OngoingVoidStubbing then(VoidAnswer0 answer) {
+        return thenAnswer(i -> answer.answer());
+    }
+
+    @Override
+    public <A> OngoingVoidStubbing then(VoidAnswer1<A> answer) {
+        return then(answerVoid(answer));
+    }
+
+    @Override
+    public <A, B> OngoingVoidStubbing then(VoidAnswer2<A, B> answer) {
+        return then(answerVoid(answer));
+    }
+
+    @Override
+    public <A, B, C> OngoingVoidStubbing then(VoidAnswer3<A, B, C> answer) {
+        return then(answerVoid(answer));
+    }
+
+    @Override
+    public <A, B, C, D> OngoingVoidStubbing then(VoidAnswer4<A, B, C, D> answer) {
+        return then(answerVoid(answer));
+    }
+
+    @Override
+    public <A, B, C, D, E> OngoingVoidStubbing then(VoidAnswer5<A, B, C, D, E> answer) {
+        return then(answerVoid(answer));
+    }
+    
+    private OngoingVoidStubbing then(Answer<Void> answer){
+        ongoingStubbing = ongoingStubbing.then(answer);
+        return this;
+    }
+
+    @Override
+    public <M> M getMock() {
+        return ongoingStubbing.getMock();
+    }
+
+    private static void checkExactlyOneCallOnMockWasMade(OngoingStubbing<Object> ongoingStubbing) {
+        List<Invocation> allInvocations = ((OngoingStubbingImpl<?>) ongoingStubbing).getRegisteredInvocations();
+        if (allInvocations.size() > 1) {
+            throw new MockitoException("Too many mock methods were called! Expected exactly one call to mock: " + ongoingStubbing.getMock() + "! Got: " + allInvocations);
+        }
+        if (allInvocations.size() < 1) {
+            throw new MockitoException("No mock method called was called! Expected exactly one call to mock: " + ongoingStubbing.getMock() + "! Got: " + allInvocations);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static OngoingStubbing<Object> execute(VoidCall methodCall) {
+        try {
+            methodCall.run();
+        } catch (Throwable mustNotHappen) {
+            throw new MockitoException("Unexpected exception was thrown from: " + methodCall);
+        }
+        return (OngoingStubbing<Object>) mockingProgress().pullOngoingStubbing();
+    }
+}

--- a/src/main/java/org/mockito/stubbing/OngoingVoidStubbing.java
+++ b/src/main/java/org/mockito/stubbing/OngoingVoidStubbing.java
@@ -1,0 +1,47 @@
+package org.mockito.stubbing;
+
+public interface OngoingVoidStubbing {
+    OngoingVoidStubbing thenAnswer(VoidAnswer answer);
+    
+    OngoingVoidStubbing then(VoidAnswer0 answer);
+    
+    <A> OngoingVoidStubbing then(VoidAnswer1<A> answer);
+    
+    <A,B> OngoingVoidStubbing then(VoidAnswer2<A,B> answer);
+    
+    <A,B,C> OngoingVoidStubbing then(VoidAnswer3<A,B,C> answer);
+    
+    <A,B,C,D> OngoingVoidStubbing then(VoidAnswer4<A,B,C,D> answer);
+    
+    <A,B,C, D,E> OngoingVoidStubbing then(VoidAnswer5<A,B,C,D,E> answer);
+
+    OngoingVoidStubbing thenDoNothing();
+    
+    OngoingVoidStubbing thenThrow(Throwable... throwables);
+
+    OngoingVoidStubbing thenThrow(Class<? extends Throwable> throwableType);
+
+    @SuppressWarnings ("unchecked")
+    OngoingVoidStubbing thenThrow(Class<? extends Throwable> toBeThrown, Class<? extends Throwable>... nextToBeThrown);
+
+    OngoingVoidStubbing thenCallRealMethod();
+
+    /**
+     * Returns the mock that was used for this stub.
+     * <p>
+     * It allows to create a stub in one line of code.
+     * This can be helpful to keep test code clean.
+     * For example, some boring stub can be created & stubbed at field initialization in a test:
+     * <pre class="code"><code class="java">
+     * public class CarTest {
+     *   Car boringStubbedCar = when(mock(Car.class).shiftGear()).thenThrow(EngineNotStarted.class).getMock();
+     *
+     *   &#064;Test public void should... {}
+     * </code></pre>
+     *
+     * @param <M> The mock type given by the variable type.
+     * @return Mock used in this ongoing stubbing.
+     * @since 1.9.0
+     */
+    <M> M getMock();
+}

--- a/src/main/java/org/mockito/stubbing/VoidAnswer.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer.java
@@ -1,0 +1,8 @@
+package org.mockito.stubbing;
+
+import org.mockito.invocation.InvocationOnMock;
+
+@FunctionalInterface
+public interface VoidAnswer {
+    void answer(InvocationOnMock invocation) throws Throwable;
+}

--- a/src/main/java/org/mockito/stubbing/VoidAnswer0.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer0.java
@@ -1,0 +1,6 @@
+package org.mockito.stubbing;
+
+@FunctionalInterface
+public interface VoidAnswer0 {
+    void answer();
+}

--- a/src/test/java/org/mockitousage/basicapi/ResetTest.java
+++ b/src/test/java/org/mockitousage/basicapi/ResetTest.java
@@ -30,7 +30,7 @@ public class ResetTest extends TestBase {
         mock.booleanReturningMethod();
         reset(mock);
         try {
-            when(null).thenReturn("anything");
+            when((Object)null).thenReturn("anything");
             fail();
         } catch (MissingMethodInvocationException e) {
         }

--- a/src/test/java/org/mockitousage/misuse/CleaningUpPotentialStubbingTest.java
+++ b/src/test/java/org/mockitousage/misuse/CleaningUpPotentialStubbingTest.java
@@ -47,7 +47,7 @@ public class CleaningUpPotentialStubbingTest extends TestBase {
         try {
             //In real, there might be a call to real object or a final method call
             //I'm modelling it with null
-            when(null).thenReturn("anything");
+            when((Object)null).thenReturn("anything");
             fail();
         } catch (MissingMethodInvocationException e) {}
     }

--- a/src/test/java/org/mockitousage/stubbing/VoidStubbingTest.java
+++ b/src/test/java/org/mockitousage/stubbing/VoidStubbingTest.java
@@ -1,0 +1,106 @@
+package org.mockitousage.stubbing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.mockito.junit.MockitoJUnit.rule;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.exceptions.base.MockitoException;
+import org.mockito.junit.MockitoRule;
+import org.mockitousage.IMethods;
+
+public class VoidStubbingTest {
+
+    @Rule
+    public MockitoRule mockito = rule();
+
+    @Mock
+    private IMethods mock;
+
+    private List<Integer> result;
+    
+    @Before
+    public void init(){
+        result= new ArrayList<>();
+    }
+    
+    @Test
+    public void instanceReferenceStubbing() {
+        when(mock::voidMethod).then(() -> {
+            result.add(1);
+        });
+        
+        mock.voidMethod();
+        
+        assertThat(result).contains(1);
+    }
+
+    @Test
+    public void consecutiveStubbing() throws Exception {
+        when(() -> mock.intArgumentMethod(5))
+        .then((Integer a) -> result.add(a))
+        .then((Integer a) -> result.add(100 * a));
+
+        mock.intArgumentMethod(5);
+        mock.intArgumentMethod(10);
+        mock.intArgumentMethod(5);
+
+        assertThat(result).containsExactly(5, 500);
+    }
+
+    
+    @Test
+    public void replaceStubbing() {
+        when(() -> mock.voidMethod()).thenDoNothing();
+        when(() -> mock.voidMethod()).thenThrow(new IllegalArgumentException());
+
+        assertThatThrownBy(mock::voidMethod).isInstanceOf(IllegalArgumentException.class);
+    }
+    
+    @Test
+    public void mixedStubbings() {
+        when(mock::voidMethod).thenThrow(new IllegalArgumentException());
+        doThrow(new UnsupportedOperationException()).when(mock).differentMethod();
+        
+        assertThatThrownBy(mock::voidMethod).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(mock::differentMethod).isInstanceOf(UnsupportedOperationException.class);
+    }
+    
+    @Test
+    public void captureArgument() {
+        ArgumentCaptor<Integer> captor = forClass(int.class);
+        
+        when(()->mock.intArgumentMethod(captor.capture())).thenDoNothing();
+        
+        mock.intArgumentMethod(123);
+        
+        assertThat(captor.getValue()).isEqualTo(123);
+    }
+    
+    
+    
+    @Test
+    public void tooManyCallsOnMock() {
+        assertThatThrownBy(() -> {
+
+            when(() -> {
+                mock.intArgumentMethod(5);
+                mock.intArgumentMethod(2);
+            });
+
+        })
+        .isInstanceOf(MockitoException.class)
+        .hasMessageContaining("Too many mock methods were called").hasMessageContaining("Expected exactly one call to mock: " + mock);
+
+    }
+}


### PR DESCRIPTION
This PR relates to #815, it allows to stub void methods like returning methods by using a method reference or a lambda containing a call to a void method.

```java
when(mock::voidMethod).then(...);
when(()->mock.voidMethod(gt(4))).then(...);
```

The prototype supports: argument matchers, argument capturing, consecutive answers, overriding answers and checks for lambda expressions that call more than one mock-method or no mock method.
