### PR TITLE
Improves exception message in case a matcher is used for a primitive parameter

### DIFF
--- a/src/main/java/org/mockito/internal/exceptions/Reporter.java
+++ b/src/main/java/org/mockito/internal/exceptions/Reporter.java
@@ -5,10 +5,32 @@
 
 package org.mockito.internal.exceptions;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import org.mockito.exceptions.base.MockitoAssertionError;
 import org.mockito.exceptions.base.MockitoException;
-import org.mockito.exceptions.misusing.*;
-import org.mockito.exceptions.verification.*;
+import org.mockito.exceptions.misusing.CannotStubVoidMethodWithReturnValue;
+import org.mockito.exceptions.misusing.CannotVerifyStubOnlyMock;
+import org.mockito.exceptions.misusing.FriendlyReminderException;
+import org.mockito.exceptions.misusing.InvalidUseOfMatchersException;
+import org.mockito.exceptions.misusing.MissingMethodInvocationException;
+import org.mockito.exceptions.misusing.NotAMockException;
+import org.mockito.exceptions.misusing.NullInsteadOfMockException;
+import org.mockito.exceptions.misusing.PotentialStubbingProblem;
+import org.mockito.exceptions.misusing.UnfinishedStubbingException;
+import org.mockito.exceptions.misusing.UnfinishedVerificationException;
+import org.mockito.exceptions.misusing.UnnecessaryStubbingException;
+import org.mockito.exceptions.misusing.WrongTypeOfReturnValue;
+import org.mockito.exceptions.verification.NeverWantedButInvoked;
+import org.mockito.exceptions.verification.NoInteractionsWanted;
+import org.mockito.exceptions.verification.SmartNullPointerException;
+import org.mockito.exceptions.verification.TooLittleActualInvocations;
+import org.mockito.exceptions.verification.TooManyActualInvocations;
+import org.mockito.exceptions.verification.VerificationInOrderFailure;
+import org.mockito.exceptions.verification.WantedButNotInvoked;
 import org.mockito.internal.debugging.LocationImpl;
 import org.mockito.internal.exceptions.util.ScenarioPrinter;
 import org.mockito.internal.junit.JUnitTool;
@@ -22,12 +44,6 @@ import org.mockito.invocation.Location;
 import org.mockito.listeners.InvocationListener;
 import org.mockito.mock.MockName;
 import org.mockito.mock.SerializableMode;
-
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 
 import static org.mockito.internal.reporting.Pluralizer.pluralize;
 import static org.mockito.internal.reporting.Pluralizer.were_exactly_x_interactions;
@@ -506,7 +522,7 @@ public class Reporter {
 
     public static MockitoException misplacedArgumentMatcher(List<LocalizedMatcher> lastMatchers) {
         return new InvalidUseOfMatchersException(join(
-                "Misplaced argument matcher detected here:",
+                "Misplaced or misused argument matcher detected here:",
                 locationsOf(lastMatchers),
                 "",
                 "You cannot use argument matchers outside of verification or stubbing.",
@@ -514,6 +530,12 @@ public class Reporter {
                 "    when(mock.get(anyInt())).thenReturn(null);",
                 "    doThrow(new RuntimeException()).when(mock).someVoidMethod(anyObject());",
                 "    verify(mock).someMethod(contains(\"foo\"))",
+                "",
+                "This message may appear after an NullPointerException if the last matcher is returning an object ",
+                "like any() but the stubbed method signature expect a primitive argument, in this case,",
+                "use primitive alternatives.",
+                "    when(mock.get(any())); // bad use, will raise NPE",
+                "    when(mock.get(anyInt())); // correct usage use",
                 "",
                 "Also, this error might show up because you use argument matchers with methods that cannot be mocked.",
                 "Following methods *cannot* be stubbed/verified: final/private/equals()/hashCode().",

--- a/src/test/java/org/mockitousage/bugs/MockitoRunnerBreaksWhenNoTestMethodsTest.java
+++ b/src/test/java/org/mockitousage/bugs/MockitoRunnerBreaksWhenNoTestMethodsTest.java
@@ -5,19 +5,20 @@
 
 package org.mockitousage.bugs;
 
+import java.io.OutputStream;
+import java.io.PrintStream;
 import org.junit.Test;
 import org.junit.internal.TextListener;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
 import org.junit.runner.RunWith;
+import org.mockito.exceptions.base.MockitoException;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockitoutil.TestBase;
 
-import java.io.OutputStream;
-import java.io.PrintStream;
-
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
 
 
 // @Ignore("for demo only. this test cannot be enabled as it fails :)")
@@ -32,6 +33,7 @@ public class MockitoRunnerBreaksWhenNoTestMethodsTest extends TestBase {
         Result result = runner.run(TestClassWithoutTestMethod.class);
 
         assertEquals(1, result.getFailureCount());
+        assertTrue(result.getFailures().get(0).getException() instanceof MockitoException);
         assertFalse(result.wasSuccessful());
     }
 

--- a/src/test/java/org/mockitousage/misuse/DetectingMisusedMatchersTest.java
+++ b/src/test/java/org/mockitousage/misuse/DetectingMisusedMatchersTest.java
@@ -4,6 +4,7 @@
  */
 package org.mockitousage.misuse;
 
+import java.util.Observer;
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -12,12 +13,15 @@ import org.mockito.exceptions.misusing.UnfinishedVerificationException;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import java.util.Observer;
-
 import static junit.framework.TestCase.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assume.assumeTrue;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyObject;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.validateMockitoUsage;
+import static org.mockito.Mockito.verify;
 
 public class DetectingMisusedMatchersTest extends TestBase {
 
@@ -53,7 +57,7 @@ public class DetectingMisusedMatchersTest extends TestBase {
             mock(IMethods.class);
             fail();
         } catch (InvalidUseOfMatchersException e) {
-            assertThat(e).hasMessageContaining("Misplaced argument matcher");
+            assertThat(e).hasMessageContaining("Misplaced or misused argument matcher");
         }
     }
     


### PR DESCRIPTION
This should help for cases like #822 

NPE can be raised by the JVM on the callsite of a matcher returning object like `any()`.
The thing is that the JVM does several thing like to allows a type to match a signature like `<T> T any()`, type inference with Java 8, cast and unboxing. However `any()` can only return `null` so the JVM raises an NPE on the cast opcode. Of course the problem isn't new but more possible due to Java 8 flexibility. That's why Mockito had for a long time the primitive.

When mockito is used with the junit runner or the junit rule there's a `InvalidUseOfMatchersException` raised **afer** the NPE with a message about misplaced matchers. This exception is raised because the matchers were not consumed by the mock since the NPE is raised first. So this exception is correct and can help the neophyte to discover the primitive variant like `anyInt()`.