### PR TITLE
Simplified ArgumentMatcherStorageImpl and logic matchers

### DIFF
--- a/src/main/java/org/mockito/internal/matchers/And.java
+++ b/src/main/java/org/mockito/internal/matchers/And.java
@@ -5,40 +5,25 @@
 
 package org.mockito.internal.matchers;
 
+import java.io.Serializable;
+
 import org.mockito.ArgumentMatcher;
 
-import java.io.Serializable;
-import java.util.Iterator;
-import java.util.List;
+@SuppressWarnings({ "unchecked", "serial","rawtypes" })
+public class And implements ArgumentMatcher<Object>, Serializable {
+    private ArgumentMatcher m1;
+    private ArgumentMatcher m2;
 
-@SuppressWarnings("unchecked")
-public class And implements ArgumentMatcher, Serializable {
-
-    private final List<ArgumentMatcher> matchers;
-
-    public And(List<ArgumentMatcher> matchers) {
-        this.matchers = matchers;
+    public And(ArgumentMatcher<?> m1, ArgumentMatcher<?> m2) {
+        this.m1 = m1;
+        this.m2 = m2;
     }
 
     public boolean matches(Object actual) {
-        for (ArgumentMatcher matcher : matchers) {
-            if (!matcher.matches(actual)) {
-                return false;
-            }
-        }
-        return true;
+        return m1.matches(actual) && m2.matches(actual);
     }
 
     public String toString() {
-        StringBuilder out = new StringBuilder();
-        out.append("and(");
-        for (Iterator<ArgumentMatcher> it = matchers.iterator(); it.hasNext();) {
-            out.append(it.next().toString());
-            if (it.hasNext()) {
-                out.append(", ");
-            }
-        }
-        out.append(")");
-        return out.toString();
+        return "and("+m1+", "+m2+")";
     }
 }

--- a/src/main/java/org/mockito/internal/matchers/Not.java
+++ b/src/main/java/org/mockito/internal/matchers/Not.java
@@ -9,20 +9,20 @@ import org.mockito.ArgumentMatcher;
 
 import java.io.Serializable;
 
-@SuppressWarnings("unchecked")
-public class Not implements ArgumentMatcher, Serializable {
+@SuppressWarnings({ "unchecked", "serial","rawtypes" })
+public class Not implements ArgumentMatcher<Object>, Serializable {
 
-    private final ArgumentMatcher first;
+    private final ArgumentMatcher matcher;
 
-    public Not(ArgumentMatcher first) {
-        this.first = first;
+    public Not(ArgumentMatcher<?> matcher) {
+        this.matcher = matcher;
     }
 
     public boolean matches(Object actual) {
-        return !first.matches(actual);
+        return !matcher.matches(actual);
     }
 
     public String toString() {
-        return "not(" + first.toString() + ")";
+        return "not(" + matcher + ")";
     }
 }

--- a/src/main/java/org/mockito/internal/matchers/Or.java
+++ b/src/main/java/org/mockito/internal/matchers/Or.java
@@ -5,39 +5,25 @@
 
 package org.mockito.internal.matchers;
 
+import java.io.Serializable;
+
 import org.mockito.ArgumentMatcher;
 
-import java.io.Serializable;
-import java.util.Iterator;
-import java.util.List;
+@SuppressWarnings({ "unchecked", "serial","rawtypes" })
+public class Or implements ArgumentMatcher<Object>, Serializable {
+    private final ArgumentMatcher m1;
+    private final ArgumentMatcher m2;
 
-@SuppressWarnings("unchecked")
-public class Or implements ArgumentMatcher, Serializable {
-
-    private final List<ArgumentMatcher> matchers;
-
-    public Or(List<ArgumentMatcher> matchers) {
-        this.matchers = matchers;
+    public Or(ArgumentMatcher<?> m1, ArgumentMatcher<?> m2) {
+        this.m1 = m1;
+        this.m2 = m2;
     }
 
     public boolean matches(Object actual) {
-        for (ArgumentMatcher matcher : matchers) {
-            if (matcher.matches(actual)) {
-                return true;
-            }
-        }
-        return false;
+        return m1.matches(actual) || m2.matches(actual);
     }
 
     public String toString() {
-        //TODO SF here and in other places we should reuse ValuePrinter
-        StringBuilder sb = new StringBuilder("or(");
-        for (Iterator<ArgumentMatcher> it = matchers.iterator(); it.hasNext();) {
-            sb.append(it.next().toString());
-            if (it.hasNext()) {
-                sb.append(", ");
-            }
-        }
-        return sb.append(")").toString();
+        return "or("+m1+", "+m2+")";
     }
 }

--- a/src/test/java/org/mockito/internal/matchers/MatchersToStringTest.java
+++ b/src/test/java/org/mockito/internal/matchers/MatchersToStringTest.java
@@ -9,12 +9,8 @@ import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockitoutil.TestBase;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static junit.framework.TestCase.assertEquals;
 
-@SuppressWarnings("unchecked")
 public class MatchersToStringTest extends TestBase {
 
     @Test
@@ -77,10 +73,9 @@ public class MatchersToStringTest extends TestBase {
 
     @Test
     public void orToString() {
-        List<ArgumentMatcher> matchers = new ArrayList<ArgumentMatcher>();
-        matchers.add(new Equals(1));
-        matchers.add(new Equals(2));
-        assertEquals("or(1, 2)", new Or(matchers).toString());
+        ArgumentMatcher<?> m1=new Equals(1);
+        ArgumentMatcher<?> m2=new Equals(2);
+        assertEquals("or(1, 2)", new Or(m1,m2).toString());
     }
 
     @Test
@@ -90,10 +85,9 @@ public class MatchersToStringTest extends TestBase {
 
     @Test
     public void andToString() {
-        List<ArgumentMatcher> matchers = new ArrayList<ArgumentMatcher>();
-        matchers.add(new Equals(1));
-        matchers.add(new Equals(2));
-        assertEquals("and(1, 2)", new And(matchers).toString());
+        ArgumentMatcher<?> m1=new Equals(1);
+        ArgumentMatcher<?> m2=new Equals(2);
+        assertEquals("and(1, 2)", new And(m1,m2).toString());
     }
 
     @Test


### PR DESCRIPTION
Simplified the classes `ArgumentMatcherStorageImpl`, `And`, `Or`and `Not `by removing code duplications and unnecessary logic, saving 50 lines of code.