### PR TITLE
Release automation fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.2' //publishing to bintray
         classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.11.0' // later versions don't work on JDK6
 
         //Needed so that release notes and release workflow plugin can be applied in separate gradle/*.gradle build files
@@ -15,6 +14,7 @@ buildscript {
 
 plugins {
     id 'com.gradle.build-scan' version '1.0'
+    id "com.jfrog.bintray" version "1.7.3"
 }
 
 description = 'Mockito mock objects library core API and implementation'
@@ -22,7 +22,7 @@ description = 'Mockito mock objects library core API and implementation'
 ext {
     artifactName = 'mockito-core'
     bintrayAutoPublish = false
-    bintrayRepo = 'maven'
+    bintrayRepo = 'test'
     mavenCentralSync = true
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
     }
 
     dependencies {
+        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3" //for publications to Bintray / central
         classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.11.0' // later versions don't work on JDK6
 
         //Needed so that release notes and release workflow plugin can be applied in separate gradle/*.gradle build files
@@ -14,7 +15,6 @@ buildscript {
 
 plugins {
     id 'com.gradle.build-scan' version '1.0'
-    id "com.jfrog.bintray" version "1.7.3"
 }
 
 description = 'Mockito mock objects library core API and implementation'

--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,8 @@ description = 'Mockito mock objects library core API and implementation'
 ext {
     artifactName = 'mockito-core'
     bintrayAutoPublish = false
-    bintrayRepo = 'test'
-    mavenCentralSync = true
+    bintrayRepo = 'maven'
+    mavenCentralSync = false
 }
 
 allprojects {

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -13,8 +13,9 @@ bintray {
     user = 'szczepiq'
     key = System.env.MOCKITO_BINTRAY_API_KEY
 
+    //using 'projectsEvaluated' sledge hammer
+    // workaround for bintray plugin/Gradle bug (https://github.com/bintray/gradle-bintray-plugin/issues/159)
     gradle.projectsEvaluated {
-        //workaround for Bintray bug (https://github.com/bintray/gradle-bintray-plugin/issues/159)
         publications = project.publishing.publications*.name
     }
 

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -13,7 +13,10 @@ bintray {
     user = 'szczepiq'
     key = System.env.MOCKITO_BINTRAY_API_KEY
 
-    publications = project.publishing.publications*.name
+    gradle.projectsEvaluated {
+        //workaround for Bintray bug (https://github.com/bintray/gradle-bintray-plugin/issues/159)
+        publications = project.publishing.publications*.name
+    }
 
     publish = project.ext.bintrayAutoPublish
 

--- a/gradle/root/release.gradle
+++ b/gradle/root/release.gradle
@@ -68,6 +68,12 @@ def isReleasableBranch(String branch) {
     branch?.matches("master|release/.+")
 }
 
+def isPullRequest() {
+    //returns true only if pull request env variable points to PR number
+    def envVar = System.env.TRAVIS_PULL_REQUEST
+    envVar != null && envVar != '' && envVar != 'false'
+}
+
 configurations {
     previousSrc
     previousPom
@@ -93,10 +99,10 @@ task("comparePublications", type: PublicationsComparatorTask) {
 Release process should *not* run concurrently.
  */
 task("releaseNeeded") {
+    ext.needed = true
     dependsOn comparePublications
     doLast {
         def branch = System.env.TRAVIS_BRANCH
-        def pr = System.env.TRAVIS_PULL_REQUEST
         def skipEnvVariable = System.env.SKIP_RELEASE
         def commitMessage = System.env.TRAVIS_COMMIT_MESSAGE
         def skippedByCommitMessage = commitMessage?.contains(skipReleaseCommitMessage)
@@ -107,7 +113,7 @@ task("releaseNeeded") {
         } else if (releaseTest) {
             logger.lifecycle("Release will be initiated for testing purposes")
             ext.needed = true //testing purposes, dry run
-        } else if (pr == 'false' && isReleasableBranch(branch) && !comparePublications.publicationsEqual) {
+        } else if (!isPullRequest() && isReleasableBranch(branch) && !comparePublications.publicationsEqual) {
             logger.lifecycle("All criteria are met, the release will be initiated")
             ext.needed = true //standard, continuous delivery scenario
         } else {
@@ -116,7 +122,7 @@ task("releaseNeeded") {
         }
 
         logger.lifecycle("Release need evaluation - needed: ${ext.needed}, " +
-                "releasable branch: ${isReleasableBranch(branch)}, pull request: $pr, dry run / test release: $releaseTest, " +
+                "releasable branch: ${isReleasableBranch(branch)}, pull request: ${isPullRequest()}, dry run / test release: $releaseTest, " +
                 "publications equal: $comparePublications.publicationsEqual, " +
                 "skip env variable: $skipEnvVariable, skipped by message: $skippedByCommitMessage")
     }
@@ -145,8 +151,9 @@ allprojects {
         doFirst {
             it.dryRun = releaseTest
             if (it.dryRun) {
-                logger.lifecycle "Dry-running the release! Although $path is executed, it won't upload any binaries ('bintrayUpload.dryRun' property is set)."
+                logger.lifecycle "$it.path - dry-running the release! Although $path is executed, it won't upload any binaries ('bintrayUpload.dryRun' property is set)."
             }
+            logger.lifecycle "$it.path - now publishing $project.archivesBaseName:$project.version to '$project.bintray.pkg.repo' Bintray repository (dryRun=$it.dryRun)."
         }
     }
 }

--- a/gradle/root/release.gradle
+++ b/gradle/root/release.gradle
@@ -153,7 +153,8 @@ allprojects {
             if (it.dryRun) {
                 logger.lifecycle "$it.path - dry-running the release! Although $path is executed, it won't upload any binaries ('bintrayUpload.dryRun' property is set)."
             }
-            logger.lifecycle "$it.path - now publishing $project.archivesBaseName:$project.version to '$project.bintray.pkg.repo' Bintray repository (dryRun=$it.dryRun)."
+            logger.lifecycle "$it.path - now publishing $project.archivesBaseName:$project.version" +
+                    " to '$project.bintray.pkg.repo' Bintray repository (dryRun=$it.dryRun, autoPublish=$project.bintray.publish)."
         }
     }
 }


### PR DESCRIPTION
- made the release easier to test (slightly ;)
- stopped pushing mockito-core to maven central automatically (until we stabilize the automation after changing it to support multi-module releases)
- bumped bintray plugin