### PR TITLE
Publication fixes - workaround for Bintray plugin/Gradle bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ description = 'Mockito mock objects library core API and implementation'
 
 ext {
     artifactName = 'mockito-core'
-    bintrayAutoPublish = false
+    bintrayAutoPublish = true
     bintrayRepo = 'maven'
     mavenCentralSync = false
 }

--- a/doc/release-notes/official.md
+++ b/doc/release-notes/official.md
@@ -1,9 +1,3 @@
-### 2.3.8 (2016-12-19 00:45 UTC)
-
-* Authors: 0
-* Commits: 0
-* No notable improvements. See the commits for detailed changes.
-
 ### 2.3.7 (2016-12-18 04:31 UTC)
 
 * Authors: 1

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -13,9 +13,8 @@ bintray {
     user = 'szczepiq'
     key = System.env.MOCKITO_BINTRAY_API_KEY
 
-    //using 'projectsEvaluated' sledge hammer
-    // workaround for bintray plugin/Gradle bug (https://github.com/bintray/gradle-bintray-plugin/issues/159)
-    gradle.projectsEvaluated {
+    //Workaround for bintray plugin/Gradle bug (https://github.com/bintray/gradle-bintray-plugin/issues/159)
+    if (!('tasks' in gradle.startParameter.taskNames)) {
         publications = project.publishing.publications*.name
     }
 


### PR DESCRIPTION
The previous workaround did not quite work.

 - mockito-core publishes automatically, does not sync to central automatically (disabled temporarily)
 - mockito-android (empty jar) publishes automatically to Bintray 'test' repo
