### PR TITLE
Main jar automatically publishes to central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     artifactName = 'mockito-core'
     bintrayAutoPublish = true
     bintrayRepo = 'maven'
-    mavenCentralSync = false
+    mavenCentralSync = true
 }
 
 allprojects {


### PR DESCRIPTION
2.3.10 was correctly published, we're ready to pull the trigger and make mockito-core autopublish again. This change will not trigger publication because it does not change the mockito jar/pom in any way. However, the next version (2.3.11) will go automatically to central (only mockito-core, mockito-android will be pushed to 'test' repo in Bintray).
