### PR TITLE
Disabled maven central sync

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     artifactName = 'mockito-core'
     bintrayAutoPublish = true
     bintrayRepo = 'maven'
-    mavenCentralSync = true
+    mavenCentralSync = false
 }
 
 allprojects {


### PR DESCRIPTION
I need to investigate:
 - release of 2.3.7 to central
 - errors logging in to oss.sonatype and syncing from Bintray

I suspect that maven central sync does not work at the moment, anyway due to login / credentials problem.

