### PR TITLE
Fixes #838 : Adds a matches(Pattern)

### DIFF
--- a/src/main/java/org/mockito/ArgumentMatchers.java
+++ b/src/main/java/org/mockito/ArgumentMatchers.java
@@ -4,8 +4,6 @@
  */
 package org.mockito;
 
-import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
-import static org.mockito.internal.util.Primitives.defaultValue;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -13,6 +11,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import org.mockito.internal.matchers.Any;
 import org.mockito.internal.matchers.Contains;
 import org.mockito.internal.matchers.EndsWith;
@@ -25,6 +24,9 @@ import org.mockito.internal.matchers.Same;
 import org.mockito.internal.matchers.StartsWith;
 import org.mockito.internal.matchers.apachecommons.ReflectionEquals;
 import org.mockito.internal.util.Primitives;
+
+import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
+import static org.mockito.internal.util.Primitives.defaultValue;
 
 /**
  * Allow flexible verification or stubbing. See also {@link AdditionalMatchers}.
@@ -91,6 +93,12 @@ import org.mockito.internal.util.Primitives;
  * Internally, they record a matcher on a stack and return a dummy value (usually null).
  * This implementation is due static type safety imposed by java compiler.
  * The consequence is that you cannot use <code>anyObject()</code>, <code>eq()</code> methods outside of verified/stubbed method.
+ * </p>
+ *
+ * <h1>Additional matchers</h1>
+ * <p>
+ * The class {@link AdditionalMatchers} offers rarely used matchers, although they can be useful, when
+ * it is useful to combine multiple matchers or when it is useful to negate a matcher necessary.
  * </p>
  *
  * <h1>Custom Argument ArgumentMatchers</h1>
@@ -1104,9 +1112,26 @@ public class ArgumentMatchers {
      *
      * @param regex the regular expression.
      * @return empty String ("").
+     *
+     * @see AdditionalMatchers#not(boolean)
      */
     public static String matches(String regex) {
         reportMatcher(new Matches(regex));
+        return "";
+    }
+
+    /**
+     * <code>Pattern</code> argument that matches the given regular expression.
+     * <p>
+     * See examples in javadoc for {@link ArgumentMatchers} class
+     *
+     * @param pattern the regular expression pattern.
+     * @return empty String ("").
+     *
+     * @see AdditionalMatchers#not(boolean)
+     */
+    public static String matches(Pattern pattern) {
+        reportMatcher(new Matches(pattern));
         return "";
     }
 

--- a/src/main/java/org/mockito/internal/matchers/Matches.java
+++ b/src/main/java/org/mockito/internal/matchers/Matches.java
@@ -5,23 +5,27 @@
 
 package org.mockito.internal.matchers;
 
-import org.mockito.ArgumentMatcher;
-
 import java.io.Serializable;
+import java.util.regex.Pattern;
+import org.mockito.ArgumentMatcher;
 
 public class Matches implements ArgumentMatcher<Object>, Serializable {
 
-    private final String regex;
+    private final Pattern pattern;
 
     public Matches(String regex) {
-        this.regex = regex;
+        this(Pattern.compile(regex));
+    }
+
+    public Matches(Pattern pattern) {
+        this.pattern = pattern;
     }
 
     public boolean matches(Object actual) {
-        return (actual instanceof String) && ((String) actual).matches(regex);
+        return (actual instanceof String) && pattern.matcher((String) actual).matches();
     }
 
     public String toString() {
-        return "matches(\"" + regex.replaceAll("\\\\", "\\\\\\\\") + "\")";
+        return "matches(\"" + pattern.pattern().replaceAll("\\\\", "\\\\\\\\") + "\")";
     }
 }

--- a/src/test/java/org/mockito/internal/matchers/MatchersToStringTest.java
+++ b/src/test/java/org/mockito/internal/matchers/MatchersToStringTest.java
@@ -5,6 +5,7 @@
 
 package org.mockito.internal.matchers;
 
+import java.util.regex.Pattern;
 import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockitoutil.TestBase;
@@ -113,6 +114,7 @@ public class MatchersToStringTest extends TestBase {
     @Test
     public void matchesToString() {
         assertEquals("matches(\"\\\\s+\")", new Matches("\\s+").toString());
+        assertEquals("matches(\"\\\\s+\")", new Matches(Pattern.compile("\\s+")).toString());
     }
 
 }

--- a/src/test/java/org/mockitousage/matchers/MatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/MatchersTest.java
@@ -5,6 +5,22 @@
 
 package org.mockitousage.matchers;
 
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.RandomAccess;
+import java.util.regex.Pattern;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.exceptions.verification.WantedButNotInvoked;
+import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
+import org.mockitousage.IMethods;
+import org.mockitoutil.TestBase;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotSame;
+import static junit.framework.TestCase.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.AdditionalMatchers.and;
 import static org.mockito.AdditionalMatchers.aryEq;
@@ -43,20 +59,6 @@ import static org.mockito.Mockito.startsWith;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNotSame;
-import static junit.framework.TestCase.fail;
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.RandomAccess;
-import org.junit.Test;
-import org.mockito.Mockito;
-import org.mockito.exceptions.verification.WantedButNotInvoked;
-import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
-import org.mockitousage.IMethods;
-import org.mockitoutil.TestBase;
 
 
 @SuppressWarnings("unchecked")
@@ -493,6 +495,16 @@ public class MatchersTest extends TestBase {
     public void matches_matcher() {
         when(mock.oneArg(matches("[a-z]+\\d\\d"))).thenReturn("1");
         when(mock.oneArg(matches("\\d\\d\\d"))).thenReturn("2");
+
+        assertEquals("1", mock.oneArg("a12"));
+        assertEquals("2", mock.oneArg("131"));
+        assertEquals(null, mock.oneArg("blah"));
+    }
+
+    @Test
+    public void matches_Pattern_matcher() {
+        when(mock.oneArg(matches(Pattern.compile("[a-z]+\\d\\d")))).thenReturn("1");
+        when(mock.oneArg(matches(Pattern.compile("\\d\\d\\d")))).thenReturn("2");
 
         assertEquals("1", mock.oneArg("a12"));
         assertEquals("2", mock.oneArg("131"));


### PR DESCRIPTION
Following discussion in #838 it is sensible to add a mockito matcher that can take a `Pattern` as an argument.

The usage is the same as `matches(String)`.

```java
when(mock.oneArg(matches(Pattern.compile("[a-z]+\\d\\d")))).thenReturn(...);
```

Although it allows to build more complex regex, especially with regular expression flags.