### PR TITLE
Automatically publish main jar to central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     artifactName = 'mockito-core'
     bintrayAutoPublish = true
     bintrayRepo = 'maven'
-    mavenCentralSync = false
+    mavenCentralSync = true
 }
 
 allprojects {


### PR DESCRIPTION
I'm tired of doing it manually from the Bintray web interface.

Note that this does not make mockito-android published automatically.