### PR TITLE
Fix #845

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,12 @@ apply from: 'gradle/mockito-core/javadoc.gradle'
 apply from: 'gradle/mockito-core/license.gradle'
 apply from: 'gradle/mockito-core/testing.gradle'
 
+classes.doLast {
+    java.nio.file.Files.move(
+        file("${buildDir}/classes/main/org/mockito/internal/creation/bytebuddy/MockMethodDispatcher.class").toPath(),
+        file("${buildDir}/classes/main/org/mockito/internal/creation/bytebuddy/MockMethodDispatcher.raw").toPath())
+}
+
 task wrapper(type: Wrapper) {
     gradleVersion = '2.14.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -75,9 +75,8 @@ apply from: 'gradle/mockito-core/license.gradle'
 apply from: 'gradle/mockito-core/testing.gradle'
 
 classes.doLast {
-    java.nio.file.Files.move(
-        file("${buildDir}/classes/main/org/mockito/internal/creation/bytebuddy/MockMethodDispatcher.class").toPath(),
-        file("${buildDir}/classes/main/org/mockito/internal/creation/bytebuddy/MockMethodDispatcher.raw").toPath())
+    file("${buildDir}/classes/main/org/mockito/internal/creation/bytebuddy/MockMethodDispatcher.class")
+        .renameTo(file("${buildDir}/classes/main/org/mockito/internal/creation/bytebuddy/MockMethodDispatcher.raw"))
 }
 
 task wrapper(type: Wrapper) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Aug 19 18:41:31 PDT 2016
+#Mon Dec 26 11:22:31 BRST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 26 11:22:31 BRST 2016
+#Fri Aug 19 18:41:31 PDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip


### PR DESCRIPTION
This change renames `org/mockito/internal/creation/bytebuddy/MockMethodDispatcher.class` to `org/mockito/internal/creation/bytebuddy/MockMethodDispatcher.raw` after compilation of the root project, more precisely, after the `classes` task is done executing.