### PR TITLE
Copies compiled MockMethodDispatcher class and excludes the original file from the jar distribution.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,17 +67,13 @@ apply from: "gradle/publishable-java-library.gradle"
 apply from: 'gradle/root/ide.gradle'
 apply from: 'gradle/root/coverage.gradle'
 apply from: 'gradle/root/gradle-fix.gradle'
+apply from: 'gradle/root/classpath-fix.gradle'
 apply from: 'gradle/root/release.gradle'
 
 apply from: 'gradle/mockito-core/osgi.gradle'
 apply from: 'gradle/mockito-core/javadoc.gradle'
 apply from: 'gradle/mockito-core/license.gradle'
 apply from: 'gradle/mockito-core/testing.gradle'
-
-classes.doLast {
-    file("${buildDir}/classes/main/org/mockito/internal/creation/bytebuddy/MockMethodDispatcher.class")
-        .renameTo(file("${buildDir}/classes/main/org/mockito/internal/creation/bytebuddy/MockMethodDispatcher.raw"))
-}
 
 task wrapper(type: Wrapper) {
     gradleVersion = '2.14.1'

--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,12 @@ apply from: 'gradle/mockito-core/javadoc.gradle'
 apply from: 'gradle/mockito-core/license.gradle'
 apply from: 'gradle/mockito-core/testing.gradle'
 
+classes.doLast {
+    java.nio.file.Files.move(
+        file("${buildDir}/classes/main/org/mockito/internal/creation/bytebuddy/MockMethodDispatcher.class").toPath(),
+        file("${buildDir}/classes/main/org/mockito/internal/creation/bytebuddy/MockMethodDispatcher.raw").toPath())
+}
+
 task wrapper(type: Wrapper) {
     gradleVersion = '2.14.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -75,9 +75,8 @@ apply from: 'gradle/mockito-core/license.gradle'
 apply from: 'gradle/mockito-core/testing.gradle'
 
 classes.doLast {
-    java.nio.file.Files.move(
-        file("${buildDir}/classes/main/org/mockito/internal/creation/bytebuddy/MockMethodDispatcher.class").toPath(),
-        file("${buildDir}/classes/main/org/mockito/internal/creation/bytebuddy/MockMethodDispatcher.raw").toPath())
+    file("${buildDir}/classes/main/org/mockito/internal/creation/bytebuddy/MockMethodDispatcher.class")
+        .renameTo(file("${buildDir}/classes/main/org/mockito/internal/creation/bytebuddy/MockMethodDispatcher.raw"))
 }
 
 task wrapper(type: Wrapper) {

--- a/gradle/root/classpath-fix.gradle
+++ b/gradle/root/classpath-fix.gradle
@@ -1,0 +1,13 @@
+task copyMockMethodDispatcher(type: Copy) {
+  from "${buildDir}/classes/main/org/mockito/internal/creation/bytebuddy"
+  into "${buildDir}/classes/main/org/mockito/internal/creation/bytebuddy"
+  include "MockMethodDispatcher.class"
+  rename { String fileName ->
+    fileName.replace('.class', '.raw')
+  }
+}
+classes.dependsOn(copyMockMethodDispatcher)
+
+jar {
+  exclude("org/mockito/internal/creation/bytebuddy/MockMethodDispatcher.class")
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Aug 19 18:41:31 PDT 2016
+#Mon Dec 26 11:22:31 BRST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 26 11:22:31 BRST 2016
+#Fri Aug 19 18:41:31 PDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip


### PR DESCRIPTION
Copies the `MockMethodDispatcher.class` to `MockMethodDispatcher.raw` without deleting the former so IDEs can still recognize the compiled file, and excludes it from the final JAR distribution.