### PR TITLE
Stopped publishing java source inside main jar

### DIFF
--- a/gradle/publishable-java-library.gradle
+++ b/gradle/publishable-java-library.gradle
@@ -13,11 +13,8 @@ def licenseFiles = copySpec {
     from(".") { include 'LICENSE' }
 }
 
-//TODO why do we still ship the main jar with sources?
 jar {
-    from(sourceSets.main.allSource)
     with licenseFiles
-
 }
 
 task sourcesJar(type: Jar) {

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-version=2.4.6
+version=2.5.0
 mockito.testng.version=1.0


### PR DESCRIPTION
This feature does not make sense in modern world of declarative dependency management:
 - we didn't hear from the community that keeping the sources inside jar is useful
 - modern IDEs and dependency management automatically pulls sources
 - the feature was originally needed (2008) to help users that check in jars into VCS and do not use modern dependency management
 - keeping source code in main jar is very unusual and makes the jar bigger

Bumped minor version because the change is relatively visible