### PR TITLE
Update Byte Buddy to support recent Java 9 builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,8 @@ apply from: 'gradle/root/version.gradle'
 apply from: "gradle/java-library.gradle"
 
 dependencies {
-    compile 'net.bytebuddy:byte-buddy:1.5.5'
-    compile 'net.bytebuddy:byte-buddy-agent:1.5.5'
+    compile 'net.bytebuddy:byte-buddy:1.5.12'
+    compile 'net.bytebuddy:byte-buddy-agent:1.5.12'
 
     provided "junit:junit:4.12", "org.hamcrest:hamcrest-core:1.3"
     compile "org.objenesis:objenesis:2.4"

--- a/subprojects/android/android.gradle
+++ b/subprojects/android/android.gradle
@@ -12,7 +12,7 @@ apply from: "$rootDir/gradle/publishable-java-library.gradle"
 
 dependencies {
     compile project.rootProject
-    compile "net.bytebuddy:byte-buddy-android:1.5.5"
+    compile "net.bytebuddy:byte-buddy-android:1.5.12"
 }
 
 tasks.javadoc.enabled = false


### PR DESCRIPTION
The most recent version of Byte Buddy falls back on `sun.misc.Unsafe` if accessible reflection is forbidden what is required for injecting classes into class loaders. As we already rely on unsafe for invocation of instances without calling a constructor, this is no further limitation to the applicability of Mockito.