### PR TITLE
Mockito JUnit Runner supports strict stubbing

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -1291,9 +1291,10 @@ import org.mockito.verification.VerificationWithTimeout;
  *
  * To quickly find out how "stricter" Mockito can make you more productive and get your tests cleaner, see:
  * <ul>
- *     <li>New "strict stubs" behavior of JUnit rules - {@link MockitoRule#strictness(Strictness)} with {@link Strictness#STRICT_STUBS}</li>
- *     <li>Unnecessary stubbing detection in {@link MockitoJUnitRunner}</li>
- *     <li>Stubbing argument mismatch reporting by JUnit rules, documented in {@link org.mockito.quality.MockitoHint}</li>
+ *     <li>Strict stubbing with JUnit Rules - {@link MockitoRule#strictness(Strictness)} with {@link Strictness#STRICT_STUBS}</li>
+ *     <li>Strict stubbing with JUnit Runner - {@link org.mockito.junit.MockitoJUnitRunner.StrictStubs}</li>
+ *     <li>Unnecessary stubbing detection with {@link MockitoJUnitRunner}</li>
+ *     <li>Stubbing argument mismatch warnings by JUnit rules, documented in {@link org.mockito.quality.MockitoHint}</li>
  * </ul>
  *
  * Mockito is a "loose" mocking framework by default.

--- a/src/main/java/org/mockito/exceptions/misusing/PotentialStubbingProblem.java
+++ b/src/main/java/org/mockito/exceptions/misusing/PotentialStubbingProblem.java
@@ -10,11 +10,14 @@ import org.mockito.exceptions.base.MockitoException;
 import org.mockito.junit.MockitoRule;
 
 /**
- * Strict stubbing is a new feature introduced in Mockito 2.3.x for JUnit Rules ({@link MockitoRule#strictness(Strictness)})
- * and in 2.5.x for JUnit Runner ({@link org.mockito.junit.MockitoJUnitRunner.StrictStubs}).
+ * Strict stubbing is a new opt-in feature for JUnit Rule ({@link MockitoRule#strictness(Strictness)})
+ * and JUnit Runner ({@link org.mockito.junit.MockitoJUnitRunner.StrictStubs}).
  * Detecting potential stubbing problems is intended to help writing and debugging tests.
  * The {@code org.mockito.exceptions.misusing.PotentialStubbingProblem} exception is thrown
- * when a mock method is stubbed with argument X in test but then invoked with argument Y in code.
+ * when mocked method is stubbed with some argument in test
+ * but then invoked with <strong>different</strong> argument in code.
+ * This scenario is called "stubbing argument mismatch".
+ * <p>
  * Example:
  * <pre class="code"><code class="java">
  * //test method:
@@ -23,7 +26,7 @@ import org.mockito.junit.MockitoRule;
  * //code under test:
  * Something something = mock.getSomething(50); // <-- stubbing argument mismatch
  * </code></pre>
- * The stubbing argument mismatch typically happens in following use cases:
+ * The stubbing argument mismatch is triggered in following use cases:
  * <ol>
  *     <li>Mistake or typo in the test code, the argument(s) used when declaring stubbings is unintentionally different</li>
  *     <li>Mistake or typo in the code under test, the argument(s) used in the code under test is unintentionally different</li>
@@ -38,11 +41,11 @@ import org.mockito.junit.MockitoRule;
  *  <li>Do you see this exception because you're stubbing the same method multiple times in the test?
  *  In that case, please use {@link org.mockito.BDDMockito#willReturn(Object)} or {@link Mockito#doReturn(Object)}
  *  family of methods for stubbing.
- *  Good looking stubbing via {@link Mockito#when(Object)} has its drawbacks: the framework cannot distinguish between
- *  actual invocation on mock and the stubbing attempt in the test.
+ *  Convenient stubbing via {@link Mockito#when(Object)} has its drawbacks: the framework cannot distinguish between
+ *  actual invocation on mock (real code) and the stubbing declaration (test code).
  *  Hence the need to use {@link org.mockito.BDDMockito#willReturn(Object)} or {@link Mockito#doReturn(Object)} for certain edge cases.
  *  </li>
- *  <li>Reduce the strictness level in the test method:
+ *  <li>Reduce the strictness level in the test method (only for JUnit Rules):
  * <pre class="code"><code class="java">
  * public class ExampleTest {
  *     &#064;Rule
@@ -57,8 +60,9 @@ import org.mockito.junit.MockitoRule;
  * }
  * </code></pre>
  *  </li>
- *  <li>In Mockito 2.x, simply don't use {@link MockitoRule#strictness(Strictness)} with {@link Strictness#STRICT_STUBS} for that test.
- * You will lose stubbing strictness but at least you can complete the test.</li>
+ *  <li>In Mockito 2.x, don't use {@link MockitoRule#strictness(Strictness)} with {@link Strictness#STRICT_STUBS} for that test.
+ *  If you use JUnit Runner, don't use {@link org.mockito.junit.MockitoJUnitRunner.StrictStubs} for that test.
+ * Strict stubbing will be unavailable for that test class.</li>
  * </ol>
  * <p>
  * We are very eager to hear feedback about "strict stubbing" feature, let us know by commenting on GitHub

--- a/src/main/java/org/mockito/exceptions/misusing/PotentialStubbingProblem.java
+++ b/src/main/java/org/mockito/exceptions/misusing/PotentialStubbingProblem.java
@@ -10,9 +10,11 @@ import org.mockito.exceptions.base.MockitoException;
 import org.mockito.junit.MockitoRule;
 
 /**
- * Strict stubbing is a new feature introduced in Mockito 2.3.
+ * Strict stubbing is a new feature introduced in Mockito 2.3.x for JUnit Rules ({@link MockitoRule#strictness(Strictness)})
+ * and in 2.5.x for JUnit Runner ({@link org.mockito.junit.MockitoJUnitRunner.StrictStubs}).
  * Detecting potential stubbing problems is intended to help writing and debugging tests.
- * The {@code org.mockito.exceptions.misusing.PotentialStubbingProblem} exception is thrown when a mock method is stubbed with argument X in test but then invoked with argument Y in code.
+ * The {@code org.mockito.exceptions.misusing.PotentialStubbingProblem} exception is thrown
+ * when a mock method is stubbed with argument X in test but then invoked with argument Y in code.
  * Example:
  * <pre class="code"><code class="java">
  * //test method:

--- a/src/main/java/org/mockito/internal/exceptions/Reporter.java
+++ b/src/main/java/org/mockito/internal/exceptions/Reporter.java
@@ -878,23 +878,23 @@ public class Reporter {
         StringBuilder stubbings = new StringBuilder();
         int count = 1;
         for (Invocation s : argMismatchStubbings) {
-            stubbings.append("  ").append(count++).append(". ").append(s);
-            stubbings.append("\n    ").append(s.getLocation()).append("\n");
+            stubbings.append("    ").append(count++).append(". ").append(s);
+            stubbings.append("\n      ").append(s.getLocation()).append("\n");
         }
         stubbings.deleteCharAt(stubbings.length()-1); //remove trailing end of line
 
         throw new PotentialStubbingProblem(join(
-                "Strict JUnit rule detected stubbing argument mismatch.",
-                "This invocation of '" + actualInvocation.getMethod().getName() + "' method:",
-                "  " + actualInvocation,
-                "  " + actualInvocation.getLocation(),
-                "Has following stubbing(s) with different arguments:",
+                "Strict stubbing argument mismatch. Please check:",
+                " - this invocation of '" + actualInvocation.getMethod().getName() + "' method:",
+                "    " + actualInvocation,
+                "    " + actualInvocation.getLocation(),
+                " - has following stubbing(s) with different arguments:",
                 stubbings,
                 "Typically, stubbing argument mismatch indicates user mistake when writing tests.",
-                "In order to streamline debugging tests Mockito fails early in this scenario.",
+                "Mockito fails early so that you can debug potential problem easily.",
                 "However, there are legit scenarios when this exception generates false negative signal:",
                 "  - stubbing the same method multiple times using 'given().will()' or 'when().then()' API",
-                "    Please use 'will().given()' or 'doReturn().when()' API for stubbing",
+                "    Please use 'will().given()' or 'doReturn().when()' API for stubbing.",
                 "  - stubbed method is intentionally invoked with different arguments by code under test",
                 "    Please use 'default' or 'silent' JUnit Rule.",
                 "For more information see javadoc for PotentialStubbingProblem class."));

--- a/src/main/java/org/mockito/internal/junit/StrictStubsRunnerTestListener.java
+++ b/src/main/java/org/mockito/internal/junit/StrictStubsRunnerTestListener.java
@@ -1,0 +1,25 @@
+package org.mockito.internal.junit;
+
+import org.mockito.internal.creation.settings.CreationSettings;
+import org.mockito.mock.MockCreationSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * Fails early when mismatched arguments used for stubbing
+ */
+public class StrictStubsRunnerTestListener implements MockitoTestListener {
+
+    private final DefaultStubbingLookupListener stubbingLookupListener = new DefaultStubbingLookupListener(Strictness.STRICT_STUBS);
+
+    @Override
+    public void testFinished(TestFinishedEvent event) {}
+
+    @Override
+    public void onMockCreated(Object mock, MockCreationSettings settings) {
+        //It is not ideal that we modify the state of MockCreationSettings object
+        //MockCreationSettings is intended to be an immutable view of the creation settings
+        //In future, we should start passing MockSettings object to the creation listener
+        //TODO #793 - when completed, we should be able to get rid of the CreationSettings casting below
+        ((CreationSettings) settings).getStubbingLookupListeners().add(stubbingLookupListener);
+    }
+}

--- a/src/main/java/org/mockito/internal/runners/RunnerFactory.java
+++ b/src/main/java/org/mockito/internal/runners/RunnerFactory.java
@@ -8,6 +8,7 @@ import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.junit.MismatchReportingTestListener;
 import org.mockito.internal.junit.MockitoTestListener;
 import org.mockito.internal.junit.NoOpTestListener;
+import org.mockito.internal.junit.StrictStubsRunnerTestListener;
 import org.mockito.internal.runners.util.RunnerProvider;
 import org.mockito.internal.util.ConsoleMockitoLogger;
 import org.mockito.internal.util.Supplier;
@@ -39,6 +40,19 @@ public class RunnerFactory {
         return create(klass, new Supplier<MockitoTestListener>() {
             public MockitoTestListener get() {
                 return new MismatchReportingTestListener(new ConsoleMockitoLogger());
+            }
+        });
+    }
+
+    /**
+     * Creates strict stubs runner implementation
+     *
+     * TODO, let's try to apply Brice suggestion and use switch + Strictness
+     */
+    public InternalRunner createStrictStubs(Class<?> klass) throws InvocationTargetException {
+        return create(klass, new Supplier<MockitoTestListener>() {
+            public MockitoTestListener get() {
+                return new StrictStubsRunnerTestListener();
             }
         });
     }

--- a/src/main/java/org/mockito/junit/MockitoJUnitRunner.java
+++ b/src/main/java/org/mockito/junit/MockitoJUnitRunner.java
@@ -93,6 +93,8 @@ public class MockitoJUnitRunner extends Runner implements Filterable {
 
     /**
      * TODO document
+     *
+     * @since 2.5.0
      */
     public static class StrictStubs extends MockitoJUnitRunner {
         public StrictStubs(Class<?> klass) throws InvocationTargetException {

--- a/src/main/java/org/mockito/junit/MockitoJUnitRunner.java
+++ b/src/main/java/org/mockito/junit/MockitoJUnitRunner.java
@@ -20,7 +20,10 @@ import org.mockito.internal.runners.StrictRunner;
 
 
 /**
- * Compatible with <b>JUnit 4.4 and higher</b>, this runner adds following behavior:
+ * Mockito JUnit Runner keeps tests clean and improves debugging experience.
+ * Make sure to try out {@link MockitoJUnitRunner.StrictStubs} which automatically
+ * detects <strong>stubbing argument mismatches</strong> and is planned to be the default in Mockito v3.
+ * JUnit Runner is compatible with JUnit 4.4 and higher and adds following behavior:
  * <ul>
  *   <li>
  *       (new since Mockito 2.1.0) Detects unused stubs in the test code.
@@ -33,7 +36,7 @@ import org.mockito.internal.runners.StrictRunner;
  *      so that explicit usage of {@link MockitoAnnotations#initMocks(Object)} is not necessary. 
  *      Mocks are initialized before each test method.
  *   <li>
- *      validates framework usage after each test method. See javadoc for {@link Mockito#validateMockitoUsage()}.
+ *      Validates framework usage after each test method. See javadoc for {@link Mockito#validateMockitoUsage()}.
  * </ul>
  * 
  * Runner is completely optional - there are other ways you can get &#064;Mock working, for example by writing a base class.
@@ -66,8 +69,16 @@ public class MockitoJUnitRunner extends Runner implements Filterable {
      * they add unnecessary details, potentially making the test code harder to comprehend.
      * If you have good reasons to use the silent runner, let us know at the mailing list
      * or raise an issue in our issue tracker.
-     *
+     * <p>
      * See also {@link org.mockito.exceptions.misusing.UnnecessaryStubbingException}
+     * <p>
+     * Usage:
+     * <pre class="code"><code class="java">
+     * <b>&#064;RunWith(MockitoJUnitRunner.Silent.class)</b>
+     * public class ExampleTest {
+     *   // ...
+     * }
+     * </code></pre>
      *
      * @since 2.1.0
      */
@@ -92,9 +103,22 @@ public class MockitoJUnitRunner extends Runner implements Filterable {
     }
 
     /**
-     * TODO document
+     * Improves debugging tests, helps keeping the tests clean.
+     * Planned default behavior of Mockito v3.
+     * Test fails early on stubbing argument mismatch to streamline debugging tests.
+     * Unused stubbings trigger test failures to keep tests clean.
+     * For more information see javadoc for
+     * {@link org.mockito.exceptions.misusing.PotentialStubbingProblem}
+     * <p>
+     * Usage:
+     * <pre class="code"><code class="java">
+     * <b>&#064;RunWith(MockitoJUnitRunner.StrictStubs.class)</b>
+     * public class ExampleTest {
+     *   // ...
+     * }
+     * </code></pre>
      *
-     * @since 2.5.0
+     * @since @version@
      */
     public static class StrictStubs extends MockitoJUnitRunner {
         public StrictStubs(Class<?> klass) throws InvocationTargetException {

--- a/src/main/java/org/mockito/junit/MockitoJUnitRunner.java
+++ b/src/main/java/org/mockito/junit/MockitoJUnitRunner.java
@@ -118,7 +118,7 @@ public class MockitoJUnitRunner extends Runner implements Filterable {
      * }
      * </code></pre>
      *
-     * @since @version@
+     * @since 2.5.1
      */
     public static class StrictStubs extends MockitoJUnitRunner {
         public StrictStubs(Class<?> klass) throws InvocationTargetException {

--- a/src/main/java/org/mockito/junit/MockitoJUnitRunner.java
+++ b/src/main/java/org/mockito/junit/MockitoJUnitRunner.java
@@ -91,6 +91,15 @@ public class MockitoJUnitRunner extends Runner implements Filterable {
         }
     }
 
+    /**
+     * TODO document
+     */
+    public static class StrictStubs extends MockitoJUnitRunner {
+        public StrictStubs(Class<?> klass) throws InvocationTargetException {
+            super(new StrictRunner(new RunnerFactory().createStrictStubs(klass), klass));
+        }
+    }
+
     private final InternalRunner runner;
 
     public MockitoJUnitRunner(Class<?> klass) throws InvocationTargetException {

--- a/src/main/java/org/mockito/quality/Strictness.java
+++ b/src/main/java/org/mockito/quality/Strictness.java
@@ -6,7 +6,8 @@ import org.mockito.junit.MockitoRule;
 /**
  * Configures the "strictness" of Mockito during test execution.
  * To understand how "strictness" can improve testability refer to the javadoc
- * of the tools that use "strictness", see docs for {@link MockitoRule#strictness(Strictness)}.
+ * of the tools that use "strictness", see docs for {@link MockitoRule#strictness(Strictness)}
+ * and {@link org.mockito.junit.MockitoJUnitRunner.StrictStubs}.
  *
  * @since 2.3.0
  */
@@ -33,8 +34,9 @@ public enum Strictness {
 
     /**
      * Ensures clean tests, reduces test code duplication, improves debuggability.
-     * See {@link MockitoRule#strictness(Strictness)}.
-     * Tentatively planned default for Mockito 3.x.
+     * See {@link MockitoRule#strictness(Strictness)}
+     * and {@link org.mockito.junit.MockitoJUnitRunner.StrictStubs}.
+     * Planned as default for Mockito 3.x.
      *
      * @since 2.3.0
      */

--- a/src/test/java/org/mockito/junit/TestableJUnitRunner.java
+++ b/src/test/java/org/mockito/junit/TestableJUnitRunner.java
@@ -19,11 +19,11 @@ public class TestableJUnitRunner extends MockitoJUnitRunner {
     };
 
     public TestableJUnitRunner(Class<?> klass) throws InvocationTargetException, InitializationError {
-        super(new StrictRunner(new StrictRunner(new RunnerFactory().create(klass, new Supplier<MockitoTestListener>() {
+        super(new StrictRunner(new RunnerFactory().create(klass, new Supplier<MockitoTestListener>() {
             public MockitoTestListener get() {
                 return new MismatchReportingTestListener(LOGGER.get());
             }
-        }), klass), klass));
+        }), klass));
     }
 
     public static SimpleMockitoLogger refreshedLogger() {

--- a/src/test/java/org/mockitousage/junitrule/MutableStrictJUnitRuleTest.java
+++ b/src/test/java/org/mockitousage/junitrule/MutableStrictJUnitRuleTest.java
@@ -46,7 +46,7 @@ public class MutableStrictJUnitRuleTest {
         }
 
         @Test public void unused_stub_with_strictness() throws Throwable {
-            //making Mockito lenient only for this test method
+            //making Mockito strict only for this test method
             mockito.strictness(Strictness.STRICT_STUBS);
 
             when(mock.simpleMethod()).thenReturn("1");

--- a/src/test/java/org/mockitousage/junitrule/StrictJUnitRuleTest.java
+++ b/src/test/java/org/mockitousage/junitrule/StrictJUnitRuleTest.java
@@ -78,23 +78,23 @@ public class StrictJUnitRuleTest {
             public void doAssert(Throwable t) {
                 Assertions.assertThat(t).isInstanceOf(PotentialStubbingProblem.class);
                 assertEquals(filterLineNo("\n" +
-                    "Strict JUnit rule detected stubbing argument mismatch.\n" +
-                    "This invocation of 'simpleMethod' method:\n" +
-                    "  mock.simpleMethod(15);\n" +
-                    "  -> at org.mockitousage.junitrule.StrictJUnitRuleTest.fails_fast_when_stubbing_invoked_with_different_argument(StrictJUnitRuleTest.java:0)\n" +
-                    "Has following stubbing(s) with different arguments:\n" +
-                    "  1. mock.simpleMethod(20);\n" +
-                    "    -> at org.mockitousage.junitrule.StrictJUnitRuleTest.fails_fast_when_stubbing_invoked_with_different_argument(StrictJUnitRuleTest.java:0)\n" +
-                    "  2. mock.simpleMethod(30);\n" +
-                    "    -> at org.mockitousage.junitrule.StrictJUnitRuleTest.fails_fast_when_stubbing_invoked_with_different_argument(StrictJUnitRuleTest.java:0)\n" +
-                    "Typically, stubbing argument mismatch indicates user mistake when writing tests.\n" +
-                    "In order to streamline debugging tests Mockito fails early in this scenario.\n" +
-                    "However, there are legit scenarios when this exception generates false negative signal:\n" +
-                    "  - stubbing the same method multiple times using 'given().will()' or 'when().then()' API\n" +
-                    "    Please use 'will().given()' or 'doReturn().when()' API for stubbing\n" +
-                    "  - stubbed method is intentionally invoked with different arguments by code under test\n" +
-                    "    Please use 'default' or 'silent' JUnit Rule.\n" +
-                    "For more information see javadoc for PotentialStubbingProblem class."),
+                                "Strict stubbing argument mismatch. Please check:\n" +
+                                " - this invocation of 'simpleMethod' method:\n" +
+                                "    mock.simpleMethod(15);\n" +
+                                "    -> at org.mockitousage.junitrule.StrictJUnitRuleTest.fails_fast_when_stubbing_invoked_with_different_argument(StrictJUnitRuleTest.java:0)\n" +
+                                " - has following stubbing(s) with different arguments:\n" +
+                                "    1. mock.simpleMethod(20);\n" +
+                                "      -> at org.mockitousage.junitrule.StrictJUnitRuleTest.fails_fast_when_stubbing_invoked_with_different_argument(StrictJUnitRuleTest.java:0)\n" +
+                                "    2. mock.simpleMethod(30);\n" +
+                                "      -> at org.mockitousage.junitrule.StrictJUnitRuleTest.fails_fast_when_stubbing_invoked_with_different_argument(StrictJUnitRuleTest.java:0)\n" +
+                                "Typically, stubbing argument mismatch indicates user mistake when writing tests.\n" +
+                                "Mockito fails early so that you can debug potential problem easily.\n" +
+                                "However, there are legit scenarios when this exception generates false negative signal:\n" +
+                                "  - stubbing the same method multiple times using 'given().will()' or 'when().then()' API\n" +
+                                "    Please use 'will().given()' or 'doReturn().when()' API for stubbing.\n" +
+                                "  - stubbed method is intentionally invoked with different arguments by code under test\n" +
+                                "    Please use 'default' or 'silent' JUnit Rule.\n" +
+                                "For more information see javadoc for PotentialStubbingProblem class."),
                         filterLineNo(t.getMessage()));
             }
         });

--- a/src/test/java/org/mockitousage/junitrunner/StrictStubsRunnerTest.java
+++ b/src/test/java/org/mockitousage/junitrunner/StrictStubsRunnerTest.java
@@ -1,0 +1,73 @@
+package org.mockitousage.junitrunner;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.RunWith;
+import org.junit.runner.notification.Failure;
+import org.mockito.Mock;
+import org.mockito.exceptions.misusing.PotentialStubbingProblem;
+import org.mockito.exceptions.misusing.UnnecessaryStubbingException;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockitousage.IMethods;
+import org.mockitoutil.JUnitResultAssert;
+import org.mockitoutil.TestBase;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+public class StrictStubsRunnerTest extends TestBase {
+
+    JUnitCore runner = new JUnitCore();
+
+    @Test public void detects_unnecessary_stubbings() {
+        //when
+        Result result = runner.run(UnnecessaryStubbingTest.class);
+        //then
+        JUnitResultAssert.assertThat(result)
+                .fails(1, UnnecessaryStubbingException.class)
+                .succeeds(2);
+    }
+
+    @Test public void fails_fast_on_argument_mismatch() {
+        //when
+        Result result = runner.run(StubbingArgMismatchTest.class);
+        //then
+        JUnitResultAssert.assertThat(result)
+                .succeeds(2)
+                .fails(1, PotentialStubbingProblem.class);
+
+        //TODO update failure message: a) it's no longer JUnit rule feature b) make it more actionable
+//        Failure failure = result.getFailures().iterator().next();
+//        assertEquals("", failure.getMessage());
+    }
+
+    @RunWith(MockitoJUnitRunner.StrictStubs.class)
+    public static class UnnecessaryStubbingTest {
+        @Mock IMethods mock;
+        @Test public void unused_stubbing_1() {
+            when(mock.simpleMethod()).thenReturn("");
+        }
+        @Test public void unused_stubbing_2() {
+            when(mock.simpleMethod()).thenReturn("");
+        }
+        @Test public void correct_stubbing() {
+            when(mock.simpleMethod()).thenReturn("");
+            mock.simpleMethod();
+        }
+    }
+
+    @RunWith(MockitoJUnitRunner.StrictStubs.class)
+    public static class StubbingArgMismatchTest {
+        @Mock IMethods mock;
+        @Test public void passing1() {}
+        @Test public void passing2() {
+            when(mock.simpleMethod()).thenReturn("");
+            mock.simpleMethod();
+        }
+        @Test public void argument_mismatch() {
+            when(mock.simpleMethod(10)).thenReturn("");
+            mock.simpleMethod(20);
+        }
+    }
+}

--- a/src/test/java/org/mockitousage/junitrunner/StrictStubsRunnerTest.java
+++ b/src/test/java/org/mockitousage/junitrunner/StrictStubsRunnerTest.java
@@ -4,7 +4,6 @@ import org.junit.Test;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
 import org.junit.runner.RunWith;
-import org.junit.runner.notification.Failure;
 import org.mockito.Mock;
 import org.mockito.exceptions.misusing.PotentialStubbingProblem;
 import org.mockito.exceptions.misusing.UnnecessaryStubbingException;
@@ -22,7 +21,7 @@ public class StrictStubsRunnerTest extends TestBase {
 
     @Test public void detects_unnecessary_stubbings() {
         //when
-        Result result = runner.run(UnnecessaryStubbingTest.class);
+        Result result = runner.run(UnnecessaryStubbing.class);
         //then
         JUnitResultAssert.assertThat(result)
                 .fails(1, UnnecessaryStubbingException.class)
@@ -31,19 +30,15 @@ public class StrictStubsRunnerTest extends TestBase {
 
     @Test public void fails_fast_on_argument_mismatch() {
         //when
-        Result result = runner.run(StubbingArgMismatchTest.class);
+        Result result = runner.run(StubbingArgMismatch.class);
         //then
         JUnitResultAssert.assertThat(result)
                 .succeeds(2)
                 .fails(1, PotentialStubbingProblem.class);
-
-        //TODO update failure message: a) it's no longer JUnit rule feature b) make it more actionable
-//        Failure failure = result.getFailures().iterator().next();
-//        assertEquals("", failure.getMessage());
     }
 
     @RunWith(MockitoJUnitRunner.StrictStubs.class)
-    public static class UnnecessaryStubbingTest {
+    public static class UnnecessaryStubbing {
         @Mock IMethods mock;
         @Test public void unused_stubbing_1() {
             when(mock.simpleMethod()).thenReturn("");
@@ -58,7 +53,7 @@ public class StrictStubsRunnerTest extends TestBase {
     }
 
     @RunWith(MockitoJUnitRunner.StrictStubs.class)
-    public static class StubbingArgMismatchTest {
+    public static class StubbingArgMismatch {
         @Mock IMethods mock;
         @Test public void passing1() {}
         @Test public void passing2() {

--- a/src/test/java/org/mockitoutil/JUnitResultAssert.java
+++ b/src/test/java/org/mockitoutil/JUnitResultAssert.java
@@ -70,7 +70,7 @@ public class JUnitResultAssert {
     public JUnitResultAssert succeeds(int successCount) {
         int i = result.getRunCount() - result.getFailureCount();
         if (i != successCount) {
-            throw new AssertionError("Expected " + successCount + " passing test methods but there were " + i + " passing methods.");
+            throw new AssertionError("Expected " + successCount + " passes but " + i + "/" + result.getRunCount() + " passed.");
         }
         return this;
     }
@@ -80,7 +80,7 @@ public class JUnitResultAssert {
             return "<no failures>";
         }
         int count = 1;
-        StringBuilder out = new StringBuilder("Failures:");
+        StringBuilder out = new StringBuilder("Failures:\n");
         for (Failure f : failures) {
             out.append(count++).append(". ").append(f.getTrace());
         }


### PR DESCRIPTION
Background:

- Mockito "strictness" is explained in #769 
- Since 2.3.x Mockito JUnit Rules already provide opt-in "strict stubbing" capability, [see the javadoc](https://static.javadoc.io/org.mockito/mockito-core/2.4.5/org/mockito/junit/MockitoRule.html#strictness(org.mockito.quality.Strictness)).

This change adds new opt-in "strict stubbing" support for Mockito JUnit Runner. This behavior is tentatively planned to be the default in Mockito v3. Example usage:

```java
//Note "StrictStubs" inner class:
@RunWith(MockitoJUnitRunner.StrictStubs.class)
public class ExampleTest {
    // ...
}      
```

The behavior added by the StrictStubs runner is documented in the [javadoc](https://static.javadoc.io/org.mockito/mockito-core/2.4.5/org/mockito/junit/MockitoRule.html#strictness(org.mockito.quality.Strictness)). See also Javadoc improvements in code changes for this PR. The general direction of Mockito "strictness" is documented in #769.