### PR TITLE
Fixes #866 should not throw NPE, when custom Exception fillInStackTrace returns null

### DIFF
--- a/src/main/java/org/mockito/internal/stubbing/answers/ThrowsException.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/ThrowsException.java
@@ -29,6 +29,10 @@ public class ThrowsException implements Answer<Object>, ValidableAnswer, Seriali
             throw throwable;
         }
         Throwable t = throwable.fillInStackTrace();
+
+        if (t == null) {
+            throw throwable;
+        }
         filter.filter(t);
         throw t;
     }

--- a/src/test/java/org/mockitousage/bugs/NPEWhenCustomExceptionStackTraceReturnNullTest.java
+++ b/src/test/java/org/mockitousage/bugs/NPEWhenCustomExceptionStackTraceReturnNullTest.java
@@ -1,0 +1,32 @@
+package org.mockitousage.bugs;
+
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockitousage.IMethods;
+import org.mockitoutil.TestBase;
+
+import static junit.framework.TestCase.fail;
+import static org.mockito.Mockito.when;
+
+public class NPEWhenCustomExceptionStackTraceReturnNullTest extends TestBase {
+
+    @Mock
+    IMethods mock;
+
+    class NullStackTraceException extends RuntimeException {
+        @Override
+        public Exception fillInStackTrace() {
+            return null;
+        }
+    }
+
+    //issue 866
+    @Test
+    public void shouldNotThrowNPE() {
+        when(mock.simpleMethod()).thenThrow(new NullStackTraceException());
+        try {
+            mock.simpleMethod();
+            fail();
+        } catch(NullStackTraceException e) {}
+    }
+}


### PR DESCRIPTION
fixes #866.