### PR TITLE
Fixes #860, jacaco synthetic fields are not anymore final in 0.7.8

### DIFF
--- a/gradle/root/coverage.gradle
+++ b/gradle/root/coverage.gradle
@@ -6,13 +6,6 @@ jacoco {
     toolVersion = "0.7.8"
 }
 
-//The tests for the new plugin mechanism are broken with Jacoco 0.7.8 - https://github.com/mockito/mockito/issues/860
-test {
-    jacoco {
-        excludes = ['org.mockitoutil.ClassLoadersTest**', 'org.mockito.internal.configuration.GlobalConfigurationTest**']
-    }
-}
-
 task mockitoCoverage(type: JacocoReport, dependsOn: "test") {
     executionData files("${buildDir}/jacoco/test.exec")
 

--- a/src/test/java/org/mockitoutil/ClassLoaders.java
+++ b/src/test/java/org/mockitoutil/ClassLoaders.java
@@ -150,11 +150,13 @@ public abstract class ClassLoaders {
                     Field declaredField = taskClassReloaded.getDeclaredField(field.getName());
                     int modifiers = declaredField.getModifiers();
                     if(Modifier.isStatic(modifiers) && Modifier.isFinal(modifiers)) {
-                        // skip otherwise IllegalAccessException (can be bypassed with Unsafe though)
+                        // Skip static final fields (e.g. jacoco fields depends on version)
+                        // otherwise IllegalAccessException (can be bypassed with Unsafe though)
                         // We may also miss coverage data.
                         continue;
                     }
-                    if (declaredField.getType() == field.getType()) { // don't copy this
+                    if (declaredField.getType() == field.getType()) { // don't copy this$0
+                        field.setAccessible(true);
                         declaredField.setAccessible(true);
                         declaredField.set(reloaded, field.get(task));
                     }


### PR DESCRIPTION
Fixes #860 

This internal assumed JaCoCo fields will always be `static final`, obviously not. JaCoCo 0.7.8 changed that. The simple fix was to make the source field _accessible_ instead of skipping this field.

Hence removing the test exclusion.