### PR TITLE
Update Byte Buddy and enable injecting loading strategy for Android

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,8 @@ apply from: 'gradle/root/version.gradle'
 apply from: "gradle/java-library.gradle"
 
 dependencies {
-    compile 'net.bytebuddy:byte-buddy:1.6.0'
-    compile 'net.bytebuddy:byte-buddy-agent:1.6.0'
+    compile 'net.bytebuddy:byte-buddy:1.6.2'
+    compile 'net.bytebuddy:byte-buddy-agent:1.6.2'
 
     provided "junit:junit:4.12", "org.hamcrest:hamcrest-core:1.3"
     compile "org.objenesis:objenesis:2.4"

--- a/subprojects/android/android.gradle
+++ b/subprojects/android/android.gradle
@@ -12,7 +12,7 @@ apply from: "$rootDir/gradle/publishable-java-library.gradle"
 
 dependencies {
     compile project.rootProject
-    compile "net.bytebuddy:byte-buddy-android:1.6.0"
+    compile "net.bytebuddy:byte-buddy-android:1.6.2"
 }
 
 tasks.javadoc.enabled = false

--- a/subprojects/android/src/main/java/org/mockito/android/internal/creation/AndroidLoadingStrategy.java
+++ b/subprojects/android/src/main/java/org/mockito/android/internal/creation/AndroidLoadingStrategy.java
@@ -27,6 +27,6 @@ class AndroidLoadingStrategy implements SubclassLoader {
                     "getInstrumentation().getTargetContext().getCacheDir().getPath()"
             ));
         }
-        return new AndroidClassLoadingStrategy(target);
+        return new AndroidClassLoadingStrategy.Injecting(target);
     }
 }


### PR DESCRIPTION
This enables Byte Buddy's new injection strategy for Android which loads types within a target class loader instead of creating a new one. Also, this updates Byte Buddy with a few bug fixes.