### PR TITLE
Fixes #882: Upgrade to Objenesis 2.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     compile 'net.bytebuddy:byte-buddy-agent:1.5.12'
 
     provided "junit:junit:4.12", "org.hamcrest:hamcrest-core:1.3"
-    compile "org.objenesis:objenesis:2.4"
+    compile "org.objenesis:objenesis:2.5"
 
     testCompile 'org.ow2.asm:asm:5.1'
 

--- a/gradle/mockito-core/osgi.gradle
+++ b/gradle/mockito-core/osgi.gradle
@@ -20,7 +20,7 @@ afterEvaluate {
                     'junit.*;resolution:=optional',
                     'org.junit.*;resolution:=optional',
                     'org.hamcrest;resolution:=optional',
-                    'org.objenesis;version="[2.4,3.0)"',
+                    'org.objenesis;version="[2.5,3.0)"',
                     'org.mockito.*'
 
             instruction 'Private-Package',


### PR DESCRIPTION
Upgrade to Objenesis 2.5 in order to properly support Java 9.

Checks performed:
- build succeed
- unit tests pass
- no major slowdown in unit tests was observed

This PR fixes issue #882.