### PR TITLE
Spy annotation reports better error message if instance creation is impossible

### DIFF
--- a/src/main/java/org/mockito/internal/configuration/SpyAnnotationEngine.java
+++ b/src/main/java/org/mockito/internal/configuration/SpyAnnotationEngine.java
@@ -19,6 +19,7 @@ import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.util.MockUtil;
 import org.mockito.plugins.AnnotationEngine;
 
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.withSettings;
 import static org.mockito.internal.exceptions.Reporter.unsupportedCombinationOfAnnotations;
 
@@ -59,10 +60,10 @@ public class SpyAnnotationEngine implements AnnotationEngine, org.mockito.config
                         // for example happens when MockitoAnnotations.initMocks is called two times.
                         Mockito.reset(instance);
                     } else if (instance != null) {
-                        field.set(testInstance, Mockito.mock(instance.getClass(), withSettings()
-                                .spiedInstance(instance)
-                                .defaultAnswer(Mockito.CALLS_REAL_METHODS)
-                                .name(field.getName())));
+                        field.set(testInstance, Mockito.mock(instance.getClass(),
+                                                             withSettings().spiedInstance(instance)
+                                                                           .defaultAnswer(CALLS_REAL_METHODS)
+                                                                           .name(field.getName())));
                     } else {
                         field.set(testInstance, newSpyInstance(testInstance, field));
                     }
@@ -74,7 +75,7 @@ public class SpyAnnotationEngine implements AnnotationEngine, org.mockito.config
     }
 
     private static void assertNotInterface(Object testInstance, Class<?> type) {
-        type = testInstance != null? testInstance.getClass() : type;
+        type = testInstance != null ? testInstance.getClass() : type;
         if (type.isInterface()) {
             throw new MockitoException("Type '" + type.getSimpleName() + "' is an interface and it cannot be spied on.");
         }
@@ -82,9 +83,8 @@ public class SpyAnnotationEngine implements AnnotationEngine, org.mockito.config
 
     private static Object newSpyInstance(Object testInstance, Field field)
             throws InstantiationException, IllegalAccessException, InvocationTargetException {
-        MockSettings settings = withSettings()
-                .defaultAnswer(Mockito.CALLS_REAL_METHODS)
-                .name(field.getName());
+        MockSettings settings = withSettings().defaultAnswer(CALLS_REAL_METHODS)
+                                              .name(field.getName());
         Class<?> type = field.getType();
         if (type.isInterface()) {
             return Mockito.mock(type, settings.useConstructor());
@@ -94,12 +94,11 @@ public class SpyAnnotationEngine implements AnnotationEngine, org.mockito.config
             if (enclosing != null) {
                 if (!enclosing.isInstance(testInstance)) {
                     throw new MockitoException("@Spy annotation can only initialize inner classes declared in the test. "
-                            + "Inner class: '" + type.getSimpleName() + "', "
-                            + "outer class: '" + enclosing.getSimpleName() + "'.");
+                                               + "Inner class: '" + type.getSimpleName() + "', "
+                                               + "outer class: '" + enclosing.getSimpleName() + "'.");
                 }
-                return Mockito.mock(type, settings
-                        .useConstructor()
-                        .outerInstance(testInstance));
+                return Mockito.mock(type, settings.useConstructor()
+                                                  .outerInstance(testInstance));
             }
         }
         Constructor<?> constructor;
@@ -111,18 +110,20 @@ public class SpyAnnotationEngine implements AnnotationEngine, org.mockito.config
 
         if (Modifier.isPrivate(constructor.getModifiers())) {
             constructor.setAccessible(true);
-            return Mockito.mock(type, settings
-                    .spiedInstance(constructor.newInstance()));
+            return Mockito.mock(type, settings.spiedInstance(constructor.newInstance()));
         } else {
             return Mockito.mock(type, settings.useConstructor());
         }
     }
 
     //TODO duplicated elsewhere
-    private void assertNoIncompatibleAnnotations(Class<? extends Annotation> annotation, Field field, Class<? extends Annotation>... undesiredAnnotations) {
+    private void assertNoIncompatibleAnnotations(Class<? extends Annotation> annotation,
+                                                 Field field,
+                                                 Class<? extends Annotation>... undesiredAnnotations) {
         for (Class<? extends Annotation> u : undesiredAnnotations) {
             if (field.isAnnotationPresent(u)) {
-                throw unsupportedCombinationOfAnnotations(annotation.getSimpleName(), annotation.getClass().getSimpleName());
+                throw unsupportedCombinationOfAnnotations(annotation.getSimpleName(),
+                                                          annotation.getClass().getSimpleName());
             }
         }
     }

--- a/src/main/java/org/mockito/internal/creation/instance/ConstructorInstantiator.java
+++ b/src/main/java/org/mockito/internal/creation/instance/ConstructorInstantiator.java
@@ -4,9 +4,10 @@
  */
 package org.mockito.internal.creation.instance;
 
-import static org.mockito.internal.util.StringJoiner.join;
 import java.lang.reflect.Constructor;
 import org.mockito.internal.util.reflection.AccessibilityChanger;
+
+import static org.mockito.internal.util.StringJoiner.join;
 
 public class ConstructorInstantiator implements Instantiator {
 
@@ -36,7 +37,7 @@ public class ConstructorInstantiator implements Instantiator {
         } catch (Exception e) {
             throw paramsException(cls, e);
         }
-        throw paramsException(cls, null);
+        throw noMatchingConstructor(cls);
     }
 
     @SuppressWarnings("unchecked")
@@ -45,12 +46,19 @@ public class ConstructorInstantiator implements Instantiator {
         accessibility.enableAccess(constructor);
         return (T) constructor.newInstance(params);
     }
+    
+    private static <T> InstantiationException paramsException(Class<T> cls, Exception cause) {
+        return new InstantiationException(
+                join("Unable to create instance of '" + cls.getSimpleName() + "'.",
+                     "Please ensure that the outer instance has correct type and that the target class has 0-arg constructor."),
+                cause);
+    }
 
-    private static <T> InstantiationException paramsException(Class<T> cls, Exception e) {
-        return new InstantiationException(join(
-                "Unable to create instance of '" + cls.getSimpleName() + "'.",
-                "Please ensure that the outer instance has correct type and that the target class has 0-arg constructor.")
-                , e);
+    private static <T> InstantiationException noMatchingConstructor(Class<T> cls) {
+        return new InstantiationException(
+                join("Unable to create instance of '" + cls.getSimpleName() + "'.",
+                     "Unable to find a matching 1-arg constructor for the outer instance.")
+                , null);
     }
 
     private static boolean paramsMatch(Class<?>[] types, Object[] params) {
@@ -72,7 +80,7 @@ public class ConstructorInstantiator implements Instantiator {
             throw new InstantiationException(join(
                     "Unable to create instance of '" + cls.getSimpleName() + "'.",
                     "Please ensure it has 0-arg constructor which invokes cleanly."),
-                    t);
+                                             t);
         }
     }
 }

--- a/src/test/java/org/mockitousage/annotation/SpyAnnotationTest.java
+++ b/src/test/java/org/mockitousage/annotation/SpyAnnotationTest.java
@@ -36,10 +36,10 @@ public class SpyAnnotationTest extends TestBase {
     final List<String> spiedList = new ArrayList<String>();
 
     @Spy
-    NestedClassWithNoArgConstructor staticTypeWithNoArgConstructor;
+    InnerStaticClassWithNoArgConstructor staticTypeWithNoArgConstructor;
 
     @Spy
-    NestedClassWithoutDefinedConstructor staticTypeWithoutDefinedConstructor;
+    InnerStaticClassWithoutDefinedConstructor staticTypeWithoutDefinedConstructor;
 
     @Rule
     public final ExpectedException shouldThrow = ExpectedException.none();
@@ -175,7 +175,7 @@ public class SpyAnnotationTest extends TestBase {
     }
 
     @Test
-    public void should_report_when_encosing_instance_is_needed() throws Exception {
+    public void should_report_when_enclosing_instance_is_needed() throws Exception {
         class Outer {
             class Inner {
             }
@@ -192,14 +192,14 @@ public class SpyAnnotationTest extends TestBase {
         }
     }
 
-    static class NestedClassWithoutDefinedConstructor {
+    static class InnerStaticClassWithoutDefinedConstructor {
     }
 
-    static class NestedClassWithNoArgConstructor {
-        NestedClassWithNoArgConstructor() {
+    static class InnerStaticClassWithNoArgConstructor {
+        InnerStaticClassWithNoArgConstructor() {
         }
 
-        NestedClassWithNoArgConstructor(String f) {
+        InnerStaticClassWithNoArgConstructor(String f) {
         }
     }
 

--- a/src/test/java/org/mockitousage/annotation/SpyAnnotationTest.java
+++ b/src/test/java/org/mockitousage/annotation/SpyAnnotationTest.java
@@ -4,6 +4,11 @@
  */
 package org.mockitousage.annotation;
 
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.Rule;
 import org.junit.Test;
@@ -14,23 +19,30 @@ import org.mockito.Spy;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockitoutil.TestBase;
 
-import java.util.*;
-
-import static junit.framework.TestCase.*;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.fail;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @SuppressWarnings({"unchecked", "unused"})
 public class SpyAnnotationTest extends TestBase {
 
-    @Spy final List<String> spiedList = new ArrayList<String>();
+    @Spy
+    final List<String> spiedList = new ArrayList<String>();
 
-    @Spy NestedClassWithNoArgConstructor staticTypeWithNoArgConstructor;
+    @Spy
+    NestedClassWithNoArgConstructor staticTypeWithNoArgConstructor;
 
     @Spy
     NestedClassWithoutDefinedConstructor staticTypeWithoutDefinedConstructor;
-  
-    @Rule public final ExpectedException shouldThrow = ExpectedException.none();
+
+    @Rule
+    public final ExpectedException shouldThrow = ExpectedException.none();
 
     @Test
     public void should_init_spy_by_instance() throws Exception {
@@ -50,7 +62,8 @@ public class SpyAnnotationTest extends TestBase {
     @Test
     public void should_prevent_spying_on_interfaces() throws Exception {
         class WithSpy {
-            @Spy List<String> list;
+            @Spy
+            List<String> list;
         }
 
         WithSpy withSpy = new WithSpy();
@@ -65,7 +78,8 @@ public class SpyAnnotationTest extends TestBase {
     @Test
     public void should_allow_spying_on_interfaces_when_instance_is_concrete() throws Exception {
         class WithSpy {
-            @Spy List<String> list = new LinkedList<String>();
+            @Spy
+            List<String> list = new LinkedList<String>();
         }
 
         WithSpy withSpy = new WithSpy();
@@ -90,7 +104,7 @@ public class SpyAnnotationTest extends TestBase {
             Assertions.assertThat(e.getMessage()).contains("0-arg constructor");
         }
     }
-    
+
     @Test
     public void should_report_when_constructor_is_explosive() throws Exception {
         class FailingSpy {
@@ -109,8 +123,9 @@ public class SpyAnnotationTest extends TestBase {
     @Test
     public void should_spy_abstract_class() throws Exception {
         class SpyAbstractClass {
-            @Spy AbstractList<String> list;
-            
+            @Spy
+            AbstractList<String> list;
+
             List<String> asSingletonList(String s) {
                 when(list.size()).thenReturn(1);
                 when(list.get(0)).thenReturn(s);
@@ -124,10 +139,12 @@ public class SpyAnnotationTest extends TestBase {
 
     @Test
     public void should_spy_inner_class() throws Exception {
-         
-     class WithMockAndSpy {
-            @Spy private InnerStrength strength;
-            @Mock private List<String> list;
+
+        class WithMockAndSpy {
+            @Spy
+            private InnerStrength strength;
+            @Mock
+            private List<String> list;
 
             abstract class InnerStrength {
                 private final String name;
@@ -138,9 +155,9 @@ public class SpyAnnotationTest extends TestBase {
                     // Make sure constructor is indeed called.
                     this.name = "inner";
                 }
-                
+
                 abstract String strength();
-                
+
                 String fullStrength() {
                     return name + " " + strength();
                 }
@@ -160,10 +177,12 @@ public class SpyAnnotationTest extends TestBase {
     @Test
     public void should_report_when_encosing_instance_is_needed() throws Exception {
         class Outer {
-            class Inner {}
+            class Inner {
+            }
         }
         class WithSpy {
-            @Spy private Outer.Inner inner;
+            @Spy
+            private Outer.Inner inner;
         }
         try {
             MockitoAnnotations.initMocks(new WithSpy());
@@ -173,18 +192,25 @@ public class SpyAnnotationTest extends TestBase {
         }
     }
 
-    static class NestedClassWithoutDefinedConstructor { }
+    static class NestedClassWithoutDefinedConstructor {
+    }
 
     static class NestedClassWithNoArgConstructor {
-        NestedClassWithNoArgConstructor() { }
-        NestedClassWithNoArgConstructor(String f) { }
+        NestedClassWithNoArgConstructor() {
+        }
+
+        NestedClassWithNoArgConstructor(String f) {
+        }
     }
 
     static class NoValidConstructor {
-        NoValidConstructor(String f) { }
+        NoValidConstructor(String f) {
+        }
     }
 
     static class ThrowingConstructor {
-        ThrowingConstructor() { throw new RuntimeException("boo!"); }
+        ThrowingConstructor() {
+            throw new RuntimeException("boo!");
+        }
     }
 }

--- a/src/test/java/org/mockitousage/constructor/CreatingMocksWithConstructorTest.java
+++ b/src/test/java/org/mockitousage/constructor/CreatingMocksWithConstructorTest.java
@@ -1,16 +1,21 @@
 package org.mockitousage.constructor;
 
+import java.util.List;
 import org.junit.Test;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.mock.SerializableMode;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import java.util.List;
-
-import static junit.framework.TestCase.*;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNull;
+import static junit.framework.TestCase.fail;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 public class CreatingMocksWithConstructorTest extends TestBase {
 
@@ -78,7 +83,7 @@ public class CreatingMocksWithConstructorTest extends TestBase {
             fail();
         } catch (MockitoException e) {
             assertThat(e).hasMessage("Unable to create mock instance of type 'InnerClass'");
-            assertThat(e.getCause()).hasMessageContaining("Please ensure that the outer instance has correct type and that the target class has 0-arg constructor.");
+            assertThat(e.getCause()).hasMessageContaining("Unable to find a matching 1-arg constructor for the outer instance.");
         }
     }
 


### PR DESCRIPTION
This simple piece of code prevents the `SpyAnnotationEngine` to try create a spy instance for a some inner private class with different set of modifiers.

While preventing execution it reports slightly better error messages, before, some time the cause was `null` . This should fix #878 