### PR TITLE
Fixed build for external contributors

### DIFF
--- a/gradle/root/release.gradle
+++ b/gradle/root/release.gradle
@@ -254,10 +254,10 @@ task pushChanges(type: Exec) {
 }
 
 releaseWorkflow {
-    step assertEnvVariables
-    step assertCleanWorkingCopy
     step releaseNeeded
     onlyIf { releaseNeeded.needed }
+    step assertEnvVariables
+    step assertCleanWorkingCopy
     step bintrayUploadAll //TODO make upload task the very last task or very close to push so that the most invasive steps go last
     step pullCommits
     step configureGenericGitUser, [cleanup: restoreGitUser]


### PR DESCRIPTION
Moved the validation of env variables required for release to further release step. We don't need to assert the variables if the release is skipped.

Fixes #871

Merge at will. Reordering those release steps is safe. Those steps do not impact the release process in any way. Removing those steps completely would not break the release. It would  just make it fail later VS fast, and would make the failure less readable. Hence, the validation steps are useful but reordering them does not impact the release.

I tested it by running "./gradlew release -PdryRun". If you export the variables, you can actually use above to dry run the release.