### PR TITLE
Add detection for Android environments and give warnings if used incorrectly. Corrected documentation.

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -95,15 +95,23 @@ import org.mockito.verification.VerificationWithTimeout;
  * <h3 id="0.1">0.1. <a class="meaningful_link" href="#mockito-android">Mockito Android support</a></h3>
  *
  * With Mockito version 2.6.1 we ship "native" Android support. To enable Android support, add the `mockito-android` library as dependency
- * to your project. This artifact is published to the same mockito organization:
+ * to your project. This artifact is published to the same Mockito organization and can be imported for Android as follows:
  *
  * <pre class="code"><code>
- * repositories { jcenter() }
- * dependencies { testCompile "org.mockito:mockito-android:2.+" }
+ * repositories {
+ *   jcenter()
+ * }
+ * dependencies {
+ *   testCompile "org.mockito:mockito-core:+"
+ *   androidTestCompile "org.mockito:mockito-android:+"
+ * }
  * </code></pre>
  *
- * All features of Mockito are still in the `mockito-core` artifact. The `mockito-android` artifact implements a compatibility layer
- * with Android. If you encounter issues with mocking on Android, please open an issue <a href="https://github.com/mockito/mockito/issues/new">on the official issue tracker</a>.
+ * You can continue to run the same unit tests on a regular VM by using the `mockito-core` artifact in your "testCompile" scope as shown
+ * above. Be aware that you cannot use the <a href="#39">inline mock maker</a> on Android due to limitations in the Android VM.
+ *
+ * If you encounter issues with mocking on Android, please open an issue
+ * <a href="https://github.com/mockito/mockito/issues/new">on the official issue tracker</a>.
  * Do provide the version of Android you are working on and dependencies of your project.
  *
  * <h3 id="1">1. <a class="meaningful_link" href="#verification">Let's verify some behaviour!</a></h3>

--- a/src/main/java/org/mockito/internal/util/Platform.java
+++ b/src/main/java/org/mockito/internal/util/Platform.java
@@ -4,8 +4,11 @@
  */
 package org.mockito.internal.util;
 
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static org.mockito.internal.util.StringJoiner.join;
 
 public abstract class Platform {
 
@@ -23,8 +26,16 @@ public abstract class Platform {
     private Platform() {
     }
 
+    public static boolean isAndroid() {
+        return System.getProperty("java.vendor", "").toLowerCase(Locale.US).contains("android");
+    }
+
+    public static boolean isAndroidMockMakerRequired() {
+        return Boolean.getBoolean("org.mockito.mock.android");
+    }
+
     public static String describe() {
-        return String.format("Java               : %s\n" +
+        String description = String.format("Java               : %s\n" +
                              "JVM vendor name    : %s\n" +
                              "JVM vendor version : %s\n" +
                              "JVM name           : %s\n" +
@@ -40,6 +51,18 @@ public abstract class Platform {
                              JVM_INFO,
                              OS_NAME,
                              OS_VERSION);
+        if (isAndroid()) {
+            description = join(
+                    "IMPORTANT INFORMATION FOR ANDROID USERS:",
+                    "",
+                    "The regular Byte Buddy mock makers cannot generate code on an Android VM!",
+                    "To resolve this, please use the 'mockito-android' dependency for your application:",
+                    "http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22mockito-android%22%20g%3A%22org.mockito%22",
+                    "",
+                    description
+            );
+        }
+        return description;
     }
 
     public static boolean isJava8BelowUpdate45() {

--- a/subprojects/android/src/main/java/org/mockito/android/internal/creation/AndroidByteBuddyMockMaker.java
+++ b/subprojects/android/src/main/java/org/mockito/android/internal/creation/AndroidByteBuddyMockMaker.java
@@ -1,13 +1,34 @@
 package org.mockito.android.internal.creation;
 
 import org.mockito.internal.creation.bytebuddy.SubclassByteBuddyMockMaker;
+import org.mockito.internal.util.ConsoleMockitoLogger;
+import org.mockito.internal.util.Platform;
 import org.mockito.invocation.MockHandler;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.plugins.MockMaker;
 
+import static org.mockito.internal.util.StringJoiner.join;
+
 public class AndroidByteBuddyMockMaker implements MockMaker {
 
-    private final MockMaker delegate = new SubclassByteBuddyMockMaker(new AndroidLoadingStrategy());
+    private final MockMaker delegate;
+
+    public AndroidByteBuddyMockMaker() {
+        if (Platform.isAndroid() || Platform.isAndroidMockMakerRequired()) {
+            delegate = new SubclassByteBuddyMockMaker(new AndroidLoadingStrategy());
+        } else {
+            new ConsoleMockitoLogger().log(join(
+                    "IMPORTANT NOTE FROM MOCKITO:",
+                    "",
+                    "You included the 'mockito-android' dependency in a non-Android environment.",
+                    "The Android mock maker was disabled. You should only include the latter in your 'androidTestCompile' configuration",
+                    "If disabling was a mistake, you can set the 'org.mockito.mock.android' property to 'true' to override this detection.",
+                    "",
+                    "Visit https://javadoc.io/page/org.mockito/mockito-core/latest/org/mockito/Mockito.html#0.1 for more information"
+            ));
+            delegate = new SubclassByteBuddyMockMaker();
+        }
+    }
 
     @Override
     public <T> T createMock(MockCreationSettings<T> settings, MockHandler handler) {


### PR DESCRIPTION
The documentation gave an incorrect configuration example. Also, warnings were added for using Android on a non-Android environment.