### PR TITLE
Clarify documentation for consecutive stubbing

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -452,8 +452,8 @@ import org.mockito.verification.VerificationWithTimeout;
  *   .thenReturn("one", "two", "three");
  * </code></pre>
  *
- * <b>Warning</b>, if instead of chaining .thenReturn() calls, multiple when/thenReturn commands are used,
- * then each stubbing will override the previous one:
+ * <strong>Warning</strong> : if instead of chaining {@code .thenReturn()} calls, multiple stubbing with the same matchers or arguments
+ * is used, then each stubbing will override the previous one:
  *
  * <pre class="code"><code class="java">
  * //All mock.someMethod("some arg") calls will return "two"

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -452,6 +452,16 @@ import org.mockito.verification.VerificationWithTimeout;
  *   .thenReturn("one", "two", "three");
  * </code></pre>
  *
+ * <b>Warning</b>, if instead of chaining .thenReturn() calls, multiple when/thenReturn commands are used,
+ * then each stubbing will override the previous one:
+ *
+ * <pre class="code"><code class="java">
+ * //All mock.someMethod("some arg") calls will return "two"
+ * when(mock.someMethod("some arg"))
+ *   .thenReturn("one")
+ * when(mock.someMethod("some arg"))
+ *   .thenReturn("two")
+ * </code></pre>
  *
  *
  *


### PR DESCRIPTION
Fixes #895

As of now, the documentation does not clarify the difference of behaviour between chaining multiple .thenReturn() statements and using multiple when/thenReturn statements, when someone attempts to perform consecutive stubbing.

I added a warning/clarification in the documentation with a corresponding example, so that it's more clear (especially for new users of Mockito).