### PR TITLE
Fix TypeCache dead lock

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,8 @@ apply from: 'gradle/root/version.gradle'
 apply from: "gradle/java-library.gradle"
 
 dependencies {
-    compile 'net.bytebuddy:byte-buddy:1.6.4'
-    compile 'net.bytebuddy:byte-buddy-agent:1.6.4'
+    compile 'net.bytebuddy:byte-buddy:1.6.5'
+    compile 'net.bytebuddy:byte-buddy-agent:1.6.5'
 
     provided "junit:junit:4.12", "org.hamcrest:hamcrest-core:1.3"
     compile "org.objenesis:objenesis:2.5"

--- a/subprojects/android/android.gradle
+++ b/subprojects/android/android.gradle
@@ -11,7 +11,7 @@ apply from: "$rootDir/gradle/java-library.gradle"
 
 dependencies {
     compile project.rootProject
-    compile "net.bytebuddy:byte-buddy-android:1.6.4"
+    compile "net.bytebuddy:byte-buddy-android:1.6.5"
 }
 
 apply from: "$rootDir/gradle/publishable-java-library.gradle"


### PR DESCRIPTION
I could trace the problem to more eager resolution of types in Java u31 upon loading where concurrent mock creation with locking on the class level causes a dead lock. This can happen in other VM implementations but can be solved with a more granular lock on our type cache.

This fixes https://github.com/mockito/mockito/issues/892.