### PR TITLE
Cleans up the injection engine code

### DIFF
--- a/src/main/java/org/mockito/internal/configuration/DefaultInjectionEngine.java
+++ b/src/main/java/org/mockito/internal/configuration/DefaultInjectionEngine.java
@@ -6,7 +6,6 @@ package org.mockito.internal.configuration;
 
 import java.lang.reflect.Field;
 import java.util.Set;
-
 import org.mockito.internal.configuration.injection.MockInjection;
 
 /**
@@ -18,11 +17,11 @@ public class DefaultInjectionEngine {
 
     public void injectMocksOnFields(Set<Field> needingInjection, Set<Object> mocks, Object testClassInstance) {
         MockInjection.onFields(needingInjection, testClassInstance)
-                .withMocks(mocks)
-                .tryConstructorInjection()
-                .tryPropertyOrFieldInjection()
-                .handleSpyAnnotation()
-                .apply();
+                     .withMocks(mocks)
+                     .tryConstructorInjection()
+                     .tryPropertyOrFieldInjection()
+                     .handleSpyAnnotation()
+                     .apply();
     }
 
 }

--- a/src/main/java/org/mockito/internal/configuration/DefaultInjectionEngine.java
+++ b/src/main/java/org/mockito/internal/configuration/DefaultInjectionEngine.java
@@ -21,6 +21,7 @@ public class DefaultInjectionEngine {
                      .tryConstructorInjection()
                      .tryPropertyOrFieldInjection()
                      .handleSpyAnnotation()
+                     .poorManMultiLevelInjection()
                      .apply();
     }
 

--- a/src/main/java/org/mockito/internal/configuration/DefaultInjectionEngine.java
+++ b/src/main/java/org/mockito/internal/configuration/DefaultInjectionEngine.java
@@ -10,7 +10,7 @@ import org.mockito.internal.configuration.injection.MockInjection;
 
 /**
  * Inject mock/spies dependencies for fields annotated with &#064;InjectMocks
- * <p/>
+ * 
  * See {@link org.mockito.MockitoAnnotations}
  */
 public class DefaultInjectionEngine {

--- a/src/main/java/org/mockito/internal/configuration/SpyAnnotationEngine.java
+++ b/src/main/java/org/mockito/internal/configuration/SpyAnnotationEngine.java
@@ -4,15 +4,13 @@
  */
 package org.mockito.internal.configuration;
 
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
+import org.mockito.internal.util.reflection.Annotations;
 import org.mockito.plugins.AnnotationEngine;
-
-import static org.mockito.internal.exceptions.Reporter.unsupportedCombinationOfAnnotations;
 
 /**
  * Process fields annotated with &#64;Spy.
@@ -37,20 +35,10 @@ public class SpyAnnotationEngine implements AnnotationEngine, org.mockito.config
         for (Field field : fields) {
             // Combination of @InjectMocks and @Spy have to be handled separately by the injection engine
             if (field.isAnnotationPresent(Spy.class) && !field.isAnnotationPresent(InjectMocks.class)) {
-                assertNoIncompatibleAnnotations(Spy.class, field, Mock.class, Captor.class);
+                Annotations.assertNoIncompatibleAnnotations(Spy.class,
+                                                            field,
+                                                            Mock.class, Captor.class);
                 SpyFieldInitializer.initializeSpy(testInstance, field);
-            }
-        }
-    }
-
-    //TODO duplicated elsewhere
-    private static void assertNoIncompatibleAnnotations(Class<? extends Annotation> annotation,
-                                                        Field field,
-                                                        Class<? extends Annotation>... undesiredAnnotations) {
-        for (Class<? extends Annotation> u : undesiredAnnotations) {
-            if (field.isAnnotationPresent(u)) {
-                throw unsupportedCombinationOfAnnotations(annotation.getSimpleName(),
-                                                          annotation.getClass().getSimpleName());
             }
         }
     }

--- a/src/main/java/org/mockito/internal/configuration/SpyAnnotationEngine.java
+++ b/src/main/java/org/mockito/internal/configuration/SpyAnnotationEngine.java
@@ -5,41 +5,27 @@
 package org.mockito.internal.configuration;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Modifier;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockSettings;
-import org.mockito.Mockito;
 import org.mockito.Spy;
-import org.mockito.exceptions.base.MockitoException;
-import org.mockito.internal.util.MockUtil;
 import org.mockito.plugins.AnnotationEngine;
 
-import static org.mockito.Mockito.CALLS_REAL_METHODS;
-import static org.mockito.Mockito.withSettings;
 import static org.mockito.internal.exceptions.Reporter.unsupportedCombinationOfAnnotations;
-import static org.mockito.internal.util.StringJoiner.join;
 
 /**
  * Process fields annotated with &#64;Spy.
- * <p/>
  * <p>
  * Will try transform the field in a spy as with <code>Mockito.spy()</code>.
  * </p>
- * <p/>
  * <p>
  * If the field is not initialized, will try to initialize it, with a no-arg constructor.
  * </p>
- * <p/>
  * <p>
  * If the field is also annotated with the <strong>compatible</strong> &#64;InjectMocks then the field will be ignored,
  * The injection engine will handle this specific case.
  * </p>
- * <p/>
  * <p>This engine will fail, if the field is also annotated with incompatible Mockito annotations.
  */
 @SuppressWarnings({"unchecked"})
@@ -49,96 +35,12 @@ public class SpyAnnotationEngine implements AnnotationEngine, org.mockito.config
     public void process(Class<?> context, Object testInstance) {
         Field[] fields = context.getDeclaredFields();
         for (Field field : fields) {
+            // Combination of @InjectMocks and @Spy have to be handled separately by the injection engine
             if (field.isAnnotationPresent(Spy.class) && !field.isAnnotationPresent(InjectMocks.class)) {
                 assertNoIncompatibleAnnotations(Spy.class, field, Mock.class, Captor.class);
-                field.setAccessible(true);
-                Object instance;
-                try {
-                    instance = field.get(testInstance);
-                    assertNotInterface(instance, field.getType());
-                    if (MockUtil.isMock(instance)) {
-                        // instance has been spied earlier
-                        // for example happens when MockitoAnnotations.initMocks is called two times.
-                        Mockito.reset(instance);
-                    } else if (instance != null) {
-                        field.set(testInstance, spyInstance(field, instance));
-                    } else {
-                        field.set(testInstance, spyNewInstance(testInstance, field));
-                    }
-                } catch (Exception e) {
-                    throw new MockitoException("Unable to initialize @Spy annotated field '" + field.getName() + "'.\n" + e.getMessage(), e);
-                }
+                SpyFieldInitializer.initializeSpy(testInstance, field);
             }
         }
-    }
-
-    private static void assertNotInterface(Object testInstance, Class<?> type) {
-        type = testInstance != null ? testInstance.getClass() : type;
-        if (type.isInterface()) {
-            throw new MockitoException("Type '" + type.getSimpleName() + "' is an interface and it cannot be spied on.");
-        }
-    }
-
-    private static Object spyInstance(Field field, Object instance) {
-        return Mockito.mock(instance.getClass(),
-                            withSettings().spiedInstance(instance)
-                                          .defaultAnswer(CALLS_REAL_METHODS)
-                                          .name(field.getName()));
-    }
-
-    private static Object spyNewInstance(Object testInstance, Field field)
-            throws InstantiationException, IllegalAccessException, InvocationTargetException {
-        MockSettings settings = withSettings().defaultAnswer(CALLS_REAL_METHODS)
-                                              .name(field.getName());
-        Class<?> type = field.getType();
-        if (type.isInterface()) {
-            return Mockito.mock(type, settings.useConstructor());
-        }
-        int modifiers = type.getModifiers();
-        if (typeIsPrivateAbstractInnerClass(type, modifiers)) {
-            throw new MockitoException(join("@Spy annotation can't initialize private abstract inner classes.",
-                                            "  inner class: '" + type.getSimpleName() + "'",
-                                            "  outer class: '" + type.getEnclosingClass().getSimpleName() + "'",
-                                            "",
-                                            "You should augment the visibility of this inner class"));
-        }
-        if (typeIsNonStaticInnerClass(type, modifiers)) {
-            Class<?> enclosing = type.getEnclosingClass();
-            if (!enclosing.isInstance(testInstance)) {
-                throw new MockitoException(join("@Spy annotation can only initialize inner classes declared in the test.",
-                                                "  inner class: '" + type.getSimpleName() + "'",
-                                                "  outer class: '" + enclosing.getSimpleName() + "'",
-                                                ""));
-            }
-            return Mockito.mock(type, settings.useConstructor()
-                                              .outerInstance(testInstance));
-        }
-
-        Constructor<?> constructor = noArgConstructorOf(type);
-        if (Modifier.isPrivate(constructor.getModifiers())) {
-            constructor.setAccessible(true);
-            return Mockito.mock(type, settings.spiedInstance(constructor.newInstance()));
-        } else {
-            return Mockito.mock(type, settings.useConstructor());
-        }
-    }
-
-    private static Constructor<?> noArgConstructorOf(Class<?> type) {
-        Constructor<?> constructor;
-        try {
-            constructor = type.getDeclaredConstructor();
-        } catch (NoSuchMethodException e) {
-            throw new MockitoException("Please ensure that the type '" + type.getSimpleName() + "' has a no-arg constructor.");
-        }
-        return constructor;
-    }
-
-    private static boolean typeIsNonStaticInnerClass(Class<?> type, int modifiers) {
-        return !Modifier.isStatic(modifiers) && type.getEnclosingClass() != null;
-    }
-
-    private static boolean typeIsPrivateAbstractInnerClass(Class<?> type, int modifiers) {
-        return Modifier.isPrivate(modifiers) && Modifier.isAbstract(modifiers) && type.getEnclosingClass() != null;
     }
 
     //TODO duplicated elsewhere

--- a/src/main/java/org/mockito/internal/configuration/SpyAnnotationEngine.java
+++ b/src/main/java/org/mockito/internal/configuration/SpyAnnotationEngine.java
@@ -79,11 +79,11 @@ public class SpyAnnotationEngine implements AnnotationEngine, org.mockito.config
         }
     }
 
-    private Object spyInstance(Field field, Object instance) {
+    private static Object spyInstance(Field field, Object instance) {
         return Mockito.mock(instance.getClass(),
                             withSettings().spiedInstance(instance)
-                                                           .defaultAnswer(CALLS_REAL_METHODS)
-                                                           .name(field.getName()));
+                                          .defaultAnswer(CALLS_REAL_METHODS)
+                                          .name(field.getName()));
     }
 
     private static Object spyNewInstance(Object testInstance, Field field)
@@ -113,7 +113,7 @@ public class SpyAnnotationEngine implements AnnotationEngine, org.mockito.config
             return Mockito.mock(type, settings.useConstructor()
                                               .outerInstance(testInstance));
         }
-        
+
         Constructor<?> constructor = noArgConstructorOf(type);
         if (Modifier.isPrivate(constructor.getModifiers())) {
             constructor.setAccessible(true);
@@ -142,9 +142,9 @@ public class SpyAnnotationEngine implements AnnotationEngine, org.mockito.config
     }
 
     //TODO duplicated elsewhere
-    private void assertNoIncompatibleAnnotations(Class<? extends Annotation> annotation,
-                                                 Field field,
-                                                 Class<? extends Annotation>... undesiredAnnotations) {
+    private static void assertNoIncompatibleAnnotations(Class<? extends Annotation> annotation,
+                                                        Field field,
+                                                        Class<? extends Annotation>... undesiredAnnotations) {
         for (Class<? extends Annotation> u : undesiredAnnotations) {
             if (field.isAnnotationPresent(u)) {
                 throw unsupportedCombinationOfAnnotations(annotation.getSimpleName(),

--- a/src/main/java/org/mockito/internal/configuration/SpyFieldInitializer.java
+++ b/src/main/java/org/mockito/internal/configuration/SpyFieldInitializer.java
@@ -1,0 +1,106 @@
+package org.mockito.internal.configuration;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+import org.mockito.MockSettings;
+import org.mockito.Mockito;
+import org.mockito.exceptions.base.MockitoException;
+import org.mockito.internal.util.MockUtil;
+import org.mockito.internal.util.reflection.FieldReader;
+import org.mockito.internal.util.reflection.FieldSetter;
+
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.withSettings;
+import static org.mockito.internal.util.StringJoiner.join;
+
+class SpyFieldInitializer {
+    public static void initializeSpy(Object testInstance, Field field) {
+        FieldReader fieldReader = new FieldReader(testInstance, field);
+        try {
+            Object instance = fieldReader.read();
+            assertNotInterface(instance, field.getType());
+            if (MockUtil.isMock(instance)) {
+                // instance has been spied earlier
+                // for example happens when MockitoAnnotations.initMocks is called two times.
+                Mockito.reset(instance);
+            } else if (instance != null) {
+                FieldSetter.setField(testInstance, field, spyInstance(field, instance));
+            } else {
+                FieldSetter.setField(testInstance, field, spyNewInstance(testInstance, field));
+            }
+        } catch (Exception e) {
+            throw new MockitoException("Unable to initialize @Spy annotated field '" + field.getName() + "'.\n" + e.getMessage(), e);
+        }
+    }
+
+    private static void assertNotInterface(Object testInstance, Class<?> type) {
+        type = testInstance != null ? testInstance.getClass() : type;
+        if (type.isInterface()) {
+            throw new MockitoException("Type '" + type.getSimpleName() + "' is an interface and it cannot be spied on.");
+        }
+    }
+
+    private static Object spyInstance(Field field, Object instance) {
+        return Mockito.mock(instance.getClass(),
+                            withSettings().spiedInstance(instance)
+                                          .defaultAnswer(CALLS_REAL_METHODS)
+                                          .name(field.getName()));
+    }
+
+    private static Object spyNewInstance(Object testInstance, Field field)
+            throws InstantiationException, IllegalAccessException, InvocationTargetException {
+        MockSettings settings = withSettings().defaultAnswer(CALLS_REAL_METHODS)
+                                              .name(field.getName());
+        Class<?> type = field.getType();
+        if (type.isInterface()) {
+            return Mockito.mock(type, settings.useConstructor());
+        }
+        int modifiers = type.getModifiers();
+        if (typeIsPrivateAbstractInnerClass(type, modifiers)) {
+            throw new MockitoException(join("@Spy annotation can't initialize private abstract inner classes.",
+                                            "  inner class: '" + type.getSimpleName() + "'",
+                                            "  outer class: '" + type.getEnclosingClass().getSimpleName() + "'",
+                                            "",
+                                            "You should augment the visibility of this inner class"));
+        }
+        if (typeIsNonStaticInnerClass(type, modifiers)) {
+            Class<?> enclosing = type.getEnclosingClass();
+            if (!enclosing.isInstance(testInstance)) {
+                throw new MockitoException(join("@Spy annotation can only initialize inner classes declared in the test.",
+                                                "  inner class: '" + type.getSimpleName() + "'",
+                                                "  outer class: '" + enclosing.getSimpleName() + "'",
+                                                ""));
+            }
+            return Mockito.mock(type, settings.useConstructor()
+                                              .outerInstance(testInstance));
+        }
+
+        Constructor<?> constructor = noArgConstructorOf(type);
+        if (Modifier.isPrivate(constructor.getModifiers())) {
+            constructor.setAccessible(true);
+            return Mockito.mock(type, settings.spiedInstance(constructor.newInstance()));
+        } else {
+            return Mockito.mock(type, settings.useConstructor());
+        }
+    }
+
+    private static Constructor<?> noArgConstructorOf(Class<?> type) {
+        Constructor<?> constructor;
+        try {
+            constructor = type.getDeclaredConstructor();
+        } catch (NoSuchMethodException e) {
+            throw new MockitoException("Please ensure that the type '" + type.getSimpleName() + "' has a no-arg constructor.");
+        }
+        return constructor;
+    }
+
+    private static boolean typeIsNonStaticInnerClass(Class<?> type, int modifiers) {
+        return !Modifier.isStatic(modifiers) && type.getEnclosingClass() != null;
+    }
+
+    private static boolean typeIsPrivateAbstractInnerClass(Class<?> type, int modifiers) {
+        return Modifier.isPrivate(modifiers) && Modifier.isAbstract(modifiers) && type.getEnclosingClass() != null;
+    }
+}

--- a/src/main/java/org/mockito/internal/configuration/SpyFieldInitializer.java
+++ b/src/main/java/org/mockito/internal/configuration/SpyFieldInitializer.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.withSettings;
 import static org.mockito.internal.util.StringJoiner.join;
 
 public class SpyFieldInitializer {
-    public static void initializeSpy(Object fieldOwner, Field field) {
+    public static Object initializeSpy(Object fieldOwner, Field field) {
         FieldReader fieldReader = new FieldReader(fieldOwner, field);
         try {
             Object fieldInstance = fieldReader.read();
@@ -34,6 +34,7 @@ public class SpyFieldInitializer {
             } else {
                 FieldSetter.setField(fieldOwner, field, spyNewInstance(fieldOwner, field));
             }
+            return fieldReader.read();
         } catch (Exception e) {
             throw new MockitoException("Unable to initialize @Spy annotated field '" + field.getName() + "'.\n" + e.getMessage(), e);
         }

--- a/src/main/java/org/mockito/internal/configuration/injection/SpyOnInjectedFieldsHandler.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/SpyOnInjectedFieldsHandler.java
@@ -23,7 +23,8 @@ public class SpyOnInjectedFieldsHandler extends MockInjectionStrategy {
     @Override
     protected boolean processInjection(Field field, Object fieldOwner, Set<Object> ignored) {
         if (field.isAnnotationPresent(Spy.class)) {
-            SpyFieldInitializer.initializeSpy(fieldOwner, field);
+            Object spy = SpyFieldInitializer.initializeSpy(fieldOwner, field);
+            ignored.add(spy);
         }
 
         return false;

--- a/src/main/java/org/mockito/internal/configuration/injection/SpyOnInjectedFieldsHandler.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/SpyOnInjectedFieldsHandler.java
@@ -7,15 +7,8 @@ package org.mockito.internal.configuration.injection;
 
 import java.lang.reflect.Field;
 import java.util.Set;
-import org.mockito.Mockito;
 import org.mockito.Spy;
-import org.mockito.exceptions.base.MockitoException;
-import org.mockito.internal.util.MockUtil;
-import org.mockito.internal.util.reflection.FieldReader;
-
-import static org.mockito.Mockito.CALLS_REAL_METHODS;
-import static org.mockito.Mockito.withSettings;
-import static org.mockito.internal.util.reflection.FieldSetter.setField;
+import org.mockito.internal.configuration.SpyFieldInitializer;
 
 /**
  * Handler for field annotated with &#64;InjectMocks and &#64;Spy.
@@ -28,27 +21,9 @@ import static org.mockito.internal.util.reflection.FieldSetter.setField;
 public class SpyOnInjectedFieldsHandler extends MockInjectionStrategy {
 
     @Override
-    protected boolean processInjection(Field field, Object fieldOwner, Set<Object> mockCandidates) {
-        FieldReader fieldReader = new FieldReader(fieldOwner, field);
-
-        // TODO refactor : code duplicated in SpyAnnotationEngine
-        if (!fieldReader.isNull() && field.isAnnotationPresent(Spy.class)) {
-            try {
-                Object instance = fieldReader.read();
-                if (MockUtil.isMock(instance)) {
-                    // A. instance has been spied earlier
-                    // B. protect against multiple use of MockitoAnnotations.initMocks()
-                    Mockito.reset(instance);
-                } else {
-                    Object mock = Mockito.mock(instance.getClass(),
-                                               withSettings().spiedInstance(instance)
-                                                             .defaultAnswer(CALLS_REAL_METHODS)
-                                                             .name(field.getName()));
-                    setField(fieldOwner, field, mock);
-                }
-            } catch (Exception e) {
-                throw new MockitoException("Problems initiating spied field " + field.getName(), e);
-            }
+    protected boolean processInjection(Field field, Object fieldOwner, Set<Object> ignored) {
+        if (field.isAnnotationPresent(Spy.class)) {
+            SpyFieldInitializer.initializeSpy(fieldOwner, field);
         }
 
         return false;

--- a/src/main/java/org/mockito/internal/configuration/injection/SpyOnInjectedFieldsHandler.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/SpyOnInjectedFieldsHandler.java
@@ -5,15 +5,15 @@
 
 package org.mockito.internal.configuration.injection;
 
+import java.lang.reflect.Field;
+import java.util.Set;
 import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.util.MockUtil;
 import org.mockito.internal.util.reflection.FieldReader;
 
-import java.lang.reflect.Field;
-import java.util.Set;
-
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.withSettings;
 import static org.mockito.internal.util.reflection.FieldSetter.setField;
 
@@ -31,8 +31,8 @@ public class SpyOnInjectedFieldsHandler extends MockInjectionStrategy {
     protected boolean processInjection(Field field, Object fieldOwner, Set<Object> mockCandidates) {
         FieldReader fieldReader = new FieldReader(fieldOwner, field);
 
-        // TODO refoctor : code duplicated in SpyAnnotationEngine
-        if(!fieldReader.isNull() && field.isAnnotationPresent(Spy.class)) {
+        // TODO refactor : code duplicated in SpyAnnotationEngine
+        if (!fieldReader.isNull() && field.isAnnotationPresent(Spy.class)) {
             try {
                 Object instance = fieldReader.read();
                 if (MockUtil.isMock(instance)) {
@@ -40,11 +40,11 @@ public class SpyOnInjectedFieldsHandler extends MockInjectionStrategy {
                     // B. protect against multiple use of MockitoAnnotations.initMocks()
                     Mockito.reset(instance);
                 } else {
-                    Object mock = Mockito.mock(instance.getClass(), withSettings()
-					    .spiedInstance(instance)
-					    .defaultAnswer(Mockito.CALLS_REAL_METHODS)
-					    .name(field.getName()));
-					setField(fieldOwner, field, mock);
+                    Object mock = Mockito.mock(instance.getClass(),
+                                               withSettings().spiedInstance(instance)
+                                                             .defaultAnswer(CALLS_REAL_METHODS)
+                                                             .name(field.getName()));
+                    setField(fieldOwner, field, mock);
                 }
             } catch (Exception e) {
                 throw new MockitoException("Problems initiating spied field " + field.getName(), e);

--- a/src/main/java/org/mockito/internal/configuration/injection/scanner/InjectMocksScanner.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/scanner/InjectMocksScanner.java
@@ -4,16 +4,13 @@
  */
 package org.mockito.internal.configuration.injection.scanner;
 
-import org.mockito.Captor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-
-import static org.mockito.internal.exceptions.Reporter.unsupportedCombinationOfAnnotations;
-
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.util.HashSet;
 import java.util.Set;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.internal.util.reflection.Annotations;
 
 /**
  * Scan field for injection.
@@ -24,7 +21,7 @@ public class InjectMocksScanner {
     /**
      * Create a new InjectMocksScanner for the given clazz on the given instance
      *
-     * @param clazz    Current class in the hierarchy of the test
+     * @param clazz Current class in the hierarchy of the test
      */
     public InjectMocksScanner(Class<?> clazz) {
         this.clazz = clazz;
@@ -51,7 +48,9 @@ public class InjectMocksScanner {
         Field[] fields = clazz.getDeclaredFields();
         for (Field field : fields) {
             if (null != field.getAnnotation(InjectMocks.class)) {
-                assertNoAnnotations(field, Mock.class, Captor.class);
+                Annotations.assertNoIncompatibleAnnotations(InjectMocks.class,
+                                                            field,
+                                                            Mock.class, Captor.class);
                 mockDependentFields.add(field);
             }
         }
@@ -59,11 +58,4 @@ public class InjectMocksScanner {
         return mockDependentFields;
     }
 
-    private static void assertNoAnnotations(Field field, Class<? extends Annotation>... annotations) {
-        for (Class<? extends Annotation> annotation : annotations) {
-            if (field.isAnnotationPresent(annotation)) {
-                throw unsupportedCombinationOfAnnotations(annotation.getSimpleName(), InjectMocks.class.getSimpleName());
-            }
-        }
-    }
 }

--- a/src/main/java/org/mockito/internal/exceptions/Reporter.java
+++ b/src/main/java/org/mockito/internal/exceptions/Reporter.java
@@ -12,7 +12,19 @@ import java.util.Collection;
 import java.util.List;
 import org.mockito.exceptions.base.MockitoAssertionError;
 import org.mockito.exceptions.base.MockitoException;
-import org.mockito.exceptions.misusing.*;
+import org.mockito.exceptions.misusing.CannotStubVoidMethodWithReturnValue;
+import org.mockito.exceptions.misusing.CannotVerifyStubOnlyMock;
+import org.mockito.exceptions.misusing.FriendlyReminderException;
+import org.mockito.exceptions.misusing.InvalidUseOfMatchersException;
+import org.mockito.exceptions.misusing.MissingMethodInvocationException;
+import org.mockito.exceptions.misusing.NotAMockException;
+import org.mockito.exceptions.misusing.NullInsteadOfMockException;
+import org.mockito.exceptions.misusing.PotentialStubbingProblem;
+import org.mockito.exceptions.misusing.RedundantListenerException;
+import org.mockito.exceptions.misusing.UnfinishedStubbingException;
+import org.mockito.exceptions.misusing.UnfinishedVerificationException;
+import org.mockito.exceptions.misusing.UnnecessaryStubbingException;
+import org.mockito.exceptions.misusing.WrongTypeOfReturnValue;
 import org.mockito.exceptions.verification.NeverWantedButInvoked;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockito.exceptions.verification.SmartNullPointerException;
@@ -622,9 +634,10 @@ public class Reporter {
                                             "For info how to use annotations see examples in javadoc for MockitoAnnotations class.");
     }
 
-    public static MockitoException unsupportedCombinationOfAnnotations(String undesiredAnnotationOne, String undesiredAnnotationTwo) {
-        return new MockitoException("This combination of annotations is not permitted on a single field:\n" +
-                                            "@" + undesiredAnnotationOne + " and @" + undesiredAnnotationTwo);
+    public static MockitoException unsupportedCombinationOfAnnotations(Field field, String undesiredAnnotationOne, String undesiredAnnotationTwo) {
+        return new MockitoException(join("This combination of annotations is not permitted on the field '" + field.getName() + "' :",
+                                         "@" + undesiredAnnotationOne + " and @" + undesiredAnnotationTwo,
+                                         ""));
     }
 
     public static MockitoException cannotInitializeForSpyAnnotation(String fieldName, Exception details) {

--- a/src/main/java/org/mockito/internal/util/Checks.java
+++ b/src/main/java/org/mockito/internal/util/Checks.java
@@ -24,4 +24,11 @@ public class Checks {
         }
         return iterable;
     }
+
+    public static <T> T check(boolean assertion, T arg, String checkedValue) {
+        if (!assertion) {
+            throw new IllegalArgumentException(checkedValue + " is invalid");
+        }
+        return arg;
+    }
 }

--- a/src/main/java/org/mockito/internal/util/reflection/Annotations.java
+++ b/src/main/java/org/mockito/internal/util/reflection/Annotations.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito.internal.util.reflection;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+
+import static org.mockito.internal.exceptions.Reporter.unsupportedCombinationOfAnnotations;
+
+public class Annotations {
+
+    public static void assertNoIncompatibleAnnotations(Class<? extends Annotation> annotation,
+                                                       Field field,
+                                                       Class<? extends Annotation>... undesiredAnnotations) {
+        for (Class<? extends Annotation> undesired : undesiredAnnotations) {
+            if (field.isAnnotationPresent(undesired)) {
+                throw unsupportedCombinationOfAnnotations(field,
+                                                          annotation.getSimpleName(),
+                                                          undesired.getSimpleName());
+            }
+        }
+    }
+}

--- a/src/main/java/org/mockito/internal/util/reflection/FieldSetter.java
+++ b/src/main/java/org/mockito/internal/util/reflection/FieldSetter.java
@@ -6,20 +6,31 @@ package org.mockito.internal.util.reflection;
 
 import java.lang.reflect.Field;
 
+import static java.lang.String.format;
+
 public class FieldSetter {
 
-    private FieldSetter(){}
+    private FieldSetter() {
+    }
 
-    public static void setField(Object target, Field field,Object value) {
+    public static void setField(Object target, Field field, Object value) {
         AccessibilityChanger changer = new AccessibilityChanger();
         changer.enableAccess(field);
         try {
             field.set(target, value);
-        } catch (IllegalAccessException e) {
-            throw new RuntimeException("Access not authorized on field '" + field + "' of object '" + target + "' with value: '" + value + "'", e);
-        } catch (IllegalArgumentException e) {
-            throw new RuntimeException("Wrong argument on field '" + field + "' of object '" + target + "' with value: '" + value + "', \n" +
-                    "reason : " + e.getMessage(), e);
+        } catch (IllegalAccessException illegalAccess) {
+            throw new RuntimeException(format("Access not authorized on field '%s' of object '%s' with value: '%s'",
+                                              field,
+                                              target,
+                                              value),
+                                       illegalAccess);
+        } catch (IllegalArgumentException illegalArgument) {
+            throw new RuntimeException(format("Wrong argument on field '%s' of object '%s' with value: '%s', \nreason : %s",
+                                              field,
+                                              target,
+                                              value,
+                                              illegalArgument.getMessage()),
+                                       illegalArgument);
         }
         changer.safelyDisableAccess(field);
     }

--- a/src/test/java/org/mockito/internal/util/reflection/AnnotationsTest.java
+++ b/src/test/java/org/mockito/internal/util/reflection/AnnotationsTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito.internal.util.reflection;
+
+import java.lang.annotation.Retention;
+import java.lang.reflect.Field;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@SuppressWarnings("unchecked")
+public class AnnotationsTest {
+
+    @WorksAlone
+    @DoNotWorkWithWorksAlone
+    Object with_WorksAlone_and_DoNotWorkWithWorksAlone_annotations;
+
+    @WorksAlone
+    Object with_WorksAlone_annotations;
+
+    @Test
+    public void should_report_unsupported_combination_of_annotation() {
+        try {
+            Annotations.assertNoIncompatibleAnnotations(WorksAlone.class,
+                                                        field("with_WorksAlone_and_DoNotWorkWithWorksAlone_annotations"),
+                                                        DoNotWorkWithWorksAlone.class);
+            Assertions.fail("should have raised a misuse");
+        } catch (Exception e) {
+            assertThat(e).hasMessageContaining("This combination of annotations is not permitted on the field")
+                         .hasMessageContaining("with_WorksAlone_and_DoNotWorkWithWorksAlone_annotations")
+                         .hasMessageContaining(WorksAlone.class.getSimpleName())
+                         .hasMessageContaining(DoNotWorkWithWorksAlone.class.getSimpleName());
+        }
+    }
+
+    @Test
+    public void should_not_report_unsupported_combination_of_annotation_when_annotations_not_present() {
+        Annotations.assertNoIncompatibleAnnotations(WorksAlone.class,
+                                                    field("with_WorksAlone_annotations"),
+                                                    DoNotWorkWithWorksAlone.class);
+        // noting raised
+    }
+    
+    private Field field(String fieldName) {
+        try {
+            return this.getClass().getDeclaredField(fieldName);
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Retention(RUNTIME)
+    private @interface WorksAlone {
+    }
+
+    @Retention(RUNTIME)
+    private @interface DoNotWorkWithWorksAlone {
+    }
+}

--- a/src/test/java/org/mockitousage/annotation/MultiLevelInjectionNotSupportedTest.java
+++ b/src/test/java/org/mockitousage/annotation/MultiLevelInjectionNotSupportedTest.java
@@ -1,0 +1,79 @@
+package org.mockitousage.annotation;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Enclosed.class)
+public class MultiLevelInjectionNotSupportedTest {
+
+    public static class MultiLevelInjectionFailsWithoutSuperClass {
+        @Spy
+        private DependencyOfDependency dep_of_dep;
+
+        @Spy
+        @InjectMocks
+        private MidLevelDependencyWithInjectMocks mid_level_dependency;
+
+        @InjectMocks
+        private TopLevelInjectee top_level_injectee;
+
+        @Rule
+        public MockitoRule rule = MockitoJUnit.rule();
+
+        @Test
+        public void should_inject_dependency() {
+            assertThat(top_level_injectee).describedAs("'top_level_injectee' should be initialized").isNotNull();
+            assertThat(mid_level_dependency).describedAs("'mid_level_dependency' should be initialized").isNotNull();
+            assertThat(mid_level_dependency.dep_of_dep).describedAs("'mid_level_dependency' should be initialized").isNotNull();
+            assertThat(top_level_injectee.dependency).describedAs("'dependency' can't be injected, as Mockito can't decide whether to spy or injectmocks first for 'mid_level_dependency'")
+                                                     .isNull();
+        }
+    }
+
+    static class EmptySuperClass {
+    }
+
+    public static class MultiLevelInjectionDoesntFailWithSuperClass extends EmptySuperClass {
+        @Spy
+        private DependencyOfDependency dep_of_dep;
+
+        @Spy
+        @InjectMocks
+        private MidLevelDependencyWithInjectMocks mid_level_dependency;
+
+        @InjectMocks
+        private TopLevelInjectee top_level_injectee;
+
+        @Rule
+        public MockitoRule rule = MockitoJUnit.rule();
+
+        @Test
+        public void should_inject_dependency() {
+            assertThat(top_level_injectee).describedAs("'injectee' should be initialized").isNotNull();
+            assertThat(mid_level_dependency).describedAs("'mid_level_dependency' should be initialized").isNotNull();
+            assertThat(mid_level_dependency.dep_of_dep).describedAs("'mid_level_dependency' should be initialized").isNotNull();
+            assertThat(top_level_injectee.dependency).describedAs("'dependency' can't be injected, as Mockito can't decide whether to spy or injectmocks first for 'mid_level_dependency'")
+                                                     .isNull();
+        }
+    }
+
+    static class DependencyOfDependency {
+        
+    }
+
+    static class MidLevelDependencyWithInjectMocks {
+        DependencyOfDependency dep_of_dep;
+    }
+
+    static class TopLevelInjectee {
+        MidLevelDependencyWithInjectMocks dependency;
+    }
+}

--- a/src/test/java/org/mockitousage/annotation/MultiLevelInjectionNotSupportedTest.java
+++ b/src/test/java/org/mockitousage/annotation/MultiLevelInjectionNotSupportedTest.java
@@ -14,13 +14,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(Enclosed.class)
 public class MultiLevelInjectionNotSupportedTest {
 
-    public static class MultiLevelInjectionFailsWithoutSuperClass {
+    public static class MultiLevelInjectionWithoutSuperClass {
         @Spy
         private DependencyOfDependency dep_of_dep;
 
         @Spy
         @InjectMocks
-        private MidLevelDependencyWithInjectMocks mid_level_dependency;
+        private SecondLevelDependencyWithInjectMocks mid_level_dependency;
 
         @InjectMocks
         private TopLevelInjectee top_level_injectee;
@@ -32,22 +32,22 @@ public class MultiLevelInjectionNotSupportedTest {
         public void should_inject_dependency() {
             assertThat(top_level_injectee).describedAs("'top_level_injectee' should be initialized").isNotNull();
             assertThat(mid_level_dependency).describedAs("'mid_level_dependency' should be initialized").isNotNull();
-            assertThat(mid_level_dependency.dep_of_dep).describedAs("'mid_level_dependency' should be initialized").isNotNull();
-            assertThat(top_level_injectee.dependency).describedAs("'dependency' can't be injected, as Mockito can't decide whether to spy or injectmocks first for 'mid_level_dependency'")
-                                                     .isNull();
+            assertThat(mid_level_dependency.independant_dep).describedAs("'mid_level_dependency.independant_dep' should be initialized").isNotNull();
+            assertThat(top_level_injectee._2nd_level).describedAs("'_2nd_level' should be injected")
+                                                     .isNotNull();
         }
     }
 
     static class EmptySuperClass {
     }
 
-    public static class MultiLevelInjectionDoesntFailWithSuperClass extends EmptySuperClass {
+    public static class MultiLevelInjectionWithSuperClass extends EmptySuperClass {
         @Spy
         private DependencyOfDependency dep_of_dep;
 
         @Spy
         @InjectMocks
-        private MidLevelDependencyWithInjectMocks mid_level_dependency;
+        private SecondLevelDependencyWithInjectMocks mid_level_dependency;
 
         @InjectMocks
         private TopLevelInjectee top_level_injectee;
@@ -59,21 +59,97 @@ public class MultiLevelInjectionNotSupportedTest {
         public void should_inject_dependency() {
             assertThat(top_level_injectee).describedAs("'injectee' should be initialized").isNotNull();
             assertThat(mid_level_dependency).describedAs("'mid_level_dependency' should be initialized").isNotNull();
-            assertThat(mid_level_dependency.dep_of_dep).describedAs("'mid_level_dependency' should be initialized").isNotNull();
-            assertThat(top_level_injectee.dependency).describedAs("'dependency' can't be injected, as Mockito can't decide whether to spy or injectmocks first for 'mid_level_dependency'")
-                                                     .isNull();
+            assertThat(mid_level_dependency.independant_dep).describedAs("'mid_level_dependency.independant_dep' should be initialized").isNotNull();
+            assertThat(top_level_injectee._2nd_level).describedAs("'_2nd_level' should be injected")
+                                                     .isNotNull();
         }
     }
+
+    public static class ThreeLevelInjection {
+        @Spy
+        private DependencyOfDependency dep_of_dep;
+
+        @Spy
+        @InjectMocks
+        private ThirdLevelDependencyWithInjectMocks third_level;
+
+        @Spy
+        @InjectMocks
+        private SecondLevelDependencyWithInjectMocks second_level;
+
+        @InjectMocks
+        private TopLevelInjectee top_level_injectee;
+
+        @Rule
+        public MockitoRule rule = MockitoJUnit.rule();
+
+        @Test
+        public void should_inject_dependency() {
+            assertThat(top_level_injectee).describedAs("'top_level_injectee' should be initialized").isNotNull();
+            assertThat(second_level).describedAs("'second_level' should be initialized").isNotNull();
+            assertThat(second_level.independant_dep).describedAs("'second_level.independant_dep' should be initialized").isNotNull();
+            assertThat(third_level).describedAs("'third_level' should be initialized").isNotNull();
+            assertThat(third_level.independent_dep).describedAs("'third_level.independant_dep' should be initialized").isNotNull();
+            assertThat(top_level_injectee._2nd_level).describedAs("'_2nd_level' should be injected")
+                                                     .isNotNull();
+        }
+    }
+
+    public static class FourLevelInjection {
+        @Spy
+        private DependencyOfDependency dep_of_dep;
+
+        @Spy
+        @InjectMocks
+        private FourthLevelDependencyWithInjectMocks fourth_level;
+
+        @Spy
+        @InjectMocks
+        private ThirdLevelDependencyWithInjectMocks third_level;
+
+        @Spy
+        @InjectMocks
+        private SecondLevelDependencyWithInjectMocks second_level;
+
+        @InjectMocks
+        private TopLevelInjectee top_level_injectee;
+
+        @Rule
+        public MockitoRule rule = MockitoJUnit.rule();
+
+        @Test
+        public void should_inject_dependency() {
+            assertThat(top_level_injectee).describedAs("'top_level_injectee' should be initialized").isNotNull();
+            assertThat(second_level).describedAs("'second_level' should be initialized").isNotNull();
+            assertThat(second_level.independant_dep).describedAs("'second_level.independant_dep' should be initialized").isNotNull();
+            assertThat(third_level).describedAs("'third_level' should be initialized").isNotNull();
+            assertThat(third_level.independent_dep).describedAs("'third_level.independant_dep' should be initialized").isNotNull();
+            assertThat(fourth_level).describedAs("'fourth_level' should be initialized").isNotNull();
+            assertThat(fourth_level.independent_dep).describedAs("'fourth_level.independant_dep' should be initialized").isNotNull();
+            assertThat(top_level_injectee._2nd_level).describedAs("'_2nd_level' should be injected")
+                                                     .isNotNull();
+        }
+    }
+
 
     static class DependencyOfDependency {
         
     }
 
-    static class MidLevelDependencyWithInjectMocks {
-        DependencyOfDependency dep_of_dep;
+    static class FourthLevelDependencyWithInjectMocks {
+        DependencyOfDependency independent_dep;
+    }
+
+    static class ThirdLevelDependencyWithInjectMocks {
+        DependencyOfDependency independent_dep;
+    }
+
+    static class SecondLevelDependencyWithInjectMocks {
+        DependencyOfDependency independant_dep;
+        ThirdLevelDependencyWithInjectMocks _3rd_level;
     }
 
     static class TopLevelInjectee {
-        MidLevelDependencyWithInjectMocks dependency;
+        SecondLevelDependencyWithInjectMocks _2nd_level;
     }
 }


### PR DESCRIPTION
This is mostly a boyscout change, reviewing commit by commit should makes more sense.

Basically the refactoring removes some old identified code duplication. And few tweaks on reporting.
More refining can be done in this area.

I'm quite unsure at this moment if allowing edge cases like in #810 is a godd thing. Yet, with the current code base it is still possible to have multi level depedency working by incoking serveral time `MockitoAnnotations.initMocks(this)`.