### PR TITLE
Added subproject for configuration-free inline mock making.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
+include 'inline'
 include 'testng'
 include 'extTest'
 include 'android'

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -1265,6 +1265,7 @@ import org.mockito.verification.*;
  * Previously they were considered <em>unmockable</em>, preventing the user from mocking.
  * We already started discussing how to make this feature enabled by default.
  * Currently, the feature is still optional as we wait for more feedback from the community.
+ *
  * <p>
  * This feature is turned off by default because it is based on completely different mocking mechanism
  * that requires more feedback from the community.
@@ -1279,6 +1280,11 @@ import org.mockito.verification.*;
  * that requires more feedback from the community. It can be activated explicitly by the mockito extension mechanism,
  * just create in the classpath a file <code>/mockito-extensions/org.mockito.plugins.MockMaker</code>
  * containing the value <code>mock-maker-inline</code>.
+ *
+ * <p>
+ * As a convenience, the Mockito team provides an artifact where this mock maker is preconfigured. Instead of using the
+ * <i>mockito-core</i> artifact, include the <i>mockito-inline</i> artifact in your project. Note that this artifact is
+ * likely to be discontinued once mocking of final classes and methods gets integrated into the default mock maker.
  *
  * <p>
  * Some noteworthy notes about this mock maker:

--- a/subprojects/inline/inline.gradle
+++ b/subprojects/inline/inline.gradle
@@ -1,0 +1,18 @@
+description = "Mockito preconfigured inline mock maker (intermediate and to be superseeded by automatic usage in a future version)"
+
+ext {
+    artifactName = 'mockito-inline'
+    bintrayAutoPublish = true
+    bintrayRepo = 'maven'
+    mavenCentralSync = false
+}
+
+apply from: "$rootDir/gradle/java-library.gradle"
+
+dependencies {
+    compile project.rootProject
+}
+
+apply from: "$rootDir/gradle/publishable-java-library.gradle"
+
+tasks.javadoc.enabled = false

--- a/subprojects/inline/src/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/subprojects/inline/src/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Added a preconfiguration for using the inline mock maker as a convenience artifact that can be included instead of creating the plugin file. This is very helpful when creating multi-module projects where the mock maker file has to repeated many times.

Once we choose to change the mock maker to be default or enable programmatic access, we can decide to drop this artifact similar to `mockito-all` from version one.