### PR TITLE
Deleted dead code

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,5 +1,0 @@
-dependencies {
-    //needed by JavadocExclude
-    //TODO find out if we really need JavadocExclude. Why don't we just exclude internal packages using Gradle API (Javadoc.exclude)?
-    compile files("${System.properties['java.home']}/../lib/tools.jar")
-}


### PR DESCRIPTION
buildSrc directory and the file it holds is no longer needed given that JavadocExclude class was removed some time ago. We forgot to delete this directory.