### PR TITLE
Remove string concatination inside an append call

### DIFF
--- a/src/main/java/org/mockito/internal/debugging/InvocationsPrinter.java
+++ b/src/main/java/org/mockito/internal/debugging/InvocationsPrinter.java
@@ -46,7 +46,7 @@ public class InvocationsPrinter {
         if (unused.isEmpty()) {
             return sb.toString();
         }
-        sb.append("[Mockito] Unused stubbings of: " + mock).append("\n");
+        sb.append("[Mockito] Unused stubbings of: ").append(mock).append("\n");
 
         x = 1;
         for(Stubbing s:stubbings) {


### PR DESCRIPTION
Concatinating Strings creates a temporary StringBuilder, which is then
converted to a String. Having such an argument inside a
StringBuilder#append call thus pointless. Using a chained append call
will have the exact same outcome, and would profit a slight [probably
unnoticeable in this instance] performance benefit.