### PR TITLE
Checkstyle conf. to enforce whitespace rules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,10 @@ allprojects {
         options.warnings = false
         options.encoding = 'UTF-8'
     }
+    apply plugin: 'checkstyle'
+    checkstyle {
+       configFile = rootProject.file('config/checkstyle/checkstyle.xml')
+    }
 }
 
 configurations {

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+    "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
+    "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<module name="Checker">
+    <!--
+     Different editors and IDEs may insert or remove trailing
+     whitespaces at the end of source lines or newline characyers
+     at the end of source files.
+
+     This changes have no actual meaning, but may cause visual spam
+     when [re]viewing diffs.
+     Having checkstyles rules to strictly enforce the defacto
+     standards of the project helps avoid such issues and make the
+     review process more efficient.
+
+     See also https://github.com/mockito/mockito/issues/903
+     -->
+    <module name="NewlineAtEndOfFile"/>
+    <module name="RegexpSingleline">
+        <!-- \s matches whitespace character, $ matches end of line. -->
+        <property name="format" value="\s+$"/>
+        <property name="message" value="Line has trailing spaces."/>
+    </module>
+</module>
+

--- a/config/checkstyle/checkstyle.xsl
+++ b/config/checkstyle/checkstyle.xsl
@@ -1,0 +1,207 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+	<xsl:output method="html" indent="yes"/>
+	<xsl:decimal-format decimal-separator="." grouping-separator="," />
+
+	<xsl:key name="files" match="file" use="@name" />
+
+	<!-- Checkstyle XML Style Sheet by Rolf Wojtech <rolf@wojtech.de>                   -->
+	<!-- (based on checkstyle-noframe-sorted.xsl by Stephane Bailliez                   -->
+	<!--  <sbailliez@apache.org> and sf-patch 1721291 by Leo Liang)                     -->
+	<!-- Changes: 																								                      -->
+	<!--  * Outputs seperate columns for error/warning/info                             -->
+	<!--  * Sorts primarily by #error, secondarily by #warning, tertiary by #info       -->
+	<!--  * Compatible with windows path names (converts '\' to '/' for html anchor)    -->
+	<!--                                                                                -->
+	<!-- Part of the Checkstyle distribution found at http://checkstyle.sourceforge.net -->
+	<!-- Usage (generates checkstyle_report.html):                                      -->
+	<!--    <checkstyle failonviolation="false" config="${check.config}">               -->
+	<!--      <fileset dir="${src.dir}" includes="**/*.java"/>                          -->
+	<!--      <formatter type="xml" toFile="${doc.dir}/checkstyle_report.xml"/>         -->
+	<!--    </checkstyle>                                                               -->
+	<!--    <style basedir="${doc.dir}" destdir="${doc.dir}"                            -->
+	<!--            includes="checkstyle_report.xml"                                    -->
+	<!--            style="${doc.dir}/checkstyle-noframes-severity-sorted.xsl"/>        -->
+
+	<xsl:template match="checkstyle">
+		<html>
+			<head>
+				<style type="text/css">
+					.bannercell {
+					border: 0px;
+					padding: 0px;
+					}
+					body {
+					margin-left: 10;
+					margin-right: 10;
+					font:normal 80% arial,helvetica,sanserif;
+					background-color:#FFFFFF;
+					color:#000000;
+					}
+					.a td {
+					background: #efefef;
+					}
+					.b td {
+					background: #fff;
+					}
+					th, td {
+					text-align: left;
+					vertical-align: top;
+					}
+					th {
+					font-weight:bold;
+					background: #ccc;
+					color: black;
+					}
+					table, th, td {
+					font-size:100%;
+					border: none
+					}
+					table.log tr td, tr th {
+
+					}
+					h2 {
+					font-weight:bold;
+					font-size:140%;
+					margin-bottom: 5;
+					}
+					h3 {
+					font-size:100%;
+					font-weight:bold;
+					background: #525D76;
+					color: white;
+					text-decoration: none;
+					padding: 5px;
+					margin-right: 2px;
+					margin-left: 2px;
+					margin-bottom: 0;
+					}
+				</style>
+			</head>
+			<body>
+				<a name="top"></a>
+				<!-- jakarta logo -->
+				<table border="0" cellpadding="0" cellspacing="0" width="100%">
+					<tr>
+						<td class="bannercell" rowspan="2">
+							<!--a href="http://jakarta.apache.org/">
+							<img src="http://jakarta.apache.org/images/jakarta-logo.gif" alt="http://jakarta.apache.org" align="left" border="0"/>
+							</a-->
+						</td>
+						<td class="text-align:right"><h2>CheckStyle Audit</h2></td>
+					</tr>
+					<tr>
+						<td class="text-align:right">Designed for use with <a href='http://checkstyle.sourceforge.net/'>CheckStyle</a> and <a href='http://jakarta.apache.org'>Ant</a>.</td>
+					</tr>
+				</table>
+				<hr size="1"/>
+
+				<!-- Summary part -->
+				<xsl:apply-templates select="." mode="summary"/>
+				<hr size="1" width="100%" align="left"/>
+
+				<xsl:if test="count(descendant::file[error]) + count(descendant::file[warning]) + count(descendant::file[info]) > 0">
+					<!-- Package List part -->
+					<xsl:apply-templates select="." mode="filelist"/>
+					<hr size="1" width="100%" align="left"/>
+
+					<!-- For each package create its part -->
+					<xsl:apply-templates select="file[@name and generate-id(.) = generate-id(key('files', @name))][count(error) + count(warning) + count(info) > 0]" />
+					<hr size="1" width="100%" align="left"/>
+				</xsl:if>
+			</body>
+		</html>
+	</xsl:template>
+
+
+
+	<xsl:template match="checkstyle" mode="filelist">
+		<h3>Files</h3>
+		<table class="log" border="0" cellpadding="5" cellspacing="2" width="100%">
+			<tr>
+				<th>Name</th>
+				<th>Errors</th>
+				<th>Warnings</th>
+				<th>Infos</th>
+			</tr>
+			<xsl:for-each select="file[@name and generate-id(.) = generate-id(key('files', @name))][count(error) + count(warning) + count(info) > 0]">
+
+				<!-- Sort method 1: Primary by #error, secondary by #warning, tertiary by #info -->
+				<xsl:sort data-type="number" order="descending" select="count(key('files', @name)/error[@severity='error'])"/>
+				<xsl:sort data-type="number" order="descending" select="count(key('files', @name)/error[@severity='warning'])"/>
+				<xsl:sort data-type="number" order="descending" select="count(key('files', @name)/error[@severity='info'])"/>
+
+				<!-- Sort method 1: Sum(#error+#info+#warning) (uncomment to use, comment method 1)  -->
+				<!--
+				<xsl:sort data-type="number" order="descending" select="count(key('files', @name)/error)"/>
+				-->
+
+				<xsl:variable name="errorCount" select="count(key('files', @name)/error[@severity='error'])"/>
+				<xsl:variable name="warningCount" select="count(key('files', @name)/error[@severity='warning'])"/>
+				<xsl:variable name="infoCount" select="count(key('files', @name)/error[@severity='info'])"/>
+
+				<tr>
+					<xsl:call-template name="alternated-row"/>
+					<td><a href="#f-{translate(@name,'\','/')}"><xsl:value-of select="@name"/></a></td>
+					<td><xsl:value-of select="$errorCount"/></td>
+					<td><xsl:value-of select="$warningCount"/></td>
+					<td><xsl:value-of select="$infoCount"/></td>
+				</tr>
+			</xsl:for-each>
+		</table>
+	</xsl:template>
+
+
+	<xsl:template match="file">
+		<a name="f-{translate(@name,'\','/')}"></a>
+		<h3>File <xsl:value-of select="@name"/></h3>
+
+		<table class="log" border="0" cellpadding="5" cellspacing="2" width="100%">
+			<tr>
+				<th>Severity</th>
+				<th>Error Description</th>
+				<th>Line</th>
+			</tr>
+			<xsl:for-each select="key('files', @name)/error">
+				<xsl:sort data-type="number" order="ascending" select="@line"/>
+				<tr>
+					<xsl:call-template name="alternated-row"/>
+					<td><xsl:value-of select="@severity"/></td>
+					<td><xsl:value-of select="@message"/></td>
+					<td><xsl:value-of select="@line"/></td>
+				</tr>
+			</xsl:for-each>
+		</table>
+		<a href="#top">Back to top</a>
+	</xsl:template>
+
+
+	<xsl:template match="checkstyle" mode="summary">
+		<h3>Summary</h3>
+		<xsl:variable name="fileCount" select="count(file[@name and generate-id(.) = generate-id(key('files', @name))])"/>
+		<xsl:variable name="errorCount" select="count(file/error[@severity='error'])"/>
+		<xsl:variable name="warningCount" select="count(file/error[@severity='warning'])"/>
+		<xsl:variable name="infoCount" select="count(file/error[@severity='info'])"/>
+		<table class="log" border="0" cellpadding="5" cellspacing="2" width="100%">
+			<tr>
+				<th>Files</th>
+				<th>Errors</th>
+				<th>Warnings</th>
+				<th>Infos</th>
+			</tr>
+			<tr>
+				<xsl:call-template name="alternated-row"/>
+				<td><xsl:value-of select="$fileCount"/></td>
+				<td><xsl:value-of select="$errorCount"/></td>
+				<td><xsl:value-of select="$warningCount"/></td>
+				<td><xsl:value-of select="$infoCount"/></td>
+			</tr>
+		</table>
+	</xsl:template>
+
+	<xsl:template name="alternated-row">
+		<xsl:attribute name="class">
+			<xsl:if test="position() mod 2 = 1">a</xsl:if>
+			<xsl:if test="position() mod 2 = 0">b</xsl:if>
+		</xsl:attribute>
+	</xsl:template>
+</xsl:stylesheet>

--- a/gradle/java-library.gradle
+++ b/gradle/java-library.gradle
@@ -28,5 +28,13 @@ test {
     }
 }
 
+tasks.withType(Checkstyle) {
+    reports {
+        xml.enabled false
+        html.enabled true
+        html.stylesheet resources.text.fromFile("$rootDir/config/checkstyle/checkstyle.xsl")
+    }
+}
+
 assert project.hasProperty("artifactName") : "Please configure 'ext.artifactName' for project that wants to use 'java-library.gradle' plugin"
 archivesBaseName = project.ext.artifactName

--- a/src/main/java/org/mockito/internal/stubbing/answers/DoesNothing.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/DoesNothing.java
@@ -17,13 +17,13 @@ public class DoesNothing implements Answer<Object>, ValidableAnswer, Serializabl
     private static final long serialVersionUID = 4840880517740698416L;
 
     private static final DoesNothing SINGLETON = new DoesNothing();
-    
+
     private DoesNothing() {}
-    
+
     public static DoesNothing doesNothing(){
         return SINGLETON;
     }
-    
+
     @Override
     public Object answer(InvocationOnMock invocation){
         return null;

--- a/src/test/java/org/mockito/internal/stubbing/answers/DoesNothingTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/answers/DoesNothingTest.java
@@ -16,7 +16,7 @@ import org.mockito.invocation.Invocation;
 import org.mockitousage.IMethods;
 
 public class DoesNothingTest   {
-    
+
     private IMethods mock;
     private Invocation invocation_Void;
     private Invocation invocation_void;
@@ -25,17 +25,17 @@ public class DoesNothingTest   {
     @Before
     public void init(){
         mock = mock(IMethods.class);
-        
+
         mock.voidMethod();
         invocation_Void = getLastInvocation();
-        
+
         mock.voidReturningMethod();
         invocation_void = getLastInvocation();
-        
+
         mock.simpleMethod();
         invocation_String = getLastInvocation();
     }
-    
+
     @Test
     public void answer_returnsNull() throws Throwable {
         assertThat(doesNothing().answer(invocation_Void)).isNull();
@@ -52,11 +52,11 @@ public class DoesNothingTest   {
     public void validateFor_voidReturnType_shouldPass()   {
         doesNothing().validateFor(invocation_void);
     }
-    
+
     @Test
     public void validateFor_voidObjectReturnType() throws Throwable {
         doesNothing().validateFor(invocation_Void);
     }
-    
-    
+
+
 }

--- a/src/test/java/org/mockito/internal/stubbing/answers/InvocationInfoTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/answers/InvocationInfoTest.java
@@ -76,31 +76,31 @@ public class InvocationInfoTest {
         assertThat(new InvocationInfo(new InvocationBuilder().method(iAmAbstract()).toInvocation()).isDeclaredOnInterface()).isFalse();
         assertThat(new InvocationInfo(new InvocationBuilder().method("voidMethod").toInvocation()).isDeclaredOnInterface()).isTrue();
     }
-    
+
     @Test
     public void isVoid_invocationOnVoidMethod_returnTrue(){
         mock(IMethods.class).voidMethod();
-        
+
         InvocationInfo voidMethod = new InvocationInfo(getLastInvocation());
-        
+
         assertThat(voidMethod.isVoid()).isTrue();
     }
-    
+
     @Test
     public void isVoid_invocationOnVoidReturningMethod_returnTrue(){
         mock(IMethods.class).voidReturningMethod();
-        
+
         InvocationInfo voidRetuningMethod = new InvocationInfo(getLastInvocation());
-        
+
         assertThat(voidRetuningMethod.isVoid()).isTrue();
     }
-    
+
     @Test
     public void isVoid_invocationNonVoidMethod_returnFalse(){
         mock(IMethods.class).simpleMethod();
-        
+
         InvocationInfo stringReturningMethod = new InvocationInfo(getLastInvocation());
-        
+
         assertThat(stringReturningMethod.isVoid()).isFalse();
     }
 
@@ -110,7 +110,7 @@ public class InvocationInfoTest {
         }
         return TheAbstract.class.getDeclaredMethod("iAmAbstract");
     }
-    
+
     private Method iAmNotAbstract() throws NoSuchMethodException {
         abstract class TheNotAbstract {
             void iAmNotAbstract() {};

--- a/src/test/java/org/mockitousage/IMethods.java
+++ b/src/test/java/org/mockitousage/IMethods.java
@@ -187,7 +187,7 @@ public interface IMethods {
     String toString(String foo);
 
     void voidMethod();
-    
+
     Void voidReturningMethod();
 
     String forList(List<String> list);


### PR DESCRIPTION
After PR #928 cleaned up some whitespace issues in the codebase (see
details there), this patch adds the checkstyle plugin to build to
enforce the standard established there:
1. A line may not end with trailing whitespaces
2. A file must end with the newline character

Note that this PR by no means intends to provide a full checkstyle configuration to the project.
It merely introduces the framework and two basic checks discussed in PR #928. Additional patches could easily add (or remove) additional checks as the dev community sees fit.

Usage note:
With this change applied, checkstyle would be run as part fo the gradle build. If a line in a `.java` source file ends with trailing whitespaces, the build will fail and an error message would be printed to the console. Additionally, an HTML report with all the errors would be generated. 

E.g.:

```
[ant:checkstyle] /home/amureini/src/git/mockito/subprojects/android/src/main/java/org/mockito/android/internal/creation/AndroidByteBuddyMockMaker.java:14: Line has trailing spaces.
:android:checkstyleMain FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':android:checkstyleMain'.
> Checkstyle rule violations were found. See the report at: file:///home/amureini/src/git/mockito/subprojects/android/build/reports/checkstyle/main.html

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED
```

Fixes #903