### PR TITLE
New feature - enable mocking using constructor arguments

### DIFF
--- a/src/main/java/org/mockito/MockSettings.java
+++ b/src/main/java/org/mockito/MockSettings.java
@@ -240,19 +240,25 @@ public interface MockSettings extends Serializable {
      * OtherAbstract spy = mock(OtherAbstract.class, withSettings()
      *   .useConstructor().defaultAnswer(CALLS_REAL_METHODS));
      *
+     * //Mocking an abstract class with constructor arguments
+     * SomeAbstract spy = mock(SomeAbstract.class, withSettings()
+     *   .useConstructor("arg1", 123).defaultAnswer(CALLS_REAL_METHODS));
+     *
      * //Mocking a non-static inner abstract class:
      * InnerAbstract spy = mock(InnerAbstract.class, withSettings()
      *   .useConstructor().outerInstance(outerInstance).defaultAnswer(CALLS_REAL_METHODS));
      * </code></pre>
      *
+     * @param args The arguments to pass to the constructor. Not passing any arguments means that a parameter-less
+     *             constructor will be called
      * @return settings instance so that you can fluently specify other settings
-     * @since 1.10.12
+     * @since 2.7.14 (useConstructor with no arguments was supported since 1.10.12)
      */
     @Incubating
-    MockSettings useConstructor();
+    MockSettings useConstructor(Object... args);
 
     /**
-     * Makes it possible to mock non-static inner classes in conjunction with {@link #useConstructor()}.
+     * Makes it possible to mock non-static inner classes in conjunction with {@link #useConstructor(Object...)}.
      * <p>
      * Example:
      * <pre class="code"><code class="java">

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -65,7 +65,7 @@ import org.mockito.verification.*;
  *      <a href="#27">27. Delegate calls to real instance (Since 1.9.5)</a><br/>
  *      <a href="#28">28. <code>MockMaker</code> API (Since 1.9.5)</a><br/>
  *      <a href="#29">29. BDD style verification (Since 1.10.0)</a><br/>
- *      <a href="#30">30. Spying or mocking abstract classes (Since 1.10.12) and Java 8 default methods (Since release 2.x)</a><br/>
+ *      <a href="#30">30. Spying or mocking abstract classes (Since 1.10.12, further enhanced in 2.7.13 and 2.7.14)</a><br/>
  *      <a href="#31">31. Mockito mocks can be <em>serialized</em> / <em>deserialized</em> across classloaders (Since 1.10.0)</a></h3><br/>
  *      <a href="#32">32. Better generic support with deep stubs (Since 1.10.0)</a></h3><br/>
  *      <a href="#32">33. Mockito JUnit rule (Since 1.10.17)</a><br/>
@@ -1017,7 +1017,7 @@ import org.mockito.verification.*;
  *
  *
  *
- * <h3 id="30">30. <a class="meaningful_link" href="#spying_abstract_classes" name="spying_abstract_classes">Spying or mocking abstract classes (Since 1.10.12) and Java 8 default methods (Since release 2.x)</a></h3>
+ * <h3 id="30">30. <a class="meaningful_link" href="#spying_abstract_classes" name="spying_abstract_classes">Spying or mocking abstract classes (Since 1.10.12, further enhanced in 2.7.13 and 2.7.14)</a></h3>
  *
  * It is now possible to conveniently spy on abstract classes. Note that overusing spies hints at code design smells (see {@link #spy(Object)}).
  * <p>
@@ -1030,19 +1030,23 @@ import org.mockito.verification.*;
  * //convenience API, new overloaded spy() method:
  * SomeAbstract spy = spy(SomeAbstract.class);
  *
- * // Mocking abstract methods, spying default methods of an interface
+ * //Mocking abstract methods, spying default methods of an interface (only avilable since 2.7.13)
  * Function<Foo, Bar> function = spy(Function.class);
  *
  * //Robust API, via settings builder:
  * OtherAbstract spy = mock(OtherAbstract.class, withSettings()
  *    .useConstructor().defaultAnswer(CALLS_REAL_METHODS));
  *
+ * //Mocking an abstract class with constructor arguments (only available since 2.7.14)
+ * SomeAbstract spy = mock(SomeAbstract.class, withSettings()
+ *   .useConstructor("arg1", 123).defaultAnswer(CALLS_REAL_METHODS));
+ *
  * //Mocking a non-static inner abstract class:
  * InnerAbstract spy = mock(InnerAbstract.class, withSettings()
  *    .useConstructor().outerInstance(outerInstance).defaultAnswer(CALLS_REAL_METHODS));
  * </code></pre>
  *
- * For more information please see {@link MockSettings#useConstructor()}.
+ * For more information please see {@link MockSettings#useConstructor(Object...)}.
  *
  *
  *

--- a/src/main/java/org/mockito/internal/creation/MockSettingsImpl.java
+++ b/src/main/java/org/mockito/internal/creation/MockSettingsImpl.java
@@ -9,6 +9,7 @@ import org.mockito.MockSettings;
 import static org.mockito.internal.exceptions.Reporter.*;
 import org.mockito.internal.creation.settings.CreationSettings;
 import org.mockito.internal.debugging.VerboseMockInvocationLogger;
+import org.mockito.internal.util.Checks;
 import org.mockito.internal.util.MockCreationValidator;
 import org.mockito.internal.util.MockNameImpl;
 import org.mockito.listeners.InvocationListener;
@@ -18,6 +19,8 @@ import org.mockito.mock.SerializableMode;
 import org.mockito.stubbing.Answer;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -30,6 +33,7 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
     private static final long serialVersionUID = 4475297236197939569L;
     private boolean useConstructor;
     private Object outerClassInstance;
+    private Object[] constructorArgs;
 
     public MockSettings serializable() {
         return serializable(SerializableMode.BASIC);
@@ -95,8 +99,12 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
         return this;
     }
 
-    public MockSettings useConstructor() {
+    public MockSettings useConstructor(Object... constructorArgs) {
+        Checks.checkNotNull(constructorArgs,
+            "constructorArgs",
+            "If you need to pass null, please cast it to the right type, e.g.: useConstructor((String) null)");
         this.useConstructor = true;
+        this.constructorArgs = constructorArgs;
         return this;
     }
 
@@ -111,6 +119,16 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
 
     public Object getOuterClassInstance() {
         return outerClassInstance;
+    }
+
+    public Object[] getConstructorArgs() {
+        if (outerClassInstance == null) {
+            return constructorArgs;
+        }
+        List<Object> resultArgs = new ArrayList<Object>(constructorArgs.length + 1);
+        resultArgs.add(outerClassInstance);
+        resultArgs.addAll(Arrays.asList(constructorArgs));
+        return resultArgs.toArray(new Object[constructorArgs.length + 1]);
     }
 
     public boolean isStubOnly() {

--- a/src/main/java/org/mockito/internal/creation/instance/DefaultInstantiatorProvider.java
+++ b/src/main/java/org/mockito/internal/creation/instance/DefaultInstantiatorProvider.java
@@ -12,8 +12,8 @@ public class DefaultInstantiatorProvider implements InstantiatorProvider {
     private final static Instantiator INSTANCE = new ObjenesisInstantiator();
 
     public Instantiator getInstantiator(MockCreationSettings<?> settings) {
-        if (settings != null && settings.isUsingConstructor()) {
-            return new ConstructorInstantiator(settings.getOuterClassInstance());
+        if (settings != null && settings.getConstructorArgs() != null) {
+            return new ConstructorInstantiator(settings.getOuterClassInstance() != null, settings.getConstructorArgs());
         } else {
             return INSTANCE;
         }

--- a/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
+++ b/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
@@ -32,6 +32,7 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
     protected boolean stubOnly;
     private boolean useConstructor;
     private Object outerClassInstance;
+    private Object[] constructorArgs;
 
     public CreationSettings() {}
 
@@ -48,6 +49,7 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
         this.stubOnly = copy.stubOnly;
         this.useConstructor = copy.isUsingConstructor();
         this.outerClassInstance = copy.getOuterClassInstance();
+        this.constructorArgs = copy.getConstructorArgs();
     }
 
     public Class<T> getTypeToMock() {
@@ -112,6 +114,11 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
 
     public boolean isUsingConstructor() {
         return useConstructor;
+    }
+
+    @Override
+    public Object[] getConstructorArgs() {
+        return constructorArgs;
     }
 
     public Object getOuterClassInstance() {

--- a/src/main/java/org/mockito/internal/util/Checks.java
+++ b/src/main/java/org/mockito/internal/util/Checks.java
@@ -11,8 +11,16 @@ package org.mockito.internal.util;
 public class Checks {
 
     public static <T> T checkNotNull(T value, String checkedValue) {
+        return checkNotNull(value, checkedValue, null);
+    }
+
+    public static <T> T checkNotNull(T value, String checkedValue, String additionalMessage) {
         if(value == null) {
-            throw new IllegalArgumentException(checkedValue + " should not be null");
+            String message = checkedValue + " should not be null";
+            if (additionalMessage != null) {
+                message += ". " + additionalMessage;
+            }
+            throw new IllegalArgumentException(message);
         }
         return value;
     }

--- a/src/main/java/org/mockito/mock/MockCreationSettings.java
+++ b/src/main/java/org/mockito/mock/MockCreationSettings.java
@@ -73,6 +73,18 @@ public interface MockCreationSettings<T> {
     boolean isUsingConstructor();
 
     /**
+     * Used when arguments should be passed to the mocked object's constructor, regardless of whether these
+     * arguments are supplied directly, or whether they include the outer instance.
+     *
+     * @return An array of arguments that are passed to the mocked object's constructor. If
+     * {@link #getOuterClassInstance()} is available, it is prepended to the passed arguments.
+     *
+     * @since 2.7.14
+     */
+    @Incubating
+    public Object[] getConstructorArgs();
+
+    /**
      * Used when mocking non-static inner classes in conjunction with {@link #isUsingConstructor()}
      *
      * @return the outer class instance used for creation of the mock object via the constructor.

--- a/src/test/java/org/mockito/internal/creation/instance/ConstructorInstantiatorTest.java
+++ b/src/test/java/org/mockito/internal/creation/instance/ConstructorInstantiatorTest.java
@@ -28,25 +28,52 @@ public class ConstructorInstantiatorTest extends TestBase {
         }
     }
 
+    static class SomeClass3 {
+
+        SomeClass3(int i) {
+
+        }
+    }
+
     @Test
     public void creates_instances() {
-        assertEquals(new ConstructorInstantiator(null).newInstance(SomeClass.class).getClass(), SomeClass.class);
+        assertEquals(new ConstructorInstantiator(false, new Object[0]).newInstance(SomeClass.class).getClass(), SomeClass.class);
     }
 
     @Test
     public void creates_instances_of_inner_classes() {
-        assertEquals(new ConstructorInstantiator(this).newInstance(SomeInnerClass.class).getClass(), SomeInnerClass.class);
-        assertEquals(new ConstructorInstantiator(new ChildOfThis()).newInstance(SomeInnerClass.class).getClass(), SomeInnerClass.class);
+        assertEquals(new ConstructorInstantiator(true, this).newInstance(SomeInnerClass.class).getClass(), SomeInnerClass.class);
+        assertEquals(new ConstructorInstantiator(true, new ChildOfThis()).newInstance(SomeInnerClass.class).getClass(), SomeInnerClass.class);
+    }
+
+    @Test
+    public void creates_instances_with_arguments() {
+        assertEquals(new ConstructorInstantiator(false, "someString").newInstance(SomeClass2.class).getClass(), SomeClass2.class);
+    }
+
+    @Test
+    public void creates_instances_with_null_arguments() {
+        assertEquals(new ConstructorInstantiator(false, new Object[]{null}).newInstance(SomeClass2.class).getClass(), SomeClass2.class);
+    }
+
+    @Test
+    public void creates_instances_with_primitive_arguments() {
+        assertEquals(new ConstructorInstantiator(false, 123).newInstance(SomeClass3.class).getClass(), SomeClass3.class);
+    }
+
+    @Test(expected = InstantiationException.class)
+    public void fails_when_null_is_passed_for_a_primitive() {
+        assertEquals(new ConstructorInstantiator(false, new Object[]{null}).newInstance(SomeClass3.class).getClass(), SomeClass3.class);
     }
 
     @Test
     public void explains_when_constructor_cannot_be_found() {
         try {
-            new ConstructorInstantiator(null).newInstance(SomeClass2.class);
+            new ConstructorInstantiator(false, new Object[0]).newInstance(SomeClass2.class);
             fail();
         } catch (InstantiationException e) {
             assertThat(e).hasMessageContaining("Unable to create instance of 'SomeClass2'.\n" +
-                    "Please ensure it has 0-arg constructor which invokes cleanly.");
+                    "Please ensure that the target class has a 0-arg constructor.");
         }
     }
 }

--- a/src/test/java/org/mockito/internal/util/ChecksTest.java
+++ b/src/test/java/org/mockito/internal/util/ChecksTest.java
@@ -21,9 +21,21 @@ public class ChecksTest {
     }
 
     @Test
+    public void checkNotNull_not_null_additional_message() throws Exception {
+        assertEquals("abc", Checks.checkNotNull("abc", "someValue", "Oh no!"));
+    }
+
+    @Test
     public void checkNotNull_null() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("someValue should not be null");
         Checks.checkNotNull(null, "someValue");
+    }
+
+    @Test
+    public void checkNotNull_null_additonal_message() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("someValue should not be null. Oh no!");
+        Checks.checkNotNull(null, "someValue", "Oh no!");
     }
 }

--- a/src/test/java/org/mockito/internal/util/ChecksTest.java
+++ b/src/test/java/org/mockito/internal/util/ChecksTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito.internal.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ChecksTest {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void checkNotNull_not_null() throws Exception {
+        assertEquals("abc", Checks.checkNotNull("abc", "someValue"));
+    }
+
+    @Test
+    public void checkNotNull_null() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("someValue should not be null");
+        Checks.checkNotNull(null, "someValue");
+    }
+}

--- a/src/test/java/org/mockitousage/constructor/CreatingMocksWithConstructorTest.java
+++ b/src/test/java/org/mockitousage/constructor/CreatingMocksWithConstructorTest.java
@@ -24,6 +24,12 @@ public class CreatingMocksWithConstructorTest extends TestBase {
         AbstractMessage() {
             this.message = "hey!";
         }
+        AbstractMessage(String message) {
+            this.message = message;
+        }
+        AbstractMessage(int i) {
+            this.message = String.valueOf(i);
+        }
         String getMessage() {
             return message;
         }
@@ -52,9 +58,61 @@ public class CreatingMocksWithConstructorTest extends TestBase {
     }
 
     @Test
+    public void can_spy_abstract_classes_with_constructor_args() {
+        AbstractMessage mock = mock(AbstractMessage.class, withSettings().useConstructor("hello!").defaultAnswer(CALLS_REAL_METHODS));
+        assertEquals("hello!", mock.getMessage());
+    }
+
+    @Test
+    public void can_spy_abstract_classes_with_constructor_primitive_args() {
+        AbstractMessage mock = mock(AbstractMessage.class, withSettings().useConstructor(7).defaultAnswer(CALLS_REAL_METHODS));
+        assertEquals("7", mock.getMessage());
+    }
+
+    @Test
+    public void can_spy_abstract_classes_with_constructor_array_of_nulls() {
+        AbstractMessage mock = mock(AbstractMessage.class, withSettings().useConstructor(new Object[]{null}).defaultAnswer(CALLS_REAL_METHODS));
+        assertNull(mock.getMessage());
+    }
+
+    @Test
+    public void can_spy_abstract_classes_with_casted_null() {
+        AbstractMessage mock = mock(AbstractMessage.class, withSettings().useConstructor((String) null).defaultAnswer(CALLS_REAL_METHODS));
+        assertNull(mock.getMessage());
+    }
+
+    @Test
+    public void can_spy_abstract_classes_with_null_varargs() {
+        try {
+            mock(AbstractMessage.class, withSettings().useConstructor(null).defaultAnswer(CALLS_REAL_METHODS));
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertThat(e).hasMessageContaining("constructorArgs should not be null. " +
+                "If you need to pass null, please cast it to the right type, e.g.: useConstructor((String) null)");
+        }
+    }
+
+    @Test
     public void can_mock_inner_classes() {
         InnerClass mock = mock(InnerClass.class, withSettings().useConstructor().outerInstance(this).defaultAnswer(CALLS_REAL_METHODS));
         assertEquals("hey!", mock.getMessage());
+    }
+
+    public static class ThrowingConstructorClass{
+        public ThrowingConstructorClass() {
+            throw new RuntimeException();
+        }
+    }
+
+    @Test
+    public void explains_constructor_exceptions() {
+        try {
+            ThrowingConstructorClass mock = mock(ThrowingConstructorClass.class, withSettings().useConstructor().defaultAnswer(CALLS_REAL_METHODS));
+            fail();
+        } catch (MockitoException e) {
+            assertThat(e).hasRootCauseInstanceOf(RuntimeException.class);
+            assertThat(e.getCause()).hasMessageContaining("Please ensure the target class has a 0-arg constructor and executes cleanly.");
+        }
     }
 
     static class HasConstructor {
@@ -70,7 +128,49 @@ public class CreatingMocksWithConstructorTest extends TestBase {
             fail();
         } catch (MockitoException e) {
             assertThat(e).hasMessage("Unable to create mock instance of type 'HasConstructor'");
-            assertThat(e.getCause()).hasMessageContaining("0-arg constructor");
+            assertThat(e.getCause()).hasMessageContaining("Please ensure that the target class has a 0-arg constructor.");
+        }
+    }
+
+    static class Base {}
+    static class ExtendsBase extends Base {}
+    static class ExtendsExtendsBase extends ExtendsBase {}
+
+    static class UsesBase {
+        public UsesBase(Base b) {}
+        public UsesBase(ExtendsBase b) {}
+    }
+
+    @Test
+    public void can_mock_unambigous_constructor_with_inheritence() {
+        UsesBase mock = mock(UsesBase.class, withSettings().useConstructor(new Base()).defaultAnswer(CALLS_REAL_METHODS));
+    }
+
+    @Test
+    public void exception_message_when_ambiguous_constructor_found_exact_exists() {
+        try {
+            //when
+            UsesBase mock = mock(UsesBase.class, withSettings().useConstructor(new ExtendsBase()).defaultAnswer(CALLS_REAL_METHODS));
+            //then
+            fail();
+        } catch (MockitoException e) {
+            assertThat(e).hasMessage("Unable to create mock instance of type 'UsesBase'");
+            assertThat(e.getCause()).hasMessageContaining
+                ("Multiple constructors could be matched to arguments of types [org.mockitousage.constructor.CreatingMocksWithConstructorTest$ExtendsBase]");
+        }
+    }
+
+    @Test
+    public void exception_message_when_ambiguous_constructor_found_exact_doesnt_exist() {
+        try {
+            //when
+            UsesBase mock = mock(UsesBase.class, withSettings().useConstructor(new ExtendsExtendsBase()).defaultAnswer(CALLS_REAL_METHODS));
+            //then
+            fail();
+        } catch (MockitoException e) {
+            assertThat(e).hasMessage("Unable to create mock instance of type 'UsesBase'");
+            assertThat(e.getCause()).hasMessageContaining
+                ("Multiple constructors could be matched to arguments of types [org.mockitousage.constructor.CreatingMocksWithConstructorTest$ExtendsExtendsBase]");
         }
     }
 
@@ -78,12 +178,14 @@ public class CreatingMocksWithConstructorTest extends TestBase {
     public void mocking_inner_classes_with_wrong_outer_instance() {
         try {
             //when
-            mock(InnerClass.class, withSettings().useConstructor().outerInstance("foo").defaultAnswer(CALLS_REAL_METHODS));
+            mock(InnerClass.class, withSettings().useConstructor().outerInstance(123).defaultAnswer(CALLS_REAL_METHODS));
             //then
             fail();
         } catch (MockitoException e) {
             assertThat(e).hasMessage("Unable to create mock instance of type 'InnerClass'");
-            assertThat(e.getCause()).hasMessageContaining("Unable to find a matching 1-arg constructor for the outer instance.");
+            assertThat(e.getCause()).hasMessageContaining(
+                "Please ensure that the target class has a 0-arg constructor"
+                    + " and that it's indeed an inner class of the passed instance of type java.lang.Integer");
         }
     }
 


### PR DESCRIPTION
To quote the requirement (see in-depth design in #685):
> We already support spying on abstract classes by allowing
parameterless constructor. However, there is no support for
constructor parameters.
This has been asked about long time ago. Mockito API is not robust
enough if it supports mocking with constructor but not when one has
any constructor parameters.

This patch enhances the `MockSettings#useConstrctor()` method (as suggested in the alternative API comment in the issue) and adds
optional ellipsis arguments that are passed to the constructor.

The patch streamlines the creation of mocks via constructors to a
single flow, where using a no-arg constructor or an enclosing class
are just private cases of this flow, and don't require their own
special treatment.