### PR TITLE
Allow spying on interfaces so that it is convenient to work with Java 8 default methods

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -64,7 +64,7 @@ import org.mockito.verification.*;
  *      <a href="#27">27. Delegate calls to real instance (Since 1.9.5)</a><br/>
  *      <a href="#28">28. <code>MockMaker</code> API (Since 1.9.5)</a><br/>
  *      <a href="#29">29. BDD style verification (Since 1.10.0)</a><br/>
- *      <a href="#30">30. Spying or mocking abstract classes (Since 1.10.12)</a><br/>
+ *      <a href="#30">30. Spying or mocking abstract classes (Since 1.10.12) and Java 8 default methods (Since release 2.x)</a><br/>
  *      <a href="#31">31. Mockito mocks can be <em>serialized</em> / <em>deserialized</em> across classloaders (Since 1.10.0)</a></h3><br/>
  *      <a href="#32">32. Better generic support with deep stubs (Since 1.10.0)</a></h3><br/>
  *      <a href="#32">33. Mockito JUnit rule (Since 1.10.17)</a><br/>
@@ -1008,7 +1008,7 @@ import org.mockito.verification.*;
  *
  *
  *
- * <h3 id="30">30. <a class="meaningful_link" href="#spying_abstract_classes" name="spying_abstract_classes">Spying or mocking abstract classes (Since 1.10.12)</a></h3>
+ * <h3 id="30">30. <a class="meaningful_link" href="#spying_abstract_classes" name="spying_abstract_classes">Spying or mocking abstract classes (Since 1.10.12) and Java 8 default methods (Since release 2.x)</a></h3>
  *
  * It is now possible to conveniently spy on abstract classes. Note that overusing spies hints at code design smells (see {@link #spy(Object)}).
  * <p>
@@ -1020,6 +1020,9 @@ import org.mockito.verification.*;
  * <pre class="code"><code class="java">
  * //convenience API, new overloaded spy() method:
  * SomeAbstract spy = spy(SomeAbstract.class);
+ *
+ * // Mocking abstract methods, spying default methods of an interface
+ * Function<Foo, Bar> function = spy(Function.class);
  *
  * //Robust API, via settings builder:
  * OtherAbstract spy = mock(OtherAbstract.class, withSettings()

--- a/src/main/java/org/mockito/internal/configuration/SpyAnnotationEngine.java
+++ b/src/main/java/org/mockito/internal/configuration/SpyAnnotationEngine.java
@@ -55,7 +55,6 @@ public class SpyAnnotationEngine implements AnnotationEngine, org.mockito.config
                 Object instance;
                 try {
                     instance = field.get(testInstance);
-                    assertNotInterface(instance, field.getType());
                     if (MockUtil.isMock(instance)) {
                         // instance has been spied earlier
                         // for example happens when MockitoAnnotations.initMocks is called two times.
@@ -72,14 +71,7 @@ public class SpyAnnotationEngine implements AnnotationEngine, org.mockito.config
         }
     }
 
-    private static void assertNotInterface(Object testInstance, Class<?> type) {
-        type = testInstance != null ? testInstance.getClass() : type;
-        if (type.isInterface()) {
-            throw new MockitoException("Type '" + type.getSimpleName() + "' is an interface and it cannot be spied on.");
-        }
-    }
-
-    private Object spyInstance(Field field, Object instance) {
+    private static Object spyInstance(Field field, Object instance) {
         return Mockito.mock(instance.getClass(),
                             withSettings().spiedInstance(instance)
                                                            .defaultAnswer(CALLS_REAL_METHODS)
@@ -142,9 +134,9 @@ public class SpyAnnotationEngine implements AnnotationEngine, org.mockito.config
     }
 
     //TODO duplicated elsewhere
-    private void assertNoIncompatibleAnnotations(Class<? extends Annotation> annotation,
-                                                 Field field,
-                                                 Class<? extends Annotation>... undesiredAnnotations) {
+    private static void assertNoIncompatibleAnnotations(Class<? extends Annotation> annotation,
+                                                        Field field,
+                                                        Class<? extends Annotation>... undesiredAnnotations) {
         for (Class<? extends Annotation> u : undesiredAnnotations) {
             if (field.isAnnotationPresent(u)) {
                 throw unsupportedCombinationOfAnnotations(annotation.getSimpleName(),

--- a/src/test/java/org/mockitousage/annotation/SpyAnnotationTest.java
+++ b/src/test/java/org/mockitousage/annotation/SpyAnnotationTest.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@SuppressWarnings({"unchecked", "unused"})
+@SuppressWarnings("unused")
 public class SpyAnnotationTest extends TestBase {
 
     @Spy
@@ -59,19 +59,16 @@ public class SpyAnnotationTest extends TestBase {
     }
 
     @Test
-    public void should_prevent_spying_on_interfaces() throws Exception {
+    public void should_allow_spying_on_interfaces() throws Exception {
         class WithSpy {
             @Spy
             List<String> list;
         }
 
         WithSpy withSpy = new WithSpy();
-        try {
-            MockitoAnnotations.initMocks(withSpy);
-            fail();
-        } catch (MockitoException e) {
-            assertThat(e.getMessage()).contains("is an interface and it cannot be spied on");
-        }
+        MockitoAnnotations.initMocks(withSpy);
+        when(withSpy.list.size()).thenReturn(3);
+        assertEquals(3, withSpy.list.size());
     }
 
     @Test

--- a/src/test/java/org/mockitousage/annotation/WrongSetOfAnnotationsTest.java
+++ b/src/test/java/org/mockitousage/annotation/WrongSetOfAnnotationsTest.java
@@ -14,7 +14,6 @@ import java.util.List;
 
 import static junit.framework.TestCase.fail;
 
-@SuppressWarnings({"unchecked", "unused"})
 public class WrongSetOfAnnotationsTest extends TestBase {
 
     @Test(expected=MockitoException.class)
@@ -25,15 +24,9 @@ public class WrongSetOfAnnotationsTest extends TestBase {
     }
 
     @Test
-    public void should_not_allow_Spy_and_or_InjectMocks_on_interfaces() throws Exception {
+    public void should_not_allow_Spy_and_InjectMocks_on_interfaces() throws Exception {
         try {
             MockitoAnnotations.initMocks(new Object() { @InjectMocks @Spy List<?> mock; });
-            fail();
-        } catch (MockitoException me) {
-            Assertions.assertThat(me.getMessage()).contains("'List' is an interface");
-        }
-        try {
-            MockitoAnnotations.initMocks(new Object() { @Spy List<?> mock; });
             fail();
         } catch (MockitoException me) {
             Assertions.assertThat(me.getMessage()).contains("'List' is an interface");

--- a/src/test/java/org/mockitousage/constructor/CreatingMocksWithConstructorTest.java
+++ b/src/test/java/org/mockitousage/constructor/CreatingMocksWithConstructorTest.java
@@ -128,6 +128,13 @@ public class CreatingMocksWithConstructorTest extends TestBase {
     }
 
     @Test
+    public void interface_method_stubbed() {
+        List<?> list = spy(List.class);
+        when(list.size()).thenReturn(12);
+        assertEquals(12, list.size());
+    }
+
+    @Test
     public void calls_real_interface_method() {
         List list = mock(List.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
         assertNull(list.get(1));


### PR DESCRIPTION
Fixes #680 
