### PR TITLE
Fix broken build

### DIFF
--- a/src/main/java/org/mockito/internal/util/Platform.java
+++ b/src/main/java/org/mockito/internal/util/Platform.java
@@ -8,7 +8,7 @@ import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.mockito.internal.util.StringJoiner.join;
+import static org.mockito.internal.util.StringUtil.join;
 
 public abstract class Platform {
 

--- a/subprojects/android/src/main/java/org/mockito/android/internal/creation/AndroidByteBuddyMockMaker.java
+++ b/subprojects/android/src/main/java/org/mockito/android/internal/creation/AndroidByteBuddyMockMaker.java
@@ -7,7 +7,7 @@ import org.mockito.invocation.MockHandler;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.plugins.MockMaker;
 
-import static org.mockito.internal.util.StringJoiner.join;
+import static org.mockito.internal.util.StringUtil.join;
 
 public class AndroidByteBuddyMockMaker implements MockMaker {
 


### PR DESCRIPTION
Commit da4e42 introduced a static import from the non-existent
`org.mockito.internal.util.StringJoiner` (it exists only in the master
branch, not the release/2.x branch).
This patch fixes the build by correcting the import to reference
`org.mockito.internal.util.StringUtil`.