### PR TITLE
MockingProgress: replaced getVerificationListeners() with fireVerificationEvent(..)

### DIFF
--- a/src/main/java/org/mockito/internal/MockitoCore.java
+++ b/src/main/java/org/mockito/internal/MockitoCore.java
@@ -23,11 +23,9 @@ import static org.mockito.internal.verification.VerificationModeFactory.noMoreIn
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 import org.mockito.InOrder;
 import org.mockito.MockSettings;
 import org.mockito.MockingDetails;
-import org.mockito.exceptions.base.MockitoException;
 import org.mockito.exceptions.misusing.NotAMockException;
 import org.mockito.internal.creation.MockSettingsImpl;
 import org.mockito.internal.invocation.finder.VerifiableInvocationsFinder;
@@ -43,7 +41,6 @@ import org.mockito.internal.verification.api.InOrderContext;
 import org.mockito.internal.verification.api.VerificationDataInOrder;
 import org.mockito.internal.verification.api.VerificationDataInOrderImpl;
 import org.mockito.invocation.Invocation;
-import org.mockito.listeners.VerificationListener;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.stubbing.OngoingStubbing;
 import org.mockito.stubbing.Stubber;
@@ -70,7 +67,6 @@ public class MockitoCore {
     public <T> OngoingStubbing<T> when(T methodCall) {
         MockingProgress mockingProgress = mockingProgress();
         mockingProgress.stubbingStarted();
-        @SuppressWarnings("unchecked")
         OngoingStubbing<T> stubbing = (OngoingStubbing<T>) mockingProgress.pullOngoingStubbing();
         if (stubbing == null) {
             mockingProgress.reset();
@@ -88,7 +84,7 @@ public class MockitoCore {
         }
         MockingProgress mockingProgress = mockingProgress();
         VerificationMode actualMode = mockingProgress.maybeVerifyLazily(mode);
-        mockingProgress.verificationStarted(new MockAwareVerificationMode(mock, actualMode, mockingProgress.verificationListeners()));
+        mockingProgress.verificationStarted(new MockAwareVerificationMode(mock, actualMode, mockingProgress));
         return mock;
     }
 

--- a/src/main/java/org/mockito/internal/progress/MockingProgress.java
+++ b/src/main/java/org/mockito/internal/progress/MockingProgress.java
@@ -5,11 +5,10 @@
 
 package org.mockito.internal.progress;
 
-import java.util.Set;
 import org.mockito.listeners.MockitoListener;
-import org.mockito.listeners.VerificationListener;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.stubbing.OngoingStubbing;
+import org.mockito.verification.VerificationEvent;
 import org.mockito.verification.VerificationMode;
 import org.mockito.verification.VerificationStrategy;
 
@@ -19,7 +18,7 @@ public interface MockingProgress {
 
     OngoingStubbing<?> pullOngoingStubbing();
 
-    Set<VerificationListener> verificationListeners();
+    void fireVerificationEvent(VerificationEvent event);
 
     void verificationStarted(VerificationMode verificationMode);
 
@@ -34,8 +33,8 @@ public interface MockingProgress {
     void reset();
 
     /**
-     * Removes ongoing stubbing so that in case the framework is misused
-     * state validation errors are more accurate
+     * Removes ongoing stubbing so that in case the framework is misused state
+     * validation errors are more accurate
      */
     void resetOngoingStubbing();
 
@@ -55,4 +54,5 @@ public interface MockingProgress {
      * Removes all listeners added via {@link #addListener(MockitoListener)}.
      */
     void clearListeners();
+
 }

--- a/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
+++ b/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
@@ -15,6 +15,7 @@ import org.mockito.listeners.MockitoListener;
 import org.mockito.listeners.VerificationListener;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.stubbing.OngoingStubbing;
+import org.mockito.verification.VerificationEvent;
 import org.mockito.verification.VerificationMode;
 import org.mockito.verification.VerificationStrategy;
 
@@ -58,18 +59,13 @@ public class MockingProgressImpl implements MockingProgress {
     }
 
     @Override
-    public Set<VerificationListener> verificationListeners() {
-        final LinkedHashSet<VerificationListener> verificationListeners = new LinkedHashSet<VerificationListener>();
-
+    public void fireVerificationEvent(VerificationEvent event) {
         for (MockitoListener listener : listeners) {
             if (listener instanceof VerificationListener) {
-                verificationListeners.add((VerificationListener) listener);
+                ((VerificationListener) listener).onVerification(event);
             }
         }
-
-        return verificationListeners;
     }
-
 
     public void verificationStarted(VerificationMode verify) {
         validateState();

--- a/src/main/java/org/mockito/internal/verification/MockAwareVerificationMode.java
+++ b/src/main/java/org/mockito/internal/verification/MockAwareVerificationMode.java
@@ -4,42 +4,39 @@
  */
 package org.mockito.internal.verification;
 
-import java.util.Set;
+import org.mockito.internal.progress.MockingProgress;
 import org.mockito.internal.verification.api.VerificationData;
-import org.mockito.listeners.VerificationListener;
-import org.mockito.verification.VerificationEvent;
 import org.mockito.verification.VerificationMode;
 
 public class MockAwareVerificationMode implements VerificationMode {
 
     private final Object mock;
     private final VerificationMode mode;
-    private final Set<VerificationListener> listeners;
+    private final MockingProgress mockingProgress;
 
-    public MockAwareVerificationMode(Object mock, VerificationMode mode, Set<VerificationListener> listeners) {
+    public MockAwareVerificationMode(Object mock, VerificationMode mode, MockingProgress mockingProgress) {
         this.mock = mock;
         this.mode = mode;
-        this.listeners = listeners;
+        this.mockingProgress = mockingProgress;
     }
 
     public void verify(VerificationData data) {
         try {
             mode.verify(data);
-            notifyListeners(new VerificationEventImpl(mock, mode, data, null));
         } catch (RuntimeException e) {
-            notifyListeners(new VerificationEventImpl(mock, mode, data, e));
+            fireVerificationEvent( data, e);
             throw e;
         } catch (Error e) {
-            notifyListeners(new VerificationEventImpl(mock, mode, data, e));
+            fireVerificationEvent(data, e);
             throw e;
         }
+        
+        fireVerificationEvent(data,null);
     }
 
 
-    private void notifyListeners(VerificationEvent event) {
-        for (VerificationListener listener : listeners) {
-            listener.onVerification(event);
-        }
+    private void fireVerificationEvent(VerificationData data, Throwable error) {
+    	mockingProgress.fireVerificationEvent(new VerificationEventImpl(mock, mode, data, error));
     }
 
     public Object getMock() {

--- a/src/main/java/org/mockito/internal/verification/MockAwareVerificationMode.java
+++ b/src/main/java/org/mockito/internal/verification/MockAwareVerificationMode.java
@@ -30,7 +30,7 @@ public class MockAwareVerificationMode implements VerificationMode {
             fireVerificationEvent(data, e);
             throw e;
         }
-        
+
         fireVerificationEvent(data,null);
     }
 


### PR DESCRIPTION
With this PR MockingProgress don't need to expose its listeners. This keeps the notification of listeners and the logic in one place to avoid "solution sprawl". Later on we can unify or improve the notification behaviour in MockingProgressImpl.