### PR TITLE
Add editor config to automatically adhere to code style guide

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -78,6 +78,10 @@ But first of all, make sure that :
 * Line ending character is unix-style **`LF`**
 * New line is added at end of file: `IntelliJ setting > Editor > General > Ensure line feed at file end on save`
 
+For most editors, this should be automatically enforced by [EditorConfig](http://editorconfig.org/).
+Check if your editor has a built-in plugin or if you need to download one.
+IntelliJ has a built-in plugin, for Eclipse you need to download [this plugin](https://github.com/ncjones/editorconfig-eclipse#readme).
+
 ### Imports
 
 Imports must be sorted in the following order


### PR DESCRIPTION
I have personally tested this by adding additional whitespace, hitting save and then verify that `git diff` does not show any changes.

Fixes #960