### PR TITLE
Enabled local testing of release tools

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        mavenLocal() //for local testing of mockito-release-tools
         jcenter()
         maven { url "https://plugins.gradle.org/m2/" }
     }

--- a/gradle/root/release.gradle
+++ b/gradle/root/release.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        mavenLocal() //for local testing of mockito-release-tools
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {

--- a/gradle/root/version.gradle
+++ b/gradle/root/version.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        mavenLocal() //for local testing of mockito-release-tools
         maven { url "https://plugins.gradle.org/m2/" }
     }
 


### PR DESCRIPTION
- As requested by a contributor to release tools automation (https://github.com/mockito/mockito-release-tools/pull/14#issue-209252177) there is no easy way to end-to-end test release notes generation. This commit, along with some changes and documentation to the 'mockito-release-tools' repository will enable it.
- Configured local maven repository to be the 1st repo in the list. This way, we can locally publish release tools and test it out with Mockito repo.

For motivation, see https://github.com/mockito/mockito-release-tools/issues/15