### PR TITLE
Corrected a comment in exceptions package-info

### DIFF
--- a/src/main/java/org/mockito/exceptions/package-info.java
+++ b/src/main/java/org/mockito/exceptions/package-info.java
@@ -4,6 +4,6 @@
  */
 
 /**
- * Mockito configuration utilities
+ * Mockito exceptions utilities
  */
 package org.mockito.exceptions;


### PR DESCRIPTION
In the description comment of exceptions package-info.java, it wrote as 'Mockito configuration utilities', which should be 'Mockito exceptions utilities'.