### PR TITLE
Fixes #974: Fix to get correct stubbing location with inline mocking

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InterceptedInvocation.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InterceptedInvocation.java
@@ -42,14 +42,15 @@ class InterceptedInvocation implements Invocation, VerificationAwareInvocation {
                                  MockitoMethod mockitoMethod,
                                  Object[] arguments,
                                  SuperMethod superMethod,
+                                 Location location,
                                  int sequenceNumber) {
         this.mock = mock;
         this.mockitoMethod = mockitoMethod;
         this.arguments = ArgumentsProcessor.expandVarArgs(mockitoMethod.isVarArgs(), arguments);
         this.rawArguments = arguments;
         this.superMethod = superMethod;
+        this.location = location;
         this.sequenceNumber = sequenceNumber;
-        location = new LocationImpl();
     }
 
     @Override

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
@@ -9,6 +9,7 @@ import net.bytebuddy.implementation.bind.annotation.Argument;
 import net.bytebuddy.implementation.bind.annotation.This;
 import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import org.mockito.exceptions.base.MockitoException;
+import org.mockito.internal.debugging.LocationImpl;
 import org.mockito.internal.exceptions.stacktrace.ConditionalStackTraceFilter;
 import org.mockito.internal.invocation.SerializableMethod;
 import org.mockito.internal.util.concurrent.WeakConcurrentMap;
@@ -21,6 +22,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Callable;
 
 public class MockMethodAdvice extends MockMethodDispatcher {
@@ -91,10 +94,13 @@ public class MockMethodAdvice extends MockMethodDispatcher {
         } else {
             superMethod = new SuperMethodCall(selfCallInfo, origin, instance, arguments);
         }
+        Throwable t = new Throwable();
+        t.setStackTrace(skipInlineMethodElement(t.getStackTrace()));
         return new ReturnValueWrapper(interceptor.doIntercept(instance,
                 origin,
                 arguments,
-                superMethod));
+                superMethod,
+                new LocationImpl(t)));
     }
 
     @Override
@@ -198,6 +204,21 @@ public class MockMethodAdvice extends MockMethodDispatcher {
             new ConditionalStackTraceFilter().filter(hideRecursiveCall(cause, new Throwable().getStackTrace().length, origin.getDeclaringClass()));
             throw cause;
         }
+    }
+
+    // With inline mocking, mocks for concrete classes are not subclassed, so elements of the stubbing methods are not filtered out.
+    // Therefore, if the method is inlined, skip the element.
+    private static StackTraceElement[] skipInlineMethodElement(StackTraceElement[] elements) {
+        List<StackTraceElement> list = new ArrayList<StackTraceElement>(elements.length);
+        for (int i = 0; i < elements.length; i++) {
+            StackTraceElement element = elements[i];
+            list.add(element);
+            if (element.getClassName().equals(MockMethodAdvice.class.getName()) && element.getMethodName().equals("handle")) {
+                // If the current element is MockMethodAdvice#handle(), the next is assumed to be an inlined method.
+                i++;
+            }
+        }
+        return list.toArray(new StackTraceElement[list.size()]);
     }
 
     private static class ReturnValueWrapper implements Callable<Object> {

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodInterceptor.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodInterceptor.java
@@ -7,9 +7,11 @@ package org.mockito.internal.creation.bytebuddy;
 import net.bytebuddy.implementation.bind.annotation.*;
 import org.mockito.internal.InternalMockHandler;
 import org.mockito.internal.creation.DelegatingMethod;
+import org.mockito.internal.debugging.LocationImpl;
 import org.mockito.internal.invocation.MockitoMethod;
 import org.mockito.internal.invocation.SerializableMethod;
 import org.mockito.internal.progress.SequenceNumber;
+import org.mockito.invocation.Location;
 import org.mockito.invocation.MockHandler;
 import org.mockito.mock.MockCreationSettings;
 
@@ -38,12 +40,27 @@ public class MockMethodInterceptor implements Serializable {
                        Method invokedMethod,
                        Object[] arguments,
                        InterceptedInvocation.SuperMethod superMethod) throws Throwable {
-        return handler.handle(new InterceptedInvocation(
+        return doIntercept(
                 mock,
-                createMockitoMethod(invokedMethod),
+                invokedMethod,
                 arguments,
                 superMethod,
-                SequenceNumber.next()
+                new LocationImpl()
+        );
+    }
+
+    Object doIntercept(Object mock,
+                       Method invokedMethod,
+                       Object[] arguments,
+                       InterceptedInvocation.SuperMethod superMethod,
+                       Location location) throws Throwable {
+        return handler.handle(new InterceptedInvocation(
+            mock,
+            createMockitoMethod(invokedMethod),
+            arguments,
+            superMethod,
+            location,
+            SequenceNumber.next()
         ));
     }
 

--- a/src/main/java/org/mockito/internal/debugging/LocationImpl.java
+++ b/src/main/java/org/mockito/internal/debugging/LocationImpl.java
@@ -19,8 +19,16 @@ public class LocationImpl implements Location, Serializable {
     }
 
     public LocationImpl(StackTraceFilter stackTraceFilter) {
+        this(stackTraceFilter, new Throwable());
+    }
+
+    public LocationImpl(Throwable stackTraceHolder) {
+        this(new StackTraceFilter(), stackTraceHolder);
+    }
+
+    private LocationImpl(StackTraceFilter stackTraceFilter, Throwable stackTraceHolder) {
         this.stackTraceFilter = stackTraceFilter;
-        stackTraceHolder = new Throwable();
+        this.stackTraceHolder = stackTraceHolder;
     }
 
     @Override

--- a/subprojects/inline/src/test/java/org/mockitoinline/StubbingLocationTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/StubbingLocationTest.java
@@ -1,0 +1,34 @@
+package org.mockitoinline;
+
+import java.util.Collections;
+import java.util.Set;
+import org.junit.Test;
+import org.mockito.internal.invocation.finder.AllInvocationsFinder;
+import org.mockito.stubbing.Stubbing;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class StubbingLocationTest {
+
+    @Test
+    public void stubbing_location_should_be_the_correct_point() {
+        ConcreteClass mock = mock(ConcreteClass.class);
+        String frame;
+        // Initializing 'frame' at the method parameter point is to gain the exact line number of the stubbing point.
+        when(mock.concreteMethod(frame = Thread.currentThread().getStackTrace()[1].toString())).thenReturn("");
+        mock.concreteMethod(frame);
+        Set<Stubbing> stubbings = AllInvocationsFinder.findStubbings(Collections.singleton(mock));
+        assertEquals(1, stubbings.size());
+        String location = stubbings.iterator().next().getInvocation().getLocation().toString();
+        assertEquals("-> at " + frame, location);
+    }
+
+    static final class ConcreteClass {
+        String concreteMethod(String s) {
+            throw new RuntimeException(s);
+        }
+    }
+
+}


### PR DESCRIPTION
- Fix StackTraceFilter to support inline mocking
- Add one test to StackTraceFilterTest
- Add StubbingLocationTest into inline subproject

This PR fixes #974.
