### PR TITLE
Fixes #976: Resolve ambiguous constructors

### DIFF
--- a/src/main/java/org/mockito/internal/creation/instance/ConstructorInstantiator.java
+++ b/src/main/java/org/mockito/internal/creation/instance/ConstructorInstantiator.java
@@ -108,7 +108,7 @@ public class ConstructorInstantiator implements Instantiator {
         return new InstantiationException(join("Unable to create instance of '" + cls.getSimpleName() + "'.",
                 "Multiple constructors could be matched to arguments of types " + constructorArgTypes() + ":",
                 join("", " - ", constructors),
-                "If you believe that Mockito could do a better join deciding on which constructor to use, please let us know.",
+                "If you believe that Mockito could do a better job deciding on which constructor to use, please let us know.",
                 "Ticket 685 contains the discussion and a workaround for ambiguous constructors using inner class.",
                 "See https://github.com/mockito/mockito/issues/685"
             ), null);

--- a/src/test/java/org/mockitousage/constructor/CreatingMocksWithConstructorTest.java
+++ b/src/test/java/org/mockitousage/constructor/CreatingMocksWithConstructorTest.java
@@ -137,42 +137,90 @@ public class CreatingMocksWithConstructorTest extends TestBase {
     static class ExtendsExtendsBase extends ExtendsBase {}
 
     static class UsesBase {
-        public UsesBase(Base b) {}
-        public UsesBase(ExtendsBase b) {}
-    }
+        public UsesBase(Base b) {
+            constructorUsed = "Base";
+        }
+        public UsesBase(ExtendsBase b) {
+            constructorUsed = "ExtendsBase";
+        }
 
-    @Test
-    public void can_mock_unambigous_constructor_with_inheritence() {
-        mock(UsesBase.class, withSettings().useConstructor(new Base()).defaultAnswer(CALLS_REAL_METHODS));
-    }
-
-    @Test
-    public void exception_message_when_ambiguous_constructor_found_exact_exists() throws Exception {
-        try {
-            //when
-            mock(UsesBase.class, withSettings().useConstructor(new ExtendsBase()).defaultAnswer(CALLS_REAL_METHODS));
-            //then
-            fail();
-        } catch (MockitoException e) {
-            assertThat(e).hasMessage("Unable to create mock instance of type 'UsesBase'");
-            assertThat(e.getCause()).hasMessageContaining
-                ("Multiple constructors could be matched to arguments of types [org.mockitousage.constructor.CreatingMocksWithConstructorTest$ExtendsBase]");
+        private String constructorUsed = null;
+        String getConstructorUsed() {
+            return constructorUsed;
         }
     }
 
     @Test
-    public void fail_when_multiple_matching_constructors() {
+    public void can_mock_unambigous_constructor_with_inheritance_base_class_exact_match() {
+        UsesBase u = mock(UsesBase.class, withSettings().useConstructor(new Base()).defaultAnswer(CALLS_REAL_METHODS));
+        assertEquals("Base", u.getConstructorUsed());
+    }
+
+    @Test
+    public void can_mock_unambigous_constructor_with_inheritance_extending_class_exact_match() {
+        UsesBase u = mock(UsesBase.class, withSettings().useConstructor(new ExtendsBase()).defaultAnswer(CALLS_REAL_METHODS));
+        assertEquals("ExtendsBase", u.getConstructorUsed());
+    }
+
+    @Test
+    public void can_mock_unambigous_constructor_with_inheritance_non_exact_match() {
+        UsesBase u = mock(UsesBase.class, withSettings().useConstructor(new ExtendsExtendsBase()).defaultAnswer(CALLS_REAL_METHODS));
+        assertEquals("ExtendsBase", u.getConstructorUsed());
+    }
+
+    static class UsesTwoBases {
+        public UsesTwoBases(Base b1, Base b2) {
+            constructorUsed = "Base,Base";
+        }
+        public UsesTwoBases(ExtendsBase b1, Base b2) {
+            constructorUsed = "ExtendsBase,Base";
+        }
+        public UsesTwoBases(Base b1, ExtendsBase b2) {
+            constructorUsed = "Base,ExtendsBase";
+        }
+
+        private String constructorUsed = null;
+        String getConstructorUsed() {
+            return constructorUsed;
+        }
+    }
+
+    @Test
+    public void can_mock_unambigous_constructor_with_inheritance_multiple_base_class_exact_match() {
+        UsesTwoBases u =
+            mock(UsesTwoBases.class, withSettings().useConstructor(new Base(), new Base()).defaultAnswer(CALLS_REAL_METHODS));
+        assertEquals("Base,Base", u.getConstructorUsed());
+    }
+
+    @Test
+    public void can_mock_unambigous_constructor_with_inheritance_first_extending_class_exact_match() {
+        UsesTwoBases u =
+            mock(UsesTwoBases.class, withSettings().useConstructor(new ExtendsBase(), new Base()).defaultAnswer(CALLS_REAL_METHODS));
+        assertEquals("ExtendsBase,Base", u.getConstructorUsed());
+    }
+
+    @Test
+    public void can_mock_unambigous_constructor_with_inheritance_second_extending_class_exact_match() {
+        UsesTwoBases u =
+            mock(UsesTwoBases.class, withSettings().useConstructor(new Base(), new ExtendsBase()).defaultAnswer(CALLS_REAL_METHODS));
+        assertEquals("Base,ExtendsBase", u.getConstructorUsed());
+    }
+
+    @Test
+    public void fail_when_multiple_matching_constructors_with_inheritence() {
         try {
             //when
-            mock(UsesBase.class, withSettings().useConstructor(new ExtendsExtendsBase()).defaultAnswer(CALLS_REAL_METHODS));
+            mock(UsesTwoBases.class, withSettings().useConstructor(new ExtendsBase(), new ExtendsBase()));
             //then
             fail();
         } catch (MockitoException e) {
             //TODO the exception message includes Mockito internals like the name of the generated class name.
             //I suspect that we could make this exception message nicer.
-            assertThat(e).hasMessage("Unable to create mock instance of type 'UsesBase'");
+            assertThat(e).hasMessage("Unable to create mock instance of type 'UsesTwoBases'");
             assertThat(e.getCause())
-                .hasMessageContaining("Multiple constructors could be matched to arguments of types [org.mockitousage.constructor.CreatingMocksWithConstructorTest$ExtendsExtendsBase]")
+                .hasMessageContaining("Multiple constructors could be matched to arguments of types "
+                    + "[org.mockitousage.constructor.CreatingMocksWithConstructorTest$ExtendsBase, "
+                    + "org.mockitousage.constructor.CreatingMocksWithConstructorTest$ExtendsBase]")
                 .hasMessageContaining("If you believe that Mockito could do a better join deciding on which constructor to use, please let us know.\n" +
                     "Ticket 685 contains the discussion and a workaround for ambiguous constructors using inner class.\n" +
                     "See https://github.com/mockito/mockito/issues/685");
@@ -270,5 +318,25 @@ public class CreatingMocksWithConstructorTest extends TestBase {
         protected String getRealValue(T value) {
             return "value";
         }
+    }
+
+    private static class AmbiguousWithPrimitive {
+        public AmbiguousWithPrimitive(String s, int i) {
+            data = s;
+        }
+        public AmbiguousWithPrimitive(Object o, int i) {
+            data = "just an object";
+        }
+
+        private String data;
+        public String getData() {
+            return data;
+        }
+    }
+
+    @Test
+    public void can_spy_ambiguius_constructor_with_primitive() {
+        AmbiguousWithPrimitive mock = mock(AmbiguousWithPrimitive.class, withSettings().useConstructor("String", 7).defaultAnswer(CALLS_REAL_METHODS));
+        assertEquals("String", mock.getData());
     }
 }

--- a/src/test/java/org/mockitousage/constructor/CreatingMocksWithConstructorTest.java
+++ b/src/test/java/org/mockitousage/constructor/CreatingMocksWithConstructorTest.java
@@ -221,7 +221,7 @@ public class CreatingMocksWithConstructorTest extends TestBase {
                 .hasMessageContaining("Multiple constructors could be matched to arguments of types "
                     + "[org.mockitousage.constructor.CreatingMocksWithConstructorTest$ExtendsBase, "
                     + "org.mockitousage.constructor.CreatingMocksWithConstructorTest$ExtendsBase]")
-                .hasMessageContaining("If you believe that Mockito could do a better join deciding on which constructor to use, please let us know.\n" +
+                .hasMessageContaining("If you believe that Mockito could do a better job deciding on which constructor to use, please let us know.\n" +
                     "Ticket 685 contains the discussion and a workaround for ambiguous constructors using inner class.\n" +
                     "See https://github.com/mockito/mockito/issues/685");
         }


### PR DESCRIPTION
With the current code (introduced in Mockito 2.7.14 by commit 6a82c03), calling `MockSettings.useConstructor` with an argument list that would be applicable to more than one constructor would fail with an `org.mockito.internal.creation.instance.InstantiationException`.

This behavior, however, is suboptimal, as described in issue #976, as it makes `useConstructor` less robust than the Java compiler, which is able to resolve such ambiguities.
With this patch, Mockito will attempt to match the constructor with the most specific parameter types. A constructor X is considered more specific than a constructor Y if:

1. They are both applicable to the given argument list
2. Constructor X has at least one parameter which is a further specialization of the corresponding parameter of constructor Y (i.e. `paramX.isAssignableFrom(paramY)`).
3. Constructor Y has no parameter which is a further specialization of the corresponding parameter of constructor X, as defined above.

E.g., consider the following class:

    public class SomeClass {
        SomeClass(Object o) {}
        SomeClass(String s) {}
    }

Without this patch, calling

    mock(SomeClass.class, withSettings().useConstructor("string!"))

would fail. With this patch, such a call would invoke the `SomeClass(String)` constructor.


As noted above, this PR fixes issue #976.