### PR TITLE
Made CaturingMatcher threadsafe

### DIFF
--- a/src/main/java/org/mockito/internal/matchers/CapturingMatcher.java
+++ b/src/main/java/org/mockito/internal/matchers/CapturingMatcher.java
@@ -9,13 +9,15 @@ import org.mockito.ArgumentMatcher;
 import static org.mockito.internal.exceptions.Reporter.noArgumentValueWasCaptured;
 
 import java.io.Serializable;
-import java.util.LinkedList;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 @SuppressWarnings("unchecked")
 public class CapturingMatcher<T> implements ArgumentMatcher<T>, CapturesArguments, VarargMatcher, Serializable {
 
-    private final LinkedList<Object> arguments = new LinkedList<Object>();
+    private final List<Object> arguments = Collections.synchronizedList(new ArrayList<Object>());
 
     public boolean matches(Object argument) {
         return true;
@@ -26,16 +28,17 @@ public class CapturingMatcher<T> implements ArgumentMatcher<T>, CapturesArgument
     }
 
     public T getLastValue() {
-        if (arguments.isEmpty()) {
-            throw noArgumentValueWasCaptured();
+        synchronized (arguments) {
+            if (arguments.isEmpty()) {
+                throw noArgumentValueWasCaptured();
+            }
+
+            return (T) arguments.get(arguments.size() - 1);
         }
-
-        return (T) arguments.getLast();
-
     }
 
     public List<T> getAllValues() {
-        return (List) arguments;
+        return Arrays.asList((T[]) arguments.toArray());
     }
 
     public void captureFrom(Object argument) {

--- a/src/main/java/org/mockito/internal/matchers/CapturingMatcher.java
+++ b/src/main/java/org/mockito/internal/matchers/CapturingMatcher.java
@@ -10,7 +10,6 @@ import static org.mockito.internal.exceptions.Reporter.noArgumentValueWasCapture
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -49,7 +48,7 @@ public class CapturingMatcher<T> implements ArgumentMatcher<T>, CapturesArgument
     public List<T> getAllValues() {
         readLock.lock();
         try {
-            return Arrays.asList((T[]) arguments.toArray());
+            return new ArrayList<T>((List) arguments);
         } finally {
             readLock.unlock();
         }

--- a/src/test/java/org/mockito/internal/matchers/CapturingMatcherTest.java
+++ b/src/test/java/org/mockito/internal/matchers/CapturingMatcherTest.java
@@ -4,13 +4,15 @@
  */
 package org.mockito.internal.matchers;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.fail;
+import java.util.Iterator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class CapturingMatcherTest extends TestBase {
 
@@ -24,7 +26,7 @@ public class CapturingMatcherTest extends TestBase {
         m.captureFrom("bar");
 
         //then
-        Assertions.assertThat(m.getAllValues()).containsSequence("foo", "bar");
+        assertThat(m.getAllValues()).containsSequence("foo", "bar");
     }
 
     @Test
@@ -52,4 +54,20 @@ public class CapturingMatcherTest extends TestBase {
             fail();
         } catch (MockitoException e) {}
     }
+
+    @Test
+    public void should_not_fail_when_used_in_concurrent_tests() throws Exception {
+        //given
+        final CapturingMatcher<String> m = new CapturingMatcher<String>();
+
+        //when
+        m.captureFrom("concurrent access");
+        Iterator<String> iterator = m.getAllValues().iterator();
+        m.captureFrom("concurrent access");
+
+        //then
+        assertThat(iterator.hasNext()).isTrue();
+        assertThat(iterator.next()).isEqualTo("concurrent access"); // Potential ConcurrentModificationException
+    }
+
 }


### PR DESCRIPTION
In my tests I faced two problems with current capturing matcher.
1. It exposes its internal store through `#getAllValues()`.
2. Internal data store in CapturingMatcher is not threadsafe. Exposing internal store when interraction with mocked object isn't finished may produce all kind of weird exceptions in tests.