### PR TITLE
Improved the release notes outlook

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 
 #Declared the dependency here to avoid duplication across build.gradle files
-dependencies.mockito-release-tools=gradle.plugin.org.mockito:mockito-release-tools:0.0.3
+dependencies.mockito-release-tools=gradle.plugin.org.mockito:mockito-release-tools:0.1.0

--- a/gradle/root/release.gradle
+++ b/gradle/root/release.gradle
@@ -56,9 +56,9 @@ apply plugin: 'org.mockito.release-notes'
 apply plugin: 'org.mockito.release-workflow'
 
 notes {
-    notesFile = file("doc/release-notes/official.md")
+    releaseNotesFile = file("doc/release-notes/official.md")
     //label captions, in order of importance - this is the order they will appear in the release notes
-    labels = [
+    gitHubLabelMapping = [
         '1.* incompatible': 'Incompatible changes with previous major version (v1.x)',
         'java-9': "Java 9 support",
         'java-8': "Java 8 support",
@@ -69,6 +69,8 @@ notes {
         'android': "Android support",
         'docs': 'Documentation'
     ]
+    gitHubReadOnlyAuthToken = "a0a4c0f41c200f7c653323014d6a72a127764e17"
+    gitHubRepository = "mockito/mockito"
 }
 
 //dryRun project property is interpreted by the release-workflow plugin to enable rollbacks


### PR DESCRIPTION
- Updated version of release tools
- This way, we can pick up the GitHub profile link improvement: https://github.com/mockito/mockito-release-tools/issues/12
- Many thanks to @mstachniuk for the implementation and pull request to Mockito Release Tools repository!!! (https://github.com/mockito/mockito-release-tools/pull/14)

Tested by running "./gradlew previewReleaseNotes" locally, the output now contains the links to GitHub profiles:

```
:previewReleaseNotes
Building new release notes based on /Users/sfaber/mockito/src/doc/release-notes/official.md
Building notes for revisions: v2.7.13 -> HEAD
----------------
### 2.7.14 (2017-03-15)

* Authors: 3
* Commits: 7
  * 3: [Allon Mureinik](https://github.com/mureinik)
  * 3: [Szczepan Faber](https://github.com/szczepiq)
  * 1: [Tim van der Lippe](https://github.com/TimvdLippe)
* Improvements: 3
  * New features: 2
    * New feature - enable mocking using constructor arguments [(#935)](https://github.com/mockito/mockito/pull/935)
    * Support constructor parameters for spying on abstract classes [(#685)](https://github.com/mockito/mockito/issues/685)
  * Remaining changes: 1
    * Add editor config to automatically adhere to code style guide [(#966)](https://github.com/mockito/mockito/pull/966)

----------------

BUILD SUCCESSFUL
```