### PR TITLE
Fix #952: fix invalid examples in javadoc of AnswerX and VoidAnswerX.

### DIFF
--- a/src/main/java/org/mockito/stubbing/Answer.java
+++ b/src/main/java/org/mockito/stubbing/Answer.java
@@ -13,15 +13,15 @@ import org.mockito.invocation.InvocationOnMock;
  * Example of stubbing a mock with custom answer:
  *
  * <pre class="code"><code class="java">
- * import static org.mockito.AdditionalAnswers.answer;
  *
- * when(mock.someMethod(anyString())).then(answer(
+ * when(mock.someMethod(anyString())).thenAnswer(
  *     new Answer() {
  *         public Object answer(InvocationOnMock invocation) {
  *             Object[] args = invocation.getArguments();
  *             Object mock = invocation.getMock();
  *             return "called with arguments: " + Arrays.toString(args);
- *         }}));
+ *         }
+ * });
  *
  * //Following prints "called with arguments: [foo]"
  * System.out.println(mock.someMethod("foo"));

--- a/src/main/java/org/mockito/stubbing/Answer.java
+++ b/src/main/java/org/mockito/stubbing/Answer.java
@@ -13,13 +13,15 @@ import org.mockito.invocation.InvocationOnMock;
  * Example of stubbing a mock with custom answer:
  *
  * <pre class="code"><code class="java">
- * when(mock.someMethod(anyString())).thenAnswer(new Answer() {
- *     Object answer(InvocationOnMock invocation) {
- *         Object[] args = invocation.getArguments();
- *         Object mock = invocation.getMock();
- *         return "called with arguments: " + Arrays.toString(args);
- *     }
- * });
+ * import static org.mockito.AdditionalAnswers.answer;
+ *
+ * when(mock.someMethod(anyString())).then(answer(
+ *     new Answer() {
+ *         public Object answer(InvocationOnMock invocation) {
+ *             Object[] args = invocation.getArguments();
+ *             Object mock = invocation.getMock();
+ *             return "called with arguments: " + Arrays.toString(args);
+ *         }}));
  *
  * //Following prints "called with arguments: [foo]"
  * System.out.println(mock.someMethod("foo"));

--- a/src/main/java/org/mockito/stubbing/Answer1.java
+++ b/src/main/java/org/mockito/stubbing/Answer1.java
@@ -14,13 +14,15 @@ import org.mockito.Incubating;
  * Example of stubbing a mock with this custom answer:
  *
  * <pre class="code"><code class="java">
+ *
  * import static org.mockito.AdditionalAnswers.answer;
  *
  * when(mock.someMethod(anyString())).then(answer(
  *     new Answer1&lt;Integer, String&gt;() {
  *         public Integer answer(String arg) {
  *             return arg.length();
- *         }}));
+ *         }
+ * }));
  *
  * //Following will print "3"
  * System.out.println(mock.someMethod("foo"));

--- a/src/main/java/org/mockito/stubbing/Answer1.java
+++ b/src/main/java/org/mockito/stubbing/Answer1.java
@@ -14,11 +14,13 @@ import org.mockito.Incubating;
  * Example of stubbing a mock with this custom answer:
  *
  * <pre class="code"><code class="java">
- * when(mock.someMethod(anyString())).thenAnswer(new Answer&lt;Integer, String&gt;() {
- *     Integer answer(String arg) {
- *         return arg.length();
- *     }
- * });
+ * import static org.mockito.AdditionalAnswers.answer;
+ *
+ * when(mock.someMethod(anyString())).then(answer(
+ *     new Answer1&lt;Integer, String&gt;() {
+ *         public Integer answer(String arg) {
+ *             return arg.length();
+ *         }}));
  *
  * //Following will print "3"
  * System.out.println(mock.someMethod("foo"));
@@ -39,4 +41,3 @@ public interface Answer1<T, A0> {
      */
     T answer(A0 argument0) throws Throwable;
 }
-

--- a/src/main/java/org/mockito/stubbing/Answer2.java
+++ b/src/main/java/org/mockito/stubbing/Answer2.java
@@ -14,13 +14,15 @@ import org.mockito.Incubating;
  * Example of stubbing a mock with this custom answer:
  *
  * <pre class="code"><code class="java">
+ *
  * import static org.mockito.AdditionalAnswers.answer;
  *
  * when(mock.someMethod(anyString(), anyChar())).then(answer(
  *     new Answer2&lt;String, String, Character&gt;() {
  *         public String answer(String s, Character c) {
  *             return s.replace('f', c);
- *         }}));
+ *         }
+ * }));
  *
  * //Following will print "bar"
  * System.out.println(mock.someMethod("far", 'b'));

--- a/src/main/java/org/mockito/stubbing/Answer2.java
+++ b/src/main/java/org/mockito/stubbing/Answer2.java
@@ -14,11 +14,13 @@ import org.mockito.Incubating;
  * Example of stubbing a mock with this custom answer:
  *
  * <pre class="code"><code class="java">
- * when(mock.someMethod(anyString(), anyChar())).thenAnswer(new Answer&lt;String, String, Character&gt;() {
- *     String answer(String s, Character c) {
- *         return s.replace('f', c);
- *     }
- * });
+ * import static org.mockito.AdditionalAnswers.answer;
+ *
+ * when(mock.someMethod(anyString(), anyChar())).then(answer(
+ *     new Answer2&lt;String, String, Character&gt;() {
+ *         public String answer(String s, Character c) {
+ *             return s.replace('f', c);
+ *         }}));
  *
  * //Following will print "bar"
  * System.out.println(mock.someMethod("far", 'b'));

--- a/src/main/java/org/mockito/stubbing/Answer3.java
+++ b/src/main/java/org/mockito/stubbing/Answer3.java
@@ -14,13 +14,15 @@ import org.mockito.Incubating;
  * Example of stubbing a mock with this custom answer:
  *
  * <pre class="code"><code class="java">
+ *
  * import static org.mockito.AdditionalAnswers.answer;
  *
  * when(mock.someMethod(anyInt(), anyString(), anyChar())).then(answer(
  *     new Answer3&lt;StringBuilder, Integer, String, Character&gt;() {
  *         public StringBuilder answer(Integer i, String s, Character c) {
  *             return new StringBuilder().append(i).append(s).append(c);
- *         }}));
+ *         }
+ * }));
  *
  * //Following will print "3xyz"
  * System.out.println(mock.someMethod(3, "xy", 'z'));

--- a/src/main/java/org/mockito/stubbing/Answer3.java
+++ b/src/main/java/org/mockito/stubbing/Answer3.java
@@ -14,12 +14,13 @@ import org.mockito.Incubating;
  * Example of stubbing a mock with this custom answer:
  *
  * <pre class="code"><code class="java">
- * when(mock.someMethod(anyInt(), anyString(), anyChar())).thenAnswer(
- *     new Answer&lt;StringBuilder, Integer, String, Character&gt;() {
- *         StringBuilder answer(Integer i, String s, Character c) {
+ * import static org.mockito.AdditionalAnswers.answer;
+ *
+ * when(mock.someMethod(anyInt(), anyString(), anyChar())).then(answer(
+ *     new Answer3&lt;StringBuilder, Integer, String, Character&gt;() {
+ *         public StringBuilder answer(Integer i, String s, Character c) {
  *             return new StringBuilder().append(i).append(s).append(c);
- *         }
- *     });
+ *         }}));
  *
  * //Following will print "3xyz"
  * System.out.println(mock.someMethod(3, "xy", 'z'));

--- a/src/main/java/org/mockito/stubbing/Answer4.java
+++ b/src/main/java/org/mockito/stubbing/Answer4.java
@@ -14,13 +14,15 @@ import org.mockito.Incubating;
  * Example of stubbing a mock with this custom answer:
  *
  * <pre class="code"><code class="java">
+ *
  * import static org.mockito.AdditionalAnswers.answer;
  *
  * when(mock.someMethod(anyInt(), anyString(), anyChar(), any())).then(answer(
  *     new Answer4&lt;StringBuilder, Integer, String, Character, Object&gt;() {
  *         public StringBuilder answer(Integer i, String s, Character c, Object o) {
  *             return new StringBuilder().append(i).append(s).append(c).append(o.hashCode());
- *         }}));
+ *         }
+ * }));
  *
  * //Following will print a string like "3xyz131635550"
  * System.out.println(mock.someMethod(3, "xy", 'z', new Object()));

--- a/src/main/java/org/mockito/stubbing/Answer4.java
+++ b/src/main/java/org/mockito/stubbing/Answer4.java
@@ -14,12 +14,13 @@ import org.mockito.Incubating;
  * Example of stubbing a mock with this custom answer:
  *
  * <pre class="code"><code class="java">
- * when(mock.someMethod(anyInt(), anyString(), anyChar(), any())).thenAnswer(
- *     new Answer&lt;StringBuilder, Integer, String, Character, Object&gt;() {
- *         StringBuilder answer(Integer i, String s, Character c, Object o) {
+ * import static org.mockito.AdditionalAnswers.answer;
+ *
+ * when(mock.someMethod(anyInt(), anyString(), anyChar(), any())).then(answer(
+ *     new Answer4&lt;StringBuilder, Integer, String, Character, Object&gt;() {
+ *         public StringBuilder answer(Integer i, String s, Character c, Object o) {
  *             return new StringBuilder().append(i).append(s).append(c).append(o.hashCode());
- *         }
- *     });
+ *         }}));
  *
  * //Following will print a string like "3xyz131635550"
  * System.out.println(mock.someMethod(3, "xy", 'z', new Object()));

--- a/src/main/java/org/mockito/stubbing/Answer5.java
+++ b/src/main/java/org/mockito/stubbing/Answer5.java
@@ -14,13 +14,15 @@ import org.mockito.Incubating;
  * Example of stubbing a mock with this custom answer:
  *
  * <pre class="code"><code class="java">
+ *
  * import static org.mockito.AdditionalAnswers.answer;
  *
  * when(mock.someMethod(anyInt(), anyString(), anyChar(), any(), anyBoolean())).then(answer(
  *     new Answer5&lt;StringBuilder, Integer, String, Character, Object, Boolean&gt;() {
  *         public StringBuilder answer(Integer i, String s, Character c, Object o, Boolean isIt) {
  *             return new StringBuilder().append(i).append(s).append(c).append(o.hashCode()).append(isIt);
- *         }}));
+ *         }
+ * }));
  *
  * //Following will print a string like "3xyz131635550true"
  * System.out.println(mock.someMethod(3, "xy", 'z', new Object(), true));

--- a/src/main/java/org/mockito/stubbing/Answer5.java
+++ b/src/main/java/org/mockito/stubbing/Answer5.java
@@ -14,12 +14,13 @@ import org.mockito.Incubating;
  * Example of stubbing a mock with this custom answer:
  *
  * <pre class="code"><code class="java">
- * when(mock.someMethod(anyInt(), anyString(), anyChar(), any(), anyBoolean())).thenAnswer(
- *     new Answer&lt;StringBuilder, Integer, String, Character, Object, Boolean&gt;() {
- *         StringBuilder answer(Integer i, String s, Character c, Object o, Boolean isIt) {
+ * import static org.mockito.AdditionalAnswers.answer;
+ *
+ * when(mock.someMethod(anyInt(), anyString(), anyChar(), any(), anyBoolean())).then(answer(
+ *     new Answer5&lt;StringBuilder, Integer, String, Character, Object, Boolean&gt;() {
+ *         public StringBuilder answer(Integer i, String s, Character c, Object o, Boolean isIt) {
  *             return new StringBuilder().append(i).append(s).append(c).append(o.hashCode()).append(isIt);
- *         }
- *     });
+ *         }}));
  *
  * //Following will print a string like "3xyz131635550true"
  * System.out.println(mock.someMethod(3, "xy", 'z', new Object(), true));

--- a/src/main/java/org/mockito/stubbing/VoidAnswer1.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer1.java
@@ -14,15 +14,15 @@ import org.mockito.Incubating;
  * Example of stubbing a mock with this custom answer:
  *
  * <pre class="code"><code class="java">
- * import org.mockito.stubbing.VoidAnswer1;
  *
  * import static org.mockito.AdditionalAnswers.answerVoid;
  *
  * doAnswer(answerVoid(
  *     new VoidAnswer1&lt;String&gt;() {
- *         public void answerVoid(String msg) throws Exception {
+ *         public void answer(String msg) throws Exception {
  *             throw new Exception(msg);
- *         }})).when(mock).someMethod(anyString());
+ *         }
+ * })).when(mock).someMethod(anyString());
  *
  * //Following will raise an exception with the message "boom"
  * mock.someMethod("boom");

--- a/src/main/java/org/mockito/stubbing/VoidAnswer1.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer1.java
@@ -14,11 +14,15 @@ import org.mockito.Incubating;
  * Example of stubbing a mock with this custom answer:
  *
  * <pre class="code"><code class="java">
- * when(mock.someMethod(anyString())).thenAnswer(new Answer&lt;String&gt;() {
- *     void answer(String msg) {
- *         throw new Exception(msg);
- *     }
- * });
+ * import org.mockito.stubbing.VoidAnswer1;
+ *
+ * import static org.mockito.AdditionalAnswers.answerVoid;
+ *
+ * doAnswer(answerVoid(
+ *     new VoidAnswer1&lt;String&gt;() {
+ *         public void answerVoid(String msg) throws Exception {
+ *             throw new Exception(msg);
+ *         }})).when(mock).someMethod(anyString());
  *
  * //Following will raise an exception with the message "boom"
  * mock.someMethod("boom");

--- a/src/main/java/org/mockito/stubbing/VoidAnswer2.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer2.java
@@ -14,15 +14,15 @@ import org.mockito.Incubating;
  * Example of stubbing a mock with this custom answer:
  *
  * <pre class="code"><code class="java">
- * import org.mockito.stubbing.VoidAnswer2;
  *
  * import static org.mockito.AdditionalAnswers.answerVoid;
  *
  * doAnswer(answerVoid(
  *     new VoidAnswer2&lt;String, Integer&gt;() {
- *         public void answerVoid(String msg, Integer count) throws Exception {
+ *         public void answer(String msg, Integer count) throws Exception {
  *             throw new Exception(String.format(msg, count));
- *         }})).when(mock).someMethod(anyString(), anyInt());
+ *         }
+ * })).when(mock).someMethod(anyString(), anyInt());
  *
  * //Following will raise an exception with the message "boom 3"
  * mock.someMethod("boom %d", 3);

--- a/src/main/java/org/mockito/stubbing/VoidAnswer2.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer2.java
@@ -14,11 +14,15 @@ import org.mockito.Incubating;
  * Example of stubbing a mock with this custom answer:
  *
  * <pre class="code"><code class="java">
- * when(mock.someMethod(anyString(), anyInt())).thenAnswer(new Answer&lt;String, Integer&gt;() {
- *     void answer(String msg, Integer count) {
- *         throw new Exception(String.format(msg, count));
- *     }
- * });
+ * import org.mockito.stubbing.VoidAnswer2;
+ *
+ * import static org.mockito.AdditionalAnswers.answerVoid;
+ *
+ * doAnswer(answerVoid(
+ *     new VoidAnswer2&lt;String, Integer&gt;() {
+ *         public void answerVoid(String msg, Integer count) throws Exception {
+ *             throw new Exception(String.format(msg, count));
+ *         }})).when(mock).someMethod(anyString(), anyInt());
  *
  * //Following will raise an exception with the message "boom 3"
  * mock.someMethod("boom %d", 3);

--- a/src/main/java/org/mockito/stubbing/VoidAnswer3.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer3.java
@@ -14,11 +14,15 @@ import org.mockito.Incubating;
  * Example of stubbing a mock with this custom answer:
  *
  * <pre class="code"><code class="java">
- * when(mock.someMethod(anyString(), anyInt(), anyString())).thenAnswer(new Answer&lt;String, Integer, String&gt;() {
- *     void answer(String msg, Integer count, String another) {
- *         throw new Exception(String.format(msg, another, count));
- *     }
- * });
+ * import org.mockito.stubbing.VoidAnswer3;
+ *
+ * import static org.mockito.AdditionalAnswers.answerVoid;
+ *
+ * doAnswer(answerVoid(
+ *     new VoidAnswer3&lt;String, Integer, String&gt;() {
+ *         public void answerVoid(String msg, Integer count, String another) throws Exception {
+ *             throw new Exception(String.format(msg, another, count));
+ *         }})).when(mock).someMethod(anyString(), anyInt(), anyString());
  *
  * //Following will raise an exception with the message "ka-boom 3"
  * mock.someMethod("%s-boom %d", 3, "ka");

--- a/src/main/java/org/mockito/stubbing/VoidAnswer3.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer3.java
@@ -14,15 +14,15 @@ import org.mockito.Incubating;
  * Example of stubbing a mock with this custom answer:
  *
  * <pre class="code"><code class="java">
- * import org.mockito.stubbing.VoidAnswer3;
  *
  * import static org.mockito.AdditionalAnswers.answerVoid;
  *
  * doAnswer(answerVoid(
  *     new VoidAnswer3&lt;String, Integer, String&gt;() {
- *         public void answerVoid(String msg, Integer count, String another) throws Exception {
+ *         public void answer(String msg, Integer count, String another) throws Exception {
  *             throw new Exception(String.format(msg, another, count));
- *         }})).when(mock).someMethod(anyString(), anyInt(), anyString());
+ *         }
+ * })).when(mock).someMethod(anyString(), anyInt(), anyString());
  *
  * //Following will raise an exception with the message "ka-boom 3"
  * mock.someMethod("%s-boom %d", 3, "ka");

--- a/src/main/java/org/mockito/stubbing/VoidAnswer4.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer4.java
@@ -14,15 +14,18 @@ import org.mockito.Incubating;
  * Example of stubbing a mock with this custom answer:
  *
  * <pre class="code"><code class="java">
- * when(mock.someMethod(anyString(), anyInt(), anyString(), anyChar())).thenAnswer(
- *     new Answer&lt;String, Integer, String, Character&gt;() {
- *         void answer(String msg, Integer count, String another, Character c) {
+ * import org.mockito.stubbing.VoidAnswer4;
+ *
+ * import static org.mockito.AdditionalAnswers.answerVoid;
+ *
+ * doAnswer(answerVoid(
+ *     new VoidAnswer4&lt;String, Integer, String, Character&gt;() {
+ *         public void answerVoid(String msg, Integer count, String another, Character c) throws Exception {
  *             throw new Exception(String.format(msg, another, c, count));
- *         }
- *     });
+ *         }})).when(mock).someMethod(anyString(), anyInt(), anyString(), anyChar());
  *
  * //Following will raise an exception with the message "ka-boom <3"
- * mock.someMethod("%s-boom %c%d", 3, "ka", '&lt;');
+ * mock.someMethod("%s-boom %c%d", 3, "ka", '<');
  * </code></pre>
  *
  * @param <A0> type of the first argument

--- a/src/main/java/org/mockito/stubbing/VoidAnswer4.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer4.java
@@ -14,18 +14,18 @@ import org.mockito.Incubating;
  * Example of stubbing a mock with this custom answer:
  *
  * <pre class="code"><code class="java">
- * import org.mockito.stubbing.VoidAnswer4;
  *
  * import static org.mockito.AdditionalAnswers.answerVoid;
  *
  * doAnswer(answerVoid(
  *     new VoidAnswer4&lt;String, Integer, String, Character&gt;() {
- *         public void answerVoid(String msg, Integer count, String another, Character c) throws Exception {
+ *         public void answer(String msg, Integer count, String another, Character c) throws Exception {
  *             throw new Exception(String.format(msg, another, c, count));
- *         }})).when(mock).someMethod(anyString(), anyInt(), anyString(), anyChar());
+ *         }
+ * })).when(mock).someMethod(anyString(), anyInt(), anyString(), anyChar());
  *
  * //Following will raise an exception with the message "ka-boom <3"
- * mock.someMethod("%s-boom %c%d", 3, "ka", '<');
+ * mock.someMethod("%s-boom %c%d", 3, "ka", '&lt;');
  * </code></pre>
  *
  * @param <A0> type of the first argument

--- a/src/main/java/org/mockito/stubbing/VoidAnswer5.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer5.java
@@ -14,18 +14,18 @@ import org.mockito.Incubating;
  * Example of stubbing a mock with this custom answer:
  *
  * <pre class="code"><code class="java">
- * import org.mockito.stubbing.VoidAnswer5;
  *
  * import static org.mockito.AdditionalAnswers.answerVoid;
  *
  * doAnswer(answerVoid(
  *     new VoidAnswer5&lt;String, Integer, String, Character, String&gt;() {
- *         public void answerVoid(String msg, Integer count, String another, Character c, String subject) throws Exception {
+ *         public void answer(String msg, Integer count, String another, Character c, String subject) throws Exception {
  *             throw new Exception(String.format(msg, another, c, count, subject));
- *         }})).when(mock).someMethod(anyString(), anyInt(), anyString(), anyChar(), anyString());
+ *         }
+ * })).when(mock).someMethod(anyString(), anyInt(), anyString(), anyChar(), anyString());
  *
  * //Following will raise an exception with the message "ka-boom <3 mockito"
- * mock.someMethod("%s-boom %c%d %s", 3, "ka", '<', "mockito");
+ * mock.someMethod("%s-boom %c%d %s", 3, "ka", '&lt;', "mockito");
  * </code></pre>
  *
  * @param <A0> type of the first argument

--- a/src/main/java/org/mockito/stubbing/VoidAnswer5.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer5.java
@@ -14,15 +14,18 @@ import org.mockito.Incubating;
  * Example of stubbing a mock with this custom answer:
  *
  * <pre class="code"><code class="java">
- * when(mock.someMethod(anyString(), anyInt(), anyString(), anyChar(), anyString())).thenAnswer(
- *     new Answer&lt;String, Integer, String, Character&gt;() {
- *         void answer(String msg, Integer count, String another, Character c, String subject) {
+ * import org.mockito.stubbing.VoidAnswer5;
+ *
+ * import static org.mockito.AdditionalAnswers.answerVoid;
+ *
+ * doAnswer(answerVoid(
+ *     new VoidAnswer5&lt;String, Integer, String, Character, String&gt;() {
+ *         public void answerVoid(String msg, Integer count, String another, Character c, String subject) throws Exception {
  *             throw new Exception(String.format(msg, another, c, count, subject));
- *         }
- *     });
+ *         }})).when(mock).someMethod(anyString(), anyInt(), anyString(), anyChar(), anyString());
  *
  * //Following will raise an exception with the message "ka-boom <3 mockito"
- * mock.someMethod("%s-boom %c%d %s", 3, "ka", '&lt;', "mockito");
+ * mock.someMethod("%s-boom %c%d %s", 3, "ka", '<', "mockito");
  * </code></pre>
  *
  * @param <A0> type of the first argument


### PR DESCRIPTION
Hi,
I read in [#952](https://github.com/mockito/mockito/issues/952) that examples in interfaces AnswerX(Answer1, Answer2, etc.) and VoidAnswerX do not work. Thanks to an example correction by  Christian Schwarz in  the comment of the issue, I made some modifications in those files. If this is of any help, I'd be so happy! But do not hesitate to tell me if I did anything wrong! Sorry up front if I bring any inconvenience to you!

Below are some thoughts of mine during and after the correction work:  
- I've tried those examples in my own simple tests, luckily they all work fine. 
- I noticed that Christian also gave an example on using the interface with lambda expression. I've also worked out the "lambda" versions regarding AnswerX interfaces but not with VoidAnswerX(at least not with the same case, the throwing exception usage, in the current example). So I decide not to include the lambda version in AnswerX, either(for consistency). But if you want them I'm happy to add them(probably with your kind advice)! 
- In the examples in VoidAnswerX I have to also import org.mockito.stubbing.VoidAnswerX to build the test successfully, which appears a little bit strange:-(  

Thanks for your review!!  

Regards,
Saiyi



