### PR TITLE
Add BaseArgumentMatcher to ease migration from pre 2.x

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@ include 'inline'
 include 'testng'
 include 'extTest'
 include 'android'
+include 'migration'
 
 rootProject.name = 'mockito'
 

--- a/src/main/java/org/mockito/ArgumentMatcher.java
+++ b/src/main/java/org/mockito/ArgumentMatcher.java
@@ -89,17 +89,24 @@ package org.mockito;
  *
  * All existing custom implementations of <code>ArgumentMatcher</code> will no longer compile.
  * All locations where hamcrest matchers are passed to <code>argThat()</code> will no longer compile.
- * There are 2 approaches to fix the problems:
+ * There are 3 approaches to fix the problems:
  * <ul>
- * <li>a) Refactor the hamcrest matcher to Mockito matcher:
+ * <li>Refactor the hamcrest matcher to Mockito matcher:
  * Use "implements ArgumentMatcher" instead of "extends ArgumentMatcher".
  * Then refactor <code>describeTo()</code> method into <code>toString()</code> method.
  * </li>
+ * <li>If you need to separate the changes to the code from the switching of the Mockito versions,
+ * e.g. if you have a large repository and cannot make a single atomic change to switch Mockito
+ * version and fix any issues it causes, then you should change any of your classes that extend
+ * {@link ArgumentMatcher} directly to extend {@link BaseArgumentMatcher} instead as it is
+ * compatible across 1.x and 2.x versions. You will need to refactor the <code>describeTo()</code>
+ * method into the <code>toString()</code> method and the <code>matches(Object)</code> method into
+ * the <code>matchesSafely(T)</code> method.
+ * </li>
  * <li>
- * b) Use <code>org.mockito.hamcrest.MockitoHamcrest.argThat()</code> instead of <code>Mockito.argThat()</code>.
+ * Use <code>org.mockito.hamcrest.MockitoHamcrest.argThat()</code> instead of <code>Mockito.argThat()</code>.
  * Ensure that there is <a href="http://hamcrest.org/JavaHamcrest/">hamcrest</a> dependency on classpath
  * (Mockito does not depend on hamcrest any more).
- *
  * </li>
  * </ul>
  * What option is right for you? If you don't mind compile dependency to hamcrest
@@ -125,4 +132,12 @@ public interface ArgumentMatcher<T> {
      * @return true if this matcher accepts the given argument.
      */
     boolean matches(T argument);
+
+    /**
+     * Provide a meaningful description of the matcher in error messages.
+     *
+     * @return a description of the values that the matcher matches, e.g. the
+     * {@link ArgumentMatchers#anyString()} matcher returns {@code "<any string>"}.
+     */
+    String toString();
 }

--- a/subprojects/migration/migration.gradle
+++ b/subprojects/migration/migration.gradle
@@ -1,0 +1,9 @@
+apply plugin: 'java'
+description = "Compatibility classes to aid in migration to 2.x"
+
+dependencies {
+    compile "org.hamcrest:hamcrest-core:1.3"
+    compile project.rootProject
+
+    testCompile "junit:junit:4.10"
+}

--- a/subprojects/migration/src/main/java/org/mockito/migration/MockitoV1CompatibilityMatcher.java
+++ b/subprojects/migration/src/main/java/org/mockito/migration/MockitoV1CompatibilityMatcher.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.migration;
+
+import java.lang.reflect.Method;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Incubating;
+
+/**
+ * Base class for classes that implement {@link ArgumentMatcher}.
+ * <p>
+ * This was provided to simplify migration from pre 2.x implementations; it resolves the conflict
+ * caused by the signature of the {@code matches(...)} method changing from {@code matches(Object)}
+ * in pre 2.x to {@code matches(T)} by adding a new {@link #matchesSafely(T)} method which
+ * developers implement instead. This checks the type of the
+ * argument beforehand and returns false if it is not of the correct type to avoid a
+ * {@link ClassCastException} being thrown.
+ * <p>
+ * It does not provide a default implementation of {@link #toString()} as if no {@link #toString()}
+ * method is provided then it defaults to the pre 2.x behavior of creating a decamelized form of the
+ * class name.
+ *
+ * @deprecated this was only intended to ease migration from 1.x to 2.x please implement
+ * {@link ArgumentMatcher} directly.
+ */
+@Incubating
+@Deprecated
+public abstract class MockitoV1CompatibilityMatcher<T> implements ArgumentMatcher<T> {
+
+    /**
+     * Informs if this matcher accepts the given argument.
+     * <p>
+     * It is marked as final to prevent it being overridden because the method clashes with the
+     * equivalent method in the 1.x version of {@link ArgumentMatcher}. Implement
+     * {@link #matchesSafely(Object)} instead.
+     *
+     * @param argument the argument
+     * @return true if this matcher accepts the given argument.
+     */
+    @Override
+    public final boolean matches(Object argument) {
+        Class<T> argumentType = getArgumentType(this);
+        return argumentType.isInstance(argument) && matchesSafely(argumentType.cast(argument));
+    }
+
+    /**
+     * Informs if this matcher accepts the given argument.
+     * <p>
+     * The method should <b>never</b> assert if the argument doesn't match. It
+     * should only return false.
+     *
+     * @param argument the argument
+     * @return true if this matcher accepts the given argument.
+     */
+    public abstract boolean matchesSafely(T argument);
+
+    /**
+     * Returns the type of {@link ArgumentMatcher#matches(Object)} of the given
+     * {@link ArgumentMatcher} implementation.
+     */
+    @SuppressWarnings("unchecked")
+    private static <T> Class<T> getArgumentType(ArgumentMatcher<T> argumentMatcher) {
+        Method[] methods = argumentMatcher.getClass().getMethods();
+
+        for (Method method : methods) {
+            if (isMatchesMethod(method)) {
+                return (Class<T>) method.getParameterTypes()[0];
+            }
+        }
+        throw new NoSuchMethodError("Method '" + "matchesSafely" + "(T)' not found in ArgumentMatcher: "
+            + argumentMatcher + " !\r\n Please file a bug with this stack trace at: https://github.com/mockito/mockito/issues/new ");
+    }
+
+    /**
+     * Returns <code>true</code> if the given method is
+     * {@link MockitoV1CompatibilityMatcher#matchesSafely(Object)}
+     */
+    private static boolean isMatchesMethod(Method method) {
+        return method.getParameterTypes().length == 1 && !method.isBridge()
+            && method.getName().equals("matchesSafely");
+    }
+}

--- a/subprojects/migration/src/test/java/org/mockito/migration/MockitoV1CompatibilityMatcherTest.java
+++ b/subprojects/migration/src/test/java/org/mockito/migration/MockitoV1CompatibilityMatcherTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.migration;
+
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.internal.invocation.TypeSafeMatching;
+import org.mockito.internal.matchers.text.MatchersPrinter;
+import org.mockito.internal.reporting.PrintSettings;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MockitoV1CompatibilityMatcherTest {
+
+    @Test
+    public void testToString_AnonymousClass() {
+        ArgumentMatcher<Integer> matcher = new MockitoV1CompatibilityMatcher<Integer>() {
+            @Override
+            public boolean matchesSafely(Integer argument) {
+                return true;
+            }
+        };
+
+        assertEquals("(<custom argument matcher>);", matcherToString(matcher));
+        assertTrue(matcher.matches(1));
+        assertFalse(TypeSafeMatching.matchesTypeSafe().apply(matcher, 1L));
+    }
+
+    @SuppressWarnings("unchecked")
+    private String matcherToString(ArgumentMatcher<Integer> matcher) {
+        return new MatchersPrinter().getArgumentsLine((List) Collections.singletonList(matcher),
+            new PrintSettings());
+    }
+
+    @Test
+    public void testToString_NestedClass() {
+        ArgumentMatcher<Integer> matcher = new NoIntegerMatching();
+
+        assertEquals("(<No integer matching>);", matcherToString(matcher));
+        assertTrue(matcher.matches(1));
+        assertFalse(TypeSafeMatching.matchesTypeSafe().apply(matcher, 1L));
+    }
+
+    private static class NoIntegerMatching extends MockitoV1CompatibilityMatcher<Integer> {
+
+        @Override
+        public boolean matchesSafely(Integer argument) {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Pre 2.x ArgumentMatcher was a class that provided a default
implementation of describeTo(Description). The new
BaseArgumentMatcher class provides an equivalent implementation
of toString() making it easier for pre 2.x code that did not
override the describeTo(Description) method to be migrated.
