### PR TITLE
fix the broken link on 1357 line in Mockito.java

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -1319,7 +1319,7 @@ import org.mockito.verification.*;
  * To quickly find out how "stricter" Mockito can make you more productive and get your tests cleaner, see:
  * <ul>
  *     <li>Strict stubbing with JUnit Rules - {@link MockitoRule#strictness(Strictness)} with {@link Strictness#STRICT_STUBS}</li>
- *     <li>Strict stubbing with JUnit Runner - {@link MockitoJUnitRunner.StrictStubs}</li>
+ *     <li>Strict stubbing with JUnit Runner - {@link MockitoJUnitRunner.StrictStubs.class}</li>
  *     <li>Strict stubbing if you cannot use runner/rule (like TestNG) - {@link MockitoSession}</li>
  *     <li>Unnecessary stubbing detection with {@link MockitoJUnitRunner}</li>
  *     <li>Stubbing argument mismatch warnings, documented in {@link MockitoHint}</li>


### PR DESCRIPTION
The link 'MockitoJUnitRunner.StrictStubs' in the 40th section in Javadoc [Mockito](https://static.javadoc.io/org.mockito/mockito-core/2.7.19/org/mockito/Mockito.html) interface is broken. I fixed it by changing 
`{@link MockitoJUnitRunner.StrictStubs} ` 
to 
 `{@link MockitoJUnitRunner.StrictStubs.class} ` .