### PR TITLE
Fixes #1003: Allow reloading of plugins.

### DIFF
--- a/src/main/java/org/mockito/internal/configuration/plugins/Plugins.java
+++ b/src/main/java/org/mockito/internal/configuration/plugins/Plugins.java
@@ -14,7 +14,7 @@ import org.mockito.plugins.StackTraceCleanerProvider;
  */
 public class Plugins {
 
-    private static final PluginRegistry registry = new PluginRegistry();
+    private static PluginRegistry registry = new PluginRegistry();
 
     /**
      * The implementation of the stack trace cleaner
@@ -51,5 +51,12 @@ public class Plugins {
      */
     public static AnnotationEngine getAnnotationEngine() {
         return registry.getAnnotationEngine();
+    }
+
+    /**
+     * Refreshes the plugin registry and reloads plugins.
+     */
+    public static void refreshPluginRegistry() {
+        registry = new PluginRegistry();
     }
 }

--- a/src/test/java/org/mockito/internal/configuration/plugins/PluginsTest.java
+++ b/src/test/java/org/mockito/internal/configuration/plugins/PluginsTest.java
@@ -1,0 +1,25 @@
+package org.mockito.internal.configuration.plugins;
+
+import org.junit.Test;
+import org.mockito.plugins.MockMaker;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class PluginsTest {
+
+    @Test
+    public void refresh_plugin_registry_reloads_plugins() {
+        MockMaker oldMockMaker = Plugins.getMockMaker();
+        Plugins.refreshPluginRegistry();
+        MockMaker newMockMaker = Plugins.getMockMaker();
+        assertNotEquals(oldMockMaker, newMockMaker);
+    }
+
+    @Test
+    public void plugin_registry_reuses_plugins() {
+        MockMaker oldMockMaker = Plugins.getMockMaker();
+        MockMaker newMockMaker = Plugins.getMockMaker();
+        assertEquals(oldMockMaker, newMockMaker);
+    }
+}


### PR DESCRIPTION
Fixes #1003: Allow reloading of plugins.

This is done by making the PluginRegistry non final and exposing a public static method in Plugins so that PluginSwitch's in the future can trigger a reload of plugins if it wants to disable/enable some of them.