### PR TITLE
Clean up unused imports

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -22,5 +22,10 @@
         <property name="format" value="\s+$"/>
         <property name="message" value="Line has trailing spaces."/>
     </module>
+    <module name="TreeWalker" >
+        <module name="UnusedImports">
+            <property name="processJavadoc" value="true"/>
+        </module>
+    </module>
 </module>
 

--- a/src/main/java/org/mockito/exceptions/misusing/PotentialStubbingProblem.java
+++ b/src/main/java/org/mockito/exceptions/misusing/PotentialStubbingProblem.java
@@ -5,10 +5,8 @@
 package org.mockito.exceptions.misusing;
 
 import org.mockito.Mockito;
-import org.mockito.MockitoSession;
 import org.mockito.quality.Strictness;
 import org.mockito.exceptions.base.MockitoException;
-import org.mockito.junit.MockitoRule;
 
 /**
  * {@code PotentialStubbingProblem} improves productivity by failing the test early when the user

--- a/src/main/java/org/mockito/internal/MockitoCore.java
+++ b/src/main/java/org/mockito/internal/MockitoCore.java
@@ -23,11 +23,10 @@ import static org.mockito.internal.verification.VerificationModeFactory.noMoreIn
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
+
 import org.mockito.InOrder;
 import org.mockito.MockSettings;
 import org.mockito.MockingDetails;
-import org.mockito.exceptions.base.MockitoException;
 import org.mockito.exceptions.misusing.NotAMockException;
 import org.mockito.internal.creation.MockSettingsImpl;
 import org.mockito.internal.invocation.finder.VerifiableInvocationsFinder;
@@ -43,7 +42,6 @@ import org.mockito.internal.verification.api.InOrderContext;
 import org.mockito.internal.verification.api.VerificationDataInOrder;
 import org.mockito.internal.verification.api.VerificationDataInOrderImpl;
 import org.mockito.invocation.Invocation;
-import org.mockito.listeners.VerificationListener;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.stubbing.OngoingStubbing;
 import org.mockito.stubbing.Stubber;

--- a/src/main/java/org/mockito/internal/configuration/injection/PropertyAndSetterInjection.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/PropertyAndSetterInjection.java
@@ -26,7 +26,6 @@ import org.mockito.internal.configuration.injection.filter.TypeBasedCandidateFil
 import org.mockito.internal.util.collections.ListUtil;
 import org.mockito.internal.util.reflection.FieldInitializationReport;
 import org.mockito.internal.util.reflection.FieldInitializer;
-import org.mockito.internal.util.reflection.SuperTypesLastSorter;
 
 /**
  * Inject mocks using first setters then fields, if no setters available.

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMaker.java
@@ -7,7 +7,6 @@ package org.mockito.internal.creation.bytebuddy;
 import org.mockito.Incubating;
 import org.mockito.invocation.MockHandler;
 import org.mockito.mock.MockCreationSettings;
-import org.mockito.plugins.MockMaker;
 
 /**
  * ByteBuddy MockMaker.

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
@@ -38,7 +38,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import static net.bytebuddy.implementation.MethodDelegation.to;
 import static net.bytebuddy.implementation.MethodDelegation.withDefaultConfiguration;
 import static net.bytebuddy.implementation.bind.annotation.TargetMethodAnnotationDrivenBinder.ParameterBinder.ForFixedValue.OfConstant.of;
 import static net.bytebuddy.matcher.ElementMatchers.*;

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InterceptedInvocation.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InterceptedInvocation.java
@@ -4,7 +4,6 @@
  */
 package org.mockito.internal.creation.bytebuddy;
 
-import org.mockito.internal.debugging.LocationImpl;
 import org.mockito.internal.exceptions.VerificationAwareInvocation;
 import org.mockito.internal.exceptions.stacktrace.ConditionalStackTraceFilter;
 import org.mockito.internal.invocation.ArgumentsProcessor;

--- a/src/main/java/org/mockito/internal/reporting/PrintSettings.java
+++ b/src/main/java/org/mockito/internal/reporting/PrintSettings.java
@@ -6,7 +6,6 @@ package org.mockito.internal.reporting;
 
 import org.mockito.ArgumentMatcher;
 import org.mockito.internal.invocation.ArgumentsProcessor;
-import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockito.internal.matchers.text.MatchersPrinter;
 import org.mockito.internal.util.MockUtil;
 import org.mockito.invocation.Invocation;

--- a/src/main/java/org/mockito/internal/reporting/SmartPrinter.java
+++ b/src/main/java/org/mockito/internal/reporting/SmartPrinter.java
@@ -5,7 +5,6 @@
 package org.mockito.internal.reporting;
 
 
-import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockito.invocation.Invocation;
 import org.mockito.invocation.MatchableInvocation;
 

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValues.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValues.java
@@ -6,7 +6,6 @@ package org.mockito.internal.stubbing.defaultanswers;
 
 import org.mockito.internal.util.JavaEightUtil;
 import org.mockito.internal.util.MockUtil;
-import org.mockito.internal.util.ObjectMethodsGuru;
 import org.mockito.internal.util.Primitives;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.mock.MockName;

--- a/src/main/java/org/mockito/internal/verification/AtMost.java
+++ b/src/main/java/org/mockito/internal/verification/AtMost.java
@@ -12,7 +12,6 @@ import static org.mockito.internal.invocation.InvocationsFinder.findInvocations;
 import java.util.Iterator;
 import java.util.List;
 import org.mockito.exceptions.base.MockitoException;
-import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockito.invocation.MatchableInvocation;
 import org.mockito.internal.verification.api.VerificationData;
 import org.mockito.invocation.Invocation;

--- a/src/main/java/org/mockito/internal/verification/DefaultRegisteredInvocations.java
+++ b/src/main/java/org/mockito/internal/verification/DefaultRegisteredInvocations.java
@@ -5,7 +5,6 @@
 
 package org.mockito.internal.verification;
 
-import org.mockito.internal.util.ObjectMethodsGuru;
 import org.mockito.internal.util.collections.ListUtil;
 import org.mockito.internal.util.collections.ListUtil.Filter;
 import org.mockito.invocation.Invocation;

--- a/src/main/java/org/mockito/internal/verification/Only.java
+++ b/src/main/java/org/mockito/internal/verification/Only.java
@@ -12,7 +12,6 @@ import static org.mockito.internal.invocation.InvocationsFinder.findInvocations;
 
 import java.util.List;
 
-import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockito.invocation.MatchableInvocation;
 import org.mockito.internal.verification.api.VerificationData;
 import org.mockito.invocation.Invocation;

--- a/src/main/java/org/mockito/internal/verification/api/VerificationDataInOrder.java
+++ b/src/main/java/org/mockito/internal/verification/api/VerificationDataInOrder.java
@@ -6,7 +6,6 @@ package org.mockito.internal.verification.api;
 
 import java.util.List;
 
-import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockito.invocation.Invocation;
 import org.mockito.invocation.MatchableInvocation;
 

--- a/src/main/java/org/mockito/internal/verification/api/VerificationDataInOrderImpl.java
+++ b/src/main/java/org/mockito/internal/verification/api/VerificationDataInOrderImpl.java
@@ -6,7 +6,6 @@ package org.mockito.internal.verification.api;
 
 import java.util.List;
 
-import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockito.invocation.Invocation;
 import org.mockito.invocation.MatchableInvocation;
 

--- a/src/main/java/org/mockito/internal/verification/checkers/MissingInvocationChecker.java
+++ b/src/main/java/org/mockito/internal/verification/checkers/MissingInvocationChecker.java
@@ -15,7 +15,7 @@ import static org.mockito.internal.invocation.InvocationsFinder.findSimilarInvoc
 import static org.mockito.internal.verification.argumentmatching.ArgumentMatchingTool.getSuspiciouslyNotMatchingArgsIndexes;
 
 import java.util.List;
-import org.mockito.internal.invocation.InvocationMatcher;
+
 import org.mockito.internal.reporting.SmartPrinter;
 import org.mockito.internal.verification.api.InOrderContext;
 import org.mockito.invocation.Invocation;

--- a/src/main/java/org/mockito/internal/verification/checkers/NumberOfInvocationsInOrderChecker.java
+++ b/src/main/java/org/mockito/internal/verification/checkers/NumberOfInvocationsInOrderChecker.java
@@ -13,7 +13,6 @@ import static org.mockito.internal.invocation.InvocationsFinder.getLastLocation;
 
 import java.util.List;
 
-import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockito.internal.reporting.Discrepancy;
 import org.mockito.internal.verification.api.InOrderContext;
 import org.mockito.invocation.Invocation;

--- a/src/main/java/org/mockito/junit/MockitoRule.java
+++ b/src/main/java/org/mockito/junit/MockitoRule.java
@@ -11,7 +11,6 @@ import org.mockito.MockitoSession;
 import org.mockito.quality.MockitoHint;
 import org.mockito.quality.Strictness;
 import org.mockito.exceptions.misusing.PotentialStubbingProblem;
-import org.mockito.exceptions.misusing.UnnecessaryStubbingException;
 
 /**
  * Mockito JUnit Rule helps keeping tests clean.

--- a/src/main/java/org/mockito/junit/VerificationCollector.java
+++ b/src/main/java/org/mockito/junit/VerificationCollector.java
@@ -7,7 +7,6 @@ package org.mockito.junit;
 import org.junit.rules.TestRule;
 import org.mockito.Incubating;
 import org.mockito.exceptions.base.MockitoAssertionError;
-import org.mockito.verification.VerificationMode;
 
 /**
  * Use this rule in order to collect multiple verification failures and report at once.
@@ -35,7 +34,7 @@ import org.mockito.verification.VerificationMode;
  * </code></pre>
  *
  * @see org.mockito.Mockito#verify(Object)
- * @see org.mockito.Mockito#verify(Object, VerificationMode)
+ * @see org.mockito.Mockito#verify(Object, org.mockito.verification.VerificationMode)
  * @since 2.1.0
  */
 @Incubating

--- a/src/test/java/org/concurrentmockito/ThreadsRunAllTestsHalfManualTest.java
+++ b/src/test/java/org/concurrentmockito/ThreadsRunAllTestsHalfManualTest.java
@@ -56,7 +56,6 @@ import org.mockitoutil.TestBase;
 import java.util.*;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertFalse;
 
 public class ThreadsRunAllTestsHalfManualTest extends TestBase {
 

--- a/src/test/java/org/mockito/internal/framework/DefaultMockitoFrameworkTest.java
+++ b/src/test/java/org/mockito/internal/framework/DefaultMockitoFrameworkTest.java
@@ -18,7 +18,6 @@ import org.mockitoutil.TestBase;
 import java.util.List;
 import java.util.Set;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.mockitoutil.ThrowableAssert.assertThat;
 

--- a/src/test/java/org/mockito/internal/junit/UnusedStubbingsTest.java
+++ b/src/test/java/org/mockito/internal/junit/UnusedStubbingsTest.java
@@ -7,7 +7,6 @@ package org.mockito.internal.junit;
 import org.junit.Test;
 import org.mockito.internal.invocation.InvocationBuilder;
 import org.mockito.internal.stubbing.StubbedInvocationMatcher;
-import org.mockito.internal.stubbing.answers.DoesNothing;
 import org.mockito.internal.util.SimpleMockitoLogger;
 import org.mockitoutil.TestBase;
 

--- a/src/test/java/org/mockito/internal/progress/MockingProgressImplTest.java
+++ b/src/test/java/org/mockito/internal/progress/MockingProgressImplTest.java
@@ -13,9 +13,6 @@ import org.mockito.verification.VerificationMode;
 import org.mockitoutil.TestBase;
 
 import static junit.framework.TestCase.*;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
 public class MockingProgressImplTest extends TestBase {
 

--- a/src/test/java/org/mockito/internal/stubbing/answers/InvocationInfoTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/answers/InvocationInfoTest.java
@@ -7,15 +7,11 @@ package org.mockito.internal.stubbing.answers;
 import java.lang.reflect.Method;
 import java.nio.charset.CharacterCodingException;
 import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.internal.invocation.InvocationBuilder;
 import org.mockito.invocation.Invocation;
 import org.mockitousage.IMethods;
-import org.mockitoutil.TestBase;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockitoutil.TestBase.getLastInvocation;
 

--- a/src/test/java/org/mockito/internal/util/DefaultMockingDetailsTest.java
+++ b/src/test/java/org/mockito/internal/util/DefaultMockingDetailsTest.java
@@ -24,8 +24,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.withSettings;
 
 @SuppressWarnings("unchecked")
 public class DefaultMockingDetailsTest {

--- a/src/test/java/org/mockito/internal/util/reflection/FieldInitializerTest.java
+++ b/src/test/java/org/mockito/internal/util/reflection/FieldInitializerTest.java
@@ -6,7 +6,6 @@ package org.mockito.internal.util.reflection;
 
 import org.junit.Test;
 import org.mockito.InjectMocks;
-import org.mockito.Mockito;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.util.reflection.FieldInitializer.ConstructorArgumentResolver;
 

--- a/src/test/java/org/mockito/internal/verification/argumentmatching/ArgumentMatchingToolTest.java
+++ b/src/test/java/org/mockito/internal/verification/argumentmatching/ArgumentMatchingToolTest.java
@@ -11,12 +11,10 @@ import org.mockito.internal.matchers.Equals;
 import org.mockitoutil.TestBase;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static java.util.Collections.singletonList;
 import static junit.framework.TestCase.assertEquals;
-import static org.junit.Assert.*;
 
 @SuppressWarnings({ "unchecked", "serial" })
 public class ArgumentMatchingToolTest extends TestBase {

--- a/src/test/java/org/mockito/internal/verification/checkers/MissingInvocationInOrderCheckerTest.java
+++ b/src/test/java/org/mockito/internal/verification/checkers/MissingInvocationInOrderCheckerTest.java
@@ -15,7 +15,6 @@ import org.mockito.exceptions.verification.WantedButNotInvoked;
 import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
 import org.mockito.internal.invocation.InvocationBuilder;
 import org.mockito.internal.invocation.InvocationMatcher;
-import org.mockito.internal.progress.VerificationModeBuilder;
 import org.mockito.internal.verification.InOrderContextImpl;
 import org.mockito.internal.verification.api.InOrderContext;
 import org.mockito.invocation.Invocation;

--- a/src/test/java/org/mockitointegration/NoJUnitDependenciesTest.java
+++ b/src/test/java/org/mockitointegration/NoJUnitDependenciesTest.java
@@ -14,7 +14,6 @@ import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockitoutil.ClassLoaders;
 import org.objenesis.Objenesis;
 
-import java.util.Arrays;
 import java.util.Set;
 
 import static org.mockitoutil.ClassLoaders.coverageTool;

--- a/src/test/java/org/mockitousage/basicapi/MocksCreationTest.java
+++ b/src/test/java/org/mockitousage/basicapi/MocksCreationTest.java
@@ -6,19 +6,15 @@
 package org.mockitousage.basicapi;
 
 import org.junit.Test;
-import org.mockito.InjectMocks;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.exceptions.verification.SmartNullPointerException;
-import org.mockito.internal.debugging.LocationImpl;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 import static junit.framework.TestCase.*;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/org/mockitousage/basicapi/ReplacingObjectMethodsTest.java
+++ b/src/test/java/org/mockitousage/basicapi/ReplacingObjectMethodsTest.java
@@ -7,7 +7,6 @@ package org.mockitousage.basicapi;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockitoutil.TestBase;

--- a/src/test/java/org/mockitousage/debugging/InvocationsPrinterTest.java
+++ b/src/test/java/org/mockitousage/debugging/InvocationsPrinterTest.java
@@ -4,7 +4,6 @@
  */
 package org.mockitousage.debugging;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.internal.debugging.InvocationsPrinter;

--- a/src/test/java/org/mockitousage/junitrunner/StrictStubsRunnerTest.java
+++ b/src/test/java/org/mockitousage/junitrunner/StrictStubsRunnerTest.java
@@ -16,7 +16,6 @@ import org.mockitousage.IMethods;
 import org.mockitoutil.JUnitResultAssert;
 import org.mockitoutil.TestBase;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 public class StrictStubsRunnerTest extends TestBase {

--- a/src/test/java/org/mockitousage/spies/SpyingOnInterfacesTest.java
+++ b/src/test/java/org/mockitousage/spies/SpyingOnInterfacesTest.java
@@ -7,7 +7,6 @@ package org.mockitousage.spies;
 
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.ClassFileVersion;
-import net.bytebuddy.description.modifier.TypeManifestation;
 import net.bytebuddy.description.modifier.Visibility;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import net.bytebuddy.implementation.FixedValue;


### PR DESCRIPTION
During development work, orphaned, unused, imports sometime get left
behind in the code. At best, these imports are just redundant. At
worst, they introduce false dependencies in places there aren't
supposed to be any dependencies.

This patch removes all those unused imports and adds a Checkstyle
module to verify no such redundant imports will be introduced in the
future.