### PR TITLE
Tidy-up in build automation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,14 +52,16 @@ apply from: "gradle/java-library.gradle"
 dependencies {
     compile 'net.bytebuddy:byte-buddy:1.6.11', 'net.bytebuddy:byte-buddy-agent:1.6.11'
 
-    provided "junit:junit:4.12", "org.hamcrest:hamcrest-core:1.3"
+    compileOnly "junit:junit:4.12", "org.hamcrest:hamcrest-core:1.3"
     compile "org.objenesis:objenesis:2.5"
 
     testCompile 'org.ow2.asm:asm:5.1'
 
     testCompile 'org.assertj:assertj-core:1.7.1'
 
-    testRuntime configurations.provided
+    //putting 'provided' dependencies on test compile and runtime classpath
+    testCompileOnly configurations.compileOnly
+    testRuntime configurations.compileOnly
 
     testUtil sourceSets.test.output
 }

--- a/gradle/java-library.gradle
+++ b/gradle/java-library.gradle
@@ -7,19 +7,6 @@ targetCompatibility = 1.6
 
 apply plugin: 'maven-publish'
 
-configurations {
-    provided
-}
-
-sourceSets {
-    main {
-        compileClasspath = compileClasspath + configurations.provided
-    }
-    test {
-        compileClasspath = compileClasspath + configurations.provided
-    }
-}
-
 test {
     include "**/*Test.class"
     testLogging {

--- a/gradle/mockito-core/javadoc.gradle
+++ b/gradle/mockito-core/javadoc.gradle
@@ -6,7 +6,6 @@ javadoc {
     // For more details on the format
     // see https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html
 
-    classpath = configurations.runtime + configurations.provided
     source = sourceSets.main.allJava
     destinationDir = file("$buildDir/javadoc")
     title = "Mockito ${project.version} API"

--- a/gradle/root/ide.gradle
+++ b/gradle/root/ide.gradle
@@ -11,8 +11,3 @@ idea.project.ipr {
         provider.node.component.find { it.@name == 'VcsDirectoryMappings' }.mapping.@vcs = 'Git'
     }
 }
-
-afterEvaluate { //so the provided conf exists
-    idea.module.scopes.PROVIDED.plus += [configurations.provided]
-    eclipse.classpath.plusConfigurations += [configurations.provided]
-}

--- a/gradle/root/ide.gradle
+++ b/gradle/root/ide.gradle
@@ -5,9 +5,7 @@ allprojects {
     apply plugin: 'idea'
 }
 
-// Configure VCS in generated IPR file
-idea.project.ipr {
-    withXml { provider ->
-        provider.node.component.find { it.@name == 'VcsDirectoryMappings' }.mapping.@vcs = 'Git'
-    }
+idea.project {
+    vcs = 'Git'
 }
+


### PR DESCRIPTION
In preparation to fix #911 I needed to clean up some existing build logic that we no longer need.

1. Removed unnecessary 'provided' configuration. Gradle 2.12 introduced 'compileOnly' configuration that can be used instead. This way, we can clean up our build script and avoid unnecessary build logic.
2. Removed unnecessary manipulation of the IDEA ipr file. We can use built-in 'vcs' method to configure the version control system for the project. This way, the build logic is simpler.

Testing done:
- ran build, tests pass, jars are created, things look good
- ran old build and new build, compared build dirs, eyeballed binaries and javadocs, seem good.
- recreated idea configuration with “./gradlew cleanIdea idea”, loaded to IntelliJ, rebuilt project in IDEA, ran tests from all submodules, all good.
- cleaned idea configuration with “./gardlew cleanIdea”, then loaded to IDEA using IntelliJ-own Gradle support