### PR TITLE
Fixes #992: Backport MockitoV1CompatibilityMatcher from 2.x to aid in migration to 2.x

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 include 'testng'
 include 'extTest'
+include 'migration'
 
 rootProject.name = 'mockito'
 

--- a/subprojects/migration/migration.gradle
+++ b/subprojects/migration/migration.gradle
@@ -1,0 +1,9 @@
+apply plugin: 'java'
+description = "Compatibility classes to aid in migration to 2.x"
+
+dependencies {
+    compile "org.hamcrest:hamcrest-core:1.3"
+    compile project.rootProject
+
+    testCompile "junit:junit:4.10"
+}

--- a/subprojects/migration/src/main/java/org/mockito/migration/MockitoV1CompatibilityMatcher.java
+++ b/subprojects/migration/src/main/java/org/mockito/migration/MockitoV1CompatibilityMatcher.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.migration;
+
+import java.lang.reflect.Method;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Incubating;
+
+/**
+ * Base class for classes that implement {@link ArgumentMatcher}.
+ * <p>
+ * This was provided to simplify migration from pre 2.x implementations; it resolves the conflict
+ * caused by the signature of the {@code matches(...)} method changing from {@code matches(Object)}
+ * in pre 2.x to {@code matches(T)} by adding a new {@link #matchesSafely(T)} method which
+ * developers implement instead. This checks the type of the
+ * argument beforehand and returns false if it is not of the correct type to avoid a
+ * {@link ClassCastException} being thrown.
+ * <p>
+ * It does not provide a default implementation of {@link #toString()} as if no {@link #toString()}
+ * method is provided then it defaults to the pre 2.x behavior of creating a decamelized form of the
+ * class name.
+ *
+ * @deprecated this was only intended to ease migration from 1.x to 2.x please implement
+ * {@link ArgumentMatcher} directly.
+ */
+@Incubating
+@Deprecated
+public abstract class MockitoV1CompatibilityMatcher<T> extends ArgumentMatcher<T> {
+
+    /**
+     * Informs if this matcher accepts the given argument.
+     * <p>
+     * It is marked as final to prevent it being overridden because the method clashes with the
+     * equivalent method in the 1.x version of {@link ArgumentMatcher}. ImpleTypeSafeMatchingment
+     * {@link #matchesSafely(Object)} instead.
+     *
+     * @param argument the argument
+     * @return true if this matcher accepts the given argument.
+     */
+    @Override
+    public final boolean matches(Object argument) {
+        Class<T> argumentType = getArgumentType(this);
+        return argumentType.isInstance(argument) && matchesSafely(argumentType.cast(argument));
+    }
+
+    /**
+     * Informs if this matcher accepts the given argument.
+     * <p>
+     * The method should <b>never</b> assert if the argument doesn't match. It
+     * should only return false.
+     *
+     * @param argument the argument
+     * @return true if this matcher accepts the given argument.
+     */
+    public abstract boolean matchesSafely(T argument);
+
+    /**
+     * Returns the type of {@link ArgumentMatcher#matches(Object)} of the given
+     * {@link ArgumentMatcher} implementation.
+     */
+    @SuppressWarnings("unchecked")
+    private static <T> Class<T> getArgumentType(ArgumentMatcher<T> argumentMatcher) {
+        Method[] methods = argumentMatcher.getClass().getMethods();
+
+        for (Method method : methods) {
+            if (isMatchesMethod(method)) {
+                return (Class<T>) method.getParameterTypes()[0];
+            }
+        }
+        throw new NoSuchMethodError("Method '" + "matchesSafely" + "(T)' not found in ArgumentMatcher: "
+            + argumentMatcher + " !\r\n Please file a bug with this stack trace at: https://github.com/mockito/mockito/issues/new ");
+    }
+
+    /**
+     * Returns <code>true</code> if the given method is
+     * {@link MockitoV1CompatibilityMatcher#matchesSafely(Object)}
+     */
+    private static boolean isMatchesMethod(Method method) {
+        return method.getParameterTypes().length == 1 && !method.isBridge()
+            && method.getName().equals("matchesSafely");
+    }
+}

--- a/subprojects/migration/src/test/java/org/mockito/migration/MockitoV1CompatibilityMatcherTest.java
+++ b/subprojects/migration/src/test/java/org/mockito/migration/MockitoV1CompatibilityMatcherTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.migration;
+
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.internal.matchers.MatchersPrinter;
+import org.mockito.internal.reporting.PrintSettings;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MockitoV1CompatibilityMatcherTest {
+
+    @Test
+    public void testToString_AnonymousClass() {
+        ArgumentMatcher<Integer> matcher = new MockitoV1CompatibilityMatcher<Integer>() {
+            @Override
+            public boolean matchesSafely(Integer argument) {
+                return true;
+            }
+        };
+
+        assertEquals("(<custom argument matcher>);", matcherToString(matcher));
+        assertTrue(matcher.matches(1));
+        assertFalse(matcher.matches(1L));
+    }
+
+    @SuppressWarnings("unchecked")
+    private String matcherToString(ArgumentMatcher<Integer> matcher) {
+        return new MatchersPrinter().getArgumentsLine((List) Collections.singletonList(matcher),
+            new PrintSettings());
+    }
+
+    @Test
+    public void testToString_NestedClass() {
+        ArgumentMatcher<Integer> matcher = new NoIntegerMatching();
+
+        assertEquals("(<No integer matching>);", matcherToString(matcher));
+        assertTrue(matcher.matches(1));
+        assertFalse(matcher.matches(1L));
+    }
+
+    private static class NoIntegerMatching extends MockitoV1CompatibilityMatcher<Integer> {
+
+        @Override
+        public boolean matchesSafely(Integer argument) {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #992: Backport MockitoV1CompatibilityMatcher from 2.x to aid in migration to 2.x

The 2.x version of ArgumentMatcher<T> differs quite
significantly from the current version:
1) It is an interface not a class and no longer extends
   org.hamcrest.Matcher.
2) Its main method is matches(T) not matches(Object).
3) It uses the toString() method to construct a description and
   not the describeTo(Description) method.

This class supports the following strategy for migrating
implementations of ArgumentMatcher from 1.10.19 to 2.x:
1) First migrate to a 1.x version that has
   MockitoV1CompatibilityMatcher change in it. That should be
   relatively simple.
2) Then modify all existing implementation of ArgumentMatcher
   to extend MockitoV1CompatibilityMatcher.
3) Switch to use a version of 2.x that contains this change.
   Everything should compile as usual.
4) Modify the classes that extend MockitoV1CompatibilityMatcher
   to implement ArgumentMatcher interface directly.

The above strategy is overkill when migrating a small project
that can be updated atomically but it has proven to be a good
approach when upgrading a large project spread across multiple
git repositories. This is added in part because of the
experience doing exactly that with the Android Open Source
Platform.

check list

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/2.x/.github/CONTRIBUTING.md)
 - [ x PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_
