### PR TITLE
Change release build to JDK 7 with binary compatibility for Java 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ branches:
 install:
  - true
 script:
-  - ./gradlew ciBuild release -s
+  - ./gradlew ciBuild release -s -Pcompatibility
 after_success:
   - ./gradlew --stacktrace coverageReport && cp build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml jacoco.xml || echo "Code coverage failed"
   - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,10 @@ before_install:
   - echo "$TRAVIS_COMMIT_MESSAGE"
 
 jdk:
-  - openjdk6
+  - oraclejdk7
 
 matrix:
   include:
-  - jdk: openjdk6
-    env: SKIP_RELEASE=true MOCK_MAKER=mock-maker-inline
-  - jdk: oraclejdk7
-    env: SKIP_RELEASE=true
   - jdk: oraclejdk7
     env: SKIP_RELEASE=true MOCK_MAKER=mock-maker-inline
   - jdk: oraclejdk8
@@ -52,7 +48,7 @@ branches:
 install:
  - true
 script:
-  - ./gradlew ciBuild release -s -Pcompatibility
+  - ./gradlew ciBuild release -s -PcheckJava6Compatibility
 after_success:
   - ./gradlew --stacktrace coverageReport && cp build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml jacoco.xml || echo "Code coverage failed"
   - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
     dependencies {
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3" //for publications to Bintray / central
         classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.11.0' // later versions don't work on JDK6
+        classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.3.0'
 
         //Needed so that release notes and release workflow plugin can be applied in separate gradle/*.gradle build files
         classpath project.'dependencies.mockito-release-tools'
@@ -97,4 +98,10 @@ release.mustRunAfter ciBuild //Making sure that release task is only invoked aft
 buildScan {
     licenseAgreementUrl = 'https://gradle.com/terms-of-service'
     licenseAgree = 'yes'
+}
+
+//Cannot be simply moved to a separate script as Gradle fails with "Could not get unknown property 'ru' for root project 'mockito' of type org.gradle.api.Project."
+//(buildscript section would be required to have in that script)
+tasks.withType(ru.vyarus.gradle.plugin.animalsniffer.AnimalSniffer) {
+    onlyIf { project.hasProperty('compatibility') }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     dependencies {
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3" //for publications to Bintray / central
         classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.11.0' // later versions don't work on JDK6
-        classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.3.0'
+        classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.3.0' //for 'java6-compatibility.gradle'
 
         //Needed so that release notes and release workflow plugin can be applied in separate gradle/*.gradle build files
         classpath project.'dependencies.mockito-release-tools'
@@ -75,6 +75,7 @@ apply from: 'gradle/root/ide.gradle'
 apply from: 'gradle/root/coverage.gradle'
 apply from: 'gradle/root/gradle-fix.gradle'
 apply from: 'gradle/root/release.gradle'
+apply from: 'gradle/root/java6-compatibility.gradle'
 
 apply from: 'gradle/mockito-core/inline-mock.gradle'
 apply from: 'gradle/mockito-core/osgi.gradle'
@@ -98,10 +99,4 @@ release.mustRunAfter ciBuild //Making sure that release task is only invoked aft
 buildScan {
     licenseAgreementUrl = 'https://gradle.com/terms-of-service'
     licenseAgree = 'yes'
-}
-
-//Cannot be simply moved to a separate script as Gradle fails with "Could not get unknown property 'ru' for root project 'mockito' of type org.gradle.api.Project."
-//(buildscript section would be required to have in that script)
-tasks.withType(ru.vyarus.gradle.plugin.animalsniffer.AnimalSniffer) {
-    onlyIf { project.hasProperty('compatibility') }
 }

--- a/gradle/java-library.gradle
+++ b/gradle/java-library.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java'
-apply plugin: 'ru.vyarus.animalsniffer'
 
 group = 'org.mockito'
 
@@ -26,7 +25,3 @@ tasks.withType(Checkstyle) {
 
 assert project.hasProperty("artifactName") : "Please configure 'ext.artifactName' for project that wants to use 'java-library.gradle' plugin"
 archivesBaseName = project.ext.artifactName
-
-dependencies {
-    signature 'org.codehaus.mojo.signature:java16:1.0@signature'
-}

--- a/gradle/java-library.gradle
+++ b/gradle/java-library.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+apply plugin: 'ru.vyarus.animalsniffer'
 
 group = 'org.mockito'
 
@@ -25,3 +26,7 @@ tasks.withType(Checkstyle) {
 
 assert project.hasProperty("artifactName") : "Please configure 'ext.artifactName' for project that wants to use 'java-library.gradle' plugin"
 archivesBaseName = project.ext.artifactName
+
+dependencies {
+    signature 'org.codehaus.mojo.signature:java16:1.0@signature'
+}

--- a/gradle/root/java6-compatibility.gradle
+++ b/gradle/root/java6-compatibility.gradle
@@ -1,0 +1,12 @@
+//Use animal sniffer to detect Java6 incompatibilities
+//We can remove it when we drop support for Java8
+if (project.hasProperty('checkJava6Compatibility')) {
+    allprojects { p ->
+        plugins.withId('java') {
+            p.apply plugin: 'ru.vyarus.animalsniffer'
+            p.dependencies {
+                signature 'org.codehaus.mojo.signature:java16:1.0@signature'
+            }
+        }
+    }
+}

--- a/gradle/root/java6-compatibility.gradle
+++ b/gradle/root/java6-compatibility.gradle
@@ -1,6 +1,7 @@
 //Use animal sniffer to detect Java6 incompatibilities
 //We can remove it when we drop support for Java8
-if (project.hasProperty('checkJava6Compatibility')) {
+if (project.hasProperty('checkJava6Compatibility') && !System.getenv("SKIP_RELEASE")) {
+    //if we're skipping release, let's also skip checking compatibility (faster builds)
     allprojects { p ->
         plugins.withId('java') {
             p.apply plugin: 'ru.vyarus.animalsniffer'

--- a/gradle/root/java6-compatibility.gradle
+++ b/gradle/root/java6-compatibility.gradle
@@ -1,5 +1,5 @@
 //Use animal sniffer to detect Java6 incompatibilities
-//We can remove it when we drop support for Java8
+//We can remove it when we drop support for Java6
 if (project.hasProperty('checkJava6Compatibility') && !System.getenv("SKIP_RELEASE")) {
     //if we're skipping release, let's also skip checking compatibility (faster builds)
     allprojects { p ->


### PR DESCRIPTION
In order to fix problems with Java 6 builds (https://github.com/mockito/mockito-release-tools/issues/60) 
we have discussed the possibility of using JDK 7 for building release artifacts (#1020). We can build release artifacts with JDK7 and use animal sniffer to detect Java 6 incompatibilities.

This PR contains:
 - new Gradle build plugin to use animal sniffer tool (the plugin is not used by default for faster builds)
 - removal of Java6 build from Travis
 - setup the sniffer to detect compatibility issues when building release artifacts on Travis