### PR TITLE
Fix broken link in Mockito javadoc

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -1821,7 +1821,7 @@ public class Mockito extends ArgumentMatchers {
      * This method, in contrast to the original {@link #spy(Object)}, creates a spy based on class instead of an object.
      * Sometimes it is more convenient to create spy based on the class and avoid providing an instance of a spied object.
      * This is particularly useful for spying on abstract classes because they cannot be instantiated.
-     * See also {@link MockSettings#useConstructor()}.
+     * See also {@link MockSettings#useConstructor(Object...)}.
      * <p>
      * Examples:
      * <pre class="code"><code class="java">


### PR DESCRIPTION
Commit  6a82c030756a30932406d6b807e7ca34f20631e3 (included in Mockito 2.7.14) changed
`MockSetting#useConstructor`'s signature to accept an `Object...` argument. While this change is backwards compatible (as calls can continue passing an empty argument list), it broke the javadoc
reference to `useConstructor()` in Mockito's javadoc.