### PR TITLE
SmartPrinterTest toString() calls

### DIFF
--- a/src/test/java/org/mockito/internal/verification/SmartPrinterTest.java
+++ b/src/test/java/org/mockito/internal/verification/SmartPrinterTest.java
@@ -35,8 +35,8 @@ public class SmartPrinterTest extends TestBase {
         SmartPrinter printer = new SmartPrinter(multi, shortie.getInvocation());
 
         //then
-        assertThat(printer.getWanted().toString()).contains("\n");
-        assertThat(printer.getActual().toString()).contains("\n");
+        assertThat(printer.getWanted()).contains("\n");
+        assertThat(printer.getActual()).contains("\n");
     }
 
     @Test
@@ -45,8 +45,8 @@ public class SmartPrinterTest extends TestBase {
         SmartPrinter printer = new SmartPrinter(shortie, multi.getInvocation());
 
         //then
-        assertThat(printer.getWanted().toString()).contains("\n");
-        assertThat(printer.getActual().toString()).contains("\n");
+        assertThat(printer.getWanted()).contains("\n");
+        assertThat(printer.getActual()).contains("\n");
     }
 
     @Test
@@ -55,8 +55,8 @@ public class SmartPrinterTest extends TestBase {
         SmartPrinter printer = new SmartPrinter(multi, multi.getInvocation());
 
         //then
-        assertThat(printer.getWanted().toString()).contains("\n");
-        assertThat(printer.getActual().toString()).contains("\n");
+        assertThat(printer.getWanted()).contains("\n");
+        assertThat(printer.getActual()).contains("\n");
     }
 
     @Test
@@ -65,7 +65,7 @@ public class SmartPrinterTest extends TestBase {
         SmartPrinter printer = new SmartPrinter(shortie, shortie.getInvocation());
 
         //then
-        assertThat(printer.getWanted().toString()).doesNotContain("\n");
-        assertThat(printer.getActual().toString()).doesNotContain("\n");
+        assertThat(printer.getWanted()).doesNotContain("\n");
+        assertThat(printer.getActual()).doesNotContain("\n");
     }
 }


### PR DESCRIPTION
Calling `toString()` on a String object just returns the same object, making such calls useless in most cases.

This patch removes such calls from `SmartPrinterTest`, making the code a cleaner and easier to read.