### PR TITLE
Fix NullPointerException on TestName.getTestName

### DIFF
--- a/src/main/java/org/mockito/internal/runners/DefaultInternalRunner.java
+++ b/src/main/java/org/mockito/internal/runners/DefaultInternalRunner.java
@@ -35,8 +35,8 @@ public class DefaultInternalRunner implements InternalRunner {
                 Mockito.framework().addListener(mockitoTestListener);
 
                 // init annotated mocks before tests
-                MockitoAnnotations.initMocks(target);
                 this.target = target;
+                MockitoAnnotations.initMocks(target);
                 return super.withBefores(method, target, statement);
             }
 


### PR DESCRIPTION
On case of  `MockitoAnnotations.initMocks(target)`  throw any exception `this.target` still null.
As impact to throw a **NullPointerException on all following tests** from the method `DefaultInternalRunner.testFinished`.

To avoid this issue `this.target` should be defined before calling `initMocks()`.

Original error :

>  Underlying exception : java.lang.UnsupportedOperationException: class redefinition failed: attempted to add a method
	at org.mockito.internal.runners.DefaultInternalRunner$1.withBefores(DefaultInternalRunner.java:39)
	at org.junit.runners.BlockJUnit4ClassRunner.methodBlock(BlockJUnit4ClassRunner.java:276)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.mockito.internal.runners.DefaultInternalRunner$1.run(DefaultInternalRunner.java:72)
`

Following errors :

> java.lang.NullPointerException 
at org.mockito.internal.junit.util.TestName.getTestName(TestName.java:15)
	at org.mockito.internal.junit.MismatchReportingTestListener.testFinished(MismatchReportingTestListener.java:33)
	at org.mockito.internal.runners.DefaultInternalRunner$1$1.testFinished(DefaultInternalRunner.java:60)
	at org.junit.runner.notification.SynchronizedRunListener.testFinished(SynchronizedRunListener.java:56)
`
