### PR TITLE
MockitoTestListener must be remove on case test fail on the initialization.

### DIFF
--- a/src/test/java/org/mockito/internal/runners/DefaultInternalRunnerTest.java
+++ b/src/test/java/org/mockito/internal/runners/DefaultInternalRunnerTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.runners;
+
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunListener;
+import org.junit.runner.notification.RunNotifier;
+import org.mockito.Mock;
+import org.mockito.internal.junit.MockitoTestListener;
+import org.mockito.internal.junit.TestFinishedEvent;
+import org.mockito.internal.util.Supplier;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class DefaultInternalRunnerTest {
+
+    private final RunListener runListener = mock(RunListener.class);
+    private final MockitoTestListener mockitoTestListener = mock(MockitoTestListener.class);
+    private final Supplier<MockitoTestListener> supplier = new Supplier<MockitoTestListener>() {
+        public MockitoTestListener get() {
+            return mockitoTestListener;
+        }
+    };
+
+    @Test
+    public void does_not_fail_when_tests_succeeds() throws Exception {
+        new DefaultInternalRunner(SuccessTest.class, supplier)
+            .run(newNotifier(runListener));
+
+        verify(runListener, never()).testFailure(any(Failure.class));
+        verify(runListener, times(1)).testFinished(any(Description.class));
+        verify(mockitoTestListener, only()).testFinished(any(TestFinishedEvent.class));
+    }
+
+    @Test
+    public void does_not_fail_second_test_when_first_test_fail() throws Exception {
+        new DefaultInternalRunner(TestFailOnInitialization.class, supplier)
+            .run(newNotifier(runListener));
+
+        verify(runListener, times(1)).testFailure(any(Failure.class));
+        verify(runListener, never()).testFinished(any(Description.class));
+        verify(mockitoTestListener, never()).testFinished(any(TestFinishedEvent.class));
+
+        reset(runListener);
+
+        new DefaultInternalRunner(SuccessTest.class, supplier)
+            .run(newNotifier(runListener));
+
+        verify(runListener, never()).testFailure(any(Failure.class));
+        verify(runListener, times(1)).testFinished(any(Description.class));
+        verify(mockitoTestListener, only()).testFinished(any(TestFinishedEvent.class));
+    }
+
+    private RunNotifier newNotifier(RunListener listener) {
+        RunNotifier notifier = new RunNotifier();
+        notifier.addListener(listener);
+        return notifier;
+    }
+
+    public static final class SuccessTest {
+
+        @Test
+        public void test() {
+            assertTrue(true);
+        }
+    }
+
+    public static final class TestFailOnInitialization {
+
+        @Mock
+        private System system;
+
+        @Test
+        public void test() {
+            assertNotNull(system);
+        }
+    }
+}


### PR DESCRIPTION
On case of  `MockitoAnnotations.initMocks(target)`  throw any exception `this.target` still null.
As impact to throw a **NullPointerException on all next tests** on the method `DefaultInternalRunner.testFinished`.

What append, the method testFinished is never call on case of any error on the initialization phase as impact that the listener is not cleanup.
On next tests the method testFinished will notify the previous listener that have not been unregistered.

To avoid this issue the mockitoListener must be remove if test fail and never started.

> java.lang.NullPointerException 
at org.mockito.internal.junit.util.TestName.getTestName(TestName.java:15)
	at org.mockito.internal.junit.MismatchReportingTestListener.testFinished(MismatchReportingTestListener.java:33)
	at org.mockito.internal.runners.DefaultInternalRunner$1$1.testFinished(DefaultInternalRunner.java:60)
	at org.junit.runner.notification.SynchronizedRunListener.testFinished(SynchronizedRunListener.java:56)
`
