### PR TITLE
Fix javadoc issues

### DIFF
--- a/src/test/java/org/mockito/internal/invocation/TypeSafeMatchingTest.java
+++ b/src/test/java/org/mockito/internal/invocation/TypeSafeMatchingTest.java
@@ -34,7 +34,7 @@ public class TypeSafeMatchingTest {
     /**
      * Should not throw an {@link NullPointerException}
      *
-     * @see Bug-ID https://github.com/mockito/mockito/issues/457
+     * @see <a href="https://github.com/mockito/mockito/issues/457">Bug 457</a>
      */
     @Test
     public void compareNullArgument() {

--- a/src/test/java/org/mockito/internal/verification/argumentmatching/ArgumentMatchingToolTest.java
+++ b/src/test/java/org/mockito/internal/verification/argumentmatching/ArgumentMatchingToolTest.java
@@ -84,16 +84,12 @@ public class ArgumentMatchingToolTest extends TestBase {
         assertEquals(0, suspicious.length);
     }
 
-
-    /**
-     *
-     */
     @Test
     @SuppressWarnings("rawtypes")
     public void shouldUseMatchersSafely() {
-        /** This matcher is evil cause typeMatches(Object) returns true for every passed type but matches(T)
-         * method accepts only Strings. When a Integer is passed (thru the matches(Object) bridge method )  a
-         * ClassCastException will be thrown. */
+        // This matcher is evil cause typeMatches(Object) returns true for every passed type but matches(T)
+        // method accepts only Strings. When a Integer is passed (thru the matches(Object) bridge method )  a
+        // ClassCastException will be thrown.
         class StringMatcher implements ArgumentMatcher<String>, ContainsExtraTypeInfo {
             @Override
             public boolean matches(String item) {

--- a/src/test/java/org/mockitousage/bugs/CompareMatcherTest.java
+++ b/src/test/java/org/mockitousage/bugs/CompareMatcherTest.java
@@ -32,7 +32,7 @@ public class CompareMatcherTest {
     /**
      * Should not throw an {@link NullPointerException}
      *
-     * @see Bug-ID https://github.com/mockito/mockito/issues/457
+     * @see <a href="https://github.com/mockito/mockito/issues/457">Bug 457</a>
      */
     @Test
     public void compareNullArgument() {

--- a/src/test/java/org/mockitousage/junitrunner/SilentRunnerTest.java
+++ b/src/test/java/org/mockitousage/junitrunner/SilentRunnerTest.java
@@ -109,10 +109,10 @@ public class SilentRunnerTest extends TestBase {
         }
     }
 
-    @RunWith(MockitoJUnitRunner.Silent.class)
     /**
      * The test class itself is passing but it has some unnecessary stubs
      */
+    @RunWith(MockitoJUnitRunner.Silent.class)
     public static class HasUnnecessaryStubs {
         IMethods mock1 = when(mock(IMethods.class).simpleMethod(1)).thenReturn("1").getMock();
         IMethods mock2 = when(mock(IMethods.class).simpleMethod(2)).thenReturn("2").getMock();

--- a/src/test/java/org/mockitousage/matchers/VarargsTest.java
+++ b/src/test/java/org/mockitousage/matchers/VarargsTest.java
@@ -309,8 +309,6 @@ public class VarargsTest {
      * <li>#565 ArgumentCaptor should be type aware' are fixed this test must
      * succeed
      * </ul>
-     *
-     * @throws Exception
      */
     @Test
     @Ignore("Blocked by github issue: #584 & #565")


### PR DESCRIPTION
This PR fixes several javadoc issues reported by IntelliJ IDEA. Two types of errors are not handled in this PR:

- References which gradle is unable to resolve - these references seem to be valid javadoc links, so there's either an issue with gradle itself of with the configuration this project is using, and needs a deeper look
- Javadoc tags missing descriptions, which require a deeper understanding of the methods in question in order to resolve.