### PR TITLE
New notable version 2.7.22 and bumped release tools version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,6 @@ install:
 script:
   - ./gradlew build idea -s -PcheckJava6Compatibility
 after_success:
-  - ./gradlew travisRelease -s
+  - ./gradlew assertReleaseNeeded && ./gradlew travisReleasePrepare && ./gradlew performRelease
   - ./gradlew --stacktrace coverageReport && cp build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml jacoco.xml || echo "Code coverage failed"
   - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 
 #Declared the dependency here to avoid duplication across build.gradle files
-dependencies.mockito-release-tools=gradle.plugin.org.mockito:mockito-release-tools:0.6.0
+dependencies.mockito-release-tools=gradle.plugin.org.mockito:mockito-release-tools:0.7.1

--- a/gradle/root/release.gradle
+++ b/gradle/root/release.gradle
@@ -1,14 +1,15 @@
 apply plugin: "org.mockito.mockito-release-tools.continuous-delivery"
 
-ext {
-    gh_repository = "mockito/mockito"
+releasing {
+    gitHub.repository = "mockito/mockito"
+    gitHub.readOnlyAuthToken = "a0a4c0f41c200f7c653323014d6a72a127764e17"
     //TODO document why we are using real user name here and for Bintray user, too
-    gh_user = "szczepiq"
-    gh_readOnlyAuthToken = "a0a4c0f41c200f7c653323014d6a72a127764e17"
+    gitHub.writeAuthUser = "szczepiq"
+    gitHub.writeAuthToken = System.getenv("GH_WRITE_TOKEN")
 
-    releaseNotes_file = "doc/release-notes/official.md"
-    releaseNotes_notableFile = "doc/release-notes/notable.md"
-    releaseNotes_labelMapping = [
+    releaseNotes.file = "doc/release-notes/official.md"
+    releaseNotes.notableFile = "doc/release-notes/notable.md"
+    releaseNotes.labelMapping = [
         '1.* incompatible': 'Incompatible changes with previous major version (v1.x)',
         'java-9': "Java 9 support",
         'java-8': "Java 8 support",
@@ -20,20 +21,19 @@ ext {
         'docs': 'Documentation'
     ]
 
-    git_genericUser = "Mockito Release Tools"
-    git_genericEmail = "<mockito.release.tools@gmail.com>"
+    git.user = "Mockito Release Tools"
+    git.email = "<mockito.release.tools@gmail.com>"
+    //git.releasableBranchRegex = "master|release/.+"  // matches 'master', 'release/2.x', 'release/3.x', etc.
+    git.releasableBranchRegex = "release/.+"  // 'release/2.x', 'release/3.x', etc.
 
-    //TODO replace with when building Mockito 3:
-    // git_releasableBranchRegex = "master|release/.+"  // matches 'master', 'release/2.x', 'release/3.x', etc.
-    git_releasableBranchRegex = "release/.+"  // 'release/2.x', 'release/3.x', etc.
-
-    pom_developers = ['szczepiq:Szczepan Faber', 'bric3:Brice Dutheil', 'raphw:Rafael Winterhalter', 'TimvdLippe:Tim van der Lippe']
-    pom_contributors = []
+    team.developers = ['szczepiq:Szczepan Faber', 'bric3:Brice Dutheil', 'raphw:Rafael Winterhalter', 'TimvdLippe:Tim van der Lippe']
+    team.contributors = []
 }
 
 allprojects {
     plugins.withId("org.mockito.mockito-release-tools.bintray") {
         bintray {
+            key = System.getenv("BINTRAY_API_KEY")
             pkg {
                 repo = 'maven' //https://bintray.com/mockito/maven
                 user = 'szczepiq' //https://bintray.com/szczepiq

--- a/version.properties
+++ b/version.properties
@@ -2,7 +2,7 @@
 version=2.8.8
 
 #Used for generating notable release notes
-notableVersions=2.7.1, 2.6.1, 2.5.0, 2.4.0
+notableVersions=2.7.22, 2.7.1, 2.6.1, 2.5.0, 2.4.0
 
 #Not published currently, see https://github.com/mockito/mockito/issues/962
 mockito.testng.version=1.0


### PR DESCRIPTION
#### 1. Added 2.7.22 to notable version list.

This is the last version we directly published to maven central
so it is our current 'official' notable version. For more information on the progress on Continuous Delivery Pipeline 2.0 see #911

#### 2. Bumped version of tools

Updated the release configuration in the process. The way releasing is configured is not final so don't get hung up on this (but please provide feedback!). Most important changes (you can navigate from PR to issue with design and motivation):

1. Formal extension object for configuring the releasing (mockito/mockito-release-tools#77)
2. Changed travis release command (mockito/mockito-release-tools#81)