### PR TITLE
Fixes #1050 : Improve error if class not found

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassByteBuddyMockMaker.java
@@ -100,6 +100,14 @@ public class SubclassByteBuddyMockMaker implements ClassCreatingMockMaker {
                     ""
             ), generationFailed);
         }
+        ClassNotFoundException classNotFoundException = findClassNotFoundExceptionIfAny(generationFailed);
+        if (classNotFoundException != null) {
+            throw new MockitoException(join(
+                "Mockito cannot mock this class: " + mockFeatures.getTypeToMock() + ",",
+                "because a dependent class is not in the classpath: " + classNotFoundException.getMessage(),
+                ""
+            ), generationFailed);
+        }
         throw new MockitoException(join(
                 "Mockito cannot mock this class: " + mockFeatures.getTypeToMock() + ".",
                 "",
@@ -114,6 +122,18 @@ public class SubclassByteBuddyMockMaker implements ClassCreatingMockMaker {
                 "",
                 "Underlying exception : " + generationFailed
         ), generationFailed);
+    }
+
+    private ClassNotFoundException findClassNotFoundExceptionIfAny(Throwable generationFailed) {
+        if (generationFailed == null) {
+            return null;
+        }
+
+        if (generationFailed instanceof ClassNotFoundException) {
+            return (ClassNotFoundException)generationFailed;
+        }
+
+        return findClassNotFoundExceptionIfAny(generationFailed.getCause());
     }
 
     private static String describeClass(Class<?> type) {


### PR DESCRIPTION
If a `ClassNotFoundException` is the root cause of not being able to mock an object, present that information to the user, instead of saying it's probably because the class is private or final. This can avoid a lot of confusion when a user is trying to figure out why they can't mock an object.
