### PR TITLE
Fixed problems with releases

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 
 #Declared the dependency here to avoid duplication across build.gradle files
-dependencies.mockito-release-tools=gradle.plugin.org.mockito:mockito-release-tools:0.7.1
+dependencies.mockito-release-tools=gradle.plugin.org.mockito:mockito-release-tools:0.7.5

--- a/gradle/root/release.gradle
+++ b/gradle/root/release.gradle
@@ -25,6 +25,7 @@ releasing {
     git.email = "<mockito.release.tools@gmail.com>"
     //git.releasableBranchRegex = "master|release/.+"  // matches 'master', 'release/2.x', 'release/3.x', etc.
     git.releasableBranchRegex = "release/.+"  // 'release/2.x', 'release/3.x', etc.
+    git.commitMessagePostfix = " [ci skip-release]"
 
     team.developers = ['szczepiq:Szczepan Faber', 'bric3:Brice Dutheil', 'raphw:Rafael Winterhalter', 'TimvdLippe:Tim van der Lippe']
     team.contributors = []
@@ -41,10 +42,10 @@ allprojects {
                 name = 'mockito' //https://bintray.com/mockito/maven/mockito
                 licenses = ['MIT']
                 labels = ['mocks', 'tdd', 'unit tests']
-                publish = true //can be changed to 'false' for testing
+                publish = false //can be changed to 'false' for testing
 
                 //See our Bintray packages at https://bintray.com/mockito/maven
-                name = rootProject.ext.has('release_notable')? "mockito" : "mockito-development"
+                name = (rootProject.ext.has('release_notable') && rootProject.release_notable)? "mockito" : "mockito-development"
 
                 version {
                     //Automatically syncs to central repository (https://oss.sonatype.org/)


### PR DESCRIPTION
- fixed the logic that determines if the release is notable or not.
We shipped a couple of releases to wrong Bintray repo but we should be ok :)
I plan to make this configuration simpler but now it has to be this way.
- bumped to new version of tools to pick up a couple of improvements
including the fix for #984
- configured commit message postfix that will ensure that
code coverage is collected after CI automated commits (see #984)
- disabled automatic publication because it's still not ready