### PR TITLE
Ensured the release actually happens automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,6 @@ install:
 script:
   - ./gradlew build idea -s -PcheckJava6Compatibility
 after_success:
-  - ./gradlew assertReleaseNeeded && ./gradlew travisReleasePrepare && ./gradlew performRelease
+  - ./gradlew assertReleaseNeeded && ./gradlew travisReleasePrepare && ./gradlew performRelease -Preleasing.dryRun=false
   - ./gradlew --stacktrace coverageReport && cp build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml jacoco.xml || echo "Code coverage failed"
   - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"


### PR DESCRIPTION
New version of release tools make the release use 'dryRun' by default.
This way, we have less risk of accidental release.
I updated .travis.yml file to turn off dry run in release build step.

Please prioritize this merge over other changes
so that we can continue releasing automatically.

