### PR TITLE
Enabled automatic releasing without using skip-release keyword yet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,6 @@ install:
 script:
   - ./gradlew build idea -s -PcheckJava6Compatibility
 after_success:
-  - ./gradlew assertReleaseNeeded && ./gradlew travisReleasePrepare && ./gradlew performRelease
+  - ./gradlew assertReleaseNeeded && ./gradlew travisReleasePrepare && ./gradlew performRelease -Preleasing.dryRun=false
   - ./gradlew --stacktrace coverageReport && cp build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml jacoco.xml || echo "Code coverage failed"
   - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"

--- a/gradle/root/release.gradle
+++ b/gradle/root/release.gradle
@@ -27,7 +27,7 @@ releasing {
     git.releasableBranchRegex = "release/.+"  // 'release/2.x', 'release/3.x', etc.
 
     def buildNo = System.getenv("TRAVIS_BUILD_NUMBER")
-    git.commitMessagePostfix = buildNo? "by CI build $buildNo [ci skip-release]" : "by local build [ci skip-release]"
+    git.commitMessagePostfix = buildNo? "by CI build $buildNo [ci skip]" : "by local build [ci skip]"
 
     team.developers = ['szczepiq:Szczepan Faber', 'bric3:Brice Dutheil', 'raphw:Rafael Winterhalter', 'TimvdLippe:Tim van der Lippe']
     team.contributors = []


### PR DESCRIPTION
1. This change enables automatic releases to 'mockito-development'
without exposing us to endless loop bug I planted earlier
(https://github.com/mockito/mockito/issues/1059).

2. The skip-release behavior will be fixed soon, pr is open:
https://github.com/mockito/mockito-release-tools/pull/103
If it is fixed, we can reapply the skip-release behavior for mockito,
which will fix the codecov issue:
https://github.com/mockito/mockito/issues/984