### PR TITLE
Bumped release tools to 0.8.4 - concise release notes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 
 #Declared the dependency here to avoid duplication across build.gradle files
-dependencies.mockito-release-tools=gradle.plugin.org.mockito:mockito-release-tools:0.8.1
+dependencies.mockito-release-tools=gradle.plugin.org.mockito:mockito-release-tools:0.8.4

--- a/version.properties
+++ b/version.properties
@@ -1,6 +1,9 @@
 #Currently building Mockito version
 version=2.8.26
 
+#Previously released version, needed for release notes generation
+previousVersion=2.8.25
+
 #Used for generating notable release notes
 notableVersions=2.7.22, 2.7.1, 2.6.1, 2.5.0, 2.4.0
 


### PR DESCRIPTION
1. Bumped version of tools.
- The main improvement that is picked up is concise format of release notes: https://github.com/mockito/mockito-release-tools/pull/108
- Also picked up some internal refactorings of release tools. The previous version number will be automatically bumped / added to version.properties file.