### PR TITLE
Streamline assertj and junit4 usage in gradle files and update assertj (v2.7.0)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ apply from: 'gradle/mockito-core/javadoc.gradle'
 apply from: 'gradle/mockito-core/license.gradle'
 apply from: 'gradle/mockito-core/testing.gradle'
 
+apply from: "gradle/dependencies.gradle"
+
 archivesBaseName = "mockito-core"
 
 allprojects {
@@ -57,12 +59,12 @@ configurations {
 dependencies {
     compile 'net.bytebuddy:byte-buddy:1.6.14', 'net.bytebuddy:byte-buddy-agent:1.6.14'
 
-    compileOnly "junit:junit:4.12", "org.hamcrest:hamcrest-core:1.3"
+    compileOnly libraries.junit4, "org.hamcrest:hamcrest-core:1.3"
     compile "org.objenesis:objenesis:2.5"
 
     testCompile 'org.ow2.asm:asm:5.2'
 
-    testCompile 'org.assertj:assertj-core:2.6.0'
+    testCompile libraries.assertj
 
     //putting 'provided' dependencies on test compile and runtime classpath
     testCompileOnly configurations.compileOnly

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,0 +1,6 @@
+ext {
+    libraries = [:]
+}
+
+libraries.junit4 = 'junit:junit:4.12'
+libraries.assertj = 'org.assertj:assertj-core:2.6.0'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -3,4 +3,4 @@ ext {
 }
 
 libraries.junit4 = 'junit:junit:4.12'
-libraries.assertj = 'org.assertj:assertj-core:2.6.0'
+libraries.assertj = 'org.assertj:assertj-core:2.7.0'

--- a/src/test/java/org/mockitoutil/SafeJUnitRuleTest.java
+++ b/src/test/java/org/mockitoutil/SafeJUnitRuleTest.java
@@ -101,7 +101,7 @@ public class SafeJUnitRuleTest {
             }, mock(FrameworkMethod.class), this).evaluate();
             fail();
         } catch (AssertionError throwable) {
-            Assertions.assertThat(throwable).hasMessageContaining("but was instance of");
+            Assertions.assertThat(throwable).hasMessageContaining("but was:");
         }
     }
 

--- a/subprojects/extTest/extTest.gradle
+++ b/subprojects/extTest/extTest.gradle
@@ -14,8 +14,8 @@ repositories {
 dependencies {
     testCompile "org.mockito:mockito-core:$version"
     testCompile project(path: ':', configuration: 'testUtil')
-    testCompile "junit:junit:4.12"
-    testCompile 'org.assertj:assertj-core:1.7.1'
+    testCompile libraries.junit4
+    testCompile libraries.assertj
 }
 
 configurations.all {

--- a/subprojects/inline/inline.gradle
+++ b/subprojects/inline/inline.gradle
@@ -4,7 +4,7 @@ apply from: "$rootDir/gradle/java-library.gradle"
 
 dependencies {
     compile project.rootProject
-    testCompile 'junit:junit:4.12'
+    testCompile libraries.junit4
 }
 
 tasks.javadoc.enabled = false

--- a/subprojects/kotlinTest/kotlinTest.gradle
+++ b/subprojects/kotlinTest/kotlinTest.gradle
@@ -13,7 +13,7 @@ kotlin {
 
 dependencies {
     testCompile project(":")
-    testCompile "junit:junit:4.12"
+    testCompile libraries.junit4
 
     testCompile 'org.jetbrains.kotlin:kotlin-stdlib:1.1.1'
     testCompile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.14'

--- a/subprojects/testng/testng.gradle
+++ b/subprojects/testng/testng.gradle
@@ -48,7 +48,7 @@ uploadArchives {
 dependencies {
     compile project.rootProject
     compile 'org.testng:testng:6.3.1'
-    testCompile 'org.assertj:assertj-core:1.7.1'
+    testCompile libraries.assertj
 }
 
 test {


### PR DESCRIPTION
It looks like I missed some occurrences of assertj-core 1.7.1 in #1058.
Therefore I thought it might be a good idea to add a `dependencies.gradle` file which defines certain dependencies (for now assertj and junit4).

