### PR TITLE
Fixed validation in returnArgumentAt(int) in case of type erasure on the parameter

### DIFF
--- a/src/main/java/org/mockito/internal/stubbing/answers/ReturnsArgumentAt.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/ReturnsArgumentAt.java
@@ -135,3 +135,4 @@ public class ReturnsArgumentAt implements Answer<Object>, ValidableAnswer, Seria
 
     }
 }
+

--- a/src/test/java/org/mockito/internal/stubbing/answers/ReturnsArgumentAtTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/answers/ReturnsArgumentAtTest.java
@@ -185,6 +185,17 @@ public class ReturnsArgumentAtTest {
         }
     }
 
+    @Test
+    public void shouldNotFailWhenArgumentIsGenericAndCompatibleWithReturnType() throws Exception {
+        new ReturnsArgumentAt(0 ).validateFor(
+                new InvocationBuilder().method("genericToString")
+                                       .argTypes(Object.class)
+                                       .args("anyString")
+                                       .toInvocation()
+        );
+    }
+
+
     private static InvocationOnMock invocationWith(Object... parameters) {
         return new InvocationBuilder().method("varargsReturningString")
                                       .argTypes(Object[].class)

--- a/src/test/java/org/mockitousage/IMethods.java
+++ b/src/test/java/org/mockitousage/IMethods.java
@@ -233,6 +233,6 @@ public interface IMethods {
     Integer toIntWrapper(int i);
 
     String forObject(Object object);
-    
+
     <T> String genericToString(T arg);
 }

--- a/src/test/java/org/mockitousage/IMethods.java
+++ b/src/test/java/org/mockitousage/IMethods.java
@@ -233,4 +233,6 @@ public interface IMethods {
     Integer toIntWrapper(int i);
 
     String forObject(Object object);
+    
+    <T> String genericToString(T arg);
 }

--- a/src/test/java/org/mockitousage/MethodsImpl.java
+++ b/src/test/java/org/mockitousage/MethodsImpl.java
@@ -451,4 +451,9 @@ public class MethodsImpl implements IMethods {
     public Void voidReturningMethod() {
         return null;
     }
+
+    @Override
+    public <T> String genericToString(T arg) {
+        return null;
+    }
 }


### PR DESCRIPTION
Fixes #1071 

The parameter type inference takes now the type of the actual instance
into account to avoid type erasure issues in case the parameter is
generic.

see also: https://github.com/mockito/mockito/issues/1071#issuecomment-300091021