### PR TITLE
Fixes #1083: Interfaces only declare toString implicitly and should t…

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
@@ -80,7 +80,7 @@ public class InlineBytecodeGenerator implements BytecodeGenerator, ClassFileTran
         advice = new MockMethodAdvice(mocks, identifier);
         subclassEngine = new TypeCachingBytecodeGenerator(new SubclassBytecodeGenerator(withDefaultConfiguration()
                 .withBinders(of(MockMethodAdvice.Identifier.class, identifier))
-                .to(MockMethodAdvice.ForReadObject.class), isAbstract().or(isNative())), false);
+                .to(MockMethodAdvice.ForReadObject.class), isAbstract().or(isNative()).or(isToString())), false);
         MockMethodDispatcher.set(identifier, advice);
         instrumentation.addTransformer(this, true);
     }

--- a/src/test/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMakerTest.java
+++ b/src/test/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMakerTest.java
@@ -20,10 +20,7 @@ import org.mockito.mock.MockCreationSettings;
 import org.mockito.mock.SerializableMode;
 import org.mockito.plugins.MockMaker;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Observable;
-import java.util.Observer;
+import java.util.*;
 import java.util.regex.Pattern;
 
 import static net.bytebuddy.ClassFileVersion.JAVA_V8;
@@ -148,6 +145,26 @@ public class InlineByteBuddyMockMakerTest extends AbstractByteBuddyMockMakerTest
                     .hasMessageContaining("serialization")
                     .hasMessageContaining("extra interfaces");
         }
+    }
+
+    @Test
+    public void should_mock_interface() {
+        MockSettingsImpl<Set> mockSettings = new MockSettingsImpl<Set>();
+        mockSettings.setTypeToMock(Set.class);
+        mockSettings.defaultAnswer(new Returns(10));
+        Set<?> proxy = mockMaker.createMock(mockSettings, new MockHandlerImpl<Set>(mockSettings));
+
+        assertThat(proxy.size()).isEqualTo(10);
+    }
+
+    @Test
+    public void should_mock_interface_to_string() {
+        MockSettingsImpl<Set> mockSettings = new MockSettingsImpl<Set>();
+        mockSettings.setTypeToMock(Set.class);
+        mockSettings.defaultAnswer(new Returns("foo"));
+        Set<?> proxy = mockMaker.createMock(mockSettings, new MockHandlerImpl<Set>(mockSettings));
+
+        assertThat(proxy.toString()).isEqualTo("foo");
     }
 
     @Test


### PR DESCRIPTION
…herefore override it explicitly from the inline mock maker.