### PR TITLE
Fixes #1088 : Updating documentation of verify feature to correct a s…

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -293,7 +293,7 @@ import org.mockito.verification.*;
  *
  * //verification using atLeast()/atMost()
  * verify(mockedList, atLeastOnce()).add("three times");
- * verify(mockedList, atLeast(2)).add("five times");
+ * verify(mockedList, atLeast(2)).add("three times");
  * verify(mockedList, atMost(5)).add("three times");
  *
  * </code></pre>


### PR DESCRIPTION
Updating documentation of verify feature to correct a supposed typo that results in confusing behaviour when cut, pasted, and run verbatim.

The documentation presents the following example of the verify exact number of invocations feature:

    //using mock
    mockedList.add("once");
    
    mockedList.add("twice");
    mockedList.add("twice");
    
    mockedList.add("three times");
    mockedList.add("three times");
    mockedList.add("three times");
    
    //following two verifications work exactly the same - times(1) is used by default
    verify(mockedList).add("once");
    verify(mockedList, times(1)).add("once");
    
    //exact number of invocations verification
    verify(mockedList, times(2)).add("twice");
    verify(mockedList, times(3)).add("three times");
    
    //verification using never(). never() is an alias to times(0)
    verify(mockedList, never()).add("never happened");
    
    //verification using atLeast()/atMost()
    verify(mockedList, atLeastOnce()).add("three times");
    verify(mockedList, atLeast(2)).add("five times");
    verify(mockedList, atMost(5)).add("three times");

The last but one line says:

    verify(mockedList, atLeast(2)).add("five times");

This could be confusing to someone using these examples as it would result in a TooLittleActualInvocations failure being reported by Mockito. This is because in the example the `add()` method is never called with the String `five times`. In order to have this example make sense in the way I think it should I've replaced the String `five times` with `three times`, as suggested by @szczepiq 

Cheers,
Tim Cooke