### PR TITLE
update assertj (v2.8.0)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -3,4 +3,4 @@ ext {
 }
 
 libraries.junit4 = 'junit:junit:4.12'
-libraries.assertj = 'org.assertj:assertj-core:2.7.0'
+libraries.assertj = 'org.assertj:assertj-core:2.8.0'


### PR DESCRIPTION
assertj v2.8.0 basically contains a bugfix and a small breaking change, see http://joel-costigliola.github.io/assertj/assertj-core-news.html#assertj-core-2.8.0 for details.