### PR TITLE
InOrderImpl constructor signature

### DIFF
--- a/src/main/java/org/mockito/internal/InOrderImpl.java
+++ b/src/main/java/org/mockito/internal/InOrderImpl.java
@@ -35,7 +35,7 @@ public class InOrderImpl implements InOrder, InOrderContext {
         return mocksToBeVerifiedInOrder;
     }
 
-    public InOrderImpl(List<? extends Object> mocksToBeVerifiedInOrder) {
+    public InOrderImpl(List<?> mocksToBeVerifiedInOrder) {
         this.mocksToBeVerifiedInOrder.addAll(mocksToBeVerifiedInOrder);
     }
 


### PR DESCRIPTION
Replace `List<? extends Object>` in the constructor's argument list with a simpler `List<?>`.
The `extends Object` adds nothing, and just serves to confuse the reader.