### PR TITLE
Fixed contributor links and bintray badge in release notes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 
 #Declared the dependency here to avoid duplication across build.gradle files
-dependencies.mockito-release-tools=gradle.plugin.org.mockito:mockito-release-tools:0.8.50
+dependencies.mockito-release-tools=gradle.plugin.org.mockito:mockito-release-tools:0.8.53


### PR DESCRIPTION
This change introduces 2 improvements:
 - visual badge for downloads in release notes: https://github.com/mockito/mockito-release-tools/issues/117
 - missing contributor links: https://github.com/mockito/mockito-release-tools/issues/184

Tested by:
 - running ```./gradlew testRelease``` in mockito
 - running ```./gradlew previewReleaseNotes```, the output was:

```
:previewReleaseNotes
  Building new release notes based on /Users/sfaber/mockito/src/doc/release-notes/official.md
----------------
**2.8.38** - [1 commit](https://github.com/mockito/mockito/compare/v2.8.37...v2.8.38) by [Szczepan Faber](http://github.com/szczepiq) - *2017-05-29* - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.38-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.38)
 - No pull requests referenced in commit messages.
```