### PR TITLE
Renamed configuration extension 'releasing' into 'shipkit'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,6 @@ install:
 script:
   - ./gradlew build idea -s -PcheckJava6Compatibility
 after_success:
-  - ./gradlew assertReleaseNeeded && ./gradlew ciReleasePrepare && ./gradlew performRelease -Preleasing.dryRun=false
+  - ./gradlew assertReleaseNeeded && ./gradlew ciReleasePrepare && ./gradlew performRelease -Pshipkit.dryRun=false
   - ./gradlew --stacktrace coverageReport && cp build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml jacoco.xml || echo "Code coverage failed"
   - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
 
 description = 'Mockito mock objects library core API and implementation'
 
-apply plugin: "org.mockito.mockito-release-tools.continuous-delivery"
+apply plugin: "org.shipkit.continuous-delivery"
 
 apply from: 'gradle/root/ide.gradle'
 apply from: 'gradle/root/gradle-fix.gradle'

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 
 #Declared the dependency here to avoid duplication across build.gradle files
-dependencies.mockito-release-tools=gradle.plugin.org.mockito:mockito-release-tools:0.8.53
+dependencies.mockito-release-tools=gradle.plugin.org.mockito:mockito-release-tools:0.8.56

--- a/gradle/java-library.gradle
+++ b/gradle/java-library.gradle
@@ -1,4 +1,4 @@
-apply plugin: "org.mockito.mockito-release-tools.java-library"
+apply plugin: "org.shipkit.java-library"
 
 group = 'org.mockito'
 archivesBaseName = "mockito-" + project.name

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -1,4 +1,4 @@
-releasing {
+shipkit {
     gitHub.repository = "mockito/mockito"
     gitHub.readOnlyAuthToken = "a0a4c0f41c200f7c653323014d6a72a127764e17"
     //TODO document why we are using real user name here and for Bintray user, too
@@ -38,7 +38,7 @@ releasing {
 boolean centralRelease = shouldReleaseToCentral(project)
 
 allprojects {
-    plugins.withId("org.mockito.mockito-release-tools.bintray") {
+    plugins.withId("org.shipkit.bintray") {
         bintray {
             key = System.getenv("BINTRAY_API_KEY")
             pkg {


### PR DESCRIPTION
Bumped version of `mockito-release-tools` that contains renamed gradle extension to (`shipkit`)
Fixes https://github.com/mockito/mockito-release-tools/issues/172
