### PR TITLE
Fixed Travis configuration for matrix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,9 @@ before_install:
   - export TRAVIS_COMMIT_MESSAGE=$(git log --format=%B -n 1 $TRAVIS_COMMIT)
   - echo "$TRAVIS_COMMIT_MESSAGE"
 
-jdk:
-  - oraclejdk7
-
 matrix:
   include:
+  - jdk: oraclejdk7
   - jdk: oraclejdk7
     env: SKIP_RELEASE=true MOCK_MAKER=mock-maker-inline
   - jdk: oraclejdk8


### PR DESCRIPTION
Travis CI introduced a good change that unfortunately is slightly backwards incompatible.
This change to configuration file fixes our Travis configuration for updated Travis behavior wrt matrix builds.
More info, in the GitHub ticket

Fixes #1107
