### PR TITLE
Use Throwable.<init>, stop using ObjenesisHelper

### DIFF
--- a/src/main/java/org/mockito/internal/stubbing/answers/ThrowsExceptionClass.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/ThrowsExceptionClass.java
@@ -8,14 +8,62 @@ package org.mockito.internal.stubbing.answers;
 import org.mockito.internal.exceptions.stacktrace.ConditionalStackTraceFilter;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.objenesis.ObjenesisHelper;
+import org.objenesis.Objenesis;
+import org.objenesis.ObjenesisBase;
+import org.objenesis.ObjenesisStd;
+import org.objenesis.strategy.StdInstantiatorStrategy;
 
 import static org.mockito.internal.exceptions.Reporter.notAnException;
 
 import java.io.Serializable;
+import java.lang.invoke.MethodHandle;
+import java.lang.reflect.Constructor;
 
 public class ThrowsExceptionClass implements Answer<Object>, Serializable {
 
+    private static final Objenesis objenesis;
+    
+    static {
+        final MethodHandle newConstructorForSerialization;
+        final Constructor<Throwable> throwableInit;
+        try {
+            newConstructorForSerialization = MethodHandles.lookup().unreflect(
+                Class.forName("org.objenesis.instantiator.sun.SunReflectionFactoryInstantiator")
+                             .getDeclaredMethod("newConstructorForSerialization"));
+        } catch (Exception e) {
+            // TODO: Log a warning
+            objenesis = new ObjenesisStd();
+            return;
+        }
+        try {
+            throwableInit = Throwable.class.getDeclaredConstructor();
+        } catch (Exception e) {
+            // TODO: Log a warning
+            objenesis = new ObjenesisStd();
+            return;
+        }
+        objenesis = new ObjenesisBase(new StdInstantiatorStrategy() {
+            @Override
+            public <T> ObjectInstantiator<T> newInstantiatorOf(Class<T> type) {
+                if (newConstructorForSerialization != null
+                        && throwableInit != null
+                        && Throwable.class.isAssignableFrom(type)) {
+                   final Constructor<T> ctor = newConstructorForSerialization.invokeExact(type, throwableInit);
+                   return new ObjectInstantiator<T>() {
+                       @Override
+                       public T newInstance() {
+                           return ctor.newInstance();
+                       }
+                   }
+                } else {
+                    return super.newInstantiatorOf(type);
+                }
+            }
+        });
+    }
+    
+    private static final Objenesis objenesis = new ObjenesisBase(new TryCtorStrategy);
+    
     private final Class<? extends Throwable> throwableClass;
     private final ConditionalStackTraceFilter filter = new ConditionalStackTraceFilter();
 
@@ -32,7 +80,7 @@ public class ThrowsExceptionClass implements Answer<Object>, Serializable {
 
     public Object answer(InvocationOnMock invocation) throws Throwable {
         //TODO centralize the use of Objenesis. Why do we use ObjenesisHelper?
-        Throwable throwable = ObjenesisHelper.newInstance(throwableClass);
+        Throwable throwable = objenesis.newInstance(throwableClass);
         throwable.fillInStackTrace();
         filter.filter(throwable);
         throw throwable;

--- a/src/main/java/org/mockito/internal/stubbing/answers/ThrowsExceptionClass.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/ThrowsExceptionClass.java
@@ -11,6 +11,7 @@ import org.mockito.stubbing.Answer;
 import org.objenesis.Objenesis;
 import org.objenesis.ObjenesisBase;
 import org.objenesis.ObjenesisStd;
+import org.objenesis.instantiator.ObjectInstantiator;
 import org.objenesis.strategy.StdInstantiatorStrategy;
 
 import static org.mockito.internal.exceptions.Reporter.notAnException;

--- a/src/main/java/org/mockito/internal/stubbing/answers/ThrowsExceptionClass.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/ThrowsExceptionClass.java
@@ -62,8 +62,6 @@ public class ThrowsExceptionClass implements Answer<Object>, Serializable {
         });
     }
     
-    private static final Objenesis objenesis = new ObjenesisBase(new TryCtorStrategy());
-    
     private final Class<? extends Throwable> throwableClass;
     private final ConditionalStackTraceFilter filter = new ConditionalStackTraceFilter();
 

--- a/src/main/java/org/mockito/internal/stubbing/answers/ThrowsExceptionClass.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/ThrowsExceptionClass.java
@@ -54,7 +54,7 @@ public class ThrowsExceptionClass implements Answer<Object>, Serializable {
                        public T newInstance() {
                            return ctor.newInstance();
                        }
-                   }
+                   };
                 } else {
                     return super.newInstantiatorOf(type);
                 }
@@ -62,7 +62,7 @@ public class ThrowsExceptionClass implements Answer<Object>, Serializable {
         });
     }
     
-    private static final Objenesis objenesis = new ObjenesisBase(new TryCtorStrategy);
+    private static final Objenesis objenesis = new ObjenesisBase(new TryCtorStrategy());
     
     private final Class<? extends Throwable> throwableClass;
     private final ConditionalStackTraceFilter filter = new ConditionalStackTraceFilter();


### PR DESCRIPTION
…lper

Eliminate references to deprecated ObjenesisHelper from ThrowsExceptionClass. On Oracle and OpenJDK JVMs, thenThrow(Class<>) will now call Throwable.&lt;init&gt;(), which should improve the chances of getting a stack trace.

> Hey, 
> 
> Thanks for the contribution, this is awesome.
> As you may have read, project members have somehow an opinionated view on what and how should be
> Mockito, e.g. we don't want mockito to be a feature bloat.
> There may be a thorough review, with feedback -> code change loop.
> 
> Which branch : 
> - On mockito 2.x, make your pull request target `release/2.x`
> - On next mockito version make your pull request target `master`
>
> _This block can be removed_
> _Something wrong in the template fix it here `.github/PULL_REQUEST_TEMPLATE.md`


check list

 - [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/2.x/.github/CONTRIBUTING.md)
 - [ ] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [ ] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [ ] Avoid other runtime dependencies
 - [ ] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [ ] The pull request follows coding style
 - [ ] Mention `Fixes #<issue number>` in the description _if relevant_
 - [ ] At least one commit should mention `Fixes #<issue number>` _if relevant_

