### PR TITLE
Fixed issue with releases to Maven Central

### DIFF
--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -84,4 +84,5 @@ static boolean shouldReleaseToCentral(project) {
     project.afterEvaluate {
         project.tasks.performRelease.doLast { logger.lifecycle(message) }
     }
+    return centralRelease
 }


### PR DESCRIPTION
After 1.0 release of Shipkit we need to figure out how to model this conditional release.
This bug leads me to believe that we need to eliminate this logic from Mockito.
This way it can be a part of Shipkit and be well tested & documented.

Fixes #1127

Tested by running command: ```./gradlew bintrayUpload -Pmaven-central-release -Pshipkit.dryRun```

The output was (note the "Maven Central sync: true"):
```
:bintrayUpload - publishing to Bintray
  - dry run: true, version: 2.8.44, Maven Central sync: true
  - user/org: szczepiq/mockito, repository/package: maven/mockito
```

Thank you for reporting and the initial debugging that helped me resolve it quickly.

PS. I wished build.gradle was in Kotlin, this error would not be possible ;)