### PR TITLE
make use of shipkit v0.8.92

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 
 #Declared the dependency here to avoid duplication across build.gradle files
-dependencies.shipkit=gradle.plugin.org.shipkit:shipkit:0.8.72
+dependencies.shipkit=gradle.plugin.org.shipkit:shipkit:0.8.92


### PR DESCRIPTION
 - speed up of `fetchAllContributors` task:
we did some performance improvements which results in a task duration of ~7s compared to ~22 sec in older versions of the plugin. 

