### PR TITLE
org.shipkit.publications-comparator plugin applied

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 
 #Declared the dependency here to avoid duplication across build.gradle files
-dependencies.shipkit=gradle.plugin.org.shipkit:shipkit:0.8.92
+dependencies.shipkit=org.shipkit:shipkit:0.8.110

--- a/gradle/java-library.gradle
+++ b/gradle/java-library.gradle
@@ -1,4 +1,5 @@
 apply plugin: "org.shipkit.java-library"
+apply plugin: "org.shipkit.publications-comparator"
 
 group = 'org.mockito'
 archivesBaseName = "mockito-" + project.name


### PR DESCRIPTION
- Shipkit version bumped and dependency renamed
- Plugin org.shipkit.publications-comparator applied in all subprojects using java-library.gradle

Publications comparison is important so that Shipkit task "assertReleaseNeeded" can fail if nothing important, from the client perspective, changed. 
It is related to the issue https://github.com/mockito/shipkit/issues/156 in Shipkit. 

I tested it by adding System.out.println line in Java classes in root and android projects, and also adding a guava dependency in inline project. AssertReleaseNeeded identified these changes correctly. Also it identified that no changes were made if I executed it without any changes. 

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/2.x/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_
