### PR TITLE
Bumped shipkit, simplified Travis file, removed unnecessary code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ install:
  - true
 
 script:
+  # We are using && below on purpose
+  # ciPerformRelease must run only when the entire build has completed
+  # This guarantees that no release steps are executed when the build or tests fail
   - ./gradlew build idea -s -PcheckJava6Compatibility && ./gradlew ciPerformRelease
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,9 @@ install:
  - true
 
 script:
-  - ./gradlew build idea -s -PcheckJava6Compatibility
+  - ./gradlew build idea -s -PcheckJava6Compatibility && ./gradlew ciPerformRelease
 
 after_success:
-  #Releases new version:
-  - ./gradlew assertReleaseNeeded && ./gradlew ciReleasePrepare && ./gradlew performRelease -Pshipkit.dryRun=false
   #Generates coverage report:
   - ./gradlew --stacktrace coverageReport && cp build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml jacoco.xml || echo "Code coverage failed"
   - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,12 @@ plugins {
 description = 'Mockito mock objects library core API and implementation'
 
 apply plugin: "org.shipkit.java"
+allprojects {
+    plugins.withId("java") {
+        //Only upload specific modules we select
+        bintrayUpload.enabled = false
+    }
+}
 
 apply from: 'gradle/root/ide.gradle'
 apply from: 'gradle/root/gradle-fix.gradle'

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 
 #Declared the dependency here to avoid duplication across build.gradle files
-dependencies.shipkit=org.shipkit:shipkit:0.8.110
+dependencies.shipkit=org.shipkit:shipkit:0.8.112

--- a/gradle/java-library.gradle
+++ b/gradle/java-library.gradle
@@ -1,8 +1,8 @@
-apply plugin: "org.shipkit.java-library"
-apply plugin: "org.shipkit.publications-comparator"
+apply plugin: "java"
 
 group = 'org.mockito'
 archivesBaseName = "mockito-" + project.name
+bintrayUpload.enabled = true
 
 sourceCompatibility = 1.6
 targetCompatibility = 1.6

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -18,8 +18,6 @@ shipkit {
         'docs': 'Documentation'
     ]
 
-    publishAllJavaSubprojects = false
-
     git.user = "Mockito Release Tools"
     git.email = "<mockito.release.tools@gmail.com>"
     //git.releasableBranchRegex = "master|release/.+"  // matches 'master', 'release/2.x', 'release/3.x', etc.

--- a/subprojects/testng/testng.gradle
+++ b/subprojects/testng/testng.gradle
@@ -16,23 +16,6 @@ jar {
             "${System.getProperty("java.version")} (${System.getProperty("java.specification.vendor")})"
     manifest.attributes["Implementation-Title"] = project.name
     manifest.attributes["Implementation-Version"] = project.version
-
-    from("${rootProject.projectDir}") {
-        include "LICENSE"
-        into "META-INF"
-        expand(copyright: new Date().format("yyyy"), version: project.version)
-    }
-
-}
-
-task sourcesJar(type: Jar, dependsOn:classes) {
-    classifier = "sources"
-    from sourceSets.main.allJava.srcDirs
-    include "**/*.java", "**/*.aj"
-}
-
-artifacts {
-    archives sourcesJar
 }
 
 tasks.javadoc.enabled = false


### PR DESCRIPTION
- Now when the release fails Mockito CI job will fail, too. This is really useful to acknowledge problems early. Previously, the release was a part of 'after_success' Travis configuration and any failures of release build were ignored.
- Replaced Shipkit's java plugin with Gradle's vanilla 'java' plugin. This way the build is simpler.
- Removed Shipkit configuration that has been discontinued ("publishAllJavaSubprojects"). Instead, I disabled the bintrayUpload for modules we don't want to publish at this point.