### PR TITLE
Bumped shipkit to fix unnecessary releasing problem

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 
 #Declared the dependency here to avoid duplication across build.gradle files
-dependencies.shipkit=org.shipkit:shipkit:0.8.112
+dependencies.shipkit=org.shipkit:shipkit:0.8.114


### PR DESCRIPTION
Addresses issue #1144 (unnecessary releasing problem).

Tested locally:
- with change to sources:
```
:releaseNeeded
  Environment variable SKIP_RELEASE present: false
  Commit message to inspect for keyword '[ci skip-release]': <unknown commit message>
  Current branch 'release/2.x' matches 'release/.+': true

  Results of publications comparison:

  Differences between files:
  --- /Users/sfaber/mockito/src/build/previous-release-artifacts/mockito-2.8.53-sources.jar
  +++ /Users/sfaber/mockito/src/build/libs/mockito-core-2.8.54-sources.jar

    Modified files:
    +- org/mockito/Mockito.java



  Release is needed: true
    - skip by env variable: false
    - skip by commit message: false
    - is pull request build:  false
    - is releasable branch:  true
    - publications changed since previous release:  true

BUILD SUCCESSFUL
```

- without change to sources:

```
:releaseNeeded
  Environment variable SKIP_RELEASE present: false
  Commit message to inspect for keyword '[ci skip-release]': <unknown commit message>
  Current branch 'release/2.x' matches 'release/.+': true

  Results of publications comparison:

  Release is needed: false
    - skip by env variable: false
    - skip by commit message: false
    - is pull request build:  false
    - is releasable branch:  true
    - publications changed since previous release:  false

BUILD SUCCESSFUL
```

- ```./gradlew testRelease``` was successful, too.