### PR TITLE
Enable stubOnly() on @Mock annotation

### DIFF
--- a/src/main/java/org/mockito/Mock.java
+++ b/src/main/java/org/mockito/Mock.java
@@ -31,11 +31,12 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *       &#064;Mock(name = "database") private ArticleDatabase dbMock;
  *       &#064;Mock(answer = RETURNS_MOCKS) private UserProvider userProvider;
  *       &#064;Mock(extraInterfaces = {Queue.class, Observer.class}) private  articleMonitor;
+ *       &#064;Mock(stubOnly = true) private Logger logger;
  *
  *       private ArticleManager manager;
  *
  *       &#064;Before public void setup() {
- *           manager = new ArticleManager(userProvider, database, calculator, articleMonitor);
+ *           manager = new ArticleManager(userProvider, database, calculator, articleMonitor, logger);
  *       }
  *   }
  *
@@ -67,6 +68,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface Mock {
 
     Answers answer() default Answers.RETURNS_DEFAULTS;
+
+    boolean stubOnly() default false;
 
     String name() default "";
 

--- a/src/main/java/org/mockito/internal/configuration/MockAnnotationProcessor.java
+++ b/src/main/java/org/mockito/internal/configuration/MockAnnotationProcessor.java
@@ -27,6 +27,9 @@ public class MockAnnotationProcessor implements FieldAnnotationProcessor<Mock> {
         if(annotation.serializable()){
             mockSettings.serializable();
         }
+        if(annotation.stubOnly()){
+            mockSettings.stubOnly();
+        }
 
         // see @Mock answer default value
         mockSettings.defaultAnswer(annotation.answer());

--- a/src/test/java/org/mockitousage/annotation/AnnotationsTest.java
+++ b/src/test/java/org/mockitousage/annotation/AnnotationsTest.java
@@ -9,6 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Answers;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockitousage.IMethods;
@@ -77,6 +78,7 @@ public class AnnotationsTest extends TestBase {
     @Mock(answer = Answers.RETURNS_DEFAULTS) IMethods returningDefaults;
     @Mock(extraInterfaces = {List.class}) IMethods hasExtraInterfaces;
     @Mock() IMethods noExtraConfig;
+    @Mock(stubOnly=true) IMethods stubOnly;
 
     @Test
     public void shouldInitMocksWithGivenSettings() throws Exception {
@@ -87,6 +89,7 @@ public class AnnotationsTest extends TestBase {
         assertEquals(0, returningDefaults.intReturningMethod());
 
         assertTrue(hasExtraInterfaces instanceof List);
+        assertTrue(Mockito.mockingDetails(stubOnly).getMockCreationSettings().isStubOnly());
 
         assertEquals(0, noExtraConfig.intReturningMethod());
     }


### PR DESCRIPTION
Since Issue #86,  withSettings() has a API stubOnly() which speed up mocked stub a lots.

In my case, stubOnly() huge amount of test overhead, stacktrace and avoid invocation footprint list grow too large and cause OOM.

However,  the API is not available with `@Mock` annotation.
I had to move tens of mock annotation from `@Mock Foo foo;` into `Mockito,mock(Foo.class, withSetting().stubOnly())`.

```
@Mock(stubOnly=true)
public Foo lightweight;

```

Suggest adding the above api for convenience 

check list

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/2.x/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

