### PR TITLE
[#1147] Provide version in release commit message

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 
 #Declared the dependency here to avoid duplication across build.gradle files
-dependencies.shipkit=org.shipkit:shipkit:0.8.114
+dependencies.shipkit=org.shipkit:shipkit:0.9.2

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -24,7 +24,7 @@ shipkit {
     git.releasableBranchRegex = "release/.+"  // 'release/2.x', 'release/3.x', etc.
 
     def buildNo = System.getenv("TRAVIS_BUILD_NUMBER")
-    git.commitMessagePostfix = buildNo? "by CI build $buildNo [ci skip-release]" : "by local build [ci skip-release]"
+    git.commitMessagePostfix = buildNo? "by CI build $buildNo\n\n[ci skip-release]" : "by local build\n\n[ci skip-release]"
 
     team.developers = ['szczepiq:Szczepan Faber', 'bric3:Brice Dutheil', 'raphw:Rafael Winterhalter', 'TimvdLippe:Tim van der Lippe']
     team.contributors = []


### PR DESCRIPTION
Implemented in Shipkit: https://github.com/mockito/shipkit/issues/276

Tested manually with `gw testRelease -x gitPush -x bintrayUpload` and the following commit message was used:
> 2.8.54 release (previous 2.8.53) + release notes updated by local build
>
> [ci skip-release]
