### PR TITLE
Adds support for Java 9 in inline mock maker by Byte Buddy update.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,65 +1,45 @@
 # More details on how to configure the Travis build
 # https://docs.travis-ci.com/user/customizing-the-build/
 
-# Speed up build by leversging travis caches
-before_cache:
-  - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+# Speed up build by leveraging travis caches
 cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 
-# required for oraclejdk9
-sudo: false
-dist: trusty
-group: beta
+# Enabling container based infrastructure hoping it will help the build speed <= this didn't work well, so it's reverted
+# see https://docs.travis-ci.com/user/migrating-from-legacy/ and https://docs.travis-ci.com/user/ci-environment
+sudo: true
 
 language: java
 
-# new workaround for https://github.com/travis-ci/travis-ci/issues/5227#issuecomment-165131913
-addons:
-  hosts:
-    - mockito-cd
-  hostname: mockito-cd
-
-before_install:
-  - export TRAVIS_COMMIT_MESSAGE=$(git log --format=%B -n 1 $TRAVIS_COMMIT)
-  - echo "$TRAVIS_COMMIT_MESSAGE"
-
-jdk:
-  - oraclejdk8
-
 matrix:
   include:
+  - jdk: oraclejdk7
+  - jdk: oraclejdk7
+    env: SKIP_RELEASE=true MOCK_MAKER=mock-maker-inline
+  - jdk: oraclejdk8
+    env: SKIP_RELEASE=true
   - jdk: oraclejdk8
     env: SKIP_RELEASE=true MOCK_MAKER=mock-maker-inline
-  - jdk: oraclejdk9
-    env: SKIP_RELEASE=true
-  - jdk: oraclejdk9
-    env: SKIP_RELEASE=true MOCK_MAKER=mock-maker-inline
-
-env:
-  global:
-  - TERM=dumb
-  - GRADLE_OPTS="-XX:+UseCompressedOops -Djava.awt.headless=true"
 
 branches:
   #Don't build tags
   except:
   - /^v\d/
-  
+
 #Below skips the installation step completely (https://docs.travis-ci.com/user/customizing-the-build/#Skipping-the-Installation-Step)
 #We need it because otherwise Travis CI injects an awkward './gradlew assemble' step into the CI workflow
 #We want to control and decide what Gradle tasks are executed
 install:
  - true
- 
+
 script:
   # We are using && below on purpose
   # ciPerformRelease must run only when the entire build has completed
   # This guarantees that no release steps are executed when the build or tests fail
   - ./gradlew build idea -s -PcheckJava6Compatibility && ./gradlew ciPerformRelease
-  
+
 after_success:
   #Generates coverage report:
   - ./gradlew --stacktrace coverageReport && cp build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml jacoco.xml || echo "Code coverage failed"

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,12 +44,23 @@ env:
   - GRADLE_OPTS="-XX:+UseCompressedOops -Djava.awt.headless=true"
 
 branches:
+  #Don't build tags
   except:
   - /^v\d/
+  
+#Below skips the installation step completely (https://docs.travis-ci.com/user/customizing-the-build/#Skipping-the-Installation-Step)
+#We need it because otherwise Travis CI injects an awkward './gradlew assemble' step into the CI workflow
+#We want to control and decide what Gradle tasks are executed
 install:
  - true
+ 
 script:
-  - ./gradlew ciBuild -s
+  # We are using && below on purpose
+  # ciPerformRelease must run only when the entire build has completed
+  # This guarantees that no release steps are executed when the build or tests fail
+  - ./gradlew build idea -s -PcheckJava6Compatibility && ./gradlew ciPerformRelease
+  
 after_success:
+  #Generates coverage report:
   - ./gradlew --stacktrace coverageReport && cp build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml jacoco.xml || echo "Code coverage failed"
   - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,46 +1,55 @@
 # More details on how to configure the Travis build
 # https://docs.travis-ci.com/user/customizing-the-build/
 
-# Speed up build by leveraging travis caches
+# Speed up build by leversging travis caches
+before_cache:
+  - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
 cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 
-# Enabling container based infrastructure hoping it will help the build speed <= this didn't work well, so it's reverted
-# see https://docs.travis-ci.com/user/migrating-from-legacy/ and https://docs.travis-ci.com/user/ci-environment
-sudo: true
+# required for oraclejdk9
+sudo: false
+dist: trusty
+group: beta
 
 language: java
 
+# new workaround for https://github.com/travis-ci/travis-ci/issues/5227#issuecomment-165131913
+addons:
+  hosts:
+    - mockito-cd
+  hostname: mockito-cd
+
+before_install:
+  - export TRAVIS_COMMIT_MESSAGE=$(git log --format=%B -n 1 $TRAVIS_COMMIT)
+  - echo "$TRAVIS_COMMIT_MESSAGE"
+
+jdk:
+  - oraclejdk8
+
 matrix:
   include:
-  - jdk: oraclejdk7
-  - jdk: oraclejdk7
-    env: SKIP_RELEASE=true MOCK_MAKER=mock-maker-inline
   - jdk: oraclejdk8
+    env: SKIP_RELEASE=true MOCK_MAKER=mock-maker-inline
+  - jdk: oraclejdk9
     env: SKIP_RELEASE=true
-  - jdk: oraclejdk8
+  - jdk: oraclejdk9
     env: SKIP_RELEASE=true MOCK_MAKER=mock-maker-inline
+
+env:
+  global:
+  - TERM=dumb
+  - GRADLE_OPTS="-XX:+UseCompressedOops -Djava.awt.headless=true"
 
 branches:
-  #Don't build tags
   except:
   - /^v\d/
-
-#Below skips the installation step completely (https://docs.travis-ci.com/user/customizing-the-build/#Skipping-the-Installation-Step)
-#We need it because otherwise Travis CI injects an awkward './gradlew assemble' step into the CI workflow
-#We want to control and decide what Gradle tasks are executed
 install:
  - true
-
 script:
-  # We are using && below on purpose
-  # ciPerformRelease must run only when the entire build has completed
-  # This guarantees that no release steps are executed when the build or tests fail
-  - ./gradlew build idea -s -PcheckJava6Compatibility && ./gradlew ciPerformRelease
-
+  - ./gradlew ciBuild -s
 after_success:
-  #Generates coverage report:
   - ./gradlew --stacktrace coverageReport && cp build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml jacoco.xml || echo "Code coverage failed"
   - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -4,7 +4,7 @@ ext {
 
 def versions = [:]
 
-versions.bytebuddy = '1.7.0'
+versions.bytebuddy = '1.7.4'
 
 libraries.junit4 = 'junit:junit:4.12'
 libraries.assertj = 'org.assertj:assertj-core:2.8.0'

--- a/src/test/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMakerTest.java
+++ b/src/test/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMakerTest.java
@@ -24,7 +24,6 @@ import java.util.*;
 import java.util.regex.Pattern;
 
 import static net.bytebuddy.ClassFileVersion.JAVA_V8;
-import static net.bytebuddy.ClassFileVersion.JAVA_V9;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -50,8 +49,6 @@ public class InlineByteBuddyMockMakerTest extends AbstractByteBuddyMockMakerTest
 
     @Test
     public void should_create_mock_from_final_class_in_the_JDK() throws Exception {
-        assumeTrue(ClassFileVersion.ofThisVm().isLessThan(JAVA_V9)); // Change when ByteBuddy has ASM6 - see #788
-
         MockCreationSettings<Pattern> settings = settingsFor(Pattern.class);
         Pattern proxy = mockMaker.createMock(settings, new MockHandlerImpl<Pattern>(settings));
         assertThat(proxy.pattern()).isEqualTo("bar");
@@ -264,7 +261,6 @@ public class InlineByteBuddyMockMakerTest extends AbstractByteBuddyMockMakerTest
     @Test
     public void test_parameters_retention() throws Exception {
         assumeTrue(ClassFileVersion.ofThisVm().isAtLeast(JAVA_V8));
-        assumeTrue(ClassFileVersion.ofThisVm().isLessThan(JAVA_V9)); // Change when ByteBuddy has ASM6 - see #788
 
         Class<?> typeWithParameters = new ByteBuddy()
                 .subclass(Object.class)

--- a/subprojects/kotlinTest/kotlinTest.gradle
+++ b/subprojects/kotlinTest/kotlinTest.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.1.1'
+    id 'org.jetbrains.kotlin.jvm' version '1.1.4-3'
     id 'java'
 }
 
@@ -15,7 +15,7 @@ dependencies {
     testCompile project(":")
     testCompile libraries.junit4
 
-    testCompile 'org.jetbrains.kotlin:kotlin-stdlib:1.1.1'
-    testCompile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.14'
+    testCompile 'org.jetbrains.kotlin:kotlin-stdlib:1.1.4-3'
+    testCompile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.18'
 }
 


### PR DESCRIPTION
Byte Buddy now uses ASM 6 which enables full support for Java 9 in the inline mock maker.