### PR TITLE
Feature/list collection matchers

### DIFF
--- a/src/main/java/org/mockito/CollectionMatchers.java
+++ b/src/main/java/org/mockito/CollectionMatchers.java
@@ -11,32 +11,79 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.argThat;
 
+/**
+ * See {@link Matchers} for general info about matchers.
+ * <p>
+ * CollectionMatchers provides matchers that simplify verifications on standard java collections.
+ * <p>
+ *
+ * Scroll down to see all methods - full list of matchers.
+ *
+ * @since 2.9.0
+ */
 public class CollectionMatchers {
 
+    /**
+     * list contains the given value
+     * list contains all given values
+     *
+     * @since 2.9.0
+     */
     public static <K> List listContains(K... object) {
         return argThat(new ListContains<K>(object));
     }
 
+    /**
+     * list contains the given value at the specified index
+     *
+     * @since 2.9.0
+     */
     public static <K> List listContains(K object, int index) {
         return argThat(new ListContainsAtIndex<K>(object, index));
     }
 
+    /**
+     * list contains null
+     *
+     * @since 2.9.0
+     */
     public static List listContainsNull() {
         return argThat(new ListContainsNull());
     }
 
+    /**
+     * list does not contain the given value
+     * list does not contain all given values
+     *
+     * @since 2.9.0
+     */
     public static <K> List listDoesNotContain(K... object) {
         return argThat(new ListDoesNotContain<K>(object));
     }
 
+    /**
+     * list does not contain the given value at the specified index
+     *
+     * @since 2.9.0
+     */
     public static <K> List listDoesNotContain(K object, int index) {
         return argThat(new ListDoesNotContainAtIndex<K>(object, index));
     }
 
+    /**
+     * list does not contain null
+     *
+     * @since 2.9.0
+     */
     public static List listDoesnotContainNull() {
         return argThat(new ListDoesNotContainNull());
     }
 
+    /**
+     * list has exactly the specified size
+     *
+     * @since 2.9.0
+     */
     public static List listOfSize(int size) {
         return argThat(new ListOfSize(size));
     }

--- a/src/main/java/org/mockito/CollectionMatchers.java
+++ b/src/main/java/org/mockito/CollectionMatchers.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito;
+
+import org.mockito.internal.matchers.*;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.argThat;
+
+public class CollectionMatchers {
+
+    public static <K> List listContains(K... object) {
+        return argThat(new ListContains<K>(object));
+    }
+
+    public static <K> List listContains(K object, int index) {
+        return argThat(new ListContainsAtIndex<K>(object, index));
+    }
+
+    public static List listContainsNull() {
+        return argThat(new ListContainsNull());
+    }
+
+    public static <K> List listDoesNotContain(K... object) {
+        return argThat(new ListDoesNotContain<K>(object));
+    }
+
+    public static <K> List listDoesNotContain(K object, int index) {
+        return argThat(new ListDoesNotContainAtIndex<K>(object, index));
+    }
+
+    public static List listDoesnotContainNull() {
+        return argThat(new ListDoesNotContainNull());
+    }
+
+    public static List listOfSize(int size) {
+        return argThat(new ListOfSize(size));
+    }
+}

--- a/src/main/java/org/mockito/internal/matchers/ListContains.java
+++ b/src/main/java/org/mockito/internal/matchers/ListContains.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito.internal.matchers;
+
+import org.mockito.ArgumentMatcher;
+
+import java.util.List;
+
+public class ListContains<T> implements ArgumentMatcher<List> {
+
+    private final T[] objects;
+
+    public ListContains(T... objects) {
+        this.objects = objects;
+    }
+
+    public boolean matches(List list) {
+        for (T object : objects) {
+            if(!list.contains(object)) return false;
+        }
+        return true;
+    }
+
+    public String toString() {
+        //printed in verification errors
+        if (objects.length ==1) {
+            return String.format("[list doesn't contain object: %s]", objects[0].toString());
+        } else {
+            return "[list doesn't contain all objects]";
+        }
+    }
+}

--- a/src/main/java/org/mockito/internal/matchers/ListContainsAtIndex.java
+++ b/src/main/java/org/mockito/internal/matchers/ListContainsAtIndex.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito.internal.matchers;
+
+import org.mockito.ArgumentMatcher;
+
+import java.util.List;
+
+public class ListContainsAtIndex<T> implements ArgumentMatcher<List> {
+
+    private final T object;
+    private final int index;
+
+    public ListContainsAtIndex(T object, int index) {
+        this.object = object;
+        this.index = index;
+    }
+
+    public boolean matches(List list) {
+        return object == list.get(index);
+    }
+
+    public String toString() {
+        return String.format("[list doesn't contain object: %s at index: %d]", object.toString(), index);
+    }
+}

--- a/src/main/java/org/mockito/internal/matchers/ListContainsNull.java
+++ b/src/main/java/org/mockito/internal/matchers/ListContainsNull.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito.internal.matchers;
+
+import org.mockito.ArgumentMatcher;
+
+import java.util.List;
+
+public class ListContainsNull implements ArgumentMatcher<List> {
+
+    public boolean matches(List list) {
+        return list.contains(null);
+    }
+
+    @Override
+    public String toString() {
+        return "[list does not contain null]";
+    }
+}

--- a/src/main/java/org/mockito/internal/matchers/ListDoesNotContain.java
+++ b/src/main/java/org/mockito/internal/matchers/ListDoesNotContain.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito.internal.matchers;
+
+import org.mockito.ArgumentMatcher;
+
+import java.util.List;
+
+public class ListDoesNotContain<T> implements ArgumentMatcher<List> {
+
+    private final T[] objects;
+
+    public ListDoesNotContain(T... objects) {
+        this.objects = objects;
+    }
+
+    public boolean matches(List list) {
+        for (T object : objects) {
+            if (list.contains(object)) return false;
+        }
+        return true;
+    }
+
+    public String toString() {
+        //printed in verification errors
+        if (objects.length == 1) {
+            return String.format("[list does contain object: %s]", objects[0].toString());
+        } else {
+            return "[list does contain one or more objects]";
+        }
+    }
+}

--- a/src/main/java/org/mockito/internal/matchers/ListDoesNotContainAtIndex.java
+++ b/src/main/java/org/mockito/internal/matchers/ListDoesNotContainAtIndex.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito.internal.matchers;
+
+import org.mockito.ArgumentMatcher;
+
+import java.util.List;
+
+public class ListDoesNotContainAtIndex<T> implements ArgumentMatcher<List> {
+
+    private final T object;
+    private final int index;
+
+    public ListDoesNotContainAtIndex(T object, int index) {
+        this.object = object;
+        this.index = index;
+    }
+
+    public boolean matches(List list) {
+        return object != list.get(index);
+    }
+
+    public String toString() {
+        //printed in verification errors
+        return String.format("[list doesn't contain object: %s at index: %d]", object.toString(), index);
+    }
+}

--- a/src/main/java/org/mockito/internal/matchers/ListDoesNotContainNull.java
+++ b/src/main/java/org/mockito/internal/matchers/ListDoesNotContainNull.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito.internal.matchers;
+
+import org.mockito.ArgumentMatcher;
+
+import java.util.List;
+
+public class ListDoesNotContainNull implements ArgumentMatcher<List> {
+
+    public boolean matches(List list) {
+        return !list.contains(null);
+    }
+
+    @Override
+    public String toString() {
+        return "[list does contain null]";
+    }
+}

--- a/src/main/java/org/mockito/internal/matchers/ListOfSize.java
+++ b/src/main/java/org/mockito/internal/matchers/ListOfSize.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito.internal.matchers;
+
+import org.mockito.ArgumentMatcher;
+
+import java.util.List;
+
+public class ListOfSize implements ArgumentMatcher<List> {
+
+    private final int size;
+    private int actualSize;
+
+    public ListOfSize(int size) {
+        this.size = size;
+    }
+
+    public boolean matches(List list) {
+        actualSize = list.size();
+        return actualSize == size;
+    }
+
+    public String toString() {
+        //printed in verification errors
+        return String.format("[list has wrong size: expected %d, actual %d]", size, actualSize);
+    }
+}

--- a/src/test/java/org/mockito/internal/matchers/ListContainsAtIndexTest.java
+++ b/src/test/java/org/mockito/internal/matchers/ListContainsAtIndexTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito.internal.matchers;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ListContainsAtIndexTest {
+
+    private Object expectedObject = new Object();
+
+    @Test
+    public void listContainsValueAtIndex() throws Exception {
+        ArrayList<Object> list = createListWithObjects(new Object(), expectedObject);
+        ListContainsAtIndex<Object> containsAtIndex = new ListContainsAtIndex<Object>(expectedObject, 1);
+
+        assertThat(containsAtIndex.matches(list)).isTrue();
+    }
+
+    @Test
+    public void listDoesntContainValueAtIndex() throws Exception {
+        ArrayList<Object> list = createListWithObjects(new Object(), new Object());
+        ListContainsAtIndex<Object> containsAtIndex = new ListContainsAtIndex<Object>(expectedObject, 1);
+
+        assertThat(containsAtIndex.matches(list)).isFalse();
+    }
+
+    @Test
+    public void errorMessageContainsObject() throws Exception {
+        ListContainsAtIndex<Object> containsAtIndex = new ListContainsAtIndex<Object>(expectedObject, 1);
+
+        assertThat(containsAtIndex.toString()).contains(expectedObject.toString());
+    }
+
+    @Test
+    public void errorMessageContainsIndex() throws Exception {
+        ListContainsAtIndex<Object> containsAtIndex = new ListContainsAtIndex<Object>(expectedObject, 1);
+
+        assertThat(containsAtIndex.toString()).contains("1");
+    }
+
+    private ArrayList<Object> createListWithObjects(Object... objects) {
+        ArrayList<Object> list = new ArrayList<Object>();
+        list.addAll(Arrays.asList(objects));
+        return list;
+    }
+}

--- a/src/test/java/org/mockito/internal/matchers/ListContainsNullTest.java
+++ b/src/test/java/org/mockito/internal/matchers/ListContainsNullTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito.internal.matchers;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ListContainsNullTest {
+
+    @Test
+    public void listContainsNull() throws Exception {
+        ArrayList<Object> list = new ArrayList<Object>();
+        list.add(null);
+
+        assertThat(new ListContainsNull().matches(list)).isTrue();
+    }
+
+    @Test
+    public void listDoesNotContainNull() throws Exception {
+        ArrayList<Object> list = createListWithObjects(new Object());
+
+        assertThat(new ListContainsNull().matches(list)).isFalse();
+    }
+
+    @Test
+    public void errorMessageContainsNull() throws Exception {
+        assertThat(new ListContainsNull().toString()).contains("null");
+    }
+
+    private ArrayList<Object> createListWithObjects(Object... objects) {
+        ArrayList<Object> list = new ArrayList<Object>();
+        list.addAll(Arrays.asList(objects));
+        return list;
+    }
+}

--- a/src/test/java/org/mockito/internal/matchers/ListContainsTest.java
+++ b/src/test/java/org/mockito/internal/matchers/ListContainsTest.java
@@ -69,6 +69,13 @@ public class ListContainsTest {
         assertThat(listContains.toString()).contains(expectedObject.toString());
     }
 
+    @Test
+    public void errorMessageContainsMultipleObjects() throws Exception {
+        ListContains<Object> listContains = new ListContains<Object>(expectedObject, expectedObject2);
+
+        assertThat(listContains.toString()).contains("all objects");
+    }
+
     private ArrayList<Object> createListWithObjects(Object... objects) {
         ArrayList<Object> list = new ArrayList<Object>();
         list.addAll(Arrays.asList(objects));

--- a/src/test/java/org/mockito/internal/matchers/ListContainsTest.java
+++ b/src/test/java/org/mockito/internal/matchers/ListContainsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito.internal.matchers;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ListContainsTest {
+
+    private Object expectedObject = new Object();
+    private Object expectedObject2 = new Object();
+
+    @Test
+    public void listWithSingleObject() throws Exception {
+        ArrayList<Object> list = createListWithObjects(expectedObject);
+
+        ListContains<Object> listContains = new ListContains<Object>(expectedObject);
+
+        assertThat(listContains.matches(list)).isTrue();
+    }
+
+    @Test
+    public void listDoesntContainObject() throws Exception {
+        ArrayList<Object> list = createListWithObjects(new Object());
+
+        ListContains<Object> listContains = new ListContains<Object>(expectedObject);
+
+        assertThat(listContains.matches(list)).isFalse();
+    }
+
+    @Test
+    public void listWithMultipleObjects() throws Exception {
+        ArrayList<Object> list = createListWithObjects(new Object(), expectedObject);
+
+        ListContains<Object> listContains = new ListContains<Object>(expectedObject);
+
+        assertThat(listContains.matches(list)).isTrue();
+    }
+
+    @Test
+    public void listContainsMultipleObjects() throws Exception {
+        ArrayList<Object> list = createListWithObjects(expectedObject, expectedObject2);
+
+        ListContains<Object> listContains = new ListContains<Object>(expectedObject,expectedObject2);
+
+        assertThat(listContains.matches(list)).isTrue();
+    }
+
+    @Test
+    public void listDoenstContainAllObjects() throws Exception {
+        ArrayList<Object> list = createListWithObjects(expectedObject, new Object());
+
+        ListContains<Object> listContains = new ListContains<Object>(expectedObject,expectedObject2);
+
+        assertThat(listContains.matches(list)).isFalse();
+    }
+
+    @Test
+    public void errorMessageContainsObject() throws Exception {
+        ListContains<Object> listContains = new ListContains<Object>(expectedObject);
+
+        assertThat(listContains.toString()).contains(expectedObject.toString());
+    }
+
+    private ArrayList<Object> createListWithObjects(Object... objects) {
+        ArrayList<Object> list = new ArrayList<Object>();
+        list.addAll(Arrays.asList(objects));
+        return list;
+    }
+}

--- a/src/test/java/org/mockito/internal/matchers/ListDoesNotContainAtIndexTest.java
+++ b/src/test/java/org/mockito/internal/matchers/ListDoesNotContainAtIndexTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito.internal.matchers;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ListDoesNotContainAtIndexTest {
+
+    private Object expectedObject = new Object();
+
+    @Test
+    public void listDoenstContainValueAtIndex() throws Exception {
+        ArrayList<Object> list = createListWithObjects(new Object(), new Object());
+        ListDoesNotContainAtIndex<Object> doesNotContainAtIndex = new ListDoesNotContainAtIndex<Object>(expectedObject, 1);
+
+        assertThat(doesNotContainAtIndex.matches(list)).isTrue();
+    }
+
+    @Test
+    public void listContainsValueAtIndex() throws Exception {
+        ArrayList<Object> list = createListWithObjects(new Object(), expectedObject);
+        ListDoesNotContainAtIndex<Object> doesNotContainAtIndex = new ListDoesNotContainAtIndex<Object>(expectedObject, 1);
+
+        assertThat(doesNotContainAtIndex.matches(list)).isFalse();
+    }
+
+
+    @Test
+    public void errorMessageContainsObject() throws Exception {
+        ListDoesNotContainAtIndex<Object> doesNotContainAtIndex = new ListDoesNotContainAtIndex<Object>(expectedObject, 1);
+
+        assertThat(doesNotContainAtIndex.toString()).contains(expectedObject.toString());
+    }
+
+    @Test
+    public void errorMessageContainsIndex() throws Exception {
+        ListDoesNotContainAtIndex<Object> doesNotContainAtIndex = new ListDoesNotContainAtIndex<Object>(expectedObject, 1);
+
+        assertThat(doesNotContainAtIndex.toString()).contains("1");
+    }
+
+    private ArrayList<Object> createListWithObjects(Object... objects) {
+        ArrayList<Object> list = new ArrayList<Object>();
+        list.addAll(Arrays.asList(objects));
+        return list;
+    }
+}

--- a/src/test/java/org/mockito/internal/matchers/ListDoesNotContainNullTest.java
+++ b/src/test/java/org/mockito/internal/matchers/ListDoesNotContainNullTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito.internal.matchers;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ListDoesNotContainNullTest {
+
+    @Test
+    public void listDoesNotContainNull() throws Exception {
+        ArrayList<Object> list = createListWithObjects(new Object());
+
+        assertThat(new ListDoesNotContainNull().matches(list)).isTrue();
+    }
+
+    @Test
+    public void listDoesContainNull() throws Exception {
+        ArrayList<Object> list = new ArrayList<Object>();
+        list.add(null);
+
+        assertThat(new ListDoesNotContainNull().matches(list)).isFalse();
+    }
+
+    @Test
+    public void errorMessageContainsNull() throws Exception {
+        assertThat(new ListDoesNotContainNull().toString()).contains("null");
+    }
+
+    private ArrayList<Object> createListWithObjects(Object... objects) {
+        ArrayList<Object> list = new ArrayList<Object>();
+        list.addAll(Arrays.asList(objects));
+        return list;
+    }
+}

--- a/src/test/java/org/mockito/internal/matchers/ListDoesNotContainTest.java
+++ b/src/test/java/org/mockito/internal/matchers/ListDoesNotContainTest.java
@@ -69,6 +69,13 @@ public class ListDoesNotContainTest {
         assertThat(listDoesNotContain.toString()).contains(expectedObject.toString());
     }
 
+    @Test
+    public void errorMessageContainsMultipleObjects() throws Exception {
+        ListDoesNotContain<Object> listDoesNotContain = new ListDoesNotContain<Object>(expectedObject, expectedObject2);
+
+        assertThat(listDoesNotContain.toString()).contains("one or more objects");
+    }
+
     private ArrayList<Object> createListWithObjects(Object... objects) {
         ArrayList<Object> list = new ArrayList<Object>();
         list.addAll(Arrays.asList(objects));

--- a/src/test/java/org/mockito/internal/matchers/ListDoesNotContainTest.java
+++ b/src/test/java/org/mockito/internal/matchers/ListDoesNotContainTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito.internal.matchers;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ListDoesNotContainTest {
+
+    private Object expectedObject = new Object();
+    private Object expectedObject2 = new Object();
+
+    @Test
+    public void listWithSingleObject() throws Exception {
+        ArrayList<Object> list = createListWithObjects(new Object());
+
+        ListDoesNotContain<Object> listDoesNotContain = new ListDoesNotContain<Object>(expectedObject);
+
+        assertThat(listDoesNotContain.matches(list)).isTrue();
+    }
+
+    @Test
+    public void listContainsObject() throws Exception {
+        ArrayList<Object> list = createListWithObjects(expectedObject);
+
+        ListDoesNotContain<Object> listDoesNotContain = new ListDoesNotContain<Object>(expectedObject);
+
+        assertThat(listDoesNotContain.matches(list)).isFalse();
+    }
+
+    @Test
+    public void listWithMultipleObjects() throws Exception {
+        ArrayList<Object> list = createListWithObjects(new Object(), expectedObject);
+
+        ListDoesNotContain<Object> listDoesNotContain = new ListDoesNotContain<Object>(expectedObject);
+
+        assertThat(listDoesNotContain.matches(list)).isFalse();
+    }
+
+    @Test
+    public void listDoesNotContainMultipleObjects() throws Exception {
+        ArrayList<Object> list = createListWithObjects(new Object());
+
+        ListDoesNotContain<Object> listDoesNotContain = new ListDoesNotContain<Object>(expectedObject,expectedObject2);
+
+        assertThat(listDoesNotContain.matches(list)).isTrue();
+    }
+
+    @Test
+    public void listContainsOneOfTheObjects() throws Exception {
+        ArrayList<Object> list = createListWithObjects(expectedObject, new Object());
+
+        ListDoesNotContain<Object> listDoesNotContain = new ListDoesNotContain<Object>(expectedObject,expectedObject2);
+
+        assertThat(listDoesNotContain.matches(list)).isFalse();
+    }
+
+    @Test
+    public void errorMessageContainsObject() throws Exception {
+        ListDoesNotContain<Object> listDoesNotContain = new ListDoesNotContain<Object>(expectedObject);
+
+        assertThat(listDoesNotContain.toString()).contains(expectedObject.toString());
+    }
+
+    private ArrayList<Object> createListWithObjects(Object... objects) {
+        ArrayList<Object> list = new ArrayList<Object>();
+        list.addAll(Arrays.asList(objects));
+        return list;
+    }
+}

--- a/src/test/java/org/mockito/internal/matchers/ListOfSizeTest.java
+++ b/src/test/java/org/mockito/internal/matchers/ListOfSizeTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito.internal.matchers;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ListOfSizeTest {
+
+    @Test
+    public void emptyList() throws Exception {
+        ArrayList<Object> list = createListWithObjects();
+        ListOfSize listOfSize = new ListOfSize(0);
+
+        assertThat(listOfSize.matches(list)).isTrue();
+    }
+
+    @Test
+    public void listWithSingleObject() throws Exception {
+        ArrayList<Object> list = createListWithObjects(new Object());
+        ListOfSize listOfSize = new ListOfSize(1);
+
+        assertThat(listOfSize.matches(list)).isTrue();
+    }
+
+    @Test
+    public void errorMessageContainsSizes() throws Exception {
+        ArrayList<Object> list = createListWithObjects(new Object());
+        ListOfSize listOfSize = new ListOfSize(0);
+
+        listOfSize.matches(list);
+
+        assertThat(listOfSize.toString()).contains("1", "0");
+    }
+
+    private ArrayList<Object> createListWithObjects(Object... objects) {
+        ArrayList<Object> list = new ArrayList<Object>();
+        list.addAll(Arrays.asList(objects));
+        return list;
+    }
+}


### PR DESCRIPTION
This pull requests adds basic support for Mockito collection  matchers to simplify doing verifications on standard Java collections. At this stage only the most prominent list collection matchers have been built.

I've added the following matchers:
```
verify(mock).someMethod(listContains(expectedObject));
verify(mock).someMethod(listContains(expectedObject, index));
verify(mock).someMethod(listContainsNull());
verify(mock).someMethod(listDoesNotContain(wrongObject));
verify(mock).someMethod(listDoesNotContain(wrongObject, index));
verify(mock).someMethod(listDoesNotContainNull());
verify(mock).someMethod(listOfSize(3));
```
Thereby basically moving my personal project into Mockito: https://github.com/JeroenMols/MockitoCollectionMatchers

I did my best to adhere to the coding standards and guidelines. Please let me know if you have any questions.

