### PR TITLE
Introduce test for mock-maker-inline with Kotlin suspend functions

### DIFF
--- a/subprojects/kotlinTest/src/test/kotlin/org/mockito/kotlin/SuspendTest.kt
+++ b/subprojects/kotlinTest/src/test/kotlin/org/mockito/kotlin/SuspendTest.kt
@@ -21,6 +21,15 @@ class SuspendTest {
         suspend open fun suspendClassFunctionWithDefault(x: Int = 1): Int = error("not implemented")
     }
 
+    class FinalSuspendableClass {
+        suspend fun fetch(): Int {
+            fetchConcrete()
+            return 2
+        }
+
+        suspend fun fetchConcrete() = 1
+    }
+
     open class CallsSuspendable(private val suspendable: SuspendableInterface) {
         fun callSuspendable(x: Int) = runBlocking {
             suspendable.suspendFunction(x)
@@ -103,5 +112,13 @@ class SuspendTest {
 
         verify(mockSuspendable).suspendClassFunctionWithDefault()
         verify(mockSuspendable).suspendClassFunctionWithDefault(2)
+    }
+
+    @Test
+    fun shouldMockFinalSuspendableClass() = runBlocking<Unit> {
+        val mockClass = mock(FinalSuspendableClass::class.java)
+        `when`(mockClass.fetch()).thenReturn(10)
+        assertThat(mockClass.fetch(), IsEqual(10))
+        verify(mockClass).fetch()
     }
 }

--- a/subprojects/kotlinTest/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/subprojects/kotlinTest/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
See issue #1152
This test should pass when byte-buddy is updated with https://github.com/raphw/byte-buddy/pull/332
