### PR TITLE
Fixes #1166: Fix to be able to stub the Kotlin function with any checked exception

### DIFF
--- a/src/main/java/org/mockito/internal/stubbing/answers/ThrowsException.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/ThrowsException.java
@@ -6,6 +6,7 @@ package org.mockito.internal.stubbing.answers;
 
 import java.io.Serializable;
 import org.mockito.internal.exceptions.stacktrace.ConditionalStackTraceFilter;
+import org.mockito.internal.util.KotlinUtil;
 import org.mockito.internal.util.MockUtil;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -44,6 +45,12 @@ public class ThrowsException implements Answer<Object>, ValidableAnswer, Seriali
         }
 
         if (throwable instanceof RuntimeException || throwable instanceof Error) {
+            return;
+        }
+
+        // Kotlin does not have checked exceptions.
+        // https://kotlinlang.org/docs/reference/exceptions.html#checked-exceptions
+        if (KotlinUtil.isOfKotlin(invocation.getMock().getClass())) {
             return;
         }
 

--- a/src/main/java/org/mockito/internal/util/KotlinUtil.java
+++ b/src/main/java/org/mockito/internal/util/KotlinUtil.java
@@ -1,0 +1,29 @@
+package org.mockito.internal.util;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * Provides the utilities for the Kotlin language.
+ */
+public final class KotlinUtil {
+
+    private KotlinUtil() {
+    }
+
+    /**
+     * Tests weather the given class is compiled by the Kotlin compiler.
+     *
+     * @param c the class
+     * @return {@code true} if the given class is compiled by the Kotlin compiler; {@code false} otherwise
+     */
+    public static boolean isOfKotlin(Class<?> c) {
+        for (Annotation a : c.getDeclaredAnnotations()) {
+            // All the Kotlin classes are marked with the `kotlin.Metadata` annotation.
+            if (a.annotationType().getName().equals("kotlin.Metadata")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/subprojects/kotlinTest/src/test/kotlin/org/mockito/kotlin/ThrowsExceptionTest.kt
+++ b/subprojects/kotlinTest/src/test/kotlin/org/mockito/kotlin/ThrowsExceptionTest.kt
@@ -1,0 +1,42 @@
+package org.mockito.kotlin
+
+import org.junit.Test
+import org.mockito.Mockito.*
+import org.mockito.internal.stubbing.answers.ThrowsException
+import org.mockito.invocation.InvocationOnMock
+
+class ThrowsExceptionTest {
+
+    @Test(expected = MyException::class)
+    fun `thenThrow should stub the method with any checked exception`() {
+        val mock = mock(MyInterface::class.java)
+        `when`(mock.doIt()).thenThrow(MyException())
+        mock.doIt()
+    }
+
+    @Test(expected = MyException::class)
+    fun `doThrow should stub the method with any checked exception`() {
+        val spied = spy(MyClass::class.java)
+        doThrow(MyException()).`when`(spied).doIt()
+        spied.doIt()
+    }
+
+    @Test
+    fun `ThrowsException#validateFor should not check the method signature if the mocked class is of Kotlin`() {
+        val invocation = mock(InvocationOnMock::class.java)
+        `when`(invocation.mock).thenReturn(mock(MyInterface::class.java))
+        `when`(invocation.method).thenThrow(IllegalStateException("Should not be called!"))
+        ThrowsException(MyException()).validateFor(invocation)
+    }
+
+    interface MyInterface {
+        fun doIt(): String
+    }
+
+    open class MyClass {
+        open fun doIt() = Unit
+    }
+
+    class MyException : Exception()
+
+}


### PR DESCRIPTION
If the stubbed method is of Kotlin, skip the signature check.

This PR fixes the issue #1166.