### PR TITLE
Update objenesis version 2.5 -> 2.6 (Java9, bugfixes)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -15,6 +15,6 @@ libraries.bytebuddy = "net.bytebuddy:byte-buddy:${versions.bytebuddy}"
 libraries.bytebuddyagent = "net.bytebuddy:byte-buddy-agent:${versions.bytebuddy}"
 libraries.bytebuddyandroid = "net.bytebuddy:byte-buddy-android:${versions.bytebuddy}"
 
-libraries.objenesis = 'org.objenesis:objenesis:2.5'
+libraries.objenesis = 'org.objenesis:objenesis:2.6'
 
 libraries.asm = 'org.ow2.asm:asm:5.2'


### PR DESCRIPTION
To quote from http://objenesis.org/notes.html:

Version 2.6 (2017-06-20)
- App Engine Java 8 Runtime support
- Improve Java 9 support
- Clarify serialization strategy behavior enhancement
- SunReflectionFactoryInstantiator not working if parent class constructor isn't public
- Validate Android O
- Drop Java 5 support

