### PR TITLE
Bumped minor version so signify new Objenesis version

### DIFF
--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
 #Currently building Mockito version
-version=2.8.56
+version=2.9.0
 
 #Prevoius version used to generate release notes delta
 previousVersion=2.8.55


### PR DESCRIPTION
Also, there were 50+ versions after last minor version so it just makes sense to bump it.

[ci maven-central-release]

Note that merging this PR will release to maven central (if the automation works ;)
