### PR TITLE
Updated README.md wrt maven central release

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,11 @@ We used to publish every version to Maven Central but we changed this strategy b
 
 * Q: How to publish to Maven Central?
 
-  A: Include "[ci maven-central-release]" in the commit message.
-  To signify a new feature consider updating version to next minor/major, like: "2.8.0", "2.9.0", "3.0.0".
+  A: Include "[ci maven-central-release]" in the **merge** commit when merging the PR.
+  **Caveat**: if the PR does not change the binaries / javadoc in any way, the release will be skipped.
+  To avoid this problem, make a whitespace change in javadoc Javadoc for some public type.
+  We will address this caveat, see [issue #353](https://github.com/mockito/shipkit/issues/353) in Shipkit.
+  **Hint**: To signify a new feature consider updating version to next minor/major, like: "2.8.0", "2.9.0", "3.0.0".
 
 * Q: How to promote already released version to a notable version?
 

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -1375,6 +1375,7 @@ import org.mockito.verification.*;
  * <p>
  * Help Mockito! Try the new features, give us feedback, join the discussion about Mockito strictness at GitHub
  * <a href="https://github.com/mockito/mockito/issues/769">issue 769</a>.
+ *
  */
 @SuppressWarnings("unchecked")
 public class Mockito extends ArgumentMatchers {


### PR DESCRIPTION
Previous release did not ship to central, it was skipped because publications were identical. I updated the instruction on how to do that.

I have also opened tickets to Shipkit project to improve this part of release automation:
 - support for "[ci force-release]" keyword in Shipkit: mockito/shipkit#353
 - support for custom forcing rule in Shipkit: mockito/shipkit#354

I plan to merge this PR and include "[ci maven-central-release]" in the **merge** commit message. **Please don't merge**, just review/approve. Thank you!