### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,7 @@ language: java
 
 matrix:
   include:
-  - jdk: openjdk7
-  - jdk: openjdk7
-    env: SKIP_RELEASE=true MOCK_MAKER=mock-maker-inline
   - jdk: oraclejdk8
-    env: SKIP_RELEASE=true
   - jdk: oraclejdk8
     env: SKIP_RELEASE=true MOCK_MAKER=mock-maker-inline
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ language: java
 
 matrix:
   include:
-  - jdk: oraclejdk7
-  - jdk: oraclejdk7
+  - jdk: openjdk7
+  - jdk: openjdk7
     env: SKIP_RELEASE=true MOCK_MAKER=mock-maker-inline
   - jdk: oraclejdk8
     env: SKIP_RELEASE=true


### PR DESCRIPTION
Summary:

- Removed our JDK7 build from Travis CI completely
- Fixed issues with Mockito Travis CI build

Reference:

- Fixes Mockito ticket: #1182
- Reference Travis CI ticket: travis-ci/travis-ci#7884

Details:

- I have tried to get the build working with jdk7 but I couldn't get it to work ([example failure](https://travis-ci.org/mockito/mockito/jobs/271842699)). I kept getting: 

```Exception in thread "main" javax.net.ssl.SSLException: java.security.ProviderException.```

We remember this issue from our Jdk6 build, we could not fix it and eventually we have stopped building with Jdk6. 
- We still publish with Java6 compatibility and we have animal sniffer set up to catch regressions. It should be ok to build only on Jdk8.
- Jdk6 and jdk7 has been deprecated years ago, we need to move on.