### PR TITLE
Improve interoperability with Java 8 by specializing parameterized types

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -96,6 +96,7 @@ import org.mockito.verification.VerificationWithTimeout;
  *      <a href="#40">40. (*new*) Improved productivity and cleaner tests with "stricter" Mockito (Since 2.+)</a><br/>
  *      <a href="#41">41. (**new**) Advanced public API for framework integrations (Since 2.10.+)</a><br/>
  *      <a href="#42">42. (**new**) New API for integrations: listening on verification start events (Since 2.11.+)</a><br/>
+ *      <a href="#43">43. (**new**) Type casting Support (Since 2.11)</a><br/>
  * </b>
  *
  * <h3 id="0">0. <a class="meaningful_link" href="#mockito2" name="mockito2">Migrating to Mockito 2</a></h3>
@@ -1467,6 +1468,27 @@ import org.mockito.verification.VerificationWithTimeout;
  *     We found this method useful during the implementation.
  *     </li>
  * </ul>
+ *
+ * <h3 id="43">43. <a class="meaningful_link" href="#type_casting">Type casting Support</a> (Since 2.11)</h3>
+ *
+ * When mocking generic types you would get a compiler warning with code like this:
+ *
+ * <pre class="code"><code class="java">
+ *     Foo&lt;Bar&gt; mockFoo = mock(Foo.class);
+ * </pre>
+ *
+ * This is because there is no way to specify the generic type within the input to the <code>mock</code>
+ * method.
+ * <p>
+ *
+ * To reduce compiler warnings and to make Mockito more interoperable with inferred types in Java 8
+ * you can wrap your calls to <code>mock</code> with the function <code>typed</code>, which will apply
+ * the parameterized type.
+ *
+ * <pre class="code"><code class="java">
+ *     Foo&lt;Bar&gt; mockFoo = typed(mock(Foo.class));
+ * </pre>
+ *
  */
 @SuppressWarnings("unchecked")
 public class Mockito extends ArgumentMatchers {
@@ -1770,6 +1792,31 @@ public class Mockito extends ArgumentMatchers {
     public static MockingDetails mockingDetails(Object toInspect) {
         return MOCKITO_CORE.mockingDetails(toInspect);
     }
+
+    /**
+     * Downcasts mock object to a specific type. This is helpful for Java 8 where
+     * <code>mock(Predicate.class)</code> cannot provide a compiler-friendly value
+     * for a variable of, say, <code>Predicate&lt;String&gt;</code>. If you
+     * wrap the call to <code>mock</code> in <code>typed(...)</code>, then you will not
+     * get compiler warnings.
+     * <p>
+     *
+     * <pre class="code"><code class="java">
+     *   Foo&lt;Bar&gt; mock = typed(mock(Foo.class));
+     * </code></pre>
+     *
+     * <p>
+     * <em>Warning:</em> this method could be accidentally used to downcast to
+     * a subclass of the mock, resulting in a <code>ClasCastException</code>
+     *
+     * @param mock the return of a call to one of the <code>mock</code> methods
+     * @param <T> the return type (inferred by Java 8)
+     * @param <M> the actual type of the mock
+     * @return a downcasted version of the mock
+     */
+     public static <M, T extends M> T typed(M mock) {
+        return (T)mock;
+     }
 
     /**
      * Creates mock with a specified strategy for its answers to interactions.

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -1807,7 +1807,7 @@ public class Mockito extends ArgumentMatchers {
      *
      * <p>
      * <em>Warning:</em> this method could be accidentally used to downcast to
-     * a subclass of the mock, resulting in a <code>ClasCastException</code>
+     * a subclass of the mock, resulting in a <code>ClassCastException</code>
      *
      * @param mock the return of a call to one of the <code>mock</code> methods
      * @param <T> the return type (inferred by Java 8)

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -1807,7 +1807,14 @@ public class Mockito extends ArgumentMatchers {
      *
      * <p>
      * <em>Warning:</em> this method could be accidentally used to downcast to
-     * a subclass of the mock, resulting in a <code>ClassCastException</code>
+     * a subclass of the mock, resulting in a <code>ClassCastException</code>.
+     * For example you cannot write:
+     * <p>
+     *
+     * <pre class="code"><code class="java">
+     *     // the mock is NOT an array list, so this will throw an exception
+     *     ArrayList&lt;String&gt; list = typed(mock(List.class));
+     * </code></pre>
      *
      * @param mock the return of a call to one of the <code>mock</code> methods
      * @param <T> the return type (inferred by Java 8)

--- a/src/test/java/org/mockitousage/CompilationWarningsTest.java
+++ b/src/test/java/org/mockitousage/CompilationWarningsTest.java
@@ -11,6 +11,8 @@ import org.mockito.stubbing.Answer;
 
 import static org.mockito.BDDMockito.*;
 
+import java.util.List;
+
 
 public class CompilationWarningsTest {
 
@@ -75,6 +77,9 @@ public class CompilationWarningsTest {
         given(mock(IMethods.class).objectReturningMethodNoArgs()).will(ignore()).willThrow(new NullPointerException());
         given(mock(IMethods.class).objectReturningMethodNoArgs()).will(ignore()).willThrow(new NullPointerException(), new IllegalArgumentException());
         given(mock(IMethods.class).objectReturningMethodNoArgs()).will(ignore()).willThrow(NullPointerException.class);
+
+        List<String> mockList = typed(mock(List.class));
+        given(mockList.add("hello world")).willThrow(new NullPointerException());
     }
 
     @Test

--- a/src/test/java/org/mockitousage/basicapi/MocksCreationTest.java
+++ b/src/test/java/org/mockitousage/basicapi/MocksCreationTest.java
@@ -101,4 +101,9 @@ public class MocksCreationTest extends TestBase {
         when(mock(Set.class).isEmpty()).thenReturn(false);
     }
 
+    @Test
+    public void canCreateMockOfRequiredTypeWithoutWarning() {
+        List<String> list = typed(mock(List.class));
+        when(list.size()).thenReturn(999);
+    }
 }

--- a/src/test/java/org/mockitousage/basicapi/MocksCreationTest.java
+++ b/src/test/java/org/mockitousage/basicapi/MocksCreationTest.java
@@ -12,6 +12,7 @@ import org.mockito.exceptions.verification.SmartNullPointerException;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -105,5 +106,12 @@ public class MocksCreationTest extends TestBase {
     public void canCreateMockOfRequiredTypeWithoutWarning() {
         List<String> list = typed(mock(List.class));
         when(list.size()).thenReturn(999);
+    }
+
+    @Test(expected=ClassCastException.class)
+    public void cannotUseTypedMethodToCastToUnrelatedConcreteType() {
+        // the mock is not of type ArrayList, this will result
+        // in a class cast exception
+        ArrayList<String> list = typed(mock(List.class));
     }
 }


### PR DESCRIPTION
It can be really hard to mock things like `Predicate<String>` easily as you cannot pass the specialization of type to the `mock` method.

This PR allows the user to write and they will avoid compiler warnings.

```java
Predicate<Foo> mockedPredicate = typed(mock(Predicate.class));
```