### PR TITLE
Issue 1151 fix for multi threaded environment

### DIFF
--- a/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
+++ b/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
@@ -31,7 +31,7 @@ public class MockingProgressImpl implements MockingProgress {
 
     private OngoingStubbing<?> ongoingStubbing;
     private Localized<VerificationMode> verificationMode;
-    private Location stubbingInProgress = null;
+    private static Location stubbingInProgress = null;
     private VerificationStrategy verificationStrategy;
     private final Set<MockitoListener> listeners = new LinkedHashSet<MockitoListener>();
 

--- a/src/test/java/org/mockitousage/verification/SampleTest.java
+++ b/src/test/java/org/mockitousage/verification/SampleTest.java
@@ -1,0 +1,44 @@
+package org.mockitousage.verification;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.mockitoutil.TestBase;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SampleTest extends TestBase {
+
+    @Test
+    public void testDefaultResponse() throws Exception {
+        final String defaultAnswer = "DEFAULT ANSWER";
+        final Foo foo = Mockito.mock(Foo.class, new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                return defaultAnswer;
+            }
+        });
+        Thread checker = new Thread() {
+            @Override
+            public void run() {
+                assertTrue(foo.bar("BUG").contains(defaultAnswer));
+            }
+        };
+        checker.start();
+
+        Mockito.when(foo.bar("DOG")).thenReturn("PUG");
+        if (foo.bar("DOG").equals(defaultAnswer)) {
+            System.out.println("something went wrong");
+        }
+        assertEquals("PUG", foo.bar("DOG"));
+    }
+
+    public static class Foo {
+
+        public String bar(String arg) {
+            return "REAL METHOD";
+        }
+    }
+}


### PR DESCRIPTION
This provides a fix for the issue mockito#1151, but definitely requires a review as it might have unforeseen side effects. Code change is just one line to address the multiple threaded usage of mocks, but might require the static member to be accessed in a synchronized manner to avoid issues that might occur in a multi threaded environment. This works because most of the calls to the library invokes a call to validateState() method which internally uses stubbingInProgress member.

Note: The class SampleTest is a part of issue-1151 branch and unsure if this is required for the actual code branch.

check list

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/2.x/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

