### PR TITLE
Fixes #1189: Add stable module name

### DIFF
--- a/gradle/mockito-core/osgi.gradle
+++ b/gradle/mockito-core/osgi.gradle
@@ -27,6 +27,8 @@ afterEvaluate {
                     'org.mockito.*'
 
             instruction '-removeheaders', 'Private-Package'
+
+            attributes 'Automatic-Module-Name': 'org.mockito'
         }
     }
 }


### PR DESCRIPTION
This patch adds a stable module name to the produced JAR in order to
be forwards compatible to Java 9.
