### PR TITLE
Fixes #1151 by reporting exception when stubs in progress are being consumed

### DIFF
--- a/src/main/java/org/mockito/internal/handler/MockHandlerImpl.java
+++ b/src/main/java/org/mockito/internal/handler/MockHandlerImpl.java
@@ -65,6 +65,7 @@ public class MockHandlerImpl<T> implements MockHandler<T> {
         );
 
         mockingProgress().validateState();
+        mockingProgress().validateStubbingStatus();
 
         // if verificationMode is not null then someone is doing verify()
         if (verificationMode != null) {

--- a/src/main/java/org/mockito/internal/progress/MockingProgress.java
+++ b/src/main/java/org/mockito/internal/progress/MockingProgress.java
@@ -31,6 +31,8 @@ public interface MockingProgress {
 
     void validateState();
 
+    void validateStubbingStatus();
+
     void reset();
 
     /**

--- a/src/test/java/org/mockitousage/verification/SampleTest.java
+++ b/src/test/java/org/mockitousage/verification/SampleTest.java
@@ -1,0 +1,44 @@
+package org.mockitousage.verification;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.mockitoutil.TestBase;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SampleTest extends TestBase {
+
+    @Test
+    public void testDefaultResponse() throws Exception {
+        final String defaultAnswer = "DEFAULT ANSWER";
+        final Foo foo = Mockito.mock(Foo.class, new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                return defaultAnswer;
+            }
+        });
+        Thread checker = new Thread() {
+            @Override
+            public void run() {
+                assertTrue(foo.bar("BUG").contains(defaultAnswer));
+            }
+        };
+        checker.start();
+
+        Mockito.when(foo.bar("DOG")).thenReturn("PUG");
+        if (foo.bar("DOG").equals(defaultAnswer)) {
+            System.out.println("something went wrong");
+        }
+        assertEquals("PUG", foo.bar("DOG"));
+    }
+
+    public static class Foo {
+
+        public String bar(String arg) {
+            return "REAL METHOD";
+        }
+    }
+}


### PR DESCRIPTION
The fix provided in this PR ensures that an exception is thrown when stubs in progress are used even on a different thread.


check list

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/2.x/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

