### PR TITLE
Fix javadoc in PluginLoader#withAlias' javadoc

### DIFF
--- a/src/main/java/org/mockito/internal/configuration/plugins/PluginLoader.java
+++ b/src/main/java/org/mockito/internal/configuration/plugins/PluginLoader.java
@@ -27,7 +27,7 @@ class PluginLoader {
     }
 
     /**
-     * @Deprecated Let's avoid adding more aliases. It complicates the API.
+     * @deprecated Let's avoid adding more aliases. It complicates the API.
      * Instead of an alias, we can use fully qualified class name of the alternative implementation.
      * <p>
      * Adds an alias for a class name to this plugin loader. Instead of the fully qualified type name,


### PR DESCRIPTION
Fix the misuse of `@Deprecated` in `PluginLoader#withAlias` - `@Deprecated` is an annotation, while the correct javadoc tag is `@deprecated`.
