### PR TITLE
Fixed documentation issue, added unit tests

### DIFF
--- a/src/main/java/org/mockito/MockSettings.java
+++ b/src/main/java/org/mockito/MockSettings.java
@@ -203,9 +203,7 @@ public interface MockSettings extends Serializable {
      * Registers a listener for method invocations on this mock. The listener is
      * notified every time a method on this mock is called.
      * <p>
-     * Multiple listeners may be added, but the same object is only added once.
-     * The order, in which the listeners are added, is not guaranteed to be the
-     * order in which the listeners are notified.
+     * Multiple listeners may be added and they will be notified in the order they were supplied.
      *
      * Example:
      * <pre class="code"><code class="java">

--- a/src/test/java/org/mockitousage/debugging/InvocationListenerCallbackTest.java
+++ b/src/test/java/org/mockitousage/debugging/InvocationListenerCallbackTest.java
@@ -70,10 +70,11 @@ public class InvocationListenerCallbackTest {
         Foo foo = mock(Foo.class, withSettings().invocationListeners(listener1, listener1));
 
         // when
-        foo.giveMeSomeString("herb");
+        foo.giveMeSomeString("a");
+        foo.giveMeSomeString("b");
 
-        // then
-        assertThat(container).containsExactly(listener1, listener1);
+        // then each listener was notified 2 times (notified 4 times in total)
+        assertThat(container).containsExactly(listener1, listener1, listener1, listener1);
     }
 
     @Test

--- a/src/test/java/org/mockitousage/debugging/InvocationListenerCallbackTest.java
+++ b/src/test/java/org/mockitousage/debugging/InvocationListenerCallbackTest.java
@@ -11,11 +11,18 @@ import org.mockito.invocation.DescribedInvocation;
 import org.mockito.listeners.InvocationListener;
 import org.mockito.listeners.MethodInvocationReport;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willReturn;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
 
 
 /**
@@ -36,6 +43,37 @@ public class InvocationListenerCallbackTest {
 
         // then
         assertThat(listener).is(notifiedFor("basil", getClass().getSimpleName()));
+    }
+
+    @Test
+    public void should_call_listeners_in_order() throws Exception {
+        // given
+        List<InvocationListener> container = new ArrayList<InvocationListener>();
+        RememberingListener listener1 = new RememberingListener(container);
+        RememberingListener listener2 = new RememberingListener(container);
+
+        Foo foo = mock(Foo.class, withSettings().invocationListeners(listener1, listener2));
+
+        // when
+        foo.giveMeSomeString("herb");
+
+        // then
+        assertThat(container).containsExactly(listener1, listener2);
+    }
+
+    @Test
+    public void should_allow_same_listener() throws Exception {
+        // given
+        List<InvocationListener> container = new ArrayList<InvocationListener>();
+        RememberingListener listener1 = new RememberingListener(container);
+
+        Foo foo = mock(Foo.class, withSettings().invocationListeners(listener1, listener1));
+
+        // when
+        foo.giveMeSomeString("herb");
+
+        // then
+        assertThat(container).containsExactly(listener1, listener1);
     }
 
     @Test
@@ -86,14 +124,24 @@ public class InvocationListenerCallbackTest {
     }
 
     private static class RememberingListener implements InvocationListener {
+        private final List<InvocationListener> listenerContainer;
         DescribedInvocation invocation;
         Object returnValue;
         String locationOfStubbing;
+
+        RememberingListener(List<InvocationListener> listenerContainer) {
+            this.listenerContainer = listenerContainer;
+        }
+
+        RememberingListener() {
+            this(new ArrayList<InvocationListener>());
+        }
 
         public void reportInvocation(MethodInvocationReport mcr) {
             this.invocation = mcr.getInvocation();
             this.returnValue = mcr.getReturnedValue();
             this.locationOfStubbing = mcr.getLocationOfStubbing();
+            listenerContainer.add(this); //so that we can assert on order
         }
     }
 


### PR DESCRIPTION
- While working on new verification started listeners (#1191) I found an instance of incorrect documentation. I added unit tests and simplified the documentation.
- Currently, contrary to what the Javadoc said, we do guarantee the order in which invocation listeners get notified. Some of our users might have started to depend on this behavior. I added unit tests and fixed the Javadoc. In general, it is seems useful to guarantee the order. This way, the API is more predictable, easier to use.
