### PR TITLE
Clean up JUnit imports

### DIFF
--- a/src/test/java/org/concurrentmockito/ThreadsRunAllTestsHalfManualTest.java
+++ b/src/test/java/org/concurrentmockito/ThreadsRunAllTestsHalfManualTest.java
@@ -58,7 +58,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class ThreadsRunAllTestsHalfManualTest extends TestBase {
 

--- a/src/test/java/org/mockito/exceptions/base/MockitoAssertionErrorTest.java
+++ b/src/test/java/org/mockito/exceptions/base/MockitoAssertionErrorTest.java
@@ -8,8 +8,8 @@ package org.mockito.exceptions.base;
 import org.junit.Test;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class MockitoAssertionErrorTest extends TestBase {
 

--- a/src/test/java/org/mockito/exceptions/base/MockitoExceptionTest.java
+++ b/src/test/java/org/mockito/exceptions/base/MockitoExceptionTest.java
@@ -8,8 +8,8 @@ package org.mockito.exceptions.base;
 import org.junit.Test;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class MockitoExceptionTest extends TestBase {
 

--- a/src/test/java/org/mockito/internal/AllInvocationsFinderTest.java
+++ b/src/test/java/org/mockito/internal/AllInvocationsFinderTest.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/src/test/java/org/mockito/internal/InOrderImplTest.java
+++ b/src/test/java/org/mockito/internal/InOrderImplTest.java
@@ -12,8 +12,8 @@ import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
 import static java.util.Collections.singletonList;
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("unchecked")
 public class InOrderImplTest extends TestBase {

--- a/src/test/java/org/mockito/internal/InvalidStateDetectionTest.java
+++ b/src/test/java/org/mockito/internal/InvalidStateDetectionTest.java
@@ -15,8 +15,8 @@ import org.mockito.exceptions.misusing.UnfinishedVerificationException;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 /**

--- a/src/test/java/org/mockito/internal/configuration/plugins/PluginFileReaderTest.java
+++ b/src/test/java/org/mockito/internal/configuration/plugins/PluginFileReaderTest.java
@@ -11,8 +11,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class PluginFileReaderTest extends TestBase {
 

--- a/src/test/java/org/mockito/internal/configuration/plugins/PluginFinderTest.java
+++ b/src/test/java/org/mockito/internal/configuration/plugins/PluginFinderTest.java
@@ -18,7 +18,7 @@ import java.net.URL;
 import java.util.Collections;
 
 import static java.util.Arrays.asList;
-import static junit.framework.TestCase.*;
+import static org.junit.Assert.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;

--- a/src/test/java/org/mockito/internal/creation/DelegatingMethodTest.java
+++ b/src/test/java/org/mockito/internal/creation/DelegatingMethodTest.java
@@ -10,8 +10,8 @@ import org.mockitoutil.TestBase;
 
 import java.lang.reflect.Method;
 
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class DelegatingMethodTest extends TestBase {
 

--- a/src/test/java/org/mockito/internal/creation/InterfaceOverrideTest.java
+++ b/src/test/java/org/mockito/internal/creation/InterfaceOverrideTest.java
@@ -7,7 +7,7 @@ package org.mockito.internal.creation;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class InterfaceOverrideTest {
 

--- a/src/test/java/org/mockito/internal/creation/MockSettingsImplTest.java
+++ b/src/test/java/org/mockito/internal/creation/MockSettingsImplTest.java
@@ -16,7 +16,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
-import static junit.framework.TestCase.*;
+import static org.junit.Assert.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MockSettingsImplTest extends TestBase {

--- a/src/test/java/org/mockito/internal/creation/instance/ConstructorInstantiatorTest.java
+++ b/src/test/java/org/mockito/internal/creation/instance/ConstructorInstantiatorTest.java
@@ -9,8 +9,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class ConstructorInstantiatorTest extends TestBase {
 

--- a/src/test/java/org/mockito/internal/debugging/LoggingListenerTest.java
+++ b/src/test/java/org/mockito/internal/debugging/LoggingListenerTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import org.mockito.internal.invocation.InvocationBuilder;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class LoggingListenerTest extends TestBase {
 

--- a/src/test/java/org/mockito/internal/exceptions/stacktrace/StackTraceFilterTest.java
+++ b/src/test/java/org/mockito/internal/exceptions/stacktrace/StackTraceFilterTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 import org.mockito.exceptions.base.TraceBuilder;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.mockitoutil.Conditions.onlyThoseClasses;
 
 public class StackTraceFilterTest extends TestBase {

--- a/src/test/java/org/mockito/internal/hamcrest/MatcherGenericTypeExtractorTest.java
+++ b/src/test/java/org/mockito/internal/hamcrest/MatcherGenericTypeExtractorTest.java
@@ -13,7 +13,7 @@ import org.mockitoutil.TestBase;
 import java.io.Serializable;
 import java.util.HashMap;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.internal.hamcrest.MatcherGenericTypeExtractor.genericTypeOfMatcher;
 
 public class MatcherGenericTypeExtractorTest extends TestBase {

--- a/src/test/java/org/mockito/internal/handler/MockHandlerFactoryTest.java
+++ b/src/test/java/org/mockito/internal/handler/MockHandlerFactoryTest.java
@@ -14,8 +14,8 @@ import org.mockito.mock.MockCreationSettings;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.internal.handler.MockHandlerFactory.createMockHandler;
 
 /**

--- a/src/test/java/org/mockito/internal/handler/MockHandlerImplTest.java
+++ b/src/test/java/org/mockito/internal/handler/MockHandlerImplTest.java
@@ -25,8 +25,8 @@ import org.mockitoutil.TestBase;
 
 import java.util.Arrays;
 
-import static junit.framework.TestCase.assertNull;
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doThrow;

--- a/src/test/java/org/mockito/internal/invocation/InvocationMarkerTest.java
+++ b/src/test/java/org/mockito/internal/invocation/InvocationMarkerTest.java
@@ -13,7 +13,7 @@ import org.mockitoutil.TestBase;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static junit.framework.TestCase.*;
+import static org.junit.Assert.*;
 
 public class InvocationMarkerTest extends TestBase {
 

--- a/src/test/java/org/mockito/internal/invocation/InvocationMatcherTest.java
+++ b/src/test/java/org/mockito/internal/invocation/InvocationMatcherTest.java
@@ -6,9 +6,9 @@
 package org.mockito.internal.invocation;
 
 import static java.util.Arrays.asList;
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.internal.matchers.Any.ANY;
 

--- a/src/test/java/org/mockito/internal/invocation/InvocationsFinderTest.java
+++ b/src/test/java/org/mockito/internal/invocation/InvocationsFinderTest.java
@@ -21,9 +21,9 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
-import static junit.framework.TestCase.assertNull;
-import static junit.framework.TestCase.assertSame;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 
 public class InvocationsFinderTest extends TestBase {

--- a/src/test/java/org/mockito/internal/invocation/MatcherApplicationStrategyTest.java
+++ b/src/test/java/org/mockito/internal/invocation/MatcherApplicationStrategyTest.java
@@ -5,8 +5,8 @@
 package org.mockito.internal.invocation;
 
 import static java.util.Arrays.asList;
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.internal.invocation.MatcherApplicationStrategy.getMatcherApplicationStrategyFor;
 import static org.mockito.internal.matchers.Any.ANY;

--- a/src/test/java/org/mockito/internal/junit/util/JUnitFailureHackerTest.java
+++ b/src/test/java/org/mockito/internal/junit/util/JUnitFailureHackerTest.java
@@ -11,7 +11,7 @@ import org.junit.runner.notification.Failure;
 import org.mockito.internal.exceptions.ExceptionIncludingMockitoWarnings;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class JUnitFailureHackerTest extends TestBase {

--- a/src/test/java/org/mockito/internal/matchers/ComparableMatchersTest.java
+++ b/src/test/java/org/mockito/internal/matchers/ComparableMatchersTest.java
@@ -10,8 +10,8 @@ import org.mockitoutil.TestBase;
 
 import java.math.BigDecimal;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ComparableMatchersTest extends TestBase {
 

--- a/src/test/java/org/mockito/internal/matchers/EqualityTest.java
+++ b/src/test/java/org/mockito/internal/matchers/EqualityTest.java
@@ -7,8 +7,8 @@ package org.mockito.internal.matchers;
 import org.junit.Test;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.internal.matchers.Equality.areEqual;
 
 public class EqualityTest extends TestBase {

--- a/src/test/java/org/mockito/internal/matchers/EqualsTest.java
+++ b/src/test/java/org/mockito/internal/matchers/EqualsTest.java
@@ -8,7 +8,7 @@ package org.mockito.internal.matchers;
 import org.junit.Test;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.*;
+import static org.junit.Assert.*;
 
 
 public class EqualsTest extends TestBase {

--- a/src/test/java/org/mockito/internal/matchers/MatchersPrinterTest.java
+++ b/src/test/java/org/mockito/internal/matchers/MatchersPrinterTest.java
@@ -12,7 +12,7 @@ import org.mockitoutil.TestBase;
 import java.util.Arrays;
 import java.util.List;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 @SuppressWarnings("unchecked")
 public class MatchersPrinterTest extends TestBase {

--- a/src/test/java/org/mockito/internal/matchers/MatchersToStringTest.java
+++ b/src/test/java/org/mockito/internal/matchers/MatchersToStringTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class MatchersToStringTest extends TestBase {
 

--- a/src/test/java/org/mockito/internal/matchers/apachecommons/EqualsBuilderTest.java
+++ b/src/test/java/org/mockito/internal/matchers/apachecommons/EqualsBuilderTest.java
@@ -12,7 +12,7 @@ import org.mockitoutil.TestBase;
 import java.math.BigDecimal;
 import java.util.Arrays;
 
-import static junit.framework.TestCase.*;
+import static org.junit.Assert.*;
 
 /**
  * @author <a href="mailto:sdowney@panix.com">Steve Downey</a>

--- a/src/test/java/org/mockito/internal/matchers/text/MatcherToStringTest.java
+++ b/src/test/java/org/mockito/internal/matchers/text/MatcherToStringTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class MatcherToStringTest extends TestBase {
 

--- a/src/test/java/org/mockito/internal/progress/AtLeastTest.java
+++ b/src/test/java/org/mockito/internal/progress/AtLeastTest.java
@@ -9,8 +9,8 @@ import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.verification.VerificationModeFactory;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class AtLeastTest extends TestBase {
 

--- a/src/test/java/org/mockito/internal/progress/MockingProgressImplTest.java
+++ b/src/test/java/org/mockito/internal/progress/MockingProgressImplTest.java
@@ -12,7 +12,7 @@ import org.mockito.internal.verification.VerificationModeFactory;
 import org.mockito.verification.VerificationMode;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.*;
+import static org.junit.Assert.*;
 
 public class MockingProgressImplTest extends TestBase {
 

--- a/src/test/java/org/mockito/internal/progress/ThreadSafeMockingProgressTest.java
+++ b/src/test/java/org/mockito/internal/progress/ThreadSafeMockingProgressTest.java
@@ -11,7 +11,7 @@ import org.mockitoutil.TestBase;
 
 import java.util.List;
 
-import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;

--- a/src/test/java/org/mockito/internal/reporting/PluralizerTest.java
+++ b/src/test/java/org/mockito/internal/reporting/PluralizerTest.java
@@ -7,7 +7,7 @@ package org.mockito.internal.reporting;
 import org.junit.Test;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class PluralizerTest extends TestBase {
 

--- a/src/test/java/org/mockito/internal/runners/util/RunnerProviderTest.java
+++ b/src/test/java/org/mockito/internal/runners/util/RunnerProviderTest.java
@@ -9,7 +9,7 @@ import org.mockito.internal.runners.DefaultInternalRunner;
 import org.mockito.internal.runners.InternalRunner;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertNotNull;
 
 public class RunnerProviderTest extends TestBase {
 

--- a/src/test/java/org/mockito/internal/runners/util/TestMethodsFinderTest.java
+++ b/src/test/java/org/mockito/internal/runners/util/TestMethodsFinderTest.java
@@ -7,8 +7,8 @@ package org.mockito.internal.runners.util;
 import org.junit.Test;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class TestMethodsFinderTest extends TestBase {
 

--- a/src/test/java/org/mockito/internal/stubbing/InvocationContainerImplStubbingTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/InvocationContainerImplStubbingTest.java
@@ -19,8 +19,8 @@ import org.mockito.internal.stubbing.answers.ThrowsException;
 import org.mockito.invocation.Invocation;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class InvocationContainerImplStubbingTest extends TestBase {
 

--- a/src/test/java/org/mockito/internal/stubbing/defaultanswers/ForwardsInvocationsTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/defaultanswers/ForwardsInvocationsTest.java
@@ -7,7 +7,7 @@ package org.mockito.internal.stubbing.defaultanswers;
 import org.junit.Test;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class ForwardsInvocationsTest extends TestBase {
 

--- a/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValuesTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValuesTest.java
@@ -12,7 +12,7 @@ import org.mockitoutil.TestBase;
 
 import java.util.*;
 
-import static junit.framework.TestCase.*;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 
 public class ReturnsEmptyValuesTest extends TestBase {

--- a/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsMocksTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsMocksTest.java
@@ -9,7 +9,7 @@ import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.internal.util.MockUtil;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.*;
+import static org.junit.Assert.*;
 import static org.junit.Assume.assumeFalse;
 
 public class ReturnsMocksTest extends TestBase {

--- a/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsMoreEmptyValuesTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsMoreEmptyValuesTest.java
@@ -7,8 +7,8 @@ package org.mockito.internal.stubbing.defaultanswers;
 import org.junit.Test;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ReturnsMoreEmptyValuesTest extends TestBase {
 

--- a/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNullsTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNullsTest.java
@@ -11,8 +11,8 @@ import org.mockito.exceptions.verification.SmartNullPointerException;
 import org.mockito.stubbing.Answer;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class ReturnsSmartNullsTest extends TestBase {
 

--- a/src/test/java/org/mockito/internal/util/DefaultMockingDetailsTest.java
+++ b/src/test/java/org/mockito/internal/util/DefaultMockingDetailsTest.java
@@ -4,7 +4,6 @@
  */
 package org.mockito.internal.util;
 
-import junit.framework.TestCase;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -17,8 +16,8 @@ import org.mockitousage.IMethods;
 
 import java.util.Collection;
 
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -121,7 +120,7 @@ public class DefaultMockingDetailsTest {
             //then
             fail();
         } catch (NotAMockException e) {
-            TestCase.assertEquals("Argument passed to Mockito.mockingDetails() should be a mock, but is null!", e.getMessage());
+            assertEquals("Argument passed to Mockito.mockingDetails() should be a mock, but is null!", e.getMessage());
         }
     }
 
@@ -133,7 +132,7 @@ public class DefaultMockingDetailsTest {
             //then
             fail();
         } catch (NotAMockException e) {
-            TestCase.assertEquals("Argument passed to Mockito.mockingDetails() should be a mock, but is an instance of class java.lang.Object!", e.getMessage());
+            assertEquals("Argument passed to Mockito.mockingDetails() should be a mock, but is an instance of class java.lang.Object!", e.getMessage());
         }
     }
 
@@ -145,7 +144,7 @@ public class DefaultMockingDetailsTest {
             //then
             fail();
         } catch (NotAMockException e) {
-            TestCase.assertEquals("Argument passed to Mockito.mockingDetails() should be a mock, but is an instance of class java.lang.Object!", e.getMessage());
+            assertEquals("Argument passed to Mockito.mockingDetails() should be a mock, but is an instance of class java.lang.Object!", e.getMessage());
         }
     }
 
@@ -201,7 +200,7 @@ public class DefaultMockingDetailsTest {
             //then
             fail();
         } catch (NotAMockException e) {
-            TestCase.assertEquals("Argument passed to Mockito.mockingDetails() should be a mock, but is an instance of class java.lang.Object!", e.getMessage());
+            assertEquals("Argument passed to Mockito.mockingDetails() should be a mock, but is an instance of class java.lang.Object!", e.getMessage());
         }
     }
 

--- a/src/test/java/org/mockito/internal/util/MockNameImplTest.java
+++ b/src/test/java/org/mockito/internal/util/MockNameImplTest.java
@@ -7,7 +7,7 @@ package org.mockito.internal.util;
 import org.junit.Test;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class MockNameImplTest extends TestBase {
 

--- a/src/test/java/org/mockito/internal/util/MockUtilTest.java
+++ b/src/test/java/org/mockito/internal/util/MockUtilTest.java
@@ -16,7 +16,7 @@ import org.mockitoutil.TestBase;
 import java.util.ArrayList;
 import java.util.List;
 
-import static junit.framework.TestCase.*;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.withSettings;
 
 @SuppressWarnings("unchecked")

--- a/src/test/java/org/mockito/internal/util/ObjectMethodsGuruTest.java
+++ b/src/test/java/org/mockito/internal/util/ObjectMethodsGuruTest.java
@@ -10,8 +10,8 @@ import org.mockitoutil.TestBase;
 
 import java.util.Date;
 
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ObjectMethodsGuruTest extends TestBase {
 

--- a/src/test/java/org/mockito/internal/util/SimpleMockitoLoggerTest.java
+++ b/src/test/java/org/mockito/internal/util/SimpleMockitoLoggerTest.java
@@ -7,7 +7,7 @@ package org.mockito.internal.util;
 import org.junit.Test;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class SimpleMockitoLoggerTest extends TestBase {
 

--- a/src/test/java/org/mockito/internal/util/StringUtilTest.java
+++ b/src/test/java/org/mockito/internal/util/StringUtilTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class StringUtilTest  {

--- a/src/test/java/org/mockito/internal/util/collections/ListUtilTest.java
+++ b/src/test/java/org/mockito/internal/util/collections/ListUtilTest.java
@@ -14,7 +14,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 public class ListUtilTest extends TestBase {
 

--- a/src/test/java/org/mockito/internal/util/reflection/FieldReaderTest.java
+++ b/src/test/java/org/mockito/internal/util/reflection/FieldReaderTest.java
@@ -7,8 +7,8 @@ package org.mockito.internal.util.reflection;
 import org.junit.Test;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("unused")
 public class FieldReaderTest extends TestBase {

--- a/src/test/java/org/mockito/internal/util/reflection/GenericTypeExtractorTest.java
+++ b/src/test/java/org/mockito/internal/util/reflection/GenericTypeExtractorTest.java
@@ -11,7 +11,7 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.internal.util.reflection.GenericTypeExtractor.genericTypeOf;
 
 public class GenericTypeExtractorTest extends TestBase {

--- a/src/test/java/org/mockito/internal/util/reflection/LenientCopyToolTest.java
+++ b/src/test/java/org/mockito/internal/util/reflection/LenientCopyToolTest.java
@@ -10,8 +10,8 @@ import org.mockitoutil.TestBase;
 import java.lang.reflect.Field;
 import java.util.LinkedList;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/org/mockito/internal/verification/DefaultRegisteredInvocationsTest.java
+++ b/src/test/java/org/mockito/internal/verification/DefaultRegisteredInvocationsTest.java
@@ -11,8 +11,8 @@ import org.mockito.internal.invocation.InvocationBuilder;
 import org.mockito.invocation.Invocation;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class DefaultRegisteredInvocationsTest extends TestBase {
 

--- a/src/test/java/org/mockito/internal/verification/DescriptionTest.java
+++ b/src/test/java/org/mockito/internal/verification/DescriptionTest.java
@@ -11,8 +11,8 @@ import org.mockito.exceptions.base.MockitoAssertionError;
 import org.mockito.internal.verification.api.VerificationData;
 import org.mockito.verification.VerificationMode;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;

--- a/src/test/java/org/mockito/internal/verification/NoMoreInteractionsTest.java
+++ b/src/test/java/org/mockito/internal/verification/NoMoreInteractionsTest.java
@@ -18,7 +18,7 @@ import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
 import static java.util.Arrays.asList;
-import static junit.framework.TestCase.*;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 
 public class NoMoreInteractionsTest extends TestBase {

--- a/src/test/java/org/mockito/internal/verification/VerificationDataImplTest.java
+++ b/src/test/java/org/mockito/internal/verification/VerificationDataImplTest.java
@@ -10,7 +10,7 @@ import org.mockito.internal.invocation.InvocationBuilder;
 import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 
 public class VerificationDataImplTest extends TestBase {
 

--- a/src/test/java/org/mockito/internal/verification/VerificationWithDescriptionTest.java
+++ b/src/test/java/org/mockito/internal/verification/VerificationWithDescriptionTest.java
@@ -12,7 +12,7 @@ import org.mockito.exceptions.base.MockitoAssertionError;
 
 import java.util.List;
 
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertTrue;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.description;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/org/mockito/internal/verification/argumentmatching/ArgumentMatchingToolTest.java
+++ b/src/test/java/org/mockito/internal/verification/argumentmatching/ArgumentMatchingToolTest.java
@@ -14,7 +14,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static java.util.Collections.singletonList;
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 @SuppressWarnings({ "unchecked", "serial" })
 public class ArgumentMatchingToolTest extends TestBase {

--- a/src/test/java/org/mockito/runners/ConsoleSpammingMockitoJUnitRunnerTest.java
+++ b/src/test/java/org/mockito/runners/ConsoleSpammingMockitoJUnitRunnerTest.java
@@ -15,7 +15,7 @@ import org.mockito.internal.runners.InternalRunner;
 import org.mockito.internal.util.ConsoleMockitoLogger;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class ConsoleSpammingMockitoJUnitRunnerTest extends TestBase {
 

--- a/src/test/java/org/mockito/verification/TimeoutTest.java
+++ b/src/test/java/org/mockito/verification/TimeoutTest.java
@@ -12,7 +12,7 @@ import org.mockito.internal.util.Timer;
 import org.mockito.internal.verification.VerificationDataImpl;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 public class TimeoutTest extends TestBase {

--- a/src/test/java/org/mockitousage/PlaygroundWithDemoOfUnclonedParametersProblemTest.java
+++ b/src/test/java/org/mockitousage/PlaygroundWithDemoOfUnclonedParametersProblemTest.java
@@ -15,7 +15,7 @@ import org.mockitoutil.TestBase;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Matchers.any;

--- a/src/test/java/org/mockitousage/annotation/AnnotationsTest.java
+++ b/src/test/java/org/mockitousage/annotation/AnnotationsTest.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static junit.framework.TestCase.*;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.verify;
 
 public class AnnotationsTest extends TestBase {

--- a/src/test/java/org/mockitousage/annotation/CaptorAnnotationBasicTest.java
+++ b/src/test/java/org/mockitousage/annotation/CaptorAnnotationBasicTest.java
@@ -15,8 +15,8 @@ import org.mockitoutil.TestBase;
 import java.util.LinkedList;
 import java.util.List;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertSame;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.verify;
 
 @SuppressWarnings("unchecked")

--- a/src/test/java/org/mockitousage/annotation/CaptorAnnotationTest.java
+++ b/src/test/java/org/mockitousage/annotation/CaptorAnnotationTest.java
@@ -17,7 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import static junit.framework.TestCase.*;
+import static org.junit.Assert.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CaptorAnnotationTest extends TestBase {

--- a/src/test/java/org/mockitousage/annotation/CaptorAnnotationUnhappyPathTest.java
+++ b/src/test/java/org/mockitousage/annotation/CaptorAnnotationUnhappyPathTest.java
@@ -14,7 +14,7 @@ import org.mockitoutil.TestBase;
 
 import java.util.List;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CaptorAnnotationUnhappyPathTest extends TestBase {

--- a/src/test/java/org/mockitousage/annotation/DeprecatedAnnotationEngineApiTest.java
+++ b/src/test/java/org/mockitousage/annotation/DeprecatedAnnotationEngineApiTest.java
@@ -16,7 +16,7 @@ import org.mockito.internal.configuration.ConfigurationAccess;
 import org.mockito.internal.configuration.IndependentAnnotationEngine;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.*;
+import static org.junit.Assert.*;
 
 public class DeprecatedAnnotationEngineApiTest extends TestBase {
 

--- a/src/test/java/org/mockitousage/annotation/MockInjectionUsingSetterOrPropertyTest.java
+++ b/src/test/java/org/mockitousage/annotation/MockInjectionUsingSetterOrPropertyTest.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
-import static junit.framework.TestCase.*;
+import static org.junit.Assert.*;
 
 @SuppressWarnings({"unchecked", "unused"})
 public class MockInjectionUsingSetterOrPropertyTest extends TestBase {

--- a/src/test/java/org/mockitousage/annotation/SpyAnnotationInitializedInBaseClassTest.java
+++ b/src/test/java/org/mockitousage/annotation/SpyAnnotationInitializedInBaseClassTest.java
@@ -14,7 +14,7 @@ import org.mockitoutil.TestBase;
 import java.util.LinkedList;
 import java.util.List;
 
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.internal.util.MockUtil.isMock;
 
 @SuppressWarnings("unchecked")

--- a/src/test/java/org/mockitousage/annotation/SpyAnnotationTest.java
+++ b/src/test/java/org/mockitousage/annotation/SpyAnnotationTest.java
@@ -19,10 +19,10 @@ import org.mockito.Spy;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNotNull;
-import static junit.framework.TestCase.assertTrue;
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;

--- a/src/test/java/org/mockitousage/annotation/WrongSetOfAnnotationsTest.java
+++ b/src/test/java/org/mockitousage/annotation/WrongSetOfAnnotationsTest.java
@@ -12,7 +12,7 @@ import org.mockitoutil.TestBase;
 
 import java.util.List;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 
 public class WrongSetOfAnnotationsTest extends TestBase {
 

--- a/src/test/java/org/mockitousage/basicapi/MocksCreationTest.java
+++ b/src/test/java/org/mockitousage/basicapi/MocksCreationTest.java
@@ -16,7 +16,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
-import static junit.framework.TestCase.*;
+import static org.junit.Assert.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/org/mockitousage/basicapi/MocksSerializationForAnnotationTest.java
+++ b/src/test/java/org/mockitousage/basicapi/MocksSerializationForAnnotationTest.java
@@ -24,7 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Observable;
 
-import static junit.framework.TestCase.*;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 import static org.mockitoutil.SimpleSerializationUtil.*;
 

--- a/src/test/java/org/mockitousage/basicapi/MocksSerializationTest.java
+++ b/src/test/java/org/mockitousage/basicapi/MocksSerializationTest.java
@@ -25,7 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Observable;
 
-import static junit.framework.TestCase.*;
+import static org.junit.Assert.*;
 import static org.junit.Assume.assumeFalse;
 import static org.mockito.Mockito.*;
 import static org.mockitoutil.SimpleSerializationUtil.*;

--- a/src/test/java/org/mockitousage/basicapi/ObjectsSerializationTest.java
+++ b/src/test/java/org/mockitousage/basicapi/ObjectsSerializationTest.java
@@ -10,7 +10,7 @@ import org.mockitoutil.TestBase;
 
 import java.io.Serializable;
 
-import static junit.framework.TestCase.assertSame;
+import static org.junit.Assert.assertSame;
 import static org.mockitoutil.SimpleSerializationUtil.serializeAndBack;
 
 @SuppressWarnings("serial")

--- a/src/test/java/org/mockitousage/basicapi/ReplacingObjectMethodsTest.java
+++ b/src/test/java/org/mockitousage/basicapi/ReplacingObjectMethodsTest.java
@@ -11,7 +11,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class ReplacingObjectMethodsTest extends TestBase {
 

--- a/src/test/java/org/mockitousage/basicapi/ResetInvocationsTest.java
+++ b/src/test/java/org/mockitousage/basicapi/ResetInvocationsTest.java
@@ -10,7 +10,7 @@ import org.mockito.exceptions.misusing.NotAMockException;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 public class ResetInvocationsTest extends TestBase {

--- a/src/test/java/org/mockitousage/basicapi/ResetTest.java
+++ b/src/test/java/org/mockitousage/basicapi/ResetTest.java
@@ -12,7 +12,7 @@ import org.mockito.exceptions.misusing.UnfinishedVerificationException;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.*;
+import static org.junit.Assert.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/org/mockitousage/basicapi/UsingVarargsTest.java
+++ b/src/test/java/org/mockitousage/basicapi/UsingVarargsTest.java
@@ -14,8 +14,8 @@ import org.mockitoutil.TestBase;
 
 import java.util.ArrayList;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 public class UsingVarargsTest extends TestBase {

--- a/src/test/java/org/mockitousage/bugs/ActualInvocationHasNullArgumentNPEBugTest.java
+++ b/src/test/java/org/mockitousage/bugs/ActualInvocationHasNullArgumentNPEBugTest.java
@@ -8,7 +8,7 @@ package org.mockitousage.bugs;
 import org.junit.Test;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 public class ActualInvocationHasNullArgumentNPEBugTest extends TestBase {

--- a/src/test/java/org/mockitousage/bugs/BridgeMethodsHitAgainTest.java
+++ b/src/test/java/org/mockitousage/bugs/BridgeMethodsHitAgainTest.java
@@ -12,7 +12,7 @@ import org.mockitoutil.TestBase;
 
 import java.io.Serializable;
 
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 

--- a/src/test/java/org/mockitousage/bugs/CaptorAnnotationAutoboxingTest.java
+++ b/src/test/java/org/mockitousage/bugs/CaptorAnnotationAutoboxingTest.java
@@ -11,7 +11,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -33,7 +33,7 @@ public class CaptorAnnotationAutoboxingTest extends TestBase {
 
         //then
         verify(fun).doFun(captor.capture());
-        assertEquals(1.0, captor.getValue());
+        assertEquals(Double.valueOf(1.0), captor.getValue());
     }
 
     @Captor ArgumentCaptor<Integer> intCaptor;

--- a/src/test/java/org/mockitousage/bugs/CovariantOverrideTest.java
+++ b/src/test/java/org/mockitousage/bugs/CovariantOverrideTest.java
@@ -8,7 +8,7 @@ package org.mockitousage.bugs;
 import org.junit.Test;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 //see issue 101

--- a/src/test/java/org/mockitousage/bugs/InheritedGenericsPolimorphicCallTest.java
+++ b/src/test/java/org/mockitousage/bugs/InheritedGenericsPolimorphicCallTest.java
@@ -17,7 +17,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verify;
 
 @SuppressWarnings("unchecked")

--- a/src/test/java/org/mockitousage/bugs/MockitoRunnerBreaksWhenNoTestMethodsTest.java
+++ b/src/test/java/org/mockitousage/bugs/MockitoRunnerBreaksWhenNoTestMethodsTest.java
@@ -16,9 +16,9 @@ import org.mockito.exceptions.base.MockitoException;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 
 // @Ignore("for demo only. this test cannot be enabled as it fails :)")

--- a/src/test/java/org/mockitousage/bugs/NPEWhenCustomExceptionStackTraceReturnNullTest.java
+++ b/src/test/java/org/mockitousage/bugs/NPEWhenCustomExceptionStackTraceReturnNullTest.java
@@ -9,7 +9,7 @@ import org.mockito.Mock;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 
 public class NPEWhenCustomExceptionStackTraceReturnNullTest extends TestBase {

--- a/src/test/java/org/mockitousage/bugs/NPEWhenMockingThrowablesTest.java
+++ b/src/test/java/org/mockitousage/bugs/NPEWhenMockingThrowablesTest.java
@@ -10,7 +10,7 @@ import org.mockito.Mock;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 
 public class NPEWhenMockingThrowablesTest extends TestBase {

--- a/src/test/java/org/mockitousage/bugs/ShouldMocksCompareToBeConsistentWithEqualsTest.java
+++ b/src/test/java/org/mockitousage/bugs/ShouldMocksCompareToBeConsistentWithEqualsTest.java
@@ -12,7 +12,7 @@ import java.util.Date;
 import java.util.Set;
 import java.util.TreeSet;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 //see issue 184

--- a/src/test/java/org/mockitousage/bugs/ShouldOnlyModeAllowCapturingArgumentsTest.java
+++ b/src/test/java/org/mockitousage/bugs/ShouldOnlyModeAllowCapturingArgumentsTest.java
@@ -11,7 +11,7 @@ import org.mockito.Mock;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.verify;
 

--- a/src/test/java/org/mockitousage/bugs/SpyShouldHaveNiceNameTest.java
+++ b/src/test/java/org/mockitousage/bugs/SpyShouldHaveNiceNameTest.java
@@ -13,7 +13,7 @@ import org.mockitoutil.TestBase;
 import java.util.LinkedList;
 import java.util.List;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.verify;
 
 //see issue 216

--- a/src/test/java/org/mockitousage/bugs/VerifyingWithAnExtraCallToADifferentMockTest.java
+++ b/src/test/java/org/mockitousage/bugs/VerifyingWithAnExtraCallToADifferentMockTest.java
@@ -11,7 +11,7 @@ import org.mockito.exceptions.verification.NeverWantedButInvoked;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 //see bug 138

--- a/src/test/java/org/mockitousage/bugs/creation/ShouldAllowInlineMockCreationTest.java
+++ b/src/test/java/org/mockitousage/bugs/creation/ShouldAllowInlineMockCreationTest.java
@@ -12,7 +12,7 @@ import org.mockitoutil.TestBase;
 import java.util.List;
 import java.util.Set;
 
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/org/mockitousage/bugs/varargs/VarargsErrorWhenCallingRealMethodTest.java
+++ b/src/test/java/org/mockitousage/bugs/varargs/VarargsErrorWhenCallingRealMethodTest.java
@@ -8,7 +8,7 @@ package org.mockitousage.bugs.varargs;
 import org.junit.Test;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 public class VarargsErrorWhenCallingRealMethodTest extends TestBase {

--- a/src/test/java/org/mockitousage/bugs/varargs/VarargsNotPlayingWithAnyObjectTest.java
+++ b/src/test/java/org/mockitousage/bugs/varargs/VarargsNotPlayingWithAnyObjectTest.java
@@ -9,8 +9,8 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 //see issue 62

--- a/src/test/java/org/mockitousage/configuration/CustomizedAnnotationForSmartMockTest.java
+++ b/src/test/java/org/mockitousage/configuration/CustomizedAnnotationForSmartMockTest.java
@@ -18,7 +18,7 @@ import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
 import static java.lang.annotation.ElementType.FIELD;
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verify;
 
 

--- a/src/test/java/org/mockitousage/constructor/CreatingMocksWithConstructorTest.java
+++ b/src/test/java/org/mockitousage/constructor/CreatingMocksWithConstructorTest.java
@@ -11,9 +11,9 @@ import org.mockito.mock.SerializableMode;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;

--- a/src/test/java/org/mockitousage/customization/BDDMockitoTest.java
+++ b/src/test/java/org/mockitousage/customization/BDDMockitoTest.java
@@ -20,7 +20,7 @@ import org.mockitoutil.TestBase;
 
 import java.util.Set;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.mockito.BDDMockito.*;
 
 public class BDDMockitoTest extends TestBase {

--- a/src/test/java/org/mockitousage/internal/debugging/LocationImplTest.java
+++ b/src/test/java/org/mockitousage/internal/debugging/LocationImplTest.java
@@ -11,7 +11,7 @@ import org.mockito.internal.debugging.LocationImpl;
 import org.mockito.internal.exceptions.stacktrace.StackTraceFilter;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 @SuppressWarnings("serial")
 public class LocationImplTest extends TestBase {

--- a/src/test/java/org/mockitousage/junitrunner/ModellingVerboseMockitoTest.java
+++ b/src/test/java/org/mockitousage/junitrunner/ModellingVerboseMockitoTest.java
@@ -13,8 +13,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/org/mockitousage/junitrunner/VerboseMockitoRunnerTest.java
+++ b/src/test/java/org/mockitousage/junitrunner/VerboseMockitoRunnerTest.java
@@ -16,8 +16,8 @@ import org.mockito.runners.VerboseMockitoJUnitRunner;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
 //@RunWith(ConsoleSpammingMockitoJUnitRunner.class)

--- a/src/test/java/org/mockitousage/matchers/AnyXMatchersAcceptNullsTest.java
+++ b/src/test/java/org/mockitousage/matchers/AnyXMatchersAcceptNullsTest.java
@@ -10,7 +10,7 @@ import org.mockito.Mockito;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/org/mockitousage/matchers/CapturingArgumentsTest.java
+++ b/src/test/java/org/mockitousage/matchers/CapturingArgumentsTest.java
@@ -16,7 +16,7 @@ import org.mockitoutil.TestBase;
 import java.util.ArrayList;
 import java.util.List;
 
-import static junit.framework.TestCase.*;
+import static org.junit.Assert.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/org/mockitousage/matchers/CustomMatcherDoesYieldCCETest.java
+++ b/src/test/java/org/mockitousage/matchers/CustomMatcherDoesYieldCCETest.java
@@ -11,7 +11,7 @@ import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.verify;
 

--- a/src/test/java/org/mockitousage/matchers/CustomMatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/CustomMatchersTest.java
@@ -12,8 +12,8 @@ import org.mockito.Mockito;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/org/mockitousage/matchers/HamcrestMatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/HamcrestMatchersTest.java
@@ -15,7 +15,7 @@ import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.*;
+import static org.junit.Assert.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/org/mockitousage/matchers/MatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/MatchersTest.java
@@ -18,9 +18,9 @@ import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNotSame;
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.AdditionalMatchers.and;
 import static org.mockito.AdditionalMatchers.aryEq;

--- a/src/test/java/org/mockitousage/matchers/MoreMatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/MoreMatchersTest.java
@@ -12,8 +12,8 @@ import org.mockitoutil.TestBase;
 
 import java.util.*;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/src/test/java/org/mockitousage/matchers/NewMatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/NewMatchersTest.java
@@ -14,7 +14,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 @SuppressWarnings("unchecked")

--- a/src/test/java/org/mockitousage/matchers/VerificationAndStubbingUsingMatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/VerificationAndStubbingUsingMatchersTest.java
@@ -11,8 +11,8 @@ import org.mockito.exceptions.verification.WantedButNotInvoked;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 public class VerificationAndStubbingUsingMatchersTest extends TestBase {

--- a/src/test/java/org/mockitousage/misuse/CleaningUpPotentialStubbingTest.java
+++ b/src/test/java/org/mockitousage/misuse/CleaningUpPotentialStubbingTest.java
@@ -11,7 +11,7 @@ import org.mockito.exceptions.misusing.MissingMethodInvocationException;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 public class CleaningUpPotentialStubbingTest extends TestBase {

--- a/src/test/java/org/mockitousage/misuse/DetectingFinalMethodsTest.java
+++ b/src/test/java/org/mockitousage/misuse/DetectingFinalMethodsTest.java
@@ -10,7 +10,7 @@ import org.mockito.exceptions.misusing.MissingMethodInvocationException;
 import org.mockito.exceptions.misusing.UnfinishedVerificationException;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/org/mockitousage/misuse/DetectingMisusedMatchersTest.java
+++ b/src/test/java/org/mockitousage/misuse/DetectingMisusedMatchersTest.java
@@ -13,7 +13,7 @@ import org.mockito.exceptions.misusing.UnfinishedVerificationException;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.anyBoolean;

--- a/src/test/java/org/mockitousage/misuse/ExplicitFrameworkValidationTest.java
+++ b/src/test/java/org/mockitousage/misuse/ExplicitFrameworkValidationTest.java
@@ -14,7 +14,7 @@ import org.mockito.exceptions.misusing.UnfinishedVerificationException;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/src/test/java/org/mockitousage/misuse/RestrictedObjectMethodsTest.java
+++ b/src/test/java/org/mockitousage/misuse/RestrictedObjectMethodsTest.java
@@ -14,7 +14,7 @@ import org.mockitoutil.TestBase;
 
 import java.util.List;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/org/mockitousage/performance/LoadsOfMocksTest.java
+++ b/src/test/java/org/mockitousage/performance/LoadsOfMocksTest.java
@@ -13,7 +13,7 @@ import org.mockitoutil.TestBase;
 import java.util.LinkedList;
 import java.util.List;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 public class LoadsOfMocksTest extends TestBase {

--- a/src/test/java/org/mockitousage/plugins/MockitoPluginsTest.java
+++ b/src/test/java/org/mockitousage/plugins/MockitoPluginsTest.java
@@ -10,7 +10,7 @@ import org.mockito.plugins.PluginSwitch;
 import org.mockito.plugins.StackTraceCleanerProvider;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertNotNull;
 
 public class MockitoPluginsTest extends TestBase {
 

--- a/src/test/java/org/mockitousage/puzzlers/BridgeMethodPuzzleTest.java
+++ b/src/test/java/org/mockitousage/puzzlers/BridgeMethodPuzzleTest.java
@@ -9,7 +9,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockitoutil.Conditions.bridgeMethod;

--- a/src/test/java/org/mockitousage/puzzlers/OverloadingPuzzleTest.java
+++ b/src/test/java/org/mockitousage/puzzlers/OverloadingPuzzleTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import org.mockito.exceptions.verification.WantedButNotInvoked;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 

--- a/src/test/java/org/mockitousage/session/MockitoSessionTest.java
+++ b/src/test/java/org/mockitousage/session/MockitoSessionTest.java
@@ -16,8 +16,8 @@ import org.mockito.quality.Strictness;
 import org.mockitousage.IMethods;
 import org.mockitoutil.JUnitResultAssert;
 
-import static junit.framework.TestCase.assertNotNull;
-import static junit.framework.TestCase.assertNull;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/org/mockitousage/spies/PartialMockingWithSpiesTest.java
+++ b/src/test/java/org/mockitousage/spies/PartialMockingWithSpiesTest.java
@@ -10,8 +10,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/org/mockitousage/spies/SpyingOnInterfacesTest.java
+++ b/src/test/java/org/mockitousage/spies/SpyingOnInterfacesTest.java
@@ -19,7 +19,7 @@ import org.mockitoutil.TestBase;
 
 import java.util.List;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;

--- a/src/test/java/org/mockitousage/spies/SpyingOnRealObjectsTest.java
+++ b/src/test/java/org/mockitousage/spies/SpyingOnRealObjectsTest.java
@@ -18,7 +18,7 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
-import static junit.framework.TestCase.*;
+import static org.junit.Assert.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.*;

--- a/src/test/java/org/mockitousage/stacktrace/ClickableStackTracesTest.java
+++ b/src/test/java/org/mockitousage/stacktrace/ClickableStackTracesTest.java
@@ -11,7 +11,7 @@ import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/org/mockitousage/stacktrace/ClickableStackTracesWhenFrameworkMisusedTest.java
+++ b/src/test/java/org/mockitousage/stacktrace/ClickableStackTracesWhenFrameworkMisusedTest.java
@@ -14,7 +14,7 @@ import org.mockito.exceptions.misusing.UnfinishedVerificationException;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/org/mockitousage/stacktrace/PointingStackTraceToActualInvocationChunkInOrderTest.java
+++ b/src/test/java/org/mockitousage/stacktrace/PointingStackTraceToActualInvocationChunkInOrderTest.java
@@ -15,7 +15,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/org/mockitousage/stacktrace/PointingStackTraceToActualInvocationInOrderTest.java
+++ b/src/test/java/org/mockitousage/stacktrace/PointingStackTraceToActualInvocationInOrderTest.java
@@ -15,7 +15,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/org/mockitousage/stacktrace/PointingStackTraceToActualInvocationTest.java
+++ b/src/test/java/org/mockitousage/stacktrace/PointingStackTraceToActualInvocationTest.java
@@ -14,7 +14,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/org/mockitousage/stacktrace/StackTraceFilteringTest.java
+++ b/src/test/java/org/mockitousage/stacktrace/StackTraceFilteringTest.java
@@ -18,7 +18,7 @@ import org.mockito.exceptions.verification.WantedButNotInvoked;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;

--- a/src/test/java/org/mockitousage/stubbing/BasicStubbingTest.java
+++ b/src/test/java/org/mockitousage/stubbing/BasicStubbingTest.java
@@ -13,8 +13,8 @@ import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/org/mockitousage/stubbing/CallingRealMethodTest.java
+++ b/src/test/java/org/mockitousage/stubbing/CallingRealMethodTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 public class CallingRealMethodTest extends TestBase {

--- a/src/test/java/org/mockitousage/stubbing/CloningParameterTest.java
+++ b/src/test/java/org/mockitousage/stubbing/CloningParameterTest.java
@@ -11,7 +11,7 @@ import org.mockitoutil.TestBase;
 
 import java.util.List;
 
-import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.*;
 
 public class CloningParameterTest extends TestBase {

--- a/src/test/java/org/mockitousage/stubbing/DeepStubbingTest.java
+++ b/src/test/java/org/mockitousage/stubbing/DeepStubbingTest.java
@@ -17,7 +17,7 @@ import java.net.Socket;
 import java.util.List;
 import java.util.Locale;
 
-import static junit.framework.TestCase.*;
+import static org.junit.Assert.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/org/mockitousage/stubbing/ReturningDefaultValuesTest.java
+++ b/src/test/java/org/mockitousage/stubbing/ReturningDefaultValuesTest.java
@@ -16,8 +16,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("unchecked")
 public class ReturningDefaultValuesTest extends TestBase {

--- a/src/test/java/org/mockitousage/stubbing/SmartNullsStubbingTest.java
+++ b/src/test/java/org/mockitousage/stubbing/SmartNullsStubbingTest.java
@@ -13,8 +13,8 @@ import org.mockito.exceptions.verification.WantedButNotInvoked;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/org/mockitousage/stubbing/StubbingConsecutiveAnswersTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingConsecutiveAnswersTest.java
@@ -11,7 +11,7 @@ import org.mockito.exceptions.base.MockitoException;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.*;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 public class StubbingConsecutiveAnswersTest extends TestBase {

--- a/src/test/java/org/mockitousage/stubbing/StubbingUsingDoReturnTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingUsingDoReturnTest.java
@@ -19,7 +19,7 @@ import org.mockitoutil.TestBase;
 
 import java.io.IOException;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/org/mockitousage/stubbing/StubbingWithCustomAnswerTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingWithCustomAnswerTest.java
@@ -14,7 +14,7 @@ import org.mockitoutil.TestBase;
 import java.lang.reflect.Method;
 import java.util.Set;
 
-import static junit.framework.TestCase.*;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 public class StubbingWithCustomAnswerTest extends TestBase {

--- a/src/test/java/org/mockitousage/stubbing/StubbingWithDelegateTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingWithDelegateTest.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.AdditionalAnswers.delegatesTo;

--- a/src/test/java/org/mockitousage/stubbing/StubbingWithExtraAnswersTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingWithExtraAnswersTest.java
@@ -15,8 +15,8 @@ import org.mockitoutil.TestBase;
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 
 public class StubbingWithExtraAnswersTest extends TestBase {

--- a/src/test/java/org/mockitousage/stubbing/StubbingWithThrowablesTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingWithThrowablesTest.java
@@ -5,10 +5,10 @@
 
 package org.mockitousage.stubbing;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
-import static junit.framework.TestCase.assertTrue;
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;

--- a/src/test/java/org/mockitousage/verification/AtLeastXVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/AtLeastXVerificationTest.java
@@ -12,7 +12,7 @@ import org.mockitoutil.TestBase;
 
 import java.util.List;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 public class AtLeastXVerificationTest extends TestBase {

--- a/src/test/java/org/mockitousage/verification/AtMostXVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/AtMostXVerificationTest.java
@@ -15,8 +15,8 @@ import org.mockitoutil.TestBase;
 
 import java.util.List;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/org/mockitousage/verification/BasicVerificationInOrderTest.java
+++ b/src/test/java/org/mockitousage/verification/BasicVerificationInOrderTest.java
@@ -16,7 +16,7 @@ import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 public class BasicVerificationInOrderTest extends TestBase {

--- a/src/test/java/org/mockitousage/verification/BasicVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/BasicVerificationTest.java
@@ -15,7 +15,7 @@ import org.mockitoutil.TestBase;
 
 import java.util.List;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 public class BasicVerificationTest extends TestBase {

--- a/src/test/java/org/mockitousage/verification/CustomVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/CustomVerificationTest.java
@@ -14,7 +14,7 @@ import org.mockito.verification.VerificationMode;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.verify;
 
 public class CustomVerificationTest extends TestBase {

--- a/src/test/java/org/mockitousage/verification/DescriptiveMessagesOnVerificationInOrderErrorsTest.java
+++ b/src/test/java/org/mockitousage/verification/DescriptiveMessagesOnVerificationInOrderErrorsTest.java
@@ -14,7 +14,7 @@ import org.mockito.exceptions.verification.WantedButNotInvoked;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenTimesXVerificationFailsTest.java
+++ b/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenTimesXVerificationFailsTest.java
@@ -14,7 +14,7 @@ import org.mockitoutil.TestBase;
 
 import java.util.LinkedList;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
 

--- a/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
+++ b/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
@@ -17,7 +17,7 @@ import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.AdditionalMatchers.aryEq;
 import static org.mockito.Mockito.*;

--- a/src/test/java/org/mockitousage/verification/ExactNumberOfTimesVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/ExactNumberOfTimesVerificationTest.java
@@ -13,7 +13,7 @@ import org.mockitoutil.TestBase;
 
 import java.util.LinkedList;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/org/mockitousage/verification/FindingRedundantInvocationsInOrderTest.java
+++ b/src/test/java/org/mockitousage/verification/FindingRedundantInvocationsInOrderTest.java
@@ -13,7 +13,7 @@ import org.mockito.exceptions.verification.VerificationInOrderFailure;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/org/mockitousage/verification/NoMoreInteractionsVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/NoMoreInteractionsVerificationTest.java
@@ -15,7 +15,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/org/mockitousage/verification/OnlyVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/OnlyVerificationTest.java
@@ -13,7 +13,7 @@ import org.mockitoutil.TestBase;
 
 import java.util.List;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/org/mockitousage/verification/OrdinaryVerificationPrintsAllInteractionsTest.java
+++ b/src/test/java/org/mockitousage/verification/OrdinaryVerificationPrintsAllInteractionsTest.java
@@ -11,7 +11,7 @@ import org.mockito.exceptions.verification.WantedButNotInvoked;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 

--- a/src/test/java/org/mockitousage/verification/PrintingVerboseTypesWithArgumentsTest.java
+++ b/src/test/java/org/mockitousage/verification/PrintingVerboseTypesWithArgumentsTest.java
@@ -11,7 +11,7 @@ import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Matchers.eq;

--- a/src/test/java/org/mockitousage/verification/RelaxedVerificationInOrderTest.java
+++ b/src/test/java/org/mockitousage/verification/RelaxedVerificationInOrderTest.java
@@ -15,7 +15,7 @@ import org.mockito.exceptions.verification.WantedButNotInvoked;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 /**

--- a/src/test/java/org/mockitousage/verification/SelectedMocksInOrderVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/SelectedMocksInOrderVerificationTest.java
@@ -13,7 +13,7 @@ import org.mockito.exceptions.verification.VerificationInOrderFailure;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 public class SelectedMocksInOrderVerificationTest extends TestBase {

--- a/src/test/java/org/mockitousage/verification/VerificationAfterDelayTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationAfterDelayTest.java
@@ -20,7 +20,7 @@ import org.mockitoutil.RetryRule;
 import org.mockitoutil.Stopwatch;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.rules.ExpectedException.none;
 import static org.mockito.Mockito.after;

--- a/src/test/java/org/mockitousage/verification/VerificationExcludingStubsTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationExcludingStubsTest.java
@@ -13,7 +13,7 @@ import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 @SuppressWarnings("unchecked")

--- a/src/test/java/org/mockitousage/verification/VerificationInOrderMixedWithOrdiraryVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationInOrderMixedWithOrdiraryVerificationTest.java
@@ -14,7 +14,7 @@ import org.mockito.exceptions.verification.VerificationInOrderFailure;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.*;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 public class VerificationInOrderMixedWithOrdiraryVerificationTest extends TestBase {

--- a/src/test/java/org/mockitousage/verification/VerificationInOrderTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationInOrderTest.java
@@ -13,7 +13,7 @@ import org.mockito.exceptions.verification.WantedButNotInvoked;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/org/mockitousage/verification/VerificationUsingMatchersTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationUsingMatchersTest.java
@@ -14,9 +14,9 @@ import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNotSame;
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.fail;
 import static org.mockito.AdditionalMatchers.*;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.times;

--- a/src/test/java/org/mockitoutil/SimpleSerializationUtil.java
+++ b/src/test/java/org/mockitoutil/SimpleSerializationUtil.java
@@ -6,7 +6,7 @@ package org.mockitoutil;
 
 import java.io.*;
 
-import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertNotNull;
 
 public abstract class SimpleSerializationUtil {
 

--- a/subprojects/extTest/src/test/java/org/mockitousage/plugins/stacktrace/PluginStackTraceFilteringTest.java
+++ b/subprojects/extTest/src/test/java/org/mockitousage/plugins/stacktrace/PluginStackTraceFilteringTest.java
@@ -13,7 +13,7 @@ import org.mockito.exceptions.verification.WantedButNotInvoked;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 


### PR DESCRIPTION
Fix JUnit imports throughout the project to use the standard `org.junit.Assert` assertions instead of the obsolete `junit.framework.TestCase` assertions which just delegate to `Assert`'s methods.