### PR TITLE
Fixes #1211: Improve @deprecated JavaDoc

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -2832,7 +2832,8 @@ public class Mockito extends ArgumentMatchers {
     }
 
     /**
-     * @deprecated - please use {@link MockingDetails#printInvocations()}.
+     * @deprecated - please use {@link MockingDetails#printInvocations()} instead.
+     * An instance of {@code MockingDetails} can be retrieved via {@link #mockingDetails(Object)}.
      */
     @Deprecated
     static MockitoDebugger debug() {

--- a/src/main/java/org/mockito/MockitoDebugger.java
+++ b/src/main/java/org/mockito/MockitoDebugger.java
@@ -5,13 +5,15 @@
 package org.mockito;
 
 /**
- * @deprecated - please use {@link MockingDetails#printInvocations()}.
+ * @deprecated - please use {@link MockingDetails#printInvocations()} instead.
+ * An instance of {@code MockingDetails} can be retrieved via {@link Mockito#mockingDetails(Object)}.
  */
 @Deprecated
 public interface MockitoDebugger {
 
     /**
-     * @deprecated - please use {@link MockingDetails#printInvocations()}.
+     * @deprecated - please use {@link MockingDetails#printInvocations()} instead.
+     * An instance of {@code MockingDetails} can be retrieved via {@link Mockito#mockingDetails(Object)}.
      */
     @Deprecated
     String printInvocations(Object ... mocks);


### PR DESCRIPTION
This pull request fixes #1211 by improving the `@deprecated` JavaDoc of `Mockito.debug()`, `MockitoDebugger` and `MockitoDebugger.printInvocations(Object ... mocks)` by adding the additional information on how to retrieve an actual instance of the `MockitoDebugger` interface.

