### PR TITLE
Adresses #1206: allow opting out from annotation copying within mocks.

### DIFF
--- a/src/main/java/org/mockito/MockSettings.java
+++ b/src/main/java/org/mockito/MockSettings.java
@@ -292,6 +292,17 @@ public interface MockSettings extends Serializable {
     MockSettings outerInstance(Object outerClassInstance);
 
     /**
+     * By default, Mockito makes an attempt to preserve all annotation meta data on the mocked
+     * type and its methods to mirror the mocked type as closely as possible. If this is not
+     * desired, this option can be used to disable this behavior.
+     *
+     * @return settings instance so that you can fluently specify other settings
+     * @since 1.10.13
+     */
+    @Incubating
+    MockSettings withoutAnnotations();
+
+    /**
      * Creates immutable view of mock settings used later by Mockito.
      * Framework integrators can use this method to create instances of creation settings
      * and use them in advanced use cases, for example to create invocations with {@link InvocationFactory},

--- a/src/main/java/org/mockito/internal/creation/MockSettingsImpl.java
+++ b/src/main/java/org/mockito/internal/creation/MockSettingsImpl.java
@@ -40,15 +40,18 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
     private Object outerClassInstance;
     private Object[] constructorArgs;
 
+    @Override
     public MockSettings serializable() {
         return serializable(SerializableMode.BASIC);
     }
 
+    @Override
     public MockSettings serializable(SerializableMode mode) {
         this.serializableMode = mode;
         return this;
     }
 
+    @Override
     public MockSettings extraInterfaces(Class<?>... extraInterfaces) {
         if (extraInterfaces == null || extraInterfaces.length == 0) {
             throw extraInterfacesRequiresAtLeastOneInterface();
@@ -65,28 +68,34 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
         return this;
     }
 
+    @Override
     public MockName getMockName() {
         return mockName;
     }
 
+    @Override
     public Set<Class<?>> getExtraInterfaces() {
         return extraInterfaces;
     }
 
+    @Override
     public Object getSpiedInstance() {
         return spiedInstance;
     }
 
+    @Override
     public MockSettings name(String name) {
         this.name = name;
         return this;
     }
 
+    @Override
     public MockSettings spiedInstance(Object spiedInstance) {
         this.spiedInstance = spiedInstance;
         return this;
     }
 
+    @Override
     public MockSettings defaultAnswer(Answer defaultAnswer) {
         this.defaultAnswer = defaultAnswer;
         if (defaultAnswer == null) {
@@ -95,15 +104,18 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
         return this;
     }
 
+    @Override
     public Answer<Object> getDefaultAnswer() {
         return defaultAnswer;
     }
 
+    @Override
     public MockSettingsImpl<T> stubOnly() {
         this.stubOnly = true;
         return this;
     }
 
+    @Override
     public MockSettings useConstructor(Object... constructorArgs) {
         Checks.checkNotNull(constructorArgs,
             "constructorArgs",
@@ -113,19 +125,29 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
         return this;
     }
 
+    @Override
     public MockSettings outerInstance(Object outerClassInstance) {
         this.outerClassInstance = outerClassInstance;
         return this;
     }
 
+    @Override
+    public MockSettings withoutAnnotations() {
+        stripAnnotations = true;
+        return this;
+    }
+
+    @Override
     public boolean isUsingConstructor() {
         return useConstructor;
     }
 
+    @Override
     public Object getOuterClassInstance() {
         return outerClassInstance;
     }
 
+    @Override
     public Object[] getConstructorArgs() {
         if (outerClassInstance == null) {
             return constructorArgs;
@@ -136,10 +158,12 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
         return resultArgs.toArray(new Object[constructorArgs.length + 1]);
     }
 
+    @Override
     public boolean isStubOnly() {
         return this.stubOnly;
     }
 
+    @Override
     public MockSettings verboseLogging() {
         if (!invocationListenersContainsType(VerboseMockInvocationLogger.class)) {
             invocationListeners(new VerboseMockInvocationLogger());
@@ -147,6 +171,7 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
         return this;
     }
 
+    @Override
     public MockSettings invocationListeners(InvocationListener... listeners) {
         if (listeners == null || listeners.length == 0) {
             throw invocationListenersRequiresAtLeastOneListener();
@@ -167,6 +192,7 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
         }
     }
 
+    @Override
     public MockSettings verificationStartedListeners(VerificationStartedListener... listeners) {
         addListeners(listeners, this.verificationStartedListeners, "verificationStartedListeners");
         return this;
@@ -181,6 +207,7 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
         return false;
     }
 
+    @Override
     public List<InvocationListener> getInvocationListeners() {
         return this.invocationListeners;
     }
@@ -189,6 +216,7 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
         return !invocationListeners.isEmpty();
     }
 
+    @Override
     public Class<T> getTypeToMock() {
         return typeToMock;
     }

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
@@ -200,7 +200,8 @@ public class InlineByteBuddyMockMaker implements ClassCreatingMockMaker {
             return bytecodeGenerator.mockClass(MockFeatures.withMockFeatures(
                     settings.getTypeToMock(),
                     settings.getExtraInterfaces(),
-                    settings.getSerializableMode()
+                    settings.getSerializableMode(),
+                    settings.isStripAnnotations()
             ));
         } catch (Exception bytecodeGenerationFailed) {
             throw prettifyFailure(settings, bytecodeGenerationFailed);

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/MockFeatures.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/MockFeatures.java
@@ -10,17 +10,23 @@ import java.util.Collections;
 import java.util.Set;
 
 class MockFeatures<T> {
+
     final Class<T> mockedType;
     final Set<Class<?>> interfaces;
     final SerializableMode serializableMode;
+    final boolean stripAnnotations;
 
-    private MockFeatures(Class<T> mockedType, Set<Class<?>> interfaces, SerializableMode serializableMode) {
+    private MockFeatures(Class<T> mockedType, Set<Class<?>> interfaces, SerializableMode serializableMode, boolean stripAnnotations) {
         this.mockedType = mockedType;
         this.interfaces = Collections.unmodifiableSet(interfaces);
         this.serializableMode = serializableMode;
+        this.stripAnnotations = stripAnnotations;
     }
 
-    public static <T> MockFeatures<T> withMockFeatures(Class<T> mockedType, Set<Class<?>> interfaces, SerializableMode serializableMode) {
-        return new MockFeatures<T>(mockedType, interfaces, serializableMode);
+    public static <T> MockFeatures<T> withMockFeatures(Class<T> mockedType,
+                                                       Set<Class<?>> interfaces,
+                                                       SerializableMode serializableMode,
+                                                       boolean stripAnnotations) {
+        return new MockFeatures<T>(mockedType, interfaces, serializableMode, stripAnnotations);
     }
 }

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassByteBuddyMockMaker.java
@@ -71,7 +71,8 @@ public class SubclassByteBuddyMockMaker implements ClassCreatingMockMaker {
             return cachingMockBytecodeGenerator.mockClass(MockFeatures.withMockFeatures(
                     settings.getTypeToMock(),
                     settings.getExtraInterfaces(),
-                    settings.getSerializableMode()
+                    settings.getSerializableMode(),
+                    settings.isStripAnnotations()
             ));
         } catch (Exception bytecodeGenerationFailed) {
             throw prettifyFailure(settings, bytecodeGenerationFailed);

--- a/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
+++ b/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
@@ -33,6 +33,7 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
     protected final List<StubbingLookupListener> stubbingLookupListeners = new ArrayList<StubbingLookupListener>();
     protected List<VerificationStartedListener> verificationStartedListeners = new LinkedList<VerificationStartedListener>();
     protected boolean stubOnly;
+    protected boolean stripAnnotations;
     private boolean useConstructor;
     private Object outerClassInstance;
     private Object[] constructorArgs;
@@ -56,6 +57,7 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
         this.constructorArgs = copy.getConstructorArgs();
     }
 
+    @Override
     public Class<T> getTypeToMock() {
         return typeToMock;
     }
@@ -65,6 +67,7 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
         return this;
     }
 
+    @Override
     public Set<Class<?>> getExtraInterfaces() {
         return extraInterfaces;
     }
@@ -78,14 +81,17 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
         return name;
     }
 
+    @Override
     public Object getSpiedInstance() {
         return spiedInstance;
     }
 
+    @Override
     public Answer<Object> getDefaultAnswer() {
         return defaultAnswer;
     }
 
+    @Override
     public MockName getMockName() {
         return mockName;
     }
@@ -104,14 +110,17 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
         return this;
     }
 
+    @Override
     public SerializableMode getSerializableMode() {
         return serializableMode;
     }
 
+    @Override
     public List<InvocationListener> getInvocationListeners() {
         return invocationListeners;
     }
 
+    @Override
     public List<VerificationStartedListener> getVerificationStartedListeners() {
         return verificationStartedListeners;
     }
@@ -120,8 +129,14 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
         return stubbingLookupListeners;
     }
 
+    @Override
     public boolean isUsingConstructor() {
         return useConstructor;
+    }
+
+    @Override
+    public boolean isStripAnnotations() {
+        return stripAnnotations;
     }
 
     @Override
@@ -129,12 +144,13 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
         return constructorArgs;
     }
 
+    @Override
     public Object getOuterClassInstance() {
         return outerClassInstance;
     }
 
+    @Override
     public boolean isStubOnly() {
         return stubOnly;
     }
-
 }

--- a/src/main/java/org/mockito/mock/MockCreationSettings.java
+++ b/src/main/java/org/mockito/mock/MockCreationSettings.java
@@ -63,6 +63,11 @@ public interface MockCreationSettings<T> {
     boolean isStubOnly();
 
     /**
+     * Whether the mock should not make a best effort to preserve annotations.
+     */
+    boolean isStripAnnotations();
+
+    /**
      * {@link InvocationListener} instances attached to this mock, see {@link org.mockito.MockSettings#invocationListeners}.
      */
     List<InvocationListener> getInvocationListeners();

--- a/src/test/java/org/mockito/internal/creation/bytebuddy/AbstractByteBuddyMockMakerTest.java
+++ b/src/test/java/org/mockito/internal/creation/bytebuddy/AbstractByteBuddyMockMakerTest.java
@@ -40,7 +40,7 @@ public abstract class AbstractByteBuddyMockMakerTest<MM extends MockMaker> {
 
     @Test
     public void should_create_mock_from_interface() throws Exception {
-        SomeInterface proxy = mockMaker.createMock(settingsFor(SomeInterface.class), dummyH());
+        SomeInterface proxy = mockMaker.createMock(settingsFor(SomeInterface.class), dummyHandler());
 
         Class<?> superClass = proxy.getClass().getSuperclass();
         assertThat(superClass).isEqualTo(Object.class);
@@ -49,7 +49,7 @@ public abstract class AbstractByteBuddyMockMakerTest<MM extends MockMaker> {
 
     @Test
     public void should_create_mock_from_class() throws Exception {
-        ClassWithoutConstructor proxy = mockMaker.createMock(settingsFor(ClassWithoutConstructor.class), dummyH());
+        ClassWithoutConstructor proxy = mockMaker.createMock(settingsFor(ClassWithoutConstructor.class), dummyHandler());
 
         Class<?> superClass = mockTypeOf(proxy.getClass());
         assertThat(superClass).isEqualTo(ClassWithoutConstructor.class);
@@ -62,14 +62,14 @@ public abstract class AbstractByteBuddyMockMakerTest<MM extends MockMaker> {
             fail();
         } catch (Exception expected) {}
 
-        ClassWithDodgyConstructor mock = mockMaker.createMock(settingsFor(ClassWithDodgyConstructor.class), dummyH());
+        ClassWithDodgyConstructor mock = mockMaker.createMock(settingsFor(ClassWithDodgyConstructor.class), dummyHandler());
         assertThat(mock).isNotNull();
     }
 
     @Test
     public void should_mocks_have_different_interceptors() throws Exception {
-        SomeClass mockOne = mockMaker.createMock(settingsFor(SomeClass.class), dummyH());
-        SomeClass mockTwo = mockMaker.createMock(settingsFor(SomeClass.class), dummyH());
+        SomeClass mockOne = mockMaker.createMock(settingsFor(SomeClass.class), dummyHandler());
+        SomeClass mockTwo = mockMaker.createMock(settingsFor(SomeClass.class), dummyHandler());
 
         MockHandler handlerOne = mockMaker.getHandler(mockOne);
         MockHandler handlerTwo = mockMaker.getHandler(mockTwo);
@@ -80,20 +80,20 @@ public abstract class AbstractByteBuddyMockMakerTest<MM extends MockMaker> {
 
     @Test
     public void should_use_ancillary_Types() {
-        SomeClass mock = mockMaker.createMock(settingsFor(SomeClass.class, SomeInterface.class), dummyH());
+        SomeClass mock = mockMaker.createMock(settingsFor(SomeClass.class, SomeInterface.class), dummyHandler());
 
         assertThat(mock).isInstanceOf(SomeInterface.class);
     }
 
     @Test
     public void should_create_class_by_constructor() {
-        OtherClass mock = mockMaker.createMock(settingsWithConstructorFor(OtherClass.class), dummyH());
+        OtherClass mock = mockMaker.createMock(settingsWithConstructorFor(OtherClass.class), dummyHandler());
         assertThat(mock).isNotNull();
     }
 
     @Test
     public void should_allow_serialization() throws Exception {
-        SerializableClass proxy = mockMaker.createMock(serializableSettingsFor(SerializableClass.class, SerializableMode.BASIC), dummyH());
+        SerializableClass proxy = mockMaker.createMock(serializableSettingsFor(SerializableClass.class, SerializableMode.BASIC), dummyHandler());
 
         SerializableClass serialized = SimpleSerializationUtil.serializeAndBack(proxy);
         assertThat(serialized).isNotNull();
@@ -181,7 +181,7 @@ public abstract class AbstractByteBuddyMockMakerTest<MM extends MockMaker> {
         return mockSettings;
     }
 
-    private static MockHandler dummyH() {
+    protected static MockHandler dummyHandler() {
         return new DummyMockHandler();
     }
 

--- a/src/test/java/org/mockito/internal/creation/bytebuddy/TypeCachingMockBytecodeGeneratorTest.java
+++ b/src/test/java/org/mockito/internal/creation/bytebuddy/TypeCachingMockBytecodeGeneratorTest.java
@@ -40,7 +40,8 @@ public class TypeCachingMockBytecodeGeneratorTest {
         Class<?> the_mock_type = cachingMockBytecodeGenerator.mockClass(withMockFeatures(
                 classloader_with_life_shorter_than_cache.loadClass("foo.Bar"),
                 Collections.<Class<?>>emptySet(),
-                SerializableMode.NONE
+                SerializableMode.NONE,
+                false
         ));
 
         ReferenceQueue<Object> referenceQueue = new ReferenceQueue<Object>();
@@ -68,13 +69,15 @@ public class TypeCachingMockBytecodeGeneratorTest {
         Class<?> the_mock_type = cachingMockBytecodeGenerator.mockClass(withMockFeatures(
                         classloader_with_life_shorter_than_cache.loadClass("foo.Bar"),
                         Collections.<Class<?>>emptySet(),
-                        SerializableMode.NONE
+                        SerializableMode.NONE,
+                        false
                 ));
 
         Class<?> other_mock_type = cachingMockBytecodeGenerator.mockClass(withMockFeatures(
                 classloader_with_life_shorter_than_cache.loadClass("foo.Bar"),
                 Collections.<Class<?>>emptySet(),
-                SerializableMode.NONE
+                SerializableMode.NONE,
+                false
         ));
 
         assertThat(other_mock_type).isSameAs(the_mock_type);
@@ -105,13 +108,15 @@ public class TypeCachingMockBytecodeGeneratorTest {
         Class<?> the_mock_type = cachingMockBytecodeGenerator.mockClass(withMockFeatures(
                 classloader_with_life_shorter_than_cache.loadClass("foo.Bar"),
                 Collections.<Class<?>>emptySet(),
-                SerializableMode.NONE
+                SerializableMode.NONE,
+                false
         ));
 
         Class<?> other_mock_type = cachingMockBytecodeGenerator.mockClass(withMockFeatures(
                 classloader_with_life_shorter_than_cache.loadClass("foo.Bar"),
                 Collections.<Class<?>>emptySet(),
-                SerializableMode.BASIC
+                SerializableMode.BASIC,
+                false
         ));
 
         assertThat(other_mock_type).isNotSameAs(the_mock_type);


### PR DESCRIPTION
The `MockSettings` now include an option to disable copying of annotations to mock classes.