### PR TITLE
Fixes #1183: Make override check more forgiving to accomondate Kotlin compile patterns.

### DIFF
--- a/subprojects/kotlinTest/src/test/kotlin/org/mockito/kotlin/FunctionTest.kt
+++ b/subprojects/kotlinTest/src/test/kotlin/org/mockito/kotlin/FunctionTest.kt
@@ -1,0 +1,24 @@
+package org.mockito.kotlin
+
+import org.junit.Test
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+
+class FunctionTest {
+
+    @Test
+    fun test() {
+        val value = spy({})
+        value.invoke()
+
+        verify(value).invoke()
+    }
+
+    @Test
+    fun testAgain() {
+        val value = spy({})
+        value.invoke()
+
+        verify(value).invoke()
+    }
+}


### PR DESCRIPTION
The override check implies Java compile patterns such that Kotlin method resolutions could fail for void return types which do not fit into Java's reference-type only generic hierarchies. This PR eases this restriction to fix this resolution for Kotlin.

I added the test case of the reported issue as a reference.