### PR TITLE
Updated Byte Buddy and ASM dependencies. Fixes #1215.

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -4,7 +4,7 @@ ext {
 
 def versions = [:]
 
-versions.bytebuddy = '1.7.4'
+versions.bytebuddy = '1.7.7'
 
 libraries.junit4 = 'junit:junit:4.12'
 libraries.assertj = 'org.assertj:assertj-core:2.8.0'
@@ -17,4 +17,4 @@ libraries.bytebuddyandroid = "net.bytebuddy:byte-buddy-android:${versions.bytebu
 
 libraries.objenesis = 'org.objenesis:objenesis:2.6'
 
-libraries.asm = 'org.ow2.asm:asm:5.2'
+libraries.asm = 'org.ow2.asm:asm:6.0'


### PR DESCRIPTION
Updates Byte Buddy which at one point relied on a hash value to never collide which is rare but possible.