### PR TITLE
Fix issue #1222 and #584

### DIFF
--- a/src/main/java/org/mockito/ArgumentMatchers.java
+++ b/src/main/java/org/mockito/ArgumentMatchers.java
@@ -6,12 +6,14 @@ package org.mockito;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EmptyStackException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
+import org.mockito.exceptions.misusing.InvalidUseOfMatchersException;
 import org.mockito.internal.matchers.Any;
 import org.mockito.internal.matchers.Contains;
 import org.mockito.internal.matchers.EndsWith;
@@ -22,6 +24,7 @@ import org.mockito.internal.matchers.NotNull;
 import org.mockito.internal.matchers.Null;
 import org.mockito.internal.matchers.Same;
 import org.mockito.internal.matchers.StartsWith;
+import org.mockito.internal.matchers.TreatVarargsAsArray;
 import org.mockito.internal.matchers.apachecommons.ReflectionEquals;
 import org.mockito.internal.util.Primitives;
 
@@ -1315,6 +1318,24 @@ public class ArgumentMatchers {
     public static double doubleThat(ArgumentMatcher<Double> matcher) {
         reportMatcher(matcher);
         return 0;
+    }
+
+    /**
+     * Indicates that the varargs should be matched as an array rather than individual values.
+     *
+     * The value must be specified as a call to a method for matching an argument, e.g.
+     * {@link #eq(Object)} or {@link ArgumentCaptor#capture()}. Failure to do so will result in
+     * either an {@link EmptyStackException} or an {@link InvalidUseOfMatchersException}.
+     *
+     * @param value expected to be a matcher such as {@code eq(...) or
+     * {@code captor.capture()}
+     * @param <T> the type of the vararg or array of varargs
+     * @return {@code null}
+     */
+    public static <T> T varargsAsArray(T value) {
+        ArgumentMatcher nestedMatcher = mockingProgress().getArgumentMatcherStorage().popMatcher();
+        reportMatcher(new TreatVarargsAsArray<Object>(nestedMatcher));
+        return null;
     }
 
     private static void reportMatcher(ArgumentMatcher<?> matcher) {

--- a/src/main/java/org/mockito/internal/matchers/TreatVarargsAsArray.java
+++ b/src/main/java/org/mockito/internal/matchers/TreatVarargsAsArray.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.matchers;
+
+import org.mockito.ArgumentMatcher;
+import org.mockito.internal.matchers.text.MatcherToString;
+import java.io.Serializable;
+
+/**
+ * Wraps an {@link ArgumentMatcher} and indicates that it should be passed the varargs as a single
+ * array rather than individual values.
+ */
+public class TreatVarargsAsArray<T>
+    implements ArgumentMatcher<T>, ContainsExtraTypeInfo, CapturesArguments, Serializable {
+
+    private final ArgumentMatcher<? super T> delegate;
+
+    public TreatVarargsAsArray(ArgumentMatcher<? super T> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public boolean matches(T argument) {
+        return delegate.matches(argument);
+    }
+
+    @Override
+    public void captureFrom(Object argument) {
+        if (delegate instanceof CapturesArguments) {
+            ((CapturesArguments) delegate).captureFrom(argument);
+        }
+    }
+
+    @Override
+    public String toStringWithType() {
+        if (delegate instanceof ContainsExtraTypeInfo) {
+            String delagateAsString = ((ContainsExtraTypeInfo) delegate).toStringWithType();
+            return wrapString(delagateAsString);
+        }
+        return toString();
+    }
+
+    @Override
+    public String toString() {
+        String delegateAsString = MatcherToString.toString(delegate);
+        return wrapString(delegateAsString);
+    }
+
+    private String wrapString(String delegateAsString) {
+        return "varargsAsArray(" + delegateAsString + ")";
+    }
+
+    @Override
+    public boolean typeMatches(Object target) {
+        if (delegate instanceof ContainsExtraTypeInfo) {
+            return ((ContainsExtraTypeInfo) delegate).typeMatches(target);
+        }
+        return true;
+    }
+}

--- a/src/main/java/org/mockito/internal/matchers/text/MatcherToString.java
+++ b/src/main/java/org/mockito/internal/matchers/text/MatcherToString.java
@@ -13,7 +13,7 @@ import org.mockito.ArgumentMatcher;
 /**
  * Provides better toString() text for matcher that don't have toString() method declared.
  */
-class MatcherToString {
+public class MatcherToString {
 
     /**
      * Attempts to provide more descriptive toString() for given matcher.
@@ -25,7 +25,7 @@ class MatcherToString {
      * @param matcher
      * @return
      */
-    static String toString(ArgumentMatcher<?> matcher) {
+    public static String toString(ArgumentMatcher<?> matcher) {
         Class<?> cls = matcher.getClass();
         while(cls != Object.class) {
             Method[] methods = cls.getDeclaredMethods();

--- a/src/main/java/org/mockito/internal/progress/ArgumentMatcherStorage.java
+++ b/src/main/java/org/mockito/internal/progress/ArgumentMatcherStorage.java
@@ -26,4 +26,5 @@ public interface ArgumentMatcherStorage {
 
     void reset();
 
+    ArgumentMatcher<?> popMatcher();
 }

--- a/src/main/java/org/mockito/internal/progress/ArgumentMatcherStorageImpl.java
+++ b/src/main/java/org/mockito/internal/progress/ArgumentMatcherStorageImpl.java
@@ -84,7 +84,8 @@ public class ArgumentMatcherStorageImpl implements ArgumentMatcherStorage {
         }
     }
 
-    private ArgumentMatcher<?> popMatcher() {
+    @Override
+    public ArgumentMatcher<?> popMatcher() {
         return matcherStack.pop().getMatcher();
     }
 

--- a/src/test/java/org/mockito/internal/matchers/TreatVarargsAsArrayTest.java
+++ b/src/test/java/org/mockito/internal/matchers/TreatVarargsAsArrayTest.java
@@ -1,0 +1,64 @@
+package org.mockito.internal.matchers;
+
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class TreatVarargsAsArrayTest {
+
+    @Test
+    public void delegateDoesNotImplementCapturesArgument_captureFrom() {
+        TreatVarargsAsArray<String[]> matcher = new TreatVarargsAsArray<String[]>(
+            new Equals(new String[] {"1"}));
+
+        // Should not do anything.
+        matcher.captureFrom("2");
+    }
+
+    @Test
+    public void delegateDoesImplementCapturesArgument_captureFrom() {
+        CapturingMatcher<String[]> capturingMatcher = new CapturingMatcher<String[]>();
+        TreatVarargsAsArray<String[]> matcher =
+            new TreatVarargsAsArray<String[]>(capturingMatcher);
+
+        // Should not do anything.
+        matcher.captureFrom(new String[] {"2"});
+
+        assertArrayEquals(new String[] {"2"}, capturingMatcher.getLastValue());
+    }
+
+    @Test
+    public void delegateDoesNotImplementContainsExtraTypeInfo_toStringWithType() {
+        TreatVarargsAsArray<String[]> matcher = new TreatVarargsAsArray<String[]>(NotNull.NOT_NULL);
+
+        assertEquals("varargsAsArray(notNull())", matcher.toStringWithType());
+    }
+
+    @Test
+    public void delegateDoesImplementContainsExtraTypeInfo_toStringWithType() {
+        TreatVarargsAsArray<String[]> matcher = new TreatVarargsAsArray<String[]>(
+            new Equals(new String[] {"1"}));
+
+        assertEquals("varargsAsArray((String[]) [\"1\"])", matcher.toStringWithType());
+    }
+
+    @Test
+    public void delegateDoesNotImplementContainsExtraTypeInfo_typeMatches() {
+        TreatVarargsAsArray<String[]> matcher = new TreatVarargsAsArray<String[]>(NotNull.NOT_NULL);
+
+        assertTrue(matcher.typeMatches(new String[] {}));
+        assertTrue(matcher.typeMatches(1));
+    }
+
+    @Test
+    public void delegateDoesImplementContainsExtraTypeInfo_typeMatches() {
+        TreatVarargsAsArray<String[]> matcher = new TreatVarargsAsArray<String[]>(
+            new Equals(new String[] {"1"}));
+
+        assertTrue("String[]", matcher.typeMatches(new String[] {}));
+        assertFalse("int", matcher.typeMatches(1));
+    }
+}

--- a/src/test/java/org/mockitousage/matchers/VarargsTest.java
+++ b/src/test/java/org/mockitousage/matchers/VarargsTest.java
@@ -9,6 +9,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNotNull;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.varargsAsArray;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -303,24 +305,49 @@ public class VarargsTest {
 
     }
 
-    /**
-     * As of v2.0.0-beta.118 this test fails. Once the github issues:
-     * <ul>
-     * <li>'#584 ArgumentCaptor can't capture varargs-arrays
-     * <li>#565 ArgumentCaptor should be type aware' are fixed this test must
-     * succeed
-     * </ul>
-     */
     @Test
-    @Ignore("Blocked by github issue: #584 & #565")
-    public void shouldCaptureVarArgsAsArray() {
-        mock.varargs("1", "2");
+    public void shouldCaptureVarArgsAsArray_noVarargs() {
+        mock.varargs("1");
 
         ArgumentCaptor<String[]> varargCaptor = ArgumentCaptor.forClass(String[].class);
 
-        verify(mock).varargs(varargCaptor.capture());
+        verify(mock).varargs(varargsAsArray(varargCaptor.capture()));
+
+        assertThat(varargCaptor).containsExactly(new String[] { "1" });
+    }
+
+    @Test
+    public void shouldCaptureVarArgsAsArray_oneVararg() {
+        mock.varargs("1");
+        mock.varargs("2");
+
+        ArgumentCaptor<String[]> varargCaptor = ArgumentCaptor.forClass(String[].class);
+
+        verify(mock, times(2)).varargs(varargsAsArray(varargCaptor.capture()));
+
+        assertThat(varargCaptor).containsExactly(new String[] { "1" }, new String[] { "2" });
+    }
+
+    @Test
+    public void shouldCaptureVarArgsAsArray_twoVarargs() {
+        mock.mixedVarargs(getClass(), "1", "2");
+
+        ArgumentCaptor<String[]> varargCaptor = ArgumentCaptor.forClass(String[].class);
+
+        verify(mock).mixedVarargs(any(), varargsAsArray(varargCaptor.capture()));
 
         assertThat(varargCaptor).containsExactly(new String[] { "1", "2" });
+    }
+
+    @Test
+    public void shouldCaptureVarArgsAsByteArray_twoVarargs() {
+        mock.varargsbyte((byte) 1, (byte) 2);
+
+        ArgumentCaptor<byte[]> varargCaptor = ArgumentCaptor.forClass(byte[].class);
+
+        verify(mock).varargsbyte(varargsAsArray(varargCaptor.capture()));
+
+        assertThat(varargCaptor).containsExactly(new byte[] { (byte) 1, (byte) 2 });
     }
 
     @Test

--- a/src/test/java/org/mockitousage/verification/BasicVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/BasicVerificationTest.java
@@ -115,4 +115,49 @@ public class BasicVerificationTest extends TestBase {
             fail();
         } catch(WantedButNotInvoked e) {}
     }
+
+    @Test
+    public void shouldVerifyVarargsAsArray_nullVarargsArray() throws Exception {
+        IMethods mock = mock(IMethods.class);
+
+        mock.mixedVarargs(null, (String[]) null);
+
+        verify(mock).mixedVarargs(any(), varargsAsArray(eq((String[]) null)));
+    }
+
+    @Test
+    public void shouldVerifyVarargsAsArray_nullVararg() throws Exception {
+        IMethods mock = mock(IMethods.class);
+
+        mock.mixedVarargs(null, (String) null);
+
+        verify(mock).mixedVarargs(any(), varargsAsArray(eq(new String[] {null})));
+    }
+
+    @Test
+    public void shouldVerifyVarargsAsArray_noVarargs() throws Exception {
+        IMethods mock = mock(IMethods.class);
+
+        mock.mixedVarargs("1");
+
+        verify(mock).mixedVarargs(any(), varargsAsArray(eq(new String[] {})));
+    }
+
+    @Test
+    public void shouldVerifyVarargsAsArray_singleVararg() throws Exception {
+        IMethods mock = mock(IMethods.class);
+
+        mock.mixedVarargs("1", "2");
+
+        verify(mock).mixedVarargs(any(), varargsAsArray(eq(new String[] {"2"})));
+    }
+
+    @Test
+    public void shouldVerifyVarargsAsArray_twoVarargs() throws Exception {
+        IMethods mock = mock(IMethods.class);
+
+        mock.mixedVarargs("1", "2", "3");
+
+        verify(mock).mixedVarargs(any(), varargsAsArray(eq(new String[] {"2", "3"})));
+    }
 }


### PR DESCRIPTION
Adds a new method varargsAsArray(...) that indicates that the varargs
should be matched/captured as a single array rather than separate
values.

Fixes #1222 
Fixes #584