### PR TITLE
Change default strictness in deprecated runners/MockitoJUnitRunner to Silent

### DIFF
--- a/src/main/java/org/mockito/junit/MockitoJUnitRunner.java
+++ b/src/main/java/org/mockito/junit/MockitoJUnitRunner.java
@@ -152,7 +152,7 @@ public class MockitoJUnitRunner extends Runner implements Filterable {
         this(new StrictRunner(new RunnerFactory().createStrict(klass), klass));
     }
 
-    MockitoJUnitRunner(InternalRunner runner) throws InvocationTargetException {
+    protected MockitoJUnitRunner(InternalRunner runner) throws InvocationTargetException {
         this.runner = runner;
     }
 

--- a/src/main/java/org/mockito/runners/MockitoJUnitRunner.java
+++ b/src/main/java/org/mockito/runners/MockitoJUnitRunner.java
@@ -9,6 +9,8 @@ import org.junit.runner.Description;
 import org.junit.runner.manipulation.Filter;
 import org.junit.runner.manipulation.NoTestsRemainException;
 import org.junit.runner.notification.RunNotifier;
+import org.mockito.internal.runners.InternalRunner;
+import org.mockito.internal.runners.RunnerFactory;
 
 
 /**
@@ -27,7 +29,7 @@ public class MockitoJUnitRunner extends org.mockito.junit.MockitoJUnitRunner {
     @Deprecated
     public static class Silent extends MockitoJUnitRunner {
         public Silent(Class<?> klass) throws InvocationTargetException {
-            super(klass);
+            super(new RunnerFactory().create(klass));
         }
     }
 
@@ -45,6 +47,10 @@ public class MockitoJUnitRunner extends org.mockito.junit.MockitoJUnitRunner {
 
     public MockitoJUnitRunner(Class<?> klass) throws InvocationTargetException {
         super(klass);
+    }
+
+    MockitoJUnitRunner(InternalRunner runner) throws InvocationTargetException {
+        super(runner);
     }
 
     @Deprecated


### PR DESCRIPTION
This seemed to be an oversight incorrectly generating strict warnings for users migrating to Mockito 2. Locally I saw no test failures, so let's see what Travis says.

Fixes #1212 
