### PR TITLE
Update license plugin and add missing license headers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.11.0' // later versions don't work on JDK6
+        classpath 'gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.14.0'
         classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.3.0' //for 'java6-compatibility.gradle'
 
         //Using buildscript.classpath so that we can resolve shipkit from maven local, during local testing

--- a/src/main/java/org/mockito/NotExtensible.java
+++ b/src/main/java/org/mockito/NotExtensible.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito;
 
 import java.lang.annotation.Documented;

--- a/src/main/java/org/mockito/internal/configuration/plugins/DefaultMockitoPlugins.java
+++ b/src/main/java/org/mockito/internal/configuration/plugins/DefaultMockitoPlugins.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.configuration.plugins;
 
 import org.mockito.plugins.AnnotationEngine;

--- a/src/main/java/org/mockito/internal/creation/SuspendMethod.java
+++ b/src/main/java/org/mockito/internal/creation/SuspendMethod.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.creation;
 
 import java.util.Arrays;

--- a/src/main/java/org/mockito/internal/invocation/DefaultInvocationFactory.java
+++ b/src/main/java/org/mockito/internal/invocation/DefaultInvocationFactory.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.invocation;
 
 import org.mockito.internal.creation.bytebuddy.MockMethodInterceptor;

--- a/src/main/java/org/mockito/internal/invocation/RealMethod.java
+++ b/src/main/java/org/mockito/internal/invocation/RealMethod.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.invocation;
 
 import org.mockito.internal.exceptions.stacktrace.ConditionalStackTraceFilter;

--- a/src/main/java/org/mockito/internal/listeners/VerificationStartedNotifier.java
+++ b/src/main/java/org/mockito/internal/listeners/VerificationStartedNotifier.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.listeners;
 
 import org.mockito.MockingDetails;

--- a/src/main/java/org/mockito/invocation/InvocationFactory.java
+++ b/src/main/java/org/mockito/invocation/InvocationFactory.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.invocation;
 
 import org.mockito.Incubating;

--- a/src/main/java/org/mockito/listeners/VerificationStartedEvent.java
+++ b/src/main/java/org/mockito/listeners/VerificationStartedEvent.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.listeners;
 
 import org.mockito.Incubating;

--- a/src/main/java/org/mockito/listeners/VerificationStartedListener.java
+++ b/src/main/java/org/mockito/listeners/VerificationStartedListener.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.listeners;
 
 import org.mockito.Incubating;

--- a/src/main/java/org/mockito/plugins/MockitoPlugins.java
+++ b/src/main/java/org/mockito/plugins/MockitoPlugins.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.plugins;
 
 import org.mockito.Mockito;

--- a/src/test/java/org/mockito/StaticMockingExperimentTest.java
+++ b/src/test/java/org/mockito/StaticMockingExperimentTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito;
 
 import org.junit.Before;

--- a/src/test/java/org/mockito/internal/configuration/plugins/DefaultMockitoPluginsTest.java
+++ b/src/test/java/org/mockito/internal/configuration/plugins/DefaultMockitoPluginsTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.configuration.plugins;
 
 import org.junit.Test;

--- a/src/test/java/org/mockito/internal/listeners/VerificationStartedNotifierTest.java
+++ b/src/test/java/org/mockito/internal/listeners/VerificationStartedNotifierTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.listeners;
 
 import org.junit.Test;

--- a/src/test/java/org/mockito/internal/util/MockSettingsTest.java
+++ b/src/test/java/org/mockito/internal/util/MockSettingsTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.util;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/bugs/EnabledMockingInterfaceCloneMethodTest.java
+++ b/src/test/java/org/mockitousage/bugs/EnabledMockingInterfaceCloneMethodTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockitousage.bugs;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/plugins/MockitoPluginsTest.java
+++ b/src/test/java/org/mockitousage/plugins/MockitoPluginsTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockitousage.plugins;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/verification/VerificationStartedListenerTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationStartedListenerTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockitousage.verification;
 
 import org.assertj.core.api.Assertions;


### PR DESCRIPTION
The license plugin could be updated to later versions, as we dropped JDK6 on Travis. Moreover, quite some licenses were reported missing, so I ran `./gradlew licenseFormatMain licenseFormatTest` to add them.