### PR TITLE
InvocationsPrinter string concatination

### DIFF
--- a/src/main/java/org/mockito/internal/debugging/InvocationsPrinter.java
+++ b/src/main/java/org/mockito/internal/debugging/InvocationsPrinter.java
@@ -46,7 +46,7 @@ public class InvocationsPrinter {
         if (unused.isEmpty()) {
             return sb.toString();
         }
-        sb.append("[Mockito] Unused stubbings of: " + mock).append("\n");
+        sb.append("[Mockito] Unused stubbings of: ").append(mock).append("\n");
 
         x = 1;
         for(Stubbing s:stubbings) {


### PR DESCRIPTION
Replace string concatination inside an append call with a chained `append` calls to make the code a tad easier to read, so the reader isn't left wondering why some of the concatinations are done with `append`s and some with the `+` operator.
