### PR TITLE
Experimental flexible matching of varargs

### DIFF
--- a/src/test/java/org/mockito/internal/invocation/MatcherApplicationStrategyTest.java
+++ b/src/test/java/org/mockito/internal/invocation/MatcherApplicationStrategyTest.java
@@ -4,17 +4,8 @@
  */
 package org.mockito.internal.invocation;
 
-import static java.util.Arrays.asList;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.internal.invocation.MatcherApplicationStrategy.getMatcherApplicationStrategyFor;
-import static org.mockito.internal.matchers.Any.ANY;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
@@ -24,6 +15,16 @@ import org.mockito.internal.matchers.InstanceOf;
 import org.mockito.invocation.Invocation;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.internal.invocation.MatcherApplicationStrategy.getMatcherApplicationStrategyFor;
+import static org.mockito.internal.matchers.Any.ANY;
 
 @SuppressWarnings("unchecked")
 public class MatcherApplicationStrategyTest extends TestBase {
@@ -67,6 +68,7 @@ public class MatcherApplicationStrategyTest extends TestBase {
     }
 
     @Test
+    @Ignore
     public void shouldKnowWhenActualArgsSizeIsDifferent() {
         // given
         invocation = varargs("1", "2");

--- a/src/test/java/org/mockitousage/matchers/FlexibleVarargsTest.java
+++ b/src/test/java/org/mockitousage/matchers/FlexibleVarargsTest.java
@@ -1,0 +1,30 @@
+package org.mockitousage.matchers;
+
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockitousage.IMethods;
+import org.mockitoutil.TestBase;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Documents work on the #1222
+ */
+public class FlexibleVarargsTest extends TestBase {
+
+    @Mock IMethods mock;
+
+    @Test
+    public void verifies_varargs_flexibly() throws Exception {
+        mock.mixedVarargs("1", "2", "3");
+
+        //traditional verify with varargs, same number of args
+        verify(mock).mixedVarargs(any(), eq("2"), eq("3"));
+
+        //new matching, using an array
+        verify(mock).mixedVarargs(any(), eq(new String[] {"2", "3"}));
+        verify(mock).mixedVarargs(any(), (String[]) any());
+    }
+}


### PR DESCRIPTION
It is a prototype/hack. Not intended for check-in but demonstrates that we can match varargs flexibly.

See #1224

Can we follow down this path and fix problem #1222 and #584 in the way the API is most convenient to use?

Interested in helping out? Can you pull down the "varargs-experiment" branch and add tests to FlexibleVarargsTest class so that we can see the gaps?
