### PR TITLE
Enable Checkstyle for checking license headers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,12 +32,12 @@ apply from: 'gradle/root/ide.gradle'
 apply from: 'gradle/root/gradle-fix.gradle'
 apply from: 'gradle/root/java6-compatibility.gradle'
 apply from: 'gradle/java-library.gradle'
+apply from: 'gradle/license.gradle'
 apply from: 'gradle/root/coverage.gradle'
 
 apply from: 'gradle/mockito-core/inline-mock.gradle'
 apply from: 'gradle/mockito-core/osgi.gradle'
 apply from: 'gradle/mockito-core/javadoc.gradle'
-apply from: 'gradle/mockito-core/license.gradle'
 apply from: 'gradle/mockito-core/testing.gradle'
 
 apply from: 'gradle/dependencies.gradle'

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -27,5 +27,9 @@
             <property name="processJavadoc" value="true"/>
         </module>
     </module>
+    <module name="RegexpHeader">
+        <property name="headerFile" value="config/checkstyle/java.header"/>
+        <property name="fileExtensions" value="java"/>
+    </module>
 </module>
 

--- a/config/checkstyle/java.header
+++ b/config/checkstyle/java.header
@@ -1,0 +1,4 @@
+^/\*$
+^ \* Copyright \(c\) \d\d\d\d Mockito contributors$
+^ \* This program is made available under the terms of the MIT License.$
+^ \*/$

--- a/doc/licenses/HEADER.txt
+++ b/doc/licenses/HEADER.txt
@@ -1,2 +1,2 @@
-Copyright (c) ${year} ${name}
+Copyright (c) ${year} Mockito contributors
 This program is made available under the terms of the MIT License.

--- a/gradle/license.gradle
+++ b/gradle/license.gradle
@@ -10,5 +10,4 @@ license {
         groovy = 'SLASHSTAR_STYLE'
     }
     ext.year = Calendar.getInstance().get(Calendar.YEAR)
-    ext.name = 'Mockito contributors'
 }

--- a/gradle/license.gradle
+++ b/gradle/license.gradle
@@ -1,13 +1,16 @@
-apply plugin: 'com.github.hierynomus.license'
+def licenseHeaderFile = rootProject.file('doc/licenses/HEADER.txt')
 
-license {
-    header = rootProject.file('doc/licenses/HEADER.txt')
-    strictCheck = true
-    ignoreFailures = true
-    skipExistingHeaders = true
-    mapping {
-        java = 'SLASHSTAR_STYLE'
-        groovy = 'SLASHSTAR_STYLE'
+allprojects {
+    apply plugin: 'com.github.hierynomus.license'
+    license {
+        header = licenseHeaderFile
+        strictCheck = true
+        ignoreFailures = true
+        skipExistingHeaders = true
+        mapping {
+            java = 'SLASHSTAR_STYLE'
+            groovy = 'SLASHSTAR_STYLE'
+        }
+        ext.year = Calendar.getInstance().get(Calendar.YEAR)
     }
-    ext.year = Calendar.getInstance().get(Calendar.YEAR)
 }

--- a/src/main/java/org/mockito/CheckReturnValue.java
+++ b/src/main/java/org/mockito/CheckReturnValue.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito;
 
 import java.lang.annotation.ElementType;

--- a/src/test/java/org/mockitousage/bugs/GenericsMockitoAnnotationsTest.java
+++ b/src/test/java/org/mockitousage/bugs/GenericsMockitoAnnotationsTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockitousage.bugs;
 
 import org.junit.Before;

--- a/src/test/java/org/mockitousage/verification/VerificationAfterDelayTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationAfterDelayTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2007 Mockito contributors This program is made available under the terms of the MIT License.
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
  */
 
 package org.mockitousage.verification;

--- a/subprojects/android/android.gradle
+++ b/subprojects/android/android.gradle
@@ -1,7 +1,6 @@
 description = "Mockito for Android"
 
 apply from: "$rootDir/gradle/java-library.gradle"
-apply from: "$rootDir/gradle/license.gradle"
 
 dependencies {
     compile project.rootProject

--- a/subprojects/android/android.gradle
+++ b/subprojects/android/android.gradle
@@ -1,6 +1,7 @@
 description = "Mockito for Android"
 
 apply from: "$rootDir/gradle/java-library.gradle"
+apply from: "$rootDir/gradle/license.gradle"
 
 dependencies {
     compile project.rootProject

--- a/subprojects/android/src/main/java/org/mockito/android/internal/creation/AndroidByteBuddyMockMaker.java
+++ b/subprojects/android/src/main/java/org/mockito/android/internal/creation/AndroidByteBuddyMockMaker.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.android.internal.creation;
 
 import org.mockito.internal.creation.bytebuddy.SubclassByteBuddyMockMaker;

--- a/subprojects/android/src/main/java/org/mockito/android/internal/creation/AndroidLoadingStrategy.java
+++ b/subprojects/android/src/main/java/org/mockito/android/internal/creation/AndroidLoadingStrategy.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.android.internal.creation;
 
 import static org.mockito.internal.util.StringUtil.join;

--- a/subprojects/android/src/main/java/org/mockito/android/internal/creation/AndroidTempFileLocator.java
+++ b/subprojects/android/src/main/java/org/mockito/android/internal/creation/AndroidTempFileLocator.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.android.internal.creation;
 
 import java.io.File;

--- a/subprojects/extTest/extTest.gradle
+++ b/subprojects/extTest/extTest.gradle
@@ -1,5 +1,4 @@
 apply from: "$rootDir/gradle/dependencies.gradle"
-apply from: "$rootDir/gradle/license.gradle"
 
 apply plugin: 'java'
 description = "End-to-end tests for Mockito and its extensions."

--- a/subprojects/extTest/extTest.gradle
+++ b/subprojects/extTest/extTest.gradle
@@ -1,4 +1,5 @@
 apply from: "$rootDir/gradle/dependencies.gradle"
+apply from: "$rootDir/gradle/license.gradle"
 
 apply plugin: 'java'
 description = "End-to-end tests for Mockito and its extensions."

--- a/subprojects/extTest/src/test/java/org/mockitousage/plugins/stacktrace/MyStackTraceCleanerProvider.java
+++ b/subprojects/extTest/src/test/java/org/mockitousage/plugins/stacktrace/MyStackTraceCleanerProvider.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockitousage.plugins.stacktrace;
 
 import org.mockito.exceptions.stacktrace.StackTraceCleaner;

--- a/subprojects/extTest/src/test/java/org/mockitousage/plugins/switcher/MyMockMaker.java
+++ b/subprojects/extTest/src/test/java/org/mockitousage/plugins/switcher/MyMockMaker.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockitousage.plugins.switcher;
 
 import org.mockito.internal.creation.bytebuddy.SubclassByteBuddyMockMaker;

--- a/subprojects/extTest/src/test/java/org/mockitousage/plugins/switcher/MyPluginSwitch.java
+++ b/subprojects/extTest/src/test/java/org/mockitousage/plugins/switcher/MyPluginSwitch.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockitousage.plugins.switcher;
 
 import org.mockito.plugins.PluginSwitch;

--- a/subprojects/inline/inline.gradle
+++ b/subprojects/inline/inline.gradle
@@ -1,7 +1,6 @@
 description = "Mockito preconfigured inline mock maker (intermediate and to be superseeded by automatic usage in a future version)"
 
 apply from: "$rootDir/gradle/java-library.gradle"
-apply from: "$rootDir/gradle/license.gradle"
 
 dependencies {
     compile project.rootProject

--- a/subprojects/inline/inline.gradle
+++ b/subprojects/inline/inline.gradle
@@ -1,6 +1,7 @@
 description = "Mockito preconfigured inline mock maker (intermediate and to be superseeded by automatic usage in a future version)"
 
 apply from: "$rootDir/gradle/java-library.gradle"
+apply from: "$rootDir/gradle/license.gradle"
 
 dependencies {
     compile project.rootProject

--- a/subprojects/inline/src/test/java/org/mockitoinline/FinalClassMockingTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/FinalClassMockingTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockitoinline;
 
 import org.junit.Test;

--- a/subprojects/inline/src/test/java/org/mockitoinline/PluginTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/PluginTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockitoinline;
 
 import org.junit.Test;

--- a/subprojects/inline/src/test/java/org/mockitoinline/StubbingLocationTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/StubbingLocationTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockitoinline;
 
 import java.util.Collections;

--- a/subprojects/kotlinTest/kotlinTest.gradle
+++ b/subprojects/kotlinTest/kotlinTest.gradle
@@ -3,8 +3,6 @@ plugins {
     id 'java'
 }
 
-apply from: "$rootDir/gradle/license.gradle"
-
 description = "Kotlin tests for Mockito."
 
 kotlin {

--- a/subprojects/kotlinTest/kotlinTest.gradle
+++ b/subprojects/kotlinTest/kotlinTest.gradle
@@ -3,6 +3,8 @@ plugins {
     id 'java'
 }
 
+apply from: "$rootDir/gradle/license.gradle"
+
 description = "Kotlin tests for Mockito."
 
 kotlin {

--- a/subprojects/kotlinTest/src/test/kotlin/org/mockito/kotlin/FunctionTest.kt
+++ b/subprojects/kotlinTest/src/test/kotlin/org/mockito/kotlin/FunctionTest.kt
@@ -1,3 +1,7 @@
+/**
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.kotlin
 
 import org.junit.Test

--- a/subprojects/kotlinTest/src/test/kotlin/org/mockito/kotlin/SuspendTest.kt
+++ b/subprojects/kotlinTest/src/test/kotlin/org/mockito/kotlin/SuspendTest.kt
@@ -1,3 +1,7 @@
+/**
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.kotlin
 
 import kotlinx.coroutines.experimental.runBlocking

--- a/subprojects/testng/src/main/java/org/mockito/testng/MockitoAfterTestNGMethod.java
+++ b/subprojects/testng/src/main/java/org/mockito/testng/MockitoAfterTestNGMethod.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.testng;
 
 import org.mockito.Mock;

--- a/subprojects/testng/src/main/java/org/mockito/testng/MockitoBeforeTestNGMethod.java
+++ b/subprojects/testng/src/main/java/org/mockito/testng/MockitoBeforeTestNGMethod.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.testng;
 
 import org.mockito.Captor;

--- a/subprojects/testng/src/main/java/org/mockito/testng/MockitoTestNGListener.java
+++ b/subprojects/testng/src/main/java/org/mockito/testng/MockitoTestNGListener.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.testng;
 
 import org.testng.IInvokedMethod;

--- a/subprojects/testng/src/test/java/org/mockitousage/testng/AnnotatedFieldsShouldBeInitializedByMockitoTestNGListenerTest.java
+++ b/subprojects/testng/src/test/java/org/mockitousage/testng/AnnotatedFieldsShouldBeInitializedByMockitoTestNGListenerTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockitousage.testng;
 
 import org.mockito.ArgumentCaptor;

--- a/subprojects/testng/src/test/java/org/mockitousage/testng/CaptorAnnotatedFieldShouldBeClearedTest.java
+++ b/subprojects/testng/src/test/java/org/mockitousage/testng/CaptorAnnotatedFieldShouldBeClearedTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockitousage.testng;
 
 import org.mockito.ArgumentCaptor;

--- a/subprojects/testng/src/test/java/org/mockitousage/testng/ConfigurationMethodTest.java
+++ b/subprojects/testng/src/test/java/org/mockitousage/testng/ConfigurationMethodTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockitousage.testng;
 
 import org.mockito.Mock;

--- a/subprojects/testng/src/test/java/org/mockitousage/testng/DontResetMocksIfNoListenerTest.java
+++ b/subprojects/testng/src/test/java/org/mockitousage/testng/DontResetMocksIfNoListenerTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockitousage.testng;
 
 import org.mockito.Mock;

--- a/subprojects/testng/src/test/java/org/mockitousage/testng/EnsureMocksAreInitializedBeforeBeforeClassMethodTest.java
+++ b/subprojects/testng/src/test/java/org/mockitousage/testng/EnsureMocksAreInitializedBeforeBeforeClassMethodTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockitousage.testng;
 
 import org.mockito.Mock;

--- a/subprojects/testng/src/test/java/org/mockitousage/testng/InitializeChildTestWhenParentHasListenerTest.java
+++ b/subprojects/testng/src/test/java/org/mockitousage/testng/InitializeChildTestWhenParentHasListenerTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockitousage.testng;
 
 import org.mockito.Mock;

--- a/subprojects/testng/src/test/java/org/mockitousage/testng/MockFieldsShouldBeResetBetweenTestMethodsTest.java
+++ b/subprojects/testng/src/test/java/org/mockitousage/testng/MockFieldsShouldBeResetBetweenTestMethodsTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockitousage.testng;
 
 import org.mockito.InjectMocks;

--- a/subprojects/testng/src/test/java/org/mockitousage/testng/ParentTest.java
+++ b/subprojects/testng/src/test/java/org/mockitousage/testng/ParentTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockitousage.testng;
 
 import org.mockito.Mock;

--- a/subprojects/testng/src/test/java/org/mockitousage/testng/ResetMocksInParentTestClassTooTest.java
+++ b/subprojects/testng/src/test/java/org/mockitousage/testng/ResetMocksInParentTestClassTooTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockitousage.testng;
 
 import org.testng.annotations.Test;

--- a/subprojects/testng/src/test/java/org/mockitousage/testng/SomeType.java
+++ b/subprojects/testng/src/test/java/org/mockitousage/testng/SomeType.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockitousage.testng;
 
 import java.util.List;

--- a/subprojects/testng/src/test/java/org/mockitousage/testng/TestWithoutListenerShouldNotInitializeAnnotatedFieldsTest.java
+++ b/subprojects/testng/src/test/java/org/mockitousage/testng/TestWithoutListenerShouldNotInitializeAnnotatedFieldsTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockitousage.testng;
 
 import org.mockito.ArgumentCaptor;

--- a/subprojects/testng/src/test/java/org/mockitousage/testng/failuretests/FailingOnPurposeBecauseIncorrectAnnotationUsage.java
+++ b/subprojects/testng/src/test/java/org/mockitousage/testng/failuretests/FailingOnPurposeBecauseIncorrectAnnotationUsage.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockitousage.testng.failuretests;
 
 import org.mockito.Mock;

--- a/subprojects/testng/src/test/java/org/mockitousage/testng/failuretests/FailingOnPurposeBecauseIncorrectStubbingSyntax.java
+++ b/subprojects/testng/src/test/java/org/mockitousage/testng/failuretests/FailingOnPurposeBecauseIncorrectStubbingSyntax.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockitousage.testng.failuretests;
 
 import org.mockito.exceptions.misusing.InvalidUseOfMatchersException;

--- a/subprojects/testng/src/test/java/org/mockitousage/testng/failuretests/FailingOnPurposeBecauseWrongStubbingSyntaxInConfigurationMethod.java
+++ b/subprojects/testng/src/test/java/org/mockitousage/testng/failuretests/FailingOnPurposeBecauseWrongStubbingSyntaxInConfigurationMethod.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockitousage.testng.failuretests;
 
 import org.mockito.Mock;

--- a/subprojects/testng/src/test/java/org/mockitousage/testng/failuretests/TestNGShouldFailWhenMockitoListenerFailsTest.java
+++ b/subprojects/testng/src/test/java/org/mockitousage/testng/failuretests/TestNGShouldFailWhenMockitoListenerFailsTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockitousage.testng.failuretests;
 
 import org.mockito.exceptions.base.MockitoException;

--- a/subprojects/testng/src/test/java/org/mockitousage/testng/utils/FailureRecordingListener.java
+++ b/subprojects/testng/src/test/java/org/mockitousage/testng/utils/FailureRecordingListener.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockitousage.testng.utils;
 
 import org.testng.IConfigurationListener;

--- a/subprojects/testng/src/test/resources/mockito-testng.xml
+++ b/subprojects/testng/src/test/resources/mockito-testng.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2017 Mockito contributors
+    This program is made available under the terms of the MIT License.
+
+-->
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
 <suite name="Mockito TestNG usage" parallel="none">
     <test verbose="1" name="Mockito TestNG Integration" annotations="JDK">

--- a/subprojects/testng/testng.gradle
+++ b/subprojects/testng/testng.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'maven'
+apply from: "$rootDir/gradle/license.gradle"
 description = "Mockito for TestNG"
 
 //TODO SF ensure this one is released, too (ensure source and target compatibility, too).

--- a/subprojects/testng/testng.gradle
+++ b/subprojects/testng/testng.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java'
 apply plugin: 'maven'
-apply from: "$rootDir/gradle/license.gradle"
 description = "Mockito for TestNG"
 
 //TODO SF ensure this one is released, too (ensure source and target compatibility, too).


### PR DESCRIPTION
Apparently we weren't shipping license headers on the Android subproject as well :cry: 

Fixes #1239 