### PR TITLE
Fixes #1175: thenCallRealMethod() supports Kotlin interface function with body

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodInterceptor.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodInterceptor.java
@@ -19,6 +19,7 @@ import org.mockito.internal.invocation.MockitoMethod;
 import org.mockito.internal.invocation.RealMethod;
 import org.mockito.internal.invocation.SerializableMethod;
 import org.mockito.internal.progress.SequenceNumber;
+import org.mockito.internal.util.KotlinSupport;
 import org.mockito.invocation.Location;
 import org.mockito.invocation.MockHandler;
 import org.mockito.mock.MockCreationSettings;
@@ -154,7 +155,7 @@ public class MockMethodInterceptor implements Serializable {
                     mock,
                     invokedMethod,
                     arguments,
-                    RealMethod.IsIllegal.INSTANCE
+                    KotlinSupport.getDefaultImplementation(mock, invokedMethod, arguments, RealMethod.IsIllegal.INSTANCE)
             );
         }
     }

--- a/src/main/java/org/mockito/internal/stubbing/answers/CallsRealMethods.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/CallsRealMethods.java
@@ -5,7 +5,9 @@
 package org.mockito.internal.stubbing.answers;
 
 import java.io.Serializable;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import org.mockito.internal.util.KotlinSupport;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.mockito.stubbing.ValidableAnswer;
@@ -37,7 +39,8 @@ public class CallsRealMethods implements Answer<Object>, ValidableAnswer, Serial
     private static final long serialVersionUID = 9057165148930624087L;
 
     public Object answer(InvocationOnMock invocation) throws Throwable {
-        if (Modifier.isAbstract(invocation.getMethod().getModifiers())) {
+        Method method = invocation.getMethod();
+        if (Modifier.isAbstract(method.getModifiers()) && !KotlinSupport.hasDefaultImplementation(method)) {
             return RETURNS_DEFAULTS.answer(invocation);
         }
         return invocation.callRealMethod();
@@ -45,7 +48,7 @@ public class CallsRealMethods implements Answer<Object>, ValidableAnswer, Serial
 
     @Override
     public void validateFor(InvocationOnMock invocation) {
-        if (new InvocationInfo(invocation).isAbstract()) {
+        if (new InvocationInfo(invocation).isAbstract() && !KotlinSupport.hasDefaultImplementation(invocation.getMethod())) {
             throw cannotCallAbstractRealMethod();
         }
     }

--- a/src/main/java/org/mockito/internal/util/KotlinSupport.java
+++ b/src/main/java/org/mockito/internal/util/KotlinSupport.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.util;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import org.mockito.internal.exceptions.stacktrace.ConditionalStackTraceFilter;
+import org.mockito.internal.invocation.RealMethod;
+
+/**
+ * Provides the utilities for the Kotlin language.
+ */
+public final class KotlinSupport {
+
+    private KotlinSupport() {
+    }
+
+    /**
+     * Tests whether the given method has default implementation.
+     *
+     * @param method the method
+     * @return {@code true} if it is a Kotlin interface function with default implementation, otherwise {@code false}
+     */
+    public static boolean hasDefaultImplementation(Method method) {
+        return findDefaultImplMethod(method) != null;
+    }
+
+    /**
+     * Returns the {@link RealMethod} representing default implementation of the given method. If the method is not a
+     * Kotlin interface function with default implementation, {@code notFound} is returned.
+     *
+     * @param mock      the mock object
+     * @param method    the method
+     * @param arguments the arguments used for the given method call
+     * @param notFound  the {@link RealMethod} to be returned if default implementation is not found.
+     * @return the {@link RealMethod} representing default implementation, otherwise {@code notFound}
+     */
+    public static RealMethod getDefaultImplementation(Object mock,
+                                                      Method method,
+                                                      Object[] arguments,
+                                                      RealMethod notFound) {
+        final Method defaultImplMethod = findDefaultImplMethod(method);
+        if (defaultImplMethod == null) {
+            return notFound;
+        }
+
+        int length = arguments.length;
+        final Object[] defaultImplMethodArguments = new Object[length + 1];
+        defaultImplMethodArguments[0] = mock;
+        System.arraycopy(arguments, 0, defaultImplMethodArguments, 1, length);
+
+        return new RealMethod() {
+
+            @Override
+            public boolean isInvokable() {
+                return true;
+            }
+
+            @Override
+            public Object invoke() throws Throwable {
+                try {
+                    return defaultImplMethod.invoke(null, defaultImplMethodArguments);
+                } catch (InvocationTargetException e) {
+                    Throwable cause = e.getCause();
+                    new ConditionalStackTraceFilter().filter(cause);
+                    throw cause;
+                }
+            }
+
+        };
+    }
+
+    private static Method findDefaultImplMethod(Method method) {
+        if (!Modifier.isAbstract(method.getModifiers())) {
+            return null;
+        }
+
+        Class<?> declaringClass = method.getDeclaringClass();
+        Class<?> defaultImplsClass = findDefaultImplsClass(declaringClass);
+        if (defaultImplsClass == null) {
+            return null;
+        }
+
+        // The first argument type of default implementation is that interface itself. Others are parameter types of the
+        // given method.
+        Class<?>[] others = method.getParameterTypes();
+        int length = others.length;
+        Class<?>[] parameterTypes = new Class[length + 1];
+        parameterTypes[0] = declaringClass;
+        System.arraycopy(others, 0, parameterTypes, 1, length);
+
+        try {
+            // The method representing default implementation should be `public` and `static`.
+            Method defaultImpl = defaultImplsClass.getMethod(method.getName(), parameterTypes);
+            if (Modifier.isStatic(defaultImpl.getModifiers())) {
+                return defaultImpl;
+            }
+        } catch (NoSuchMethodException ignored) {
+        }
+
+        return null;
+    }
+
+    private static Class<?> findDefaultImplsClass(Class<?> c) {
+        if (c.isInterface() && isKotlinClass(c)) {
+            for (Class<?> cls : c.getClasses()) {
+                // The default implementation of the interface is in `DefaultImpls` class member of that interface.
+                if (cls.getSimpleName().equals("DefaultImpls") && Modifier.isStatic(cls.getModifiers())) {
+                    return cls;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static boolean isKotlinClass(Class<?> c) {
+        for (Annotation a : c.getDeclaredAnnotations()) {
+            // All the Kotlin classes are marked with `kotlin.Metadata` annotation.
+            if (a.annotationType().getName().equals("kotlin.Metadata")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/src/test/java/org/mockito/internal/util/KotlinSupportTest.java
+++ b/src/test/java/org/mockito/internal/util/KotlinSupportTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.util;
+
+import java.lang.reflect.Method;
+import org.junit.Test;
+import org.mockito.internal.invocation.RealMethod;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+
+public class KotlinSupportTest {
+
+    private static class JavaClass {
+        String method() {
+            return "";
+        }
+    }
+
+    private interface JavaInterface {
+        String method();
+    }
+
+    @Test
+    public void hasDefaultImplementation_should_return_false_if_the_given_method_is_not_abstract()
+        throws NoSuchMethodException {
+        assertFalse(KotlinSupport.hasDefaultImplementation(JavaClass.class.getDeclaredMethod("method")));
+    }
+
+    @Test
+    public void hasDefaultImplementation_should_return_false_if_the_given_interface_method_is_not_Kotlin_function()
+        throws NoSuchMethodException {
+        assertFalse(KotlinSupport.hasDefaultImplementation(JavaInterface.class.getMethod("method")));
+    }
+
+    @Test
+    public void getDefaultImplementation_should_return_notFound_if_the_given_method_is_not_abstract()
+        throws NoSuchMethodException {
+        JavaInterface mock = mock(JavaInterface.class);
+        Method method = JavaClass.class.getDeclaredMethod("method");
+        RealMethod notFound = RealMethod.IsIllegal.INSTANCE;
+        assertSame(notFound, KotlinSupport.getDefaultImplementation(mock, method, new Object[0], notFound));
+    }
+
+    @Test
+    public void getDefaultImplementation_should_return_notFound_if_the_given_interface_method_is_not_Kotlin_function()
+        throws NoSuchMethodException {
+        JavaInterface mock = mock(JavaInterface.class);
+        Method method = JavaInterface.class.getMethod("method");
+        RealMethod notFound = RealMethod.IsIllegal.INSTANCE;
+        assertSame(notFound, KotlinSupport.getDefaultImplementation(mock, method, new Object[0], notFound));
+    }
+
+}

--- a/subprojects/kotlinTest/src/test/kotlin/org/mockito/internal/stubbing/answers/CallsRealMethodsTest.kt
+++ b/subprojects/kotlinTest/src/test/kotlin/org/mockito/internal/stubbing/answers/CallsRealMethodsTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.stubbing.answers
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.Mockito.RETURNS_DEFAULTS
+import org.mockito.Mockito.mock
+import org.mockito.exceptions.base.MockitoException
+import org.mockito.internal.MockitoCore
+
+class CallsRealMethodsTest {
+
+    private interface Foo {
+        fun noBody(): String
+        fun hasBody(): String = "body"
+    }
+
+    private val testTarget = CallsRealMethods()
+
+    @Test
+    fun `answer() should delegate to RETURNS_DEFAULTS when calling interface function that has no body`() {
+        mock(Foo::class.java).noBody()
+        val invocation = MockitoCore().lastInvocation
+        assertEquals(RETURNS_DEFAULTS.answer(invocation), testTarget.answer(invocation))
+    }
+
+    @Test
+    fun `answer() should call real method when calling interface function that has body`() {
+        mock(Foo::class.java).hasBody()
+        assertEquals("body", testTarget.answer(MockitoCore().lastInvocation))
+    }
+
+    @Test
+    fun `validateFor() should throw MockitoException when calling interface function that has no body`() {
+        mock(Foo::class.java).noBody()
+        val invocation = MockitoCore().lastInvocation
+        assertTrue(
+            try {
+                testTarget.validateFor(invocation)
+                false
+            } catch (ignored: MockitoException) {
+                true
+            })
+    }
+
+    @Test
+    fun `validateFor() should be ok when calling interface function that has body`() {
+        mock(Foo::class.java).hasBody()
+        testTarget.validateFor(MockitoCore().lastInvocation)
+    }
+
+}

--- a/subprojects/kotlinTest/src/test/kotlin/org/mockito/internal/util/KotlinSupportTest.kt
+++ b/subprojects/kotlinTest/src/test/kotlin/org/mockito/internal/util/KotlinSupportTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.util
+
+import org.junit.Assert.*
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.internal.invocation.RealMethod
+
+class KotlinSupportTest {
+
+    private interface Foo {
+        fun noBody(): String
+        fun hasBody(): String = "body"
+        fun thrownInBody() {
+            throw MyException()
+        }
+    }
+
+    private class MyException : Exception()
+
+    @Test
+    fun `hasDefaultImplementation() should return false if the given interface method has no body`() {
+        assertFalse(KotlinSupport.hasDefaultImplementation(Foo::class.java.getMethod("noBody")))
+    }
+
+    @Test
+    fun `hasDefaultImplementation() should return true if the given interface method has body`() {
+        assertTrue(KotlinSupport.hasDefaultImplementation(Foo::class.java.getMethod("hasBody")))
+    }
+
+    @Test
+    fun `getDefaultImplementation() should return notFound if the given interface method has no body`() {
+        val mock = mock(Foo::class.java)
+        val method = Foo::class.java.getMethod("noBody")
+        val notFound = RealMethod.IsIllegal.INSTANCE
+        assertSame(notFound, KotlinSupport.getDefaultImplementation(mock, method, emptyArray(), notFound))
+    }
+
+    @Test
+    fun `getDefaultImplementation() should return real method representing default implementation`() {
+        val mock = mock(Foo::class.java)
+        val method = Foo::class.java.getMethod("hasBody")
+        val notFound = RealMethod.IsIllegal.INSTANCE
+        val realMethod = KotlinSupport.getDefaultImplementation(mock, method, emptyArray(), notFound)
+        assertNotSame(notFound, realMethod)
+        assertTrue(realMethod.isInvokable)
+        assertEquals("body", realMethod.invoke())
+    }
+
+    @Test
+    fun `Filtered exception should be thrown when calling default implementation that raises an exception`() {
+        val mock = mock(Foo::class.java)
+        val method = Foo::class.java.getMethod("thrownInBody")
+        val notFound = RealMethod.IsIllegal.INSTANCE
+        val realMethod = KotlinSupport.getDefaultImplementation(mock, method, emptyArray(), notFound)
+        assertNotSame(notFound, realMethod)
+        assertTrue(realMethod.isInvokable)
+        assertTrue(try {
+            realMethod.invoke()
+            false
+        } catch (e: MyException) {
+            e.stackTrace.none { it.className.startsWith("org.mockito.") }
+        })
+    }
+
+}

--- a/subprojects/kotlinTest/src/test/kotlin/org/mockitousage/kotlin/InterfaceDefaultImplsTest.kt
+++ b/subprojects/kotlinTest/src/test/kotlin/org/mockitousage/kotlin/InterfaceDefaultImplsTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage.kotlin
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.BDDMockito.given
+import org.mockito.Mockito.mock
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner.StrictStubs::class)
+class InterfaceDefaultImplsTest {
+
+    private interface Foo {
+        fun f1(): String = "Foo.f1()"
+        fun f2(): String = "Foo.f2()"
+        fun f3(arg: String): String = "Foo.f3(\"$arg\")"
+    }
+
+    private interface Bar : Foo {
+        override fun f2(): String = "Bar.f2()"
+        override fun f3(arg: String): String = "Bar.f3(\"$arg\")"
+    }
+
+    @Test
+    fun `should call default implementation of interface function`() {
+        val mock = mock(Foo::class.java)
+        given(mock.f1()).willCallRealMethod()
+        assertEquals("Foo.f1()", mock.f1())
+    }
+
+    @Test
+    fun `should call default implementation of interface function with String parameter`() {
+        val mock = mock(Foo::class.java)
+        given(mock.f3("test")).willCallRealMethod()
+        assertEquals("Foo.f3(\"test\")", mock.f3("test"))
+    }
+
+    @Test
+    fun `should call default implementation of super interface function`() {
+        val mock = mock(Bar::class.java)
+        given(mock.f1()).willCallRealMethod()
+        assertEquals("Foo.f1()", mock.f1())
+    }
+
+    @Test
+    fun `should call default implementation of overridden interface function`() {
+        val mock = mock(Bar::class.java)
+        given(mock.f2()).willCallRealMethod()
+        assertEquals("Bar.f2()", mock.f2())
+    }
+
+    @Test
+    fun `should call default implementation of overridden interface function with String parameter`() {
+        val mock = mock(Bar::class.java)
+        given(mock.f3("test")).willCallRealMethod()
+        assertEquals("Bar.f3(\"test\")", mock.f3("test"))
+    }
+
+}


### PR DESCRIPTION
In Kotlin, the default implementation of an interface function is defined in `DefaultImpls` class member of that interface.
This PR fixes so that `CallsRealMethods` calls methods on that class.