### PR TITLE
Fixes #1254 and #1256: improved check for self-invocation.

### DIFF
--- a/src/main/java/org/mockito/internal/util/concurrent/WeakConcurrentMap.java
+++ b/src/main/java/org/mockito/internal/util/concurrent/WeakConcurrentMap.java
@@ -26,7 +26,7 @@ public class WeakConcurrentMap<K, V> extends ReferenceQueue<K> implements Runnab
 
     private static final AtomicLong ID = new AtomicLong();
 
-    final ConcurrentMap<WeakKey<K>, V> target;
+    public final ConcurrentMap<WeakKey<K>, V> target;
 
     private final Thread thread;
 

--- a/subprojects/inline/src/test/java/org/mockitoinline/RecursionTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/RecursionTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitoinline;
+
+import org.junit.Test;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static org.mockito.Mockito.spy;
+
+public class RecursionTest {
+
+    @Test
+    public void testMockConcurrentHashMap() {
+        ConcurrentMap<String, String> map = spy(new ConcurrentHashMap<String, String>());
+        map.putIfAbsent("a", "b");
+    }
+}

--- a/subprojects/inline/src/test/java/org/mockitoinline/SuperCallTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/SuperCallTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitoinline;
+
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+public final class SuperCallTest {
+
+    @Test
+    public void testSuperMethodCall() {
+        Dummy d = spy(new Dummy());
+        d.foo();
+        verify(d).bar(eq("baz"));
+    }
+
+    static class Dummy {
+
+        public void foo() {
+            bar("baz");
+        }
+
+        // Also fails if public.
+        void bar(String s) {
+            return;
+        }
+    }
+}


### PR DESCRIPTION
Better checks for recursive calls and guards internally used JDK types.

Fixes #1254 
Fixes #1256