### PR TITLE
Update shipkit and configure assertReleaseNeeded task

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,6 @@ We used to publish every version to Maven Central but we changed this strategy b
 * Q: How to publish to Maven Central?
 
   A: Include "[ci maven-central-release]" in the **merge** commit when merging the PR.
-  **Caveat**: if the PR does not change the binaries / javadoc in any way, the release will be skipped.
-  To avoid this problem, make a whitespace change in javadoc Javadoc for some public type.
-  We will address this caveat, see [issue #353](https://github.com/mockito/shipkit/issues/353) in Shipkit.
   **Hint**: To signify a new feature consider updating version to next minor/major, like: "2.8.0", "2.9.0", "3.0.0".
 
 * Q: How to promote already released version to a notable version?

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.3.0' //for 'java6-compatibility.gradle'
 
         //Using buildscript.classpath so that we can resolve shipkit from maven local, during local testing
-        classpath 'org.shipkit:shipkit:0.9.38'
+        classpath 'org.shipkit:shipkit:0.9.143'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.3.0' //for 'java6-compatibility.gradle'
 
         //Using buildscript.classpath so that we can resolve shipkit from maven local, during local testing
-        classpath 'org.shipkit:shipkit:0.9.143'
+        classpath 'org.shipkit:shipkit:0.9.144'
     }
 }
 

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -31,6 +31,13 @@ shipkit {
  */
 boolean centralRelease = shouldReleaseToCentral(project)
 
+afterEvaluate {
+    //using afterEvaluate because 'assertReleaseNeeded' task is added after 'shipkit.gradle' file is evaluated by Gradle
+   [assertReleaseNeeded, releaseNeeded].each {
+        it.skipComparePublications = centralRelease
+    }
+}
+
 allprojects {
     plugins.withId("org.shipkit.bintray") {
         bintray {


### PR DESCRIPTION
After merging this pr the release will go out if "[ci maven-central-release]" keyword is present in the commit message. We no longer have to do whitespace changes in javadoc in order to convince 'assertReleaseNeeded' task that a release is needed.

See https://github.com/mockito/shipkit/issues/353 and https://github.com/mockito/shipkit/issues/354 for details.

This pr updates shipkit to the latest version and configures ReleaseNeededTask to skip the comparison of publications based on the value of 'centralRelease'.
