### PR TITLE
Fixes #1262: update doc for Answers.CALLS_REAL_METHODS

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -1643,11 +1643,15 @@ public class Mockito extends ArgumentMatchers {
      * // this calls the real implementation of Foo.getSomething()
      * value = mock.getSomething();
      *
-     * when(mock.getSomething()).thenReturn(fakeValue);
+     * doReturn(fakeValue).when(mock).getSomething();
      *
      * // now fakeValue is returned
      * value = mock.getSomething();
      * </code></pre>
+     *
+     * <p>
+     * <u>Note:</u> Stubbing partial mocks using <code>when(mock.getSomething()).thenReturn(fakeValue)</code>
+     * syntax will call the real method. For partial mock it's recommended to use <code>doReturn</code> syntax.
      */
     public static final Answer<Object> CALLS_REAL_METHODS = Answers.CALLS_REAL_METHODS;
 


### PR DESCRIPTION
Update the documentation for the Answers.CALLS_REAL_METHODS according to #1262 and also included a note with recommendation not to use when().thenReturn() for partial mock.
