### PR TITLE
Clean up, removed dead code, rename job, documentation tidy up

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ We used to publish every version to Maven Central but we changed this strategy b
 * Q: What's new in Mockito release model?
 
   A: In Q2 2017 we implemented [Mockito Continuous Delivery Pipeline 2.0](https://github.com/mockito/mockito/issues/911).
-  Not every every version is published to Maven Central.
+  Not every version is published to Maven Central.
 
 * Q: How to publish to Maven Central?
 

--- a/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
+++ b/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
@@ -47,8 +47,8 @@ public class MockingProgressImpl implements MockingProgress {
         };
     }
 
-    public void reportOngoingStubbing(OngoingStubbing iOngoingStubbing) {
-        this.ongoingStubbing = iOngoingStubbing;
+    public void reportOngoingStubbing(OngoingStubbing ongoingStubbing) {
+        this.ongoingStubbing = ongoingStubbing;
     }
 
     public OngoingStubbing<?> pullOngoingStubbing() {
@@ -129,7 +129,7 @@ public class MockingProgressImpl implements MockingProgress {
     }
 
     public String toString() {
-        return  "iOngoingStubbing: " + ongoingStubbing +
+        return  "ongoingStubbing: " + ongoingStubbing +
         ", verificationMode: " + verificationMode +
         ", stubbingInProgress: " + stubbingInProgress;
     }

--- a/src/main/java/org/mockito/internal/stubbing/InvocationContainerImpl.java
+++ b/src/main/java/org/mockito/internal/stubbing/InvocationContainerImpl.java
@@ -4,11 +4,6 @@
  */
 package org.mockito.internal.stubbing;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-
 import org.mockito.internal.invocation.StubInfoImpl;
 import org.mockito.internal.verification.DefaultRegisteredInvocations;
 import org.mockito.internal.verification.RegisteredInvocations;
@@ -20,6 +15,11 @@ import org.mockito.mock.MockCreationSettings;
 import org.mockito.stubbing.Answer;
 import org.mockito.stubbing.Stubbing;
 import org.mockito.stubbing.ValidableAnswer;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
 
 import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
 
@@ -91,10 +91,6 @@ public class InvocationContainerImpl implements InvocationContainer, Serializabl
         }
 
         return null;
-    }
-
-    public void addAnswerForVoidMethod(Answer answer) {
-        answersForStubbing.add(answer);
     }
 
     public void setAnswersForStubbing(List<Answer<?>> answers) {

--- a/src/main/java/org/mockito/stubbing/OngoingStubbing.java
+++ b/src/main/java/org/mockito/stubbing/OngoingStubbing.java
@@ -43,7 +43,7 @@ public interface OngoingStubbing<T> {
      *
      * @param value return value
      *
-     * @return iOngoingStubbing object that allows stubbing consecutive calls
+     * @return object that allows stubbing consecutive calls
      */
     OngoingStubbing<T> thenReturn(T value);
 
@@ -60,7 +60,7 @@ public interface OngoingStubbing<T> {
      * @param value first return value
      * @param values next return values
      *
-     * @return iOngoingStubbing object that allows stubbing consecutive calls
+     * @return object that allows stubbing consecutive calls
      */
     // Additional method helps users of JDK7+ to hide heap pollution / unchecked generics array creation warnings (on call site)
     @SuppressWarnings ({"unchecked", "varargs"})
@@ -84,7 +84,7 @@ public interface OngoingStubbing<T> {
      *
      * @param throwables to be thrown on method invocation
      *
-     * @return iOngoingStubbing object that allows stubbing consecutive calls
+     * @return object that allows stubbing consecutive calls
      */
     OngoingStubbing<T> thenThrow(Throwable... throwables);
 
@@ -108,7 +108,7 @@ public interface OngoingStubbing<T> {
      *
      * @param throwableType to be thrown on method invocation
      *
-     * @return iOngoingStubbing object that allows stubbing consecutive calls
+     * @return object that allows stubbing consecutive calls
      * @since 2.1.0
      */
     OngoingStubbing<T> thenThrow(Class<? extends Throwable> throwableType);
@@ -141,7 +141,7 @@ public interface OngoingStubbing<T> {
      * @param toBeThrown to be thrown on method invocation
      * @param nextToBeThrown next to be thrown on method invocation
      *
-     * @return iOngoingStubbing object that allows stubbing consecutive calls
+     * @return object that allows stubbing consecutive calls
      * @since 2.1.0
      */
     // Additional method helps users of JDK7+ to hide heap pollution / unchecked generics array creation warnings (on call site)
@@ -175,7 +175,7 @@ public interface OngoingStubbing<T> {
      * <p>
      * See examples in javadoc for {@link Mockito#when}
      *
-     * @return iOngoingStubbing object that allows stubbing consecutive calls
+     * @return object that allows stubbing consecutive calls
      */
     OngoingStubbing<T> thenCallRealMethod();
 
@@ -191,7 +191,7 @@ public interface OngoingStubbing<T> {
      *
      * @param answer the custom answer to execute.
      *
-     * @return iOngoingStubbing object that allows stubbing consecutive calls
+     * @return object that allows stubbing consecutive calls
      */
     OngoingStubbing<T> thenAnswer(Answer<?> answer);
 
@@ -209,7 +209,7 @@ public interface OngoingStubbing<T> {
      * </code></pre>
      *
      * @param answer the custom answer to execute.
-     * @return iOngoingStubbing object that allows stubbing consecutive calls
+     * @return object that allows stubbing consecutive calls
      *
      * @see #thenAnswer(Answer)
      * @since 1.9.0

--- a/src/test/java/org/mockito/internal/stubbing/InvocationContainerImplStubbingTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/InvocationContainerImplStubbingTest.java
@@ -5,8 +5,6 @@
 
 package org.mockito.internal.stubbing;
 
-import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.exceptions.base.MockitoException;
@@ -21,6 +19,7 @@ import org.mockitoutil.TestBase;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
 
 public class InvocationContainerImplStubbingTest extends TestBase {
 
@@ -93,27 +92,6 @@ public class InvocationContainerImplStubbingTest extends TestBase {
             invocationContainerImplStubOnly.answerTo(differentMethod);
             fail();
         } catch (MyException e) {}
-    }
-
-    @Test
-    public void should_add_throwable_for_void_method() throws Throwable {
-        invocationContainerImpl.addAnswerForVoidMethod(new ThrowsException(new MyException()));
-        invocationContainerImpl.setMethodForStubbing(new InvocationMatcher(simpleMethod));
-
-        try {
-            invocationContainerImpl.answerTo(simpleMethod);
-            fail();
-        } catch (MyException e) {}
-    }
-
-    @Test
-    public void should_validate_throwable_for_void_method() throws Throwable {
-        invocationContainerImpl.addAnswerForVoidMethod(new ThrowsException(new Exception()));
-
-        try {
-            invocationContainerImpl.setMethodForStubbing(new InvocationMatcher(simpleMethod));
-            fail();
-        } catch (MockitoException e) {}
     }
 
     @Test


### PR DESCRIPTION
 - Removed dead method to simplify the code
 - Renamed iOngoingStubbing -> ongoingStubbing ('i' prefix is a relict of history)
 - Removed duplicated word (thanks to @kant for inspiration in #1288)