### PR TITLE
Javadoc: Improve discoverability of #ignoreStubs

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -2123,6 +2123,7 @@ public class Mockito extends ArgumentMatchers {
      * See also {@link Mockito#never()} - it is more explicit and communicates the intent well.
      * <p>
      * Stubbed invocations (if called) are also treated as interactions.
+     * See {@link #ignoreStubs(Object...)} to ignore.
      * <p>
      * A word of <b>warning</b>:
      * Some users who did a lot of classic, expect-run-verify mocking tend to use <code>verifyNoMoreInteractions()</code> very often, even in every test method.


### PR DESCRIPTION
I've learnt of ignoreStubs from the main doc, at [paragraph 25](http://static.javadoc.io/org.mockito/mockito-core/2.13.0/org/mockito/Mockito.html#25).
Since ignoreStubs is strictly related to verifyNoMoreInteractions, I think it should be mentioned in the javadoc of verifyNoMoreInteractions as well, so as to make it more "discoverable".