### PR TITLE
Update public API of InvocationFactory needed for Android static mocking

### DIFF
--- a/src/main/java/org/mockito/internal/invocation/DefaultInvocationFactory.java
+++ b/src/main/java/org/mockito/internal/invocation/DefaultInvocationFactory.java
@@ -18,4 +18,9 @@ public class DefaultInvocationFactory implements InvocationFactory {
         RealMethod.FromCallable superMethod = new RealMethod.FromCallable(realMethod);
         return MockMethodInterceptor.createInvocation(target, method, args, superMethod, settings);
     }
+
+    public Invocation createInvocation(Object target, MockCreationSettings settings, Method method, RealMethodBehavior realMethod, Object... args) {
+        RealMethod.FromBehavior superMethod = new RealMethod.FromBehavior(realMethod);
+        return MockMethodInterceptor.createInvocation(target, method, args, superMethod, settings);
+    }
 }

--- a/src/main/java/org/mockito/internal/invocation/DefaultInvocationFactory.java
+++ b/src/main/java/org/mockito/internal/invocation/DefaultInvocationFactory.java
@@ -15,17 +15,16 @@ import java.util.concurrent.Callable;
 public class DefaultInvocationFactory implements InvocationFactory {
 
     public Invocation createInvocation(Object target, MockCreationSettings settings, Method method, final Callable realMethod, Object... args) {
-        RealMethod superMethod = new RealMethod.FromBehavior(new RealMethodBehavior<Object>() {
-            @Override
-            public Object call() throws Throwable {
-                return realMethod.call();
-            }
-        });
-        return MockMethodInterceptor.createInvocation(target, method, args, superMethod, settings);
+        RealMethod superMethod = new RealMethod.FromCallable(realMethod);
+        return createInvocation(target, settings, method, superMethod, args);
     }
 
     public Invocation createInvocation(Object target, MockCreationSettings settings, Method method, RealMethodBehavior realMethod, Object... args) {
-        RealMethod.FromBehavior superMethod = new RealMethod.FromBehavior(realMethod);
+        RealMethod superMethod = new RealMethod.FromBehavior(realMethod);
+        return createInvocation(target, settings, method, superMethod, args);
+    }
+
+    private Invocation createInvocation(Object target, MockCreationSettings settings, Method method, RealMethod superMethod, Object[] args) {
         return MockMethodInterceptor.createInvocation(target, method, args, superMethod, settings);
     }
 }

--- a/src/main/java/org/mockito/internal/invocation/DefaultInvocationFactory.java
+++ b/src/main/java/org/mockito/internal/invocation/DefaultInvocationFactory.java
@@ -14,8 +14,13 @@ import java.util.concurrent.Callable;
 
 public class DefaultInvocationFactory implements InvocationFactory {
 
-    public Invocation createInvocation(Object target, MockCreationSettings settings, Method method, Callable realMethod, Object... args) {
-        RealMethod.FromCallable superMethod = new RealMethod.FromCallable(realMethod);
+    public Invocation createInvocation(Object target, MockCreationSettings settings, Method method, final Callable realMethod, Object... args) {
+        RealMethod superMethod = new RealMethod.FromBehavior(new RealMethodBehavior<Object>() {
+            @Override
+            public Object call() throws Throwable {
+                return realMethod.call();
+            }
+        });
         return MockMethodInterceptor.createInvocation(target, method, args, superMethod, settings);
     }
 

--- a/src/main/java/org/mockito/internal/invocation/RealMethod.java
+++ b/src/main/java/org/mockito/internal/invocation/RealMethod.java
@@ -32,35 +32,18 @@ public interface RealMethod extends Serializable {
         }
     }
 
-    class FromCallable implements RealMethod {
-
-        private static final long serialVersionUID = 47957363950483625L;
-
-        private final Callable<?> callable;
-
-        public FromCallable(Callable<?> callable) {
-            this.callable = callable;
-        }
-
-        @Override
-        public boolean isInvokable() {
-            return true;
-        }
-
-        @Override
-        public Object invoke() throws Throwable {
-            try {
-                return callable.call();
-            } catch (Throwable t) {
-                new ConditionalStackTraceFilter().filter(t);
-                throw t;
-            }
+    class FromCallable extends FromBehavior implements RealMethod {
+        public FromCallable(final Callable<?> callable) {
+            super(new InvocationFactory.RealMethodBehavior() {
+                @Override
+                public Object call() throws Throwable {
+                    return callable.call();
+                }
+            });
         }
     }
 
     class FromBehavior implements RealMethod {
-
-        private static final long serialVersionUID = 27957361150487543L;
 
         private final InvocationFactory.RealMethodBehavior<?> behavior;
 

--- a/src/main/java/org/mockito/internal/invocation/RealMethod.java
+++ b/src/main/java/org/mockito/internal/invocation/RealMethod.java
@@ -5,6 +5,7 @@
 package org.mockito.internal.invocation;
 
 import org.mockito.internal.exceptions.stacktrace.ConditionalStackTraceFilter;
+import org.mockito.invocation.InvocationFactory;
 import org.mockito.invocation.InvocationOnMock;
 
 import java.io.Serializable;
@@ -50,6 +51,32 @@ public interface RealMethod extends Serializable {
         public Object invoke() throws Throwable {
             try {
                 return callable.call();
+            } catch (Throwable t) {
+                new ConditionalStackTraceFilter().filter(t);
+                throw t;
+            }
+        }
+    }
+
+    class FromBehavior implements RealMethod {
+
+        private static final long serialVersionUID = 27957361150487543L;
+
+        private final InvocationFactory.RealMethodBehavior<?> behavior;
+
+        FromBehavior(InvocationFactory.RealMethodBehavior<?> behavior) {
+            this.behavior = behavior;
+        }
+
+        @Override
+        public boolean isInvokable() {
+            return true;
+        }
+
+        @Override
+        public Object invoke() throws Throwable {
+            try {
+                return behavior.call();
             } catch (Throwable t) {
                 new ConditionalStackTraceFilter().filter(t);
                 throw t;

--- a/src/main/java/org/mockito/invocation/InvocationFactory.java
+++ b/src/main/java/org/mockito/invocation/InvocationFactory.java
@@ -27,6 +27,11 @@ import java.util.concurrent.Callable;
 public interface InvocationFactory {
 
     /**
+     * @deprecated Use {@link #createInvocation(Object, MockCreationSettings, Method, RealMethodBehavior, Object...)} instead.
+     *
+     * Why deprecated? We found use cases where we need to handle Throwable and ensure correct stack trace filtering
+     * (removing Mockito internals from the stack trace). Hence the introduction of {@link RealMethodBehavior}.
+     *
      * Creates instance of an {@link Invocation} object.
      * This method is useful for framework integrators to programmatically simulate method calls on mocks using {@link MockHandler}.
      * It enables advanced framework integrations.
@@ -39,8 +44,6 @@ public interface InvocationFactory {
      *
      * @return invocation instance
      * @since 2.10.0
-     *
-     * @deprecated Use {@link #createInvocation(Object, MockCreationSettings, Method, RealMethodBehavior, Object...)} instead
      */
     @Deprecated
     Invocation createInvocation(Object target, MockCreationSettings settings, Method method, Callable realMethod, Object... args);

--- a/src/main/java/org/mockito/invocation/InvocationFactory.java
+++ b/src/main/java/org/mockito/invocation/InvocationFactory.java
@@ -8,6 +8,7 @@ import org.mockito.Incubating;
 import org.mockito.MockitoFramework;
 import org.mockito.mock.MockCreationSettings;
 
+import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.concurrent.Callable;
 
@@ -53,7 +54,7 @@ public interface InvocationFactory {
      *
      * @since 2.14.0
      */
-    interface RealMethodBehavior<R> {
+    interface RealMethodBehavior<R> extends Serializable {
         R call() throws Throwable;
     }
 

--- a/src/main/java/org/mockito/invocation/InvocationFactory.java
+++ b/src/main/java/org/mockito/invocation/InvocationFactory.java
@@ -19,7 +19,7 @@ import java.util.concurrent.Callable;
  * <p>
  * Please don't provide your own implementation of {@link Invocation} type.
  * Mockito team needs flexibility to add new methods to this interface if we need to.
- * If you integrate Mockito framework and you need an instance of {@link Invocation}, use {@link #createInvocation(Object, MockCreationSettings, Method, Callable, Object...)}.
+ * If you integrate Mockito framework and you need an instance of {@link Invocation}, use {@link #createInvocation(Object, MockCreationSettings, Method, RealMethodBehavior, Object...)}.
  *
  * @since 2.10.0
  */
@@ -39,7 +39,35 @@ public interface InvocationFactory {
      *
      * @return invocation instance
      * @since 2.10.0
+     *
+     * @deprecated Use {@link #createInvocation(Object, MockCreationSettings, Method, RealMethodBehavior, Object...)} instead
+     */
+    @Deprecated
+    Invocation createInvocation(Object target, MockCreationSettings settings, Method method, Callable realMethod, Object... args);
+
+    /**
+     * Behavior of the real method.
+     *
+     * @since 2.14.0
+     */
+    interface RealMethodBehavior<R> {
+        R call() throws Throwable;
+    }
+
+    /**
+     * Creates instance of an {@link Invocation} object.
+     * This method is useful for framework integrators to programmatically simulate method calls on mocks using {@link MockHandler}.
+     * It enables advanced framework integrations.
+     *
+     * @param target the mock object the method is invoked on.
+     * @param settings creation settings of the mock object.
+     * @param method java method invoked on mock.
+     * @param realMethod real method behavior. Needed for spying / invoking real behavior on mock objects.
+     * @param args the java method arguments
+     *
+     * @return invocation instance
+     * @since 2.14.0
      */
     @Incubating
-    Invocation createInvocation(Object target, MockCreationSettings settings, Method method, Callable realMethod, Object... args);
+    Invocation createInvocation(Object target, MockCreationSettings settings, Method method, RealMethodBehavior realMethod, Object... args);
 }

--- a/src/test/java/org/mockito/InvocationFactoryTest.java
+++ b/src/test/java/org/mockito/InvocationFactoryTest.java
@@ -24,10 +24,10 @@ public class InvocationFactoryTest extends TestBase {
         }
     }
 
+    final TestClass mock = spy(TestClass.class);
+
     @Test
     public void call_method_that_throws_a_throwable() throws Throwable {
-        final TestClass mock = spy(TestClass.class);
-
         Invocation invocation = Mockito.framework().getInvocationFactory().createInvocation(mock,
             withSettings().build(TestClass.class),
             TestClass.class.getDeclaredMethod("testMethod"),
@@ -50,8 +50,6 @@ public class InvocationFactoryTest extends TestBase {
 
     @Test
     public void call_method_that_returns_a_string() throws Throwable {
-        final TestClass mock = spy(TestClass.class);
-
         Invocation invocation = Mockito.framework().getInvocationFactory().createInvocation(mock,
             withSettings().build(TestClass.class),
             TestClass.class.getDeclaredMethod("testMethod"),
@@ -63,14 +61,11 @@ public class InvocationFactoryTest extends TestBase {
             });
 
         Object ret = Mockito.mockingDetails(mock).getMockHandler().handle(invocation);
-        assertEquals(String.class, ret.getClass());
         assertEquals("mocked", ret);
     }
 
     @Test
     public void deprecated_api_still_works() throws Throwable {
-        final TestClass mock = spy(TestClass.class);
-
         Invocation invocation = Mockito.framework().getInvocationFactory().createInvocation(mock,
             withSettings().build(TestClass.class),
             TestClass.class.getDeclaredMethod("testMethod"),

--- a/src/test/java/org/mockito/InvocationFactoryTest.java
+++ b/src/test/java/org/mockito/InvocationFactoryTest.java
@@ -10,6 +10,8 @@ import org.mockito.invocation.Invocation;
 import org.mockito.invocation.InvocationFactory;
 import org.mockitoutil.TestBase;
 
+import java.util.concurrent.Callable;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.spy;
@@ -62,6 +64,23 @@ public class InvocationFactoryTest extends TestBase {
 
         Object ret = Mockito.mockingDetails(mock).getMockHandler().handle(invocation);
         assertEquals(String.class, ret.getClass());
+        assertEquals("mocked", ret);
+    }
+
+    @Test
+    public void deprecated_api_still_works() throws Throwable {
+        final TestClass mock = spy(TestClass.class);
+
+        Invocation invocation = Mockito.framework().getInvocationFactory().createInvocation(mock,
+            withSettings().build(TestClass.class),
+            TestClass.class.getDeclaredMethod("testMethod"),
+            new Callable() {
+                public Object call() throws Exception {
+                    return "mocked";
+                }
+            });
+
+        Object ret = Mockito.mockingDetails(mock).getMockHandler().handle(invocation);
         assertEquals("mocked", ret);
     }
 }

--- a/src/test/java/org/mockito/InvocationFactoryTest.java
+++ b/src/test/java/org/mockito/InvocationFactoryTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2018 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito;
+
+import org.junit.Test;
+import org.mockito.invocation.Invocation;
+import org.mockito.invocation.InvocationFactory;
+import org.mockitoutil.TestBase;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.withSettings;
+
+public class InvocationFactoryTest extends TestBase {
+    static class TestClass {
+        public String testMethod() throws Throwable {
+            return "un-mocked";
+        }
+    }
+
+    @Test
+    public void call_method_that_throws_a_throwable() throws Throwable {
+        final TestClass mock = spy(TestClass.class);
+
+        Invocation invocation = Mockito.framework().getInvocationFactory().createInvocation(mock,
+            withSettings().build(TestClass.class),
+            TestClass.class.getDeclaredMethod("testMethod"),
+            new InvocationFactory.RealMethodBehavior() {
+            @Override
+            public Object call() throws Throwable {
+                throw new Throwable("mocked");
+            }
+        });
+
+        try {
+            Mockito.mockingDetails(mock).getMockHandler().handle(invocation);
+        } catch (Throwable t) {
+            assertEquals("mocked", t.getMessage());
+            return;
+        }
+
+        fail();
+    }
+
+    @Test
+    public void call_method_that_returns_a_string() throws Throwable {
+        final TestClass mock = spy(TestClass.class);
+
+        Invocation invocation = Mockito.framework().getInvocationFactory().createInvocation(mock,
+            withSettings().build(TestClass.class),
+            TestClass.class.getDeclaredMethod("testMethod"),
+            new InvocationFactory.RealMethodBehavior() {
+                @Override
+                public Object call() throws Throwable {
+                    return "mocked";
+                }
+            });
+
+        Object ret = Mockito.mockingDetails(mock).getMockHandler().handle(invocation);
+        assertEquals(String.class, ret.getClass());
+        assertEquals("mocked", ret);
+    }
+}

--- a/src/test/java/org/mockito/StaticMockingExperimentTest.java
+++ b/src/test/java/org/mockito/StaticMockingExperimentTest.java
@@ -10,12 +10,12 @@ import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockito.exceptions.verification.WantedButNotInvoked;
 import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
 import org.mockito.invocation.Invocation;
+import org.mockito.invocation.InvocationFactory;
 import org.mockito.invocation.MockHandler;
 import org.mockitoutil.TestBase;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
-import java.util.concurrent.Callable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -43,9 +43,9 @@ public class StaticMockingExperimentTest extends TestBase {
     Foo mock = Mockito.mock(Foo.class);
     MockHandler handler = Mockito.mockingDetails(mock).getMockHandler();
     Method staticMethod;
-    Callable realMethod = new Callable() {
+    InvocationFactory.RealMethodBehavior realMethod = new InvocationFactory.RealMethodBehavior() {
         @Override
-        public Object call() throws Exception {
+        public Object call() throws Throwable {
             return null;
         }
     };

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
 #Currently building Mockito version
-version=2.13.4
+version=2.14.0
 
 #Previous version used to generate release notes delta
 previousVersion=2.13.3


### PR DESCRIPTION
Fixes #1306

A real method might throw a Throwable, but the invocations produced by
InvocationFactory call the real method via a Callable that can only
throw a Exception.

Hence add a new method to InvocationFactory that allows to create
invocations with a RealMethodBehavior == a Callable that throws a
Throwable.