### PR TITLE
Ensure isolation of stubbings

### DIFF
--- a/src/main/java/org/mockito/internal/handler/MockHandlerImpl.java
+++ b/src/main/java/org/mockito/internal/handler/MockHandlerImpl.java
@@ -8,7 +8,6 @@ import org.mockito.internal.creation.settings.CreationSettings;
 import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockito.internal.invocation.MatchersBinder;
 import org.mockito.internal.listeners.StubbingLookupListener;
-import org.mockito.invocation.InvocationContainer;
 import org.mockito.internal.stubbing.InvocationContainerImpl;
 import org.mockito.internal.stubbing.OngoingStubbingImpl;
 import org.mockito.internal.stubbing.StubbedInvocationMatcher;
@@ -16,6 +15,7 @@ import org.mockito.internal.stubbing.answers.DefaultAnswerValidator;
 import org.mockito.internal.verification.MockAwareVerificationMode;
 import org.mockito.internal.verification.VerificationDataImpl;
 import org.mockito.invocation.Invocation;
+import org.mockito.invocation.InvocationContainer;
 import org.mockito.invocation.MockHandler;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.verification.VerificationMode;
@@ -95,8 +95,9 @@ public class MockHandlerImpl<T> implements MockHandler<T> {
 
             try {
                 return stubbing.answer(invocation);
-            }
-            finally {
+            } finally {
+                //Needed so that we correctly isolate stubbings in some scenarios
+                //see MockitoStubbedCallInAnswerTest or issue #1279
                 mockingProgress().reportOngoingStubbing(ongoingStubbing);
             }
         } else {

--- a/src/test/java/org/mockitousage/bugs/MockitoStubbedCallInAnswerTest.java
+++ b/src/test/java/org/mockitousage/bugs/MockitoStubbedCallInAnswerTest.java
@@ -5,23 +5,26 @@
 package org.mockitousage.bugs;
 
 import org.junit.Test;
+import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.mockitoutil.TestBase;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
  * @see <a href="https://github.com/mockito/mockito/issues/1279">Issue #1279</a>
  */
-public class MockitoStubbedCallInAnswerTest {
+public class MockitoStubbedCallInAnswerTest extends TestBase {
+
+    @Mock Foo foo;
+    @Mock Bar bar;
 
     @Test
-    public void directInvocationInAnswer() throws Exception {
-        final Foo foo = mock(Foo.class);
-        final Bar bar = mock(Bar.class);
-
+    public void stubbing_the_right_mock() throws Exception {
+        //stubbing on different mock should not be altered
+        when(bar.doInt()).thenReturn(0);
         when(foo.doInt()).thenAnswer(new Answer<Integer>() {
             @Override
             public Integer answer(InvocationOnMock invocation) throws Throwable {
@@ -31,35 +34,34 @@ public class MockitoStubbedCallInAnswerTest {
         assertEquals(0, foo.doInt());
         assertEquals(0, bar.doInt());
 
+        //when we override the stubbing
         when(foo.doInt()).thenReturn(1);
+
+        //we expect it to be reflected:
         assertEquals(1, foo.doInt());
+
+        //but the stubbing on a different mock should not be altered:
         assertEquals(0, bar.doInt());
     }
 
     @Test
-    public void useOtherStubbedMethodReturnTypeInLogic() throws Exception {
-        final Foo foo = mock(Foo.class);
-        final Bar bar = mock(Bar.class);
-
+    public void return_type_validation() throws Exception {
         when(foo.doString()).thenAnswer(new Answer<String>() {
-            @Override
             public String answer(InvocationOnMock invocation) throws Throwable {
+                //invoking a method on a different mock, with different return type
                 return String.valueOf(bar.doInt());
             }
         });
         assertEquals("0", foo.doString());
 
+        //we can override stubbing without misleading return type validation errors:
         when(foo.doString()).thenReturn("");
         assertEquals("", foo.doString());
     }
 
     @Test
-    public void doesNotProduceStackOverflowWhenStubbingTwice() throws Exception {
-        final Foo foo = mock(Foo.class);
-        final Bar bar = mock(Bar.class);
-
+    public void prevents_stack_overflow() throws Exception {
         when(foo.doInt()).thenAnswer(new Answer<Integer>() {
-            @Override
             public Integer answer(InvocationOnMock invocation) throws Throwable {
                 return bar.doInt();
             }
@@ -67,22 +69,19 @@ public class MockitoStubbedCallInAnswerTest {
         assertEquals(0, foo.doInt());
 
         when(foo.doInt()).thenAnswer(new Answer<Integer>() {
-            @Override
             public Integer answer(InvocationOnMock invocation) throws Throwable {
                 return bar.doInt() + 1;
             }
         });
+
+        //calling below used to cause SO error
         assertEquals(1, foo.doInt());
     }
 
     @Test
     public void overriding_stubbing() throws Exception {
-        final Foo foo = mock(Foo.class);
-        final Bar bar = mock(Bar.class);
-
         when(bar.doInt()).thenReturn(10);
         when(foo.doInt()).thenAnswer(new Answer<Integer>() {
-            @Override
             public Integer answer(InvocationOnMock invocation) throws Throwable {
                 return bar.doInt() + 1;
             }

--- a/src/test/java/org/mockitousage/bugs/MockitoStubbedCallInAnswerTest.java
+++ b/src/test/java/org/mockitousage/bugs/MockitoStubbedCallInAnswerTest.java
@@ -9,8 +9,8 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @see <a href="https://github.com/mockito/mockito/issues/1279">Issue #1279</a>
@@ -73,6 +73,28 @@ public class MockitoStubbedCallInAnswerTest {
             }
         });
         assertEquals(1, foo.doInt());
+    }
+
+    @Test
+    public void overriding_stubbing() throws Exception {
+        final Foo foo = mock(Foo.class);
+        final Bar bar = mock(Bar.class);
+
+        when(bar.doInt()).thenReturn(10);
+        when(foo.doInt()).thenAnswer(new Answer<Integer>() {
+            @Override
+            public Integer answer(InvocationOnMock invocation) throws Throwable {
+                return bar.doInt() + 1;
+            }
+        });
+
+        assertEquals(11, foo.doInt());
+
+        //when we override the stubbing with a different one
+        when(foo.doInt()).thenReturn(100);
+
+        //we expect it to be reflected:
+        assertEquals(100, foo.doInt());
     }
 
     interface Foo {


### PR DESCRIPTION
### Bugfix compatibility

For certain corner cases, this bugfix may be incompatible. We believe that the exposure is minimal (corner cases only, possibly incorrect tests), and the bugfix important. If your test fails after upgrading to Mockito version that contains this fix, please scrutinize the test - it is very likely that the test is incorrect. We apologize for any compatibility problems arising from this change. It is a hard decision to make when a bugfix changes the behavior in a way it may not be compatible with every Mockito test in the world.

### Problem

When stubbing with answers that call different mocked methods:
```java
when(mock.foo()).thenAnswer(() -> { otherMock.bar() }
```
we need to ensure that ```mock.foo()``` and ```otherMock.bar()``` don't interfere. Prior to this bugfix, this scenario resulted in various problems like: stack overflow error, unexpected stubbings declared on different mock, unexpected invalid return type errors.

For more details, see #1279

### Solution

The solution is based on great PR #1296 by @r-smirnov. **Huge thanks** to @r-smirnov for reporting the problem diligently, then digging into the bowels of Mockito to find a clean solution, providing excellent test cases that demonstrate the problem. When I initially saw the issue report, I thought that it's not fixable and we would close it as "documented Mockito syntax caveat". Thank you @r-smirnov for persistence and getting this fixed!