### PR TITLE
Fixes #1314 : Include all the invocation in mock verification error message

### DIFF
--- a/src/main/java/org/mockito/internal/exceptions/Reporter.java
+++ b/src/main/java/org/mockito/internal/exceptions/Reporter.java
@@ -370,30 +370,30 @@ public class Reporter {
         ));
     }
 
-    public static MockitoAssertionError tooManyActualInvocations(int wantedCount, int actualCount, DescribedInvocation wanted, List<Location> invocations) {
-        String message = createTooManyInvocationsMessage(wantedCount, actualCount, wanted, invocations);
+    public static MockitoAssertionError tooManyActualInvocations(int wantedCount, int actualCount, DescribedInvocation wanted, List<Location> locations) {
+        String message = createTooManyInvocationsMessage(wantedCount, actualCount, wanted, locations);
         return new TooManyActualInvocations(message);
     }
 
     private static String createTooManyInvocationsMessage(int wantedCount, int actualCount, DescribedInvocation wanted,
                                                           List<Location> invocations) {
         return join(
-            wanted.toString(),
-            "Wanted " + pluralize(wantedCount) + ":",
-            new LocationImpl(),
-            "But was " + pluralize(actualCount) + ":",
-            createAllLocationsMessage(invocations),
-            ""
+                wanted.toString(),
+                "Wanted " + pluralize(wantedCount) + ":",
+                new LocationImpl(),
+                "But was " + pluralize(actualCount) + ":",
+                createAllLocationsMessage(invocations),
+                ""
         );
     }
 
     public static MockitoAssertionError neverWantedButInvoked(DescribedInvocation wanted, List<Location> invocations) {
         return new NeverWantedButInvoked(join(
-            wanted.toString(),
-            "Never wanted here:",
-            new LocationImpl(),
-            "But invoked here:",
-            createAllLocationsMessage(invocations)
+                wanted.toString(),
+                "Never wanted here:",
+                new LocationImpl(),
+                "But invoked here:",
+                createAllLocationsMessage(invocations)
         ));
     }
 
@@ -409,20 +409,21 @@ public class Reporter {
             return "\n";
         }
         StringBuilder sb = new StringBuilder();
-        for (Location invocation : locations) {
-            sb.append(invocation).append("\n");
+        for (Location location : locations) {
+            sb.append(location).append("\n");
         }
         return sb.toString();
     }
 
-    private static String createTooLittleInvocationsMessage(org.mockito.internal.reporting.Discrepancy discrepancy, DescribedInvocation wanted,
-                                                            List<Location> allLocations) {
+    private static String createTooLittleInvocationsMessage(org.mockito.internal.reporting.Discrepancy discrepancy,
+                                                            DescribedInvocation wanted,
+                                                            List<Location> locations) {
         return join(
                 wanted.toString(),
                 "Wanted " + discrepancy.getPluralizedWantedCount() + (discrepancy.getWantedCount() == 0 ? "." : ":"),
                 new LocationImpl(),
                 "But was " + discrepancy.getPluralizedActualCount() + (discrepancy.getActualCount() == 0 ? "." : ":"),
-                createAllLocationsMessage(allLocations)
+                createAllLocationsMessage(locations)
         );
     }
 
@@ -432,8 +433,8 @@ public class Reporter {
         return new TooLittleActualInvocations(message);
     }
 
-    public static MockitoAssertionError tooLittleActualInvocationsInOrder(org.mockito.internal.reporting.Discrepancy discrepancy, DescribedInvocation wanted, List<Location> allLocations) {
-        String message = createTooLittleInvocationsMessage(discrepancy, wanted, allLocations);
+    public static MockitoAssertionError tooLittleActualInvocationsInOrder(org.mockito.internal.reporting.Discrepancy discrepancy, DescribedInvocation wanted, List<Location> locations) {
+        String message = createTooLittleInvocationsMessage(discrepancy, wanted, locations);
 
         return new VerificationInOrderFailure(join(
                 "Verification in order failure:" + message

--- a/src/main/java/org/mockito/internal/exceptions/Reporter.java
+++ b/src/main/java/org/mockito/internal/exceptions/Reporter.java
@@ -5,9 +5,27 @@
 
 package org.mockito.internal.exceptions;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import org.mockito.exceptions.base.MockitoAssertionError;
 import org.mockito.exceptions.base.MockitoException;
-import org.mockito.exceptions.misusing.*;
+import org.mockito.exceptions.misusing.CannotStubVoidMethodWithReturnValue;
+import org.mockito.exceptions.misusing.CannotVerifyStubOnlyMock;
+import org.mockito.exceptions.misusing.FriendlyReminderException;
+import org.mockito.exceptions.misusing.InvalidUseOfMatchersException;
+import org.mockito.exceptions.misusing.MissingMethodInvocationException;
+import org.mockito.exceptions.misusing.NotAMockException;
+import org.mockito.exceptions.misusing.NullInsteadOfMockException;
+import org.mockito.exceptions.misusing.PotentialStubbingProblem;
+import org.mockito.exceptions.misusing.RedundantListenerException;
+import org.mockito.exceptions.misusing.UnfinishedMockingSessionException;
+import org.mockito.exceptions.misusing.UnfinishedStubbingException;
+import org.mockito.exceptions.misusing.UnfinishedVerificationException;
+import org.mockito.exceptions.misusing.UnnecessaryStubbingException;
+import org.mockito.exceptions.misusing.WrongTypeOfReturnValue;
 import org.mockito.exceptions.verification.NeverWantedButInvoked;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockito.exceptions.verification.SmartNullPointerException;
@@ -27,12 +45,6 @@ import org.mockito.invocation.Location;
 import org.mockito.listeners.InvocationListener;
 import org.mockito.mock.MockName;
 import org.mockito.mock.SerializableMode;
-
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 
 import static org.mockito.internal.reporting.Pluralizer.pluralize;
 import static org.mockito.internal.reporting.Pluralizer.were_exactly_x_interactions;
@@ -358,63 +370,70 @@ public class Reporter {
         ));
     }
 
-    public static MockitoAssertionError tooManyActualInvocations(int wantedCount, int actualCount, DescribedInvocation wanted, Location firstUndesired) {
-        String message = createTooManyInvocationsMessage(wantedCount, actualCount, wanted, firstUndesired);
+    public static MockitoAssertionError tooManyActualInvocations(int wantedCount, int actualCount, DescribedInvocation wanted, List<Location> invocations) {
+        String message = createTooManyInvocationsMessage(wantedCount, actualCount, wanted, invocations);
         return new TooManyActualInvocations(message);
     }
 
     private static String createTooManyInvocationsMessage(int wantedCount, int actualCount, DescribedInvocation wanted,
-                                                          Location firstUndesired) {
+                                                          List<Location> invocations) {
         return join(
-                wanted.toString(),
-                "Wanted " + pluralize(wantedCount) + ":",
-                new LocationImpl(),
-                "But was " + pluralize(actualCount) + ". Undesired invocation:",
-                firstUndesired,
-                ""
+            wanted.toString(),
+            "Wanted " + pluralize(wantedCount) + ":",
+            new LocationImpl(),
+            "But was " + pluralize(actualCount) + ":",
+            createAllLocationsMessage(invocations),
+            ""
         );
     }
 
-    public static MockitoAssertionError neverWantedButInvoked(DescribedInvocation wanted, Location firstUndesired) {
+    public static MockitoAssertionError neverWantedButInvoked(DescribedInvocation wanted, List<Location> invocations) {
         return new NeverWantedButInvoked(join(
-                wanted.toString(),
-                "Never wanted here:",
-                new LocationImpl(),
-                "But invoked here:",
-                firstUndesired,
-                ""
+            wanted.toString(),
+            "Never wanted here:",
+            new LocationImpl(),
+            "But invoked here:",
+            createAllLocationsMessage(invocations)
         ));
     }
 
-    public static MockitoAssertionError tooManyActualInvocationsInOrder(int wantedCount, int actualCount, DescribedInvocation wanted, Location firstUndesired) {
-        String message = createTooManyInvocationsMessage(wantedCount, actualCount, wanted, firstUndesired);
+    public static MockitoAssertionError tooManyActualInvocationsInOrder(int wantedCount, int actualCount, DescribedInvocation wanted, List<Location> invocations) {
+        String message = createTooManyInvocationsMessage(wantedCount, actualCount, wanted, invocations);
         return new VerificationInOrderFailure(join(
                 "Verification in order failure:" + message
         ));
     }
 
-    private static String createTooLittleInvocationsMessage(org.mockito.internal.reporting.Discrepancy discrepancy, DescribedInvocation wanted,
-                                                            Location lastActualInvocation) {
-        String ending =
-                (lastActualInvocation != null) ? lastActualInvocation + "\n" : "\n";
+    private static String createAllLocationsMessage(List<Location> locations) {
+        if (locations == null) {
+            return "\n";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (Location invocation : locations) {
+            sb.append(invocation).append("\n");
+        }
+        return sb.toString();
+    }
 
+    private static String createTooLittleInvocationsMessage(org.mockito.internal.reporting.Discrepancy discrepancy, DescribedInvocation wanted,
+                                                            List<Location> allLocations) {
         return join(
                 wanted.toString(),
                 "Wanted " + discrepancy.getPluralizedWantedCount() + (discrepancy.getWantedCount() == 0 ? "." : ":"),
                 new LocationImpl(),
                 "But was " + discrepancy.getPluralizedActualCount() + (discrepancy.getActualCount() == 0 ? "." : ":"),
-                ending
+                createAllLocationsMessage(allLocations)
         );
     }
 
-    public static MockitoAssertionError tooLittleActualInvocations(org.mockito.internal.reporting.Discrepancy discrepancy, DescribedInvocation wanted, Location lastActualLocation) {
-        String message = createTooLittleInvocationsMessage(discrepancy, wanted, lastActualLocation);
+    public static MockitoAssertionError tooLittleActualInvocations(org.mockito.internal.reporting.Discrepancy discrepancy, DescribedInvocation wanted, List<Location> allLocations) {
+        String message = createTooLittleInvocationsMessage(discrepancy, wanted, allLocations);
 
         return new TooLittleActualInvocations(message);
     }
 
-    public static MockitoAssertionError tooLittleActualInvocationsInOrder(org.mockito.internal.reporting.Discrepancy discrepancy, DescribedInvocation wanted, Location lastActualLocation) {
-        String message = createTooLittleInvocationsMessage(discrepancy, wanted, lastActualLocation);
+    public static MockitoAssertionError tooLittleActualInvocationsInOrder(org.mockito.internal.reporting.Discrepancy discrepancy, DescribedInvocation wanted, List<Location> allLocations) {
+        String message = createTooLittleInvocationsMessage(discrepancy, wanted, allLocations);
 
         return new VerificationInOrderFailure(join(
                 "Verification in order failure:" + message

--- a/src/main/java/org/mockito/internal/invocation/InvocationsFinder.java
+++ b/src/main/java/org/mockito/internal/invocation/InvocationsFinder.java
@@ -138,6 +138,14 @@ public class InvocationsFinder {
         return unverified;
     }
 
+    public static List<Location> getAllLocations(List<Invocation> invocations) {
+        List<Location> locations = new LinkedList<Location>();
+        for (Invocation invocation : invocations) {
+            locations.add(invocation.getLocation());
+        }
+        return locations;
+    }
+
     private static class RemoveNotMatching implements Filter<Invocation> {
         private final MatchableInvocation wanted;
 

--- a/src/main/java/org/mockito/internal/verification/checkers/AtLeastXNumberOfInvocationsChecker.java
+++ b/src/main/java/org/mockito/internal/verification/checkers/AtLeastXNumberOfInvocationsChecker.java
@@ -17,7 +17,7 @@ import static org.mockito.internal.invocation.InvocationMarker.markVerified;
 import static org.mockito.internal.invocation.InvocationMarker.markVerifiedInOrder;
 import static org.mockito.internal.invocation.InvocationsFinder.findAllMatchingUnverifiedChunks;
 import static org.mockito.internal.invocation.InvocationsFinder.findInvocations;
-import static org.mockito.internal.invocation.InvocationsFinder.getLastLocation;
+import static org.mockito.internal.invocation.InvocationsFinder.getAllLocations;
 
 public class AtLeastXNumberOfInvocationsChecker {
 
@@ -26,8 +26,8 @@ public class AtLeastXNumberOfInvocationsChecker {
 
         int actualCount = actualInvocations.size();
         if (wantedCount > actualCount) {
-            Location lastLocation = getLastLocation(actualInvocations);
-            throw tooLittleActualInvocations(new AtLeastDiscrepancy(wantedCount, actualCount), wanted, lastLocation);
+            List<Location> allLocations = getAllLocations(actualInvocations);
+            throw tooLittleActualInvocations(new AtLeastDiscrepancy(wantedCount, actualCount), wanted, allLocations);
         }
 
         markVerified(actualInvocations, wanted);
@@ -39,8 +39,8 @@ public class AtLeastXNumberOfInvocationsChecker {
         int actualCount = chunk.size();
 
         if (wantedCount > actualCount) {
-            Location lastLocation = getLastLocation(chunk);
-            throw tooLittleActualInvocationsInOrder(new AtLeastDiscrepancy(wantedCount, actualCount), wanted, lastLocation);
+            List<Location> allLocations = getAllLocations(chunk);
+            throw tooLittleActualInvocationsInOrder(new AtLeastDiscrepancy(wantedCount, actualCount), wanted, allLocations);
         }
 
         markVerifiedInOrder(chunk, wanted, orderingContext);

--- a/src/main/java/org/mockito/internal/verification/checkers/NumberOfInvocationsChecker.java
+++ b/src/main/java/org/mockito/internal/verification/checkers/NumberOfInvocationsChecker.java
@@ -5,6 +5,7 @@
 
 package org.mockito.internal.verification.checkers;
 
+import java.util.Arrays;
 import java.util.List;
 import org.mockito.internal.reporting.Discrepancy;
 import org.mockito.internal.verification.api.InOrderContext;
@@ -22,7 +23,7 @@ import static org.mockito.internal.invocation.InvocationMarker.markVerifiedInOrd
 import static org.mockito.internal.invocation.InvocationsFinder.findFirstMatchingUnverifiedInvocation;
 import static org.mockito.internal.invocation.InvocationsFinder.findInvocations;
 import static org.mockito.internal.invocation.InvocationsFinder.findMatchingChunk;
-import static org.mockito.internal.invocation.InvocationsFinder.getLastLocation;
+import static org.mockito.internal.invocation.InvocationsFinder.getAllLocations;
 
 public class NumberOfInvocationsChecker {
 
@@ -34,16 +35,14 @@ public class NumberOfInvocationsChecker {
 
         int actualCount = actualInvocations.size();
         if (wantedCount > actualCount) {
-            Location lastInvocation = getLastLocation(actualInvocations);
-            throw tooLittleActualInvocations(new Discrepancy(wantedCount, actualCount), wanted, lastInvocation);
+            List<Location> allLocations = getAllLocations(actualInvocations);
+            throw tooLittleActualInvocations(new Discrepancy(wantedCount, actualCount), wanted, allLocations);
         }
         if (wantedCount == 0 && actualCount > 0) {
-            Location firstUndesired = actualInvocations.get(wantedCount).getLocation();
-            throw neverWantedButInvoked(wanted, firstUndesired);
+            throw neverWantedButInvoked(wanted, getAllLocations(actualInvocations));
         }
         if (wantedCount < actualCount) {
-            Location firstUndesired = actualInvocations.get(wantedCount).getLocation();
-            throw tooManyActualInvocations(wantedCount, actualCount, wanted, firstUndesired);
+            throw tooManyActualInvocations(wantedCount, actualCount, wanted, getAllLocations(actualInvocations));
         }
 
         markVerified(actualInvocations, wanted);
@@ -55,12 +54,11 @@ public class NumberOfInvocationsChecker {
         int actualCount = chunk.size();
 
         if (wantedCount > actualCount) {
-            Location lastInvocation = getLastLocation(chunk);
-            throw tooLittleActualInvocationsInOrder(new Discrepancy(wantedCount, actualCount), wanted, lastInvocation);
+            List<Location> allLocations = getAllLocations(chunk);
+            throw tooLittleActualInvocationsInOrder(new Discrepancy(wantedCount, actualCount), wanted, allLocations);
         }
         if (wantedCount < actualCount) {
-            Location firstUndesired = chunk.get(wantedCount).getLocation();
-            throw tooManyActualInvocationsInOrder(wantedCount, actualCount, wanted, firstUndesired);
+            throw tooManyActualInvocationsInOrder(wantedCount, actualCount, wanted, getAllLocations(chunk));
         }
 
         markVerifiedInOrder(chunk, wanted, context);
@@ -72,7 +70,7 @@ public class NumberOfInvocationsChecker {
         while( actualCount < wantedCount ){
             Invocation next = findFirstMatchingUnverifiedInvocation(invocations, wanted, context );
             if( next == null ){
-                throw tooLittleActualInvocationsInOrder(new Discrepancy(wantedCount, actualCount), wanted, lastLocation );
+                throw tooLittleActualInvocationsInOrder(new Discrepancy(wantedCount, actualCount), wanted, Arrays.asList(lastLocation));
             }
             markVerified( next, wanted );
             context.markVerified( next );

--- a/src/test/java/org/mockito/internal/invocation/InvocationsFinderTest.java
+++ b/src/test/java/org/mockito/internal/invocation/InvocationsFinderTest.java
@@ -190,7 +190,10 @@ public class InvocationsFinderTest extends TestBase {
     public void shouldFindAllStackTraces() {
         List<Location> all = InvocationsFinder.getAllLocations(invocations);
         Assertions.assertThat(all).contains(simpleMethodInvocation.getLocation(), simpleMethodInvocationTwo.getLocation(), differentMethodInvocation.getLocation());
+    }
 
+    @Test
+    public void shouldNotFindLocationsForEmptyInvocationsList() {
         Assertions.assertThat(InvocationsFinder.getAllLocations(Collections.<Invocation>emptyList())).isEmpty();
     }
 }

--- a/src/test/java/org/mockito/internal/invocation/InvocationsFinderTest.java
+++ b/src/test/java/org/mockito/internal/invocation/InvocationsFinderTest.java
@@ -185,4 +185,12 @@ public class InvocationsFinderTest extends TestBase {
         previous = InvocationsFinder.findPreviousVerifiedInOrder(invocations, context);
         assertSame(simpleMethodInvocationTwo, previous);
     }
+
+    @Test
+    public void shouldFindAllStackTraces() {
+        List<Location> all = InvocationsFinder.getAllLocations(invocations);
+        Assertions.assertThat(all).contains(simpleMethodInvocation.getLocation(), simpleMethodInvocationTwo.getLocation(), differentMethodInvocation.getLocation());
+
+        Assertions.assertThat(InvocationsFinder.getAllLocations(Collections.<Invocation>emptyList())).isEmpty();
+    }
 }

--- a/src/test/java/org/mockito/internal/verification/checkers/NumberOfInvocationsCheckerTest.java
+++ b/src/test/java/org/mockito/internal/verification/checkers/NumberOfInvocationsCheckerTest.java
@@ -5,10 +5,6 @@
 
 package org.mockito.internal.verification.checkers;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.List;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -27,6 +23,10 @@ import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockito.invocation.Invocation;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockitousage.IMethods;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(MockitoJUnitRunner.class)
 public class NumberOfInvocationsCheckerTest {
@@ -58,7 +58,7 @@ public class NumberOfInvocationsCheckerTest {
     }
 
     @Test
-    public void shouldReportWithLastInvocationStackTrace() throws Exception {
+    public void shouldReportAllInvocationsStackTrace() throws Exception {
         wanted = buildSimpleMethod().toInvocationMatcher();
         invocations = asList(buildSimpleMethod().toInvocation(), buildSimpleMethod().toInvocation());
 
@@ -66,7 +66,7 @@ public class NumberOfInvocationsCheckerTest {
         exception.expectMessage("mock.simpleMethod()");
         exception.expectMessage("Wanted 100 times");
         exception.expectMessage("But was 2 times");
-        exception.expectMessage(containsTimes("-> at", 2));
+        exception.expectMessage(containsTimes("-> at", 3));
 
         NumberOfInvocationsChecker.checkNumberOfInvocations(invocations, wanted, 100);
     }
@@ -86,7 +86,7 @@ public class NumberOfInvocationsCheckerTest {
     }
 
     @Test
-    public void shouldReportWithFirstUndesiredInvocationStackTrace() throws Exception {
+    public void shouldReportWithAllInvocationsStackTrace() throws Exception {
         Invocation first = buildSimpleMethod().toInvocation();
         Invocation second = buildSimpleMethod().toInvocation();
         Invocation third = buildSimpleMethod().toInvocation();
@@ -95,6 +95,8 @@ public class NumberOfInvocationsCheckerTest {
         wanted = buildSimpleMethod().toInvocationMatcher();
 
         exception.expect(TooManyActualInvocations.class);
+        exception.expectMessage("" + first.getLocation());
+        exception.expectMessage("" + second.getLocation());
         exception.expectMessage("" + third.getLocation());
         NumberOfInvocationsChecker.checkNumberOfInvocations(invocations, wanted, 2);
     }

--- a/src/test/java/org/mockito/internal/verification/checkers/NumberOfInvocationsInOrderCheckerTest.java
+++ b/src/test/java/org/mockito/internal/verification/checkers/NumberOfInvocationsInOrderCheckerTest.java
@@ -5,11 +5,6 @@
 
 package org.mockito.internal.verification.checkers;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-
 import java.util.List;
 
 import org.hamcrest.BaseMatcher;
@@ -26,6 +21,11 @@ import org.mockito.internal.verification.InOrderContextImpl;
 import org.mockito.internal.verification.api.InOrderContext;
 import org.mockito.invocation.Invocation;
 import org.mockitousage.IMethods;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class NumberOfInvocationsInOrderCheckerTest {
 
@@ -102,7 +102,7 @@ public class NumberOfInvocationsInOrderCheckerTest {
     }
 
     @Test
-    public void shouldReportWithLastInvocationStackTrace() throws Exception {
+    public void shouldReportWithAllInvocationsStackTrace() throws Exception {
         wanted = buildSimpleMethod().toInvocationMatcher();
         invocations = asList(buildSimpleMethod().toInvocation(), buildSimpleMethod().toInvocation());
 
@@ -110,7 +110,7 @@ public class NumberOfInvocationsInOrderCheckerTest {
         exception.expectMessage("mock.simpleMethod()");
         exception.expectMessage("Wanted 100 times");
         exception.expectMessage("But was 2 times");
-        exception.expectMessage(containsTimes("-> at", 2));
+        exception.expectMessage(containsTimes("-> at", 3));
 
         NumberOfInvocationsChecker.checkNumberOfInvocations(invocations, wanted, 100, context);
 
@@ -168,7 +168,7 @@ public class NumberOfInvocationsInOrderCheckerTest {
         exception.expect(VerificationInOrderFailure.class);
         exception.expectMessage("mock.simpleMethod()");
         exception.expectMessage("Wanted 0 times");
-        exception.expectMessage("But was 1 time. Undesired invocation");
+        exception.expectMessage("But was 1 time:");
         exception.expectMessage("" + first.getLocation());
 
         NumberOfInvocationsChecker.checkNumberOfInvocations(invocations, wanted, 0, context);

--- a/src/test/java/org/mockitousage/verification/DescriptiveMessagesOnVerificationInOrderErrorsTest.java
+++ b/src/test/java/org/mockitousage/verification/DescriptiveMessagesOnVerificationInOrderErrorsTest.java
@@ -155,7 +155,7 @@ public class DescriptiveMessagesOnVerificationInOrderErrorsTest extends TestBase
 
             String expectedCause =
                 "\n" +
-                "But was 2 times. Undesired invocation:" +
+                "But was 2 times:" +
                 "\n" +
                 "-> at";
             assertThat(e).hasMessageContaining(expectedCause);


### PR DESCRIPTION
Have changes the verify error message to include all the invocation instead of including just one undesired invocation.
Previously we have message like:
```
Wanted 1 time:
-> at ...
But was 2 times. Undesired invocation:
-> at ...
```
This PR changes it to 
```
Wanted 1 time:
-> at ...
But was 2 times:
-> at ...
-> at ...
```
To make the error message consistent the similar changes was made for too little invocations case.
The message:
```
Wanted 3 times:
-> at ...
But was 2 times:
-> at ...
```
changed to:
```
Wanted 3 times:
-> at ...
But was 2 times:
-> at ...
-> at ...
```