### PR TITLE
Avoid bytebuddy import Issue to enable repackaging without bytebuddy

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodInterceptor.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodInterceptor.java
@@ -13,12 +13,8 @@ import net.bytebuddy.implementation.bind.annotation.RuntimeType;
 import net.bytebuddy.implementation.bind.annotation.StubValue;
 import net.bytebuddy.implementation.bind.annotation.SuperCall;
 import net.bytebuddy.implementation.bind.annotation.This;
-import org.mockito.internal.creation.DelegatingMethod;
 import org.mockito.internal.debugging.LocationImpl;
-import org.mockito.internal.invocation.MockitoMethod;
 import org.mockito.internal.invocation.RealMethod;
-import org.mockito.internal.invocation.SerializableMethod;
-import org.mockito.internal.progress.SequenceNumber;
 import org.mockito.invocation.Location;
 import org.mockito.invocation.MockHandler;
 import org.mockito.mock.MockCreationSettings;
@@ -27,6 +23,8 @@ import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.concurrent.Callable;
+
+import static org.mockito.internal.invocation.DefaultInvocationFactory.createInvocation;
 
 public class MockMethodInterceptor implements Serializable {
 
@@ -63,29 +61,6 @@ public class MockMethodInterceptor implements Serializable {
                        RealMethod realMethod,
                        Location location) throws Throwable {
         return handler.handle(createInvocation(mock, invokedMethod, arguments, realMethod, mockCreationSettings, location));
-    }
-
-    public static InterceptedInvocation createInvocation(Object mock, Method invokedMethod, Object[] arguments, RealMethod realMethod, MockCreationSettings settings, Location location) {
-        return new InterceptedInvocation(
-            mock,
-            createMockitoMethod(invokedMethod, settings),
-            arguments,
-            realMethod,
-            location,
-            SequenceNumber.next()
-        );
-    }
-
-    public static InterceptedInvocation createInvocation(Object mock, Method invokedMethod, Object[] arguments, RealMethod realMethod, MockCreationSettings settings) {
-        return createInvocation(mock, invokedMethod, arguments, realMethod, settings, new LocationImpl());
-    }
-
-    private static MockitoMethod createMockitoMethod(Method method, MockCreationSettings settings) {
-        if (settings.isSerializable()) {
-            return new SerializableMethod(method);
-        } else {
-            return new DelegatingMethod(method);
-        }
     }
 
     public MockHandler getMockHandler() {

--- a/src/main/java/org/mockito/internal/invocation/InterceptedInvocation.java
+++ b/src/main/java/org/mockito/internal/invocation/InterceptedInvocation.java
@@ -2,12 +2,9 @@
  * Copyright (c) 2016 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-package org.mockito.internal.creation.bytebuddy;
+package org.mockito.internal.invocation;
 
 import org.mockito.internal.exceptions.VerificationAwareInvocation;
-import org.mockito.internal.invocation.ArgumentsProcessor;
-import org.mockito.internal.invocation.MockitoMethod;
-import org.mockito.internal.invocation.RealMethod;
 import org.mockito.internal.reporting.PrintSettings;
 import org.mockito.invocation.Invocation;
 import org.mockito.invocation.Location;

--- a/src/test/java/org/mockito/internal/invocation/InvocationBuilder.java
+++ b/src/test/java/org/mockito/internal/invocation/InvocationBuilder.java
@@ -6,7 +6,6 @@
 package org.mockito.internal.invocation;
 
 import org.mockito.Mockito;
-import org.mockito.internal.creation.bytebuddy.InterceptedInvocation;
 import org.mockito.internal.debugging.LocationImpl;
 import org.mockito.invocation.Invocation;
 import org.mockito.invocation.Location;
@@ -17,7 +16,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static org.mockito.internal.creation.bytebuddy.InterceptedInvocation.NO_OP;
+import static org.mockito.internal.invocation.InterceptedInvocation.NO_OP;
 
 /**
  * Build an invocation.

--- a/src/test/java/org/mockitoutil/TestBase.java
+++ b/src/test/java/org/mockitoutil/TestBase.java
@@ -11,7 +11,7 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.StateMaster;
 import org.mockito.internal.MockitoCore;
 import org.mockito.internal.configuration.ConfigurationAccess;
-import org.mockito.internal.creation.bytebuddy.InterceptedInvocation;
+import org.mockito.internal.invocation.InterceptedInvocation;
 import org.mockito.internal.debugging.LocationImpl;
 import org.mockito.internal.invocation.InvocationBuilder;
 import org.mockito.internal.invocation.InvocationMatcher;


### PR DESCRIPTION
This allows libs that use alternate mockmakers do cleanly exclude the bytebuddy subdirectory.

Test: grep -r -e "import org\.mockito\.internal\.creation\.bytebuddy\.[^\.]*$" src/main does not return anything

Offers workaround for #1112