### PR TITLE
Improved stubbing internals and test coverage

### DIFF
--- a/src/main/java/org/mockito/internal/stubbing/BaseStubbing.java
+++ b/src/main/java/org/mockito/internal/stubbing/BaseStubbing.java
@@ -66,7 +66,7 @@ public abstract class BaseStubbing<T> implements OngoingStubbing<T> {
     @Override
     public OngoingStubbing<T> thenThrow(Class<? extends Throwable> toBeThrown, Class<? extends Throwable>... nextToBeThrown) {
         if (nextToBeThrown == null) {
-            thenThrow((Class<Throwable>) null);
+            return thenThrow((Class<Throwable>) null);
         }
         OngoingStubbing<T> stubbing = thenThrow(toBeThrown);
         for (Class<? extends Throwable> t : nextToBeThrown) {

--- a/src/main/java/org/mockito/internal/stubbing/BaseStubbing.java
+++ b/src/main/java/org/mockito/internal/stubbing/BaseStubbing.java
@@ -24,7 +24,7 @@ public abstract class BaseStubbing<T> implements OngoingStubbing<T> {
     public OngoingStubbing<T> thenReturn(T value, T... values) {
         OngoingStubbing<T> stubbing = thenReturn(value);
         if (values == null) {
-            // TODO below does not seem right
+            // Return null in the 2nd and subsequent invocations.
             return stubbing.thenReturn(null);
         }
         for (T v : values) {
@@ -56,16 +56,16 @@ public abstract class BaseStubbing<T> implements OngoingStubbing<T> {
     @Override
     public OngoingStubbing<T> thenThrow(Class<? extends Throwable> throwableType) {
         if (throwableType == null) {
-            mockingProgress().reset();
-            throw notAnException();
+            return abortNullExceptionType();
         }
         return thenThrow(newInstance(throwableType));
     }
 
     @Override
-    public OngoingStubbing<T> thenThrow(Class<? extends Throwable> toBeThrown, Class<? extends Throwable>... nextToBeThrown) {
+    public OngoingStubbing<T> thenThrow(Class<? extends Throwable> toBeThrown,
+                                        Class<? extends Throwable>... nextToBeThrown) {
         if (nextToBeThrown == null) {
-            thenThrow((Class<Throwable>) null);
+            return abortNullExceptionType();
         }
         OngoingStubbing<T> stubbing = thenThrow(toBeThrown);
         for (Class<? extends Throwable> t : nextToBeThrown) {
@@ -77,6 +77,11 @@ public abstract class BaseStubbing<T> implements OngoingStubbing<T> {
     @Override
     public OngoingStubbing<T> thenCallRealMethod() {
         return thenAnswer(new CallsRealMethods());
+    }
+
+    private OngoingStubbing<T> abortNullExceptionType() {
+        mockingProgress().reset();
+        throw notAnException();
     }
 }
 

--- a/src/main/java/org/mockito/internal/stubbing/BaseStubbing.java
+++ b/src/main/java/org/mockito/internal/stubbing/BaseStubbing.java
@@ -24,7 +24,8 @@ public abstract class BaseStubbing<T> implements OngoingStubbing<T> {
     public OngoingStubbing<T> thenReturn(T value, T... values) {
         OngoingStubbing<T> stubbing = thenReturn(value);
         if (values == null) {
-            // Return null in the 2nd and subsequent invocations.
+            // For no good reason we're configuring null answer here
+            // This has been like that since forever, so let's keep it for compatibility (unless users complain)
             return stubbing.thenReturn(null);
         }
         for (T v : values) {
@@ -56,16 +57,16 @@ public abstract class BaseStubbing<T> implements OngoingStubbing<T> {
     @Override
     public OngoingStubbing<T> thenThrow(Class<? extends Throwable> throwableType) {
         if (throwableType == null) {
-            return abortNullExceptionType();
+            mockingProgress().reset();
+            throw notAnException();
         }
         return thenThrow(newInstance(throwableType));
     }
 
     @Override
-    public OngoingStubbing<T> thenThrow(Class<? extends Throwable> toBeThrown,
-                                        Class<? extends Throwable>... nextToBeThrown) {
+    public OngoingStubbing<T> thenThrow(Class<? extends Throwable> toBeThrown, Class<? extends Throwable>... nextToBeThrown) {
         if (nextToBeThrown == null) {
-            return abortNullExceptionType();
+            thenThrow((Class<Throwable>) null);
         }
         OngoingStubbing<T> stubbing = thenThrow(toBeThrown);
         for (Class<? extends Throwable> t : nextToBeThrown) {
@@ -77,11 +78,6 @@ public abstract class BaseStubbing<T> implements OngoingStubbing<T> {
     @Override
     public OngoingStubbing<T> thenCallRealMethod() {
         return thenAnswer(new CallsRealMethods());
-    }
-
-    private OngoingStubbing<T> abortNullExceptionType() {
-        mockingProgress().reset();
-        throw notAnException();
     }
 }
 

--- a/src/main/java/org/mockito/internal/stubbing/StubberImpl.java
+++ b/src/main/java/org/mockito/internal/stubbing/StubberImpl.java
@@ -83,9 +83,9 @@ public class StubberImpl implements Stubber {
         Throwable e;
         try {
             e = newInstance(toBeThrown);
-        } catch (RuntimeException instanciationError) {
+        } catch (RuntimeException instantiationError) {
             mockingProgress().reset();
-            throw instanciationError;
+            throw instantiationError;
         }
         return doThrow(e);
     }

--- a/src/main/java/org/mockito/internal/stubbing/answers/ThrowsException.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/ThrowsException.java
@@ -14,27 +14,35 @@ import org.mockito.stubbing.ValidableAnswer;
 import static org.mockito.internal.exceptions.Reporter.cannotStubWithNullThrowable;
 import static org.mockito.internal.exceptions.Reporter.checkedExceptionInvalid;
 
+/**
+ * An answer that always throws the same throwable.
+ */
 public class ThrowsException implements Answer<Object>, ValidableAnswer, Serializable {
 
     private static final long serialVersionUID = 1128820328555183980L;
     private final Throwable throwable;
     private final ConditionalStackTraceFilter filter = new ConditionalStackTraceFilter();
 
+    /**
+     * Creates a new answer always throwing the given throwable. If it is null,
+     * {@linkplain ValidableAnswer#validateFor(InvocationOnMock) answer validation}
+     * will fail.
+     */
     public ThrowsException(Throwable throwable) {
         this.throwable = throwable;
     }
 
     public Object answer(InvocationOnMock invocation) throws Throwable {
+        if (throwable == null) {
+            throw new IllegalStateException("throwable is null: " +
+                "you shall not call #answer if #validateFor fails!");
+        }
         if (MockUtil.isMock(throwable)) {
             throw throwable;
         }
-        Throwable t = throwable.fillInStackTrace();
-
-        if (t == null) {
-            throw throwable;
-        }
-        filter.filter(t);
-        throw t;
+        throwable.fillInStackTrace();
+        filter.filter(throwable);
+        throw throwable;
     }
 
     @Override

--- a/src/main/java/org/mockito/internal/stubbing/answers/ThrowsException.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/ThrowsException.java
@@ -40,9 +40,14 @@ public class ThrowsException implements Answer<Object>, ValidableAnswer, Seriali
         if (MockUtil.isMock(throwable)) {
             throw throwable;
         }
-        throwable.fillInStackTrace();
-        filter.filter(throwable);
-        throw throwable;
+        Throwable t = throwable.fillInStackTrace();
+
+        if (t == null) {
+            //Custom exceptions sometimes return null, see #866
+            throw throwable;
+        }
+        filter.filter(t);
+        throw t;
     }
 
     @Override

--- a/src/test/java/org/mockito/internal/stubbing/answers/ThrowsExceptionTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/answers/ThrowsExceptionTest.java
@@ -28,62 +28,6 @@ public class ThrowsExceptionTest {
         }
     }
 
-    /**
-     * Tests that ThrowsException raises the same instance as passed in the constructor
-     * in case of a well-behaved Throwable implementation.
-     *
-     * @see #should_raise_same_wanted_throwable_even_if_it_returns_null_in_fill_in_stack_trace()
-     */
-    @Test
-    public void should_raise_same_wanted_throwable_on_subsequent_invocations() {
-        Throwable expectedThrowable = new IllegalStateException("An expected throwable");
-        ThrowsException throwingAnswer = new ThrowsException(expectedThrowable);
-        int numInvocations = 2;
-        for (int i = 0; i < numInvocations; i++) {
-            try {
-                throwingAnswer.answer(createMethodInvocation());
-                Assertions.fail("Should have raised wanted exception");
-            } catch (Throwable throwable) {
-                // All invocations must result in the same throwable as passed to the constructor.
-                assertThat(expectedThrowable).isSameAs(expectedThrowable);
-            }
-        }
-    }
-
-    /**
-     * Tests that a custom exception that breaks the Throwable contract returning null
-     * in fillInStackTrace does not break ThrowsException#answer.
-     *
-     * Any Throwable implementation must always return a reference to this
-     * from #fillInStackTrace.
-     *
-     * @see Throwable#fillInStackTrace()
-     * @see <a href="https://github.com/mockito/mockito/issues/866">#866</a>
-     */
-    @Test
-    public void should_raise_same_wanted_throwable_even_if_it_returns_null_in_fill_in_stack_trace() {
-        /*
-         * An evil throwable implementation that breaks Throwable#fillInStackTrace contract.
-         *
-         * We can't use a mock here because ThrowsException#answer handles mocks of exceptions
-         * differently.
-         */
-        class EvilThrowable extends Throwable {
-            @Override public synchronized Throwable fillInStackTrace() {
-                return null;
-            }
-        }
-
-        Throwable expectedThrowable = new EvilThrowable();
-        ThrowsException throwingAnswer = new ThrowsException(expectedThrowable);
-        try {
-            throwingAnswer.answer(createMethodInvocation());
-            Assertions.fail("should have raised wanted exception");
-        } catch (Throwable throwable) {
-            assertThat(throwable).isSameAs(expectedThrowable);
-        }
-    }
-
     @Test
     public void should_throw_mock_exception_without_stacktrace() throws Exception {
         try {

--- a/src/test/java/org/mockito/internal/stubbing/answers/ThrowsExceptionTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/answers/ThrowsExceptionTest.java
@@ -28,6 +28,62 @@ public class ThrowsExceptionTest {
         }
     }
 
+    /**
+     * Tests that ThrowsException raises the same instance as passed in the constructor
+     * in case of a well-behaved Throwable implementation.
+     *
+     * @see #should_raise_same_wanted_throwable_even_if_it_returns_null_in_fill_in_stack_trace()
+     */
+    @Test
+    public void should_raise_same_wanted_throwable_on_subsequent_invocations() {
+        Throwable expectedThrowable = new IllegalStateException("An expected throwable");
+        ThrowsException throwingAnswer = new ThrowsException(expectedThrowable);
+        int numInvocations = 2;
+        for (int i = 0; i < numInvocations; i++) {
+            try {
+                throwingAnswer.answer(createMethodInvocation());
+                Assertions.fail("Should have raised wanted exception");
+            } catch (Throwable throwable) {
+                // All invocations must result in the same throwable as passed to the constructor.
+                assertThat(expectedThrowable).isSameAs(expectedThrowable);
+            }
+        }
+    }
+
+    /**
+     * Tests that a custom exception that breaks the Throwable contract returning null
+     * in fillInStackTrace does not break ThrowsException#answer.
+     *
+     * Any Throwable implementation must always return a reference to this
+     * from #fillInStackTrace.
+     *
+     * @see Throwable#fillInStackTrace()
+     * @see <a href="https://github.com/mockito/mockito/issues/866">#866</a>
+     */
+    @Test
+    public void should_raise_same_wanted_throwable_even_if_it_returns_null_in_fill_in_stack_trace() {
+        /*
+         * An evil throwable implementation that breaks Throwable#fillInStackTrace contract.
+         *
+         * We can't use a mock here because ThrowsException#answer handles mocks of exceptions
+         * differently.
+         */
+        class EvilThrowable extends Throwable {
+            @Override public synchronized Throwable fillInStackTrace() {
+                return null;
+            }
+        }
+
+        Throwable expectedThrowable = new EvilThrowable();
+        ThrowsException throwingAnswer = new ThrowsException(expectedThrowable);
+        try {
+            throwingAnswer.answer(createMethodInvocation());
+            Assertions.fail("should have raised wanted exception");
+        } catch (Throwable throwable) {
+            assertThat(throwable).isSameAs(expectedThrowable);
+        }
+    }
+
     @Test
     public void should_throw_mock_exception_without_stacktrace() throws Exception {
         try {

--- a/src/test/java/org/mockito/internal/stubbing/answers/ThrowsExceptionTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/answers/ThrowsExceptionTest.java
@@ -12,6 +12,7 @@ import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.invocation.InvocationBuilder;
 import org.mockito.invocation.Invocation;
 
+import static junit.framework.TestCase.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -70,8 +71,8 @@ public class ThrowsExceptionTest {
     public void should_throw_illegal_state_exception_if_null_answer() throws Throwable {
         Invocation invocation = createMethodInvocation();
         try {
-            new ThrowsException(null)
-                .answer(invocation);
+            new ThrowsException(null).answer(invocation);
+            fail();
         } catch (IllegalStateException expected) {
         }
     }

--- a/src/test/java/org/mockito/internal/stubbing/answers/ThrowsExceptionTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/answers/ThrowsExceptionTest.java
@@ -10,6 +10,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.invocation.InvocationBuilder;
+import org.mockito.invocation.Invocation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -19,7 +20,7 @@ public class ThrowsExceptionTest {
     @Test
     public void should_raise_wanted_throwable() throws Throwable {
         try {
-            new ThrowsException(new IllegalStateException("my dear throwable")).answer(new InvocationBuilder().method("canThrowException").toInvocation());
+            new ThrowsException(new IllegalStateException("my dear throwable")).answer(createMethodInvocation());
             Assertions.fail("should have raised wanted exception");
         } catch (Throwable throwable) {
             assertThat(throwable).isInstanceOf(IllegalStateException.class).hasMessage("my dear throwable");
@@ -29,7 +30,7 @@ public class ThrowsExceptionTest {
     @Test
     public void should_throw_mock_exception_without_stacktrace() throws Exception {
         try {
-            new ThrowsException(mock(Exception.class)).answer(new InvocationBuilder().method("canThrowException").toInvocation());
+            new ThrowsException(mock(Exception.class)).answer(createMethodInvocation());
             Assertions.fail("should have raised wanted exception");
         } catch (Throwable throwable) {
             assertThat(throwable.getStackTrace()).describedAs("no stack trace, it's mock").isNull();
@@ -46,7 +47,7 @@ public class ThrowsExceptionTest {
         try {
 
             // when
-            new ThrowsException(throwableToRaise).answer(new InvocationBuilder().method("canThrowException").toInvocation());
+            new ThrowsException(throwableToRaise).answer(createMethodInvocation());
             Assertions.fail("should have raised wanted exception");
         } catch (Throwable throwable) {
             // then
@@ -59,24 +60,42 @@ public class ThrowsExceptionTest {
     @Test
     public void should_invalidate_null_throwable() throws Throwable {
         try {
-            new ThrowsException(null).validateFor(new InvocationBuilder().toInvocation());
+            Invocation invocation = createMethodInvocation();
+            new ThrowsException(null).validateFor(invocation);
             Assertions.fail("should have raised a MockitoException");
         } catch (MockitoException expected) {}
     }
 
     @Test
+    public void should_throw_illegal_state_exception_if_null_answer() throws Throwable {
+        Invocation invocation = createMethodInvocation();
+        try {
+            new ThrowsException(null)
+                .answer(invocation);
+        } catch (IllegalStateException expected) {
+        }
+    }
+
+    @Test
     public void should_pass_proper_checked_exception() throws Throwable {
-        new ThrowsException(new CharacterCodingException()).validateFor(new InvocationBuilder().method("canThrowException").toInvocation());
+        new ThrowsException(new CharacterCodingException()).validateFor(createMethodInvocation());
     }
 
     @Test(expected = MockitoException.class)
     public void should_fail_invalid_checked_exception() throws Throwable {
-        new ThrowsException(new IOException()).validateFor(new InvocationBuilder().method("canThrowException").toInvocation());
+        new ThrowsException(new IOException()).validateFor(createMethodInvocation());
     }
 
     @Test
     public void should_pass_RuntimeExceptions() throws Throwable {
-        new ThrowsException(new Error()).validateFor(new InvocationBuilder().method("canThrowException").toInvocation());
-        new ThrowsException(new RuntimeException()).validateFor(new InvocationBuilder().method("canThrowException").toInvocation());
+        new ThrowsException(new Error()).validateFor(createMethodInvocation());
+        new ThrowsException(new RuntimeException()).validateFor(createMethodInvocation());
+    }
+
+    /** Creates Invocation of a "canThrowException" method call. */
+    private static Invocation createMethodInvocation() {
+        return new InvocationBuilder()
+            .method("canThrowException")
+            .toInvocation();
     }
 }

--- a/src/test/java/org/mockitousage/bugs/FillInStackTraceScenariosTest.java
+++ b/src/test/java/org/mockitousage/bugs/FillInStackTraceScenariosTest.java
@@ -12,25 +12,40 @@ import org.mockitoutil.TestBase;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 
-public class NPEWhenCustomExceptionStackTraceReturnNullTest extends TestBase {
+public class FillInStackTraceScenariosTest extends TestBase {
 
-    @Mock
-    IMethods mock;
+    @Mock IMethods mock;
+
+    private class SomeException extends RuntimeException {}
 
     class NullStackTraceException extends RuntimeException {
-        @Override
         public Exception fillInStackTrace() {
             return null;
         }
     }
 
+    class NewStackTraceException extends RuntimeException {
+        public Exception fillInStackTrace() {
+            return new SomeException();
+        }
+    }
+
     //issue 866
     @Test
-    public void shouldNotThrowNPE() {
+    public void avoids_NPE() {
         when(mock.simpleMethod()).thenThrow(new NullStackTraceException());
         try {
             mock.simpleMethod();
             fail();
         } catch(NullStackTraceException e) {}
+    }
+
+    @Test
+    public void uses_return_value_from_fillInStackTrace() {
+        when(mock.simpleMethod()).thenThrow(new NewStackTraceException());
+        try {
+            mock.simpleMethod();
+            fail();
+        } catch(SomeException e) {}
     }
 }

--- a/src/test/java/org/mockitousage/bugs/FillInStackTraceScenariosTest.java
+++ b/src/test/java/org/mockitousage/bugs/FillInStackTraceScenariosTest.java
@@ -12,6 +12,18 @@ import org.mockitoutil.TestBase;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 
+/**
+ * These tests check that ThrowsException#answer throws an instance returned
+ * by Throwable#fillInStackTrace of the provided throwable.
+ *
+ * <p>A well-behaved Throwable implementation must always return a reference to this
+ * from #fillInStackTrace according to the method contract.
+ * However, Mockito throws the exception returned from #fillInStackTrace for backwards compatibility
+ * (or the provided exception if the method returns null).
+ *
+ * @see Throwable#fillInStackTrace()
+ * @see <a href="https://github.com/mockito/mockito/issues/866">#866</a>
+ */
 public class FillInStackTraceScenariosTest extends TestBase {
 
     @Mock IMethods mock;

--- a/src/test/java/org/mockitousage/stubbing/StubbingConsecutiveAnswersTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingConsecutiveAnswersTest.java
@@ -42,6 +42,34 @@ public class StubbingConsecutiveAnswersTest extends TestBase {
     }
 
     @Test
+    public void should_return_consecutive_values_first_var_arg_null() throws Exception {
+        when(mock.simpleMethod()).thenReturn("one", (String) null);
+
+        assertEquals("one", mock.simpleMethod());
+        assertNull(mock.simpleMethod());
+        assertNull(mock.simpleMethod());
+    }
+
+    @Test
+    public void should_return_consecutive_values_var_arg_null() throws Exception {
+        when(mock.simpleMethod()).thenReturn("one", (String[]) null);
+
+        assertEquals("one", mock.simpleMethod());
+        assertNull(mock.simpleMethod());
+        assertNull(mock.simpleMethod());
+    }
+
+    @Test
+    public void should_return_consecutive_values_var_args_contain_null() throws Exception {
+        when(mock.simpleMethod()).thenReturn("one", "two", null);
+
+        assertEquals("one", mock.simpleMethod());
+        assertEquals("two", mock.simpleMethod());
+        assertNull(mock.simpleMethod());
+        assertNull(mock.simpleMethod());
+    }
+
+    @Test
     public void should_return_consecutive_values_set_by_shorten_then_return_method() throws Exception {
         when(mock.simpleMethod()).thenReturn("one", "two", "three");
 

--- a/src/test/java/org/mockitousage/stubbing/StubbingWithThrowablesTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingWithThrowablesTest.java
@@ -22,6 +22,9 @@ import java.io.Reader;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ThrowableAssert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -49,13 +52,54 @@ public class StubbingWithThrowablesTest extends TestBase {
     }
 
     @Test
+    public void throws_same_exception_consecutively() {
+        when(mock.add("")).thenThrow(new ExceptionOne());
+
+        //1st invocation
+        Assertions.assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            public void call() {
+                mock.add("");
+            }
+        }).isInstanceOf(ExceptionOne.class);
+
+        mock.add("1");
+
+        //2nd invocation
+        Assertions.assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            public void call() {
+                mock.add("");
+            }
+        }).isInstanceOf(ExceptionOne.class);
+    }
+
+    @Test
+    public void throws_same_exception_consecutively_with_doThrow() {
+        doThrow(new ExceptionOne()).when(mock).clear();
+
+        //1st invocation
+        Assertions.assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            public void call() {
+                mock.clear();
+            }
+        }).isInstanceOf(ExceptionOne.class);
+
+        mock.add("1");
+
+        //2nd invocation
+        Assertions.assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            public void call() {
+                mock.clear();
+            }
+        }).isInstanceOf(ExceptionOne.class);
+    }
+
+    @Test
     public void shouldStubWithThrowable() throws Exception {
         IllegalArgumentException expected = new IllegalArgumentException("thrown by mock");
         when(mock.add("throw")).thenThrow(expected);
 
         exception.expect(sameInstance(expected));
         mock.add("throw");
-
     }
 
     @Test


### PR DESCRIPTION
Some improvements in exception-stubbing code:

- Clarify intentions in BaseStubbing:
  - Replace an obsolete TODO with a clarifying comment and add some tests covering related test cases.
  - Extract the code aborting the ongoing stubbing in a separate method that always throws. Use return `abortNullExceptionType` so that static-analysis tools (e.g., IDEA) yield no false-positives.

- Clarify that ThrowsException always returns the _same_ throwable.
The previous `#answer` implementation might give an illusion that `Throwable#fillInStackTrace` produces a new throwable, but that is not correct — it always returns `this`.
- Also, replace a possible NPE with a descriptive IllegalStateException.