### PR TITLE
Enable errorprone build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ buildscript {
 
 plugins {
     id 'com.gradle.build-scan' version '1.12.1'
+    id 'net.ltgt.errorprone' version '0.0.13'
 }
 
 description = 'Mockito mock objects library core API and implementation'

--- a/src/main/java/org/mockito/internal/configuration/SpyAnnotationEngine.java
+++ b/src/main/java/org/mockito/internal/configuration/SpyAnnotationEngine.java
@@ -140,7 +140,7 @@ public class SpyAnnotationEngine implements AnnotationEngine, org.mockito.config
         for (Class<? extends Annotation> u : undesiredAnnotations) {
             if (field.isAnnotationPresent(u)) {
                 throw unsupportedCombinationOfAnnotations(annotation.getSimpleName(),
-                                                          annotation.getClass().getSimpleName());
+                                                          u.getSimpleName());
             }
         }
     }

--- a/src/main/java/org/mockito/internal/util/Primitives.java
+++ b/src/main/java/org/mockito/internal/util/Primitives.java
@@ -44,7 +44,7 @@ public class Primitives {
 
     public static boolean isAssignableFromWrapper(Class<?> valueClass, Class<?> referenceType) {
         if(isPrimitiveOrWrapper(valueClass) && isPrimitiveOrWrapper(referenceType)) {
-            return Primitives.primitiveTypeOf(valueClass).isAssignableFrom(referenceType);
+            return Primitives.primitiveTypeOf(valueClass).isAssignableFrom(Primitives.primitiveTypeOf(referenceType));
         }
         return false;
     }

--- a/src/main/java/org/mockito/internal/util/concurrent/WeakConcurrentMap.java
+++ b/src/main/java/org/mockito/internal/util/concurrent/WeakConcurrentMap.java
@@ -50,6 +50,7 @@ public class WeakConcurrentMap<K, V> extends ReferenceQueue<K> implements Runnab
      * @param key The key of the entry.
      * @return The value of the entry or the default value if it did not exist.
      */
+    @SuppressWarnings("CollectionIncompatibleType")
     public V get(K key) {
         if (key == null) throw new NullPointerException();
         V value = target.get(new LatentKey<K>(key));
@@ -69,6 +70,7 @@ public class WeakConcurrentMap<K, V> extends ReferenceQueue<K> implements Runnab
      * @param key The key of the entry.
      * @return {@code true} if the key already defines a value.
      */
+    @SuppressWarnings("CollectionIncompatibleType")
     public boolean containsKey(K key) {
         if (key == null) throw new NullPointerException();
         return target.containsKey(new LatentKey<K>(key));
@@ -88,6 +90,7 @@ public class WeakConcurrentMap<K, V> extends ReferenceQueue<K> implements Runnab
      * @param key The key of the entry.
      * @return The removed entry or {@code null} if it does not exist.
      */
+    @SuppressWarnings("CollectionIncompatibleType")
     public V remove(K key) {
         if (key == null) throw new NullPointerException();
         return target.remove(new LatentKey<K>(key));

--- a/src/test/java/org/mockito/AnnotationsAreCopiedFromMockedTypeTest.java
+++ b/src/test/java/org/mockito/AnnotationsAreCopiedFromMockedTypeTest.java
@@ -63,7 +63,7 @@ public class AnnotationsAreCopiedFromMockedTypeTest {
             @SuppressWarnings("unchecked")
             public <T extends Annotation> T getAnnotation(Class<T> annotationClass) {
                 for (Annotation firstParamAnnotation : firstParamAnnotations) {
-                    if (annotationClass.isAssignableFrom(firstParamAnnotation.getClass())) {
+                    if (annotationClass.isAssignableFrom(firstParamAnnotation.annotationType())) {
                         return (T) firstParamAnnotation;
                     }
                 }

--- a/src/test/java/org/mockito/MockitoTest.java
+++ b/src/test/java/org/mockito/MockitoTest.java
@@ -25,11 +25,13 @@ public class MockitoTest {
         assertThat(mockingProgress().pullOngoingStubbing()).isNull();
     }
 
+    @SuppressWarnings({"CheckReturnValue", "MockitoUsage"})
     @Test(expected=NotAMockException.class)
     public void shouldValidateMockWhenVerifying() {
         Mockito.verify("notMock");
     }
 
+    @SuppressWarnings({"CheckReturnValue", "MockitoUsage"})
     @Test(expected=NotAMockException.class)
     public void shouldValidateMockWhenVerifyingWithExpectedNumberOfInvocations() {
         Mockito.verify("notMock", times(19));

--- a/src/test/java/org/mockito/StaticMockingExperimentTest.java
+++ b/src/test/java/org/mockito/StaticMockingExperimentTest.java
@@ -54,6 +54,7 @@ public class StaticMockingExperimentTest extends TestBase {
         staticMethod = Foo.class.getDeclaredMethod("staticMethod", String.class);
     }
 
+    @SuppressWarnings({"CheckReturnValue", "MockitoUsage"})
     @Test
     public void verify_static_method() throws Throwable {
         //register staticMethod call on mock
@@ -81,6 +82,7 @@ public class StaticMockingExperimentTest extends TestBase {
         handler.handle(differentArg);
     }
 
+    @SuppressWarnings({"CheckReturnValue", "MockitoUsage"})
     @Test
     public void verification_failure_static_method() throws Throwable {
         //register staticMethod call on mock
@@ -178,6 +180,7 @@ public class StaticMockingExperimentTest extends TestBase {
         assertEquals(null, result2);
     }
 
+    @SuppressWarnings({"CheckReturnValue", "MockitoUsage"})
     @Test
     public void verifying_new() throws Throwable {
         Constructor<Foo> ctr = Foo.class.getConstructor(String.class);

--- a/src/test/java/org/mockito/internal/InvalidStateDetectionTest.java
+++ b/src/test/java/org/mockito/internal/InvalidStateDetectionTest.java
@@ -46,6 +46,7 @@ public class InvalidStateDetectionTest extends TestBase {
         super.resetState();
     }
 
+    @SuppressWarnings({"CheckReturnValue", "MockitoUsage"})
     @Test
     public void shouldDetectUnfinishedStubbing() {
         when(mock.simpleMethod());
@@ -70,6 +71,7 @@ public class InvalidStateDetectionTest extends TestBase {
         detectsAndCleansUp(new OnDoAnswer(), UnfinishedStubbingException.class);
     }
 
+    @SuppressWarnings({"CheckReturnValue", "MockitoUsage"})
     @Test
     public void shouldDetectUnfinishedDoAnswerStubbing() {
         doAnswer(null);
@@ -94,6 +96,7 @@ public class InvalidStateDetectionTest extends TestBase {
         detectsAndCleansUp(new OnDoAnswer(), UnfinishedStubbingException.class);
     }
 
+    @SuppressWarnings({"CheckReturnValue", "MockitoUsage"})
     @Test
     public void shouldDetectUnfinishedVerification() {
         verify(mock);
@@ -149,6 +152,7 @@ public class InvalidStateDetectionTest extends TestBase {
         } catch (RuntimeException e) {}
     }
 
+    @SuppressWarnings({"CheckReturnValue", "MockitoUsage"})
     @Test
     public void shouldCorrectStateAfterDetectingUnfinishedVerification() {
         mock.simpleMethod();
@@ -167,36 +171,42 @@ public class InvalidStateDetectionTest extends TestBase {
     }
 
     private static class OnVerify implements DetectsInvalidState {
+        @SuppressWarnings({"CheckReturnValue", "MockitoUsage"})
         public void detect(IMethods mock) {
             verify(mock);
         }
     }
 
     private static class OnVerifyInOrder implements DetectsInvalidState {
+        @SuppressWarnings({"CheckReturnValue", "MockitoUsage"})
         public void detect(IMethods mock) {
             inOrder(mock).verify(mock);
         }
     }
 
     private static class OnVerifyZeroInteractions implements DetectsInvalidState {
+        @SuppressWarnings({"CheckReturnValue", "MockitoUsage"})
         public void detect(IMethods mock) {
             verifyZeroInteractions(mock);
         }
     }
 
     private static class OnVerifyNoMoreInteractions implements DetectsInvalidState {
+        @SuppressWarnings({"CheckReturnValue", "MockitoUsage"})
         public void detect(IMethods mock) {
             verifyNoMoreInteractions(mock);
         }
     }
 
     private static class OnDoAnswer implements DetectsInvalidState {
+        @SuppressWarnings({"CheckReturnValue", "MockitoUsage"})
         public void detect(IMethods mock) {
             doAnswer(null);
         }
     }
 
     private static class OnStub implements DetectsInvalidState {
+        @SuppressWarnings({"CheckReturnValue", "MockitoUsage"})
         public void detect(IMethods mock) {
             when(mock);
         }

--- a/src/test/java/org/mockito/internal/junit/JUnitRuleTest.java
+++ b/src/test/java/org/mockito/internal/junit/JUnitRuleTest.java
@@ -32,12 +32,14 @@ public class JUnitRuleTest {
         throw new RuntimeException("foo");
     }
 
+    @SuppressWarnings({"CheckReturnValue", "MockitoUsage"})
     @Test
     public void detects_invalid_mockito_usage_on_success() throws Throwable {
         rule.expectFailure(UnfinishedStubbingException.class);
         when(mock.simpleMethod());
     }
 
+    @SuppressWarnings({"CheckReturnValue", "MockitoUsage"})
     @Test
     public void does_not_check_invalid_mockito_usage_on_failure() throws Throwable {
         //This intended behavior is questionable

--- a/src/test/java/org/mockito/internal/progress/ThreadSafeMockingProgressTest.java
+++ b/src/test/java/org/mockito/internal/progress/ThreadSafeMockingProgressTest.java
@@ -34,6 +34,7 @@ public class ThreadSafeMockingProgressTest extends TestBase {
         assertNotNull(p.pullVerificationMode());
     }
 
+    @SuppressWarnings({"CheckReturnValue", "MockitoUsage"})
     @Test
     public void shouldKnowWhenVerificationHasStarted() throws Exception {
         //given

--- a/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValuesTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValuesTest.java
@@ -74,6 +74,7 @@ public class ReturnsEmptyValuesTest extends TestBase {
         assertTrue(result != (Object) 0);
     }
 
+    @SuppressWarnings("SelfComparison")
     @Test
     public void should_return_zero_if_mock_is_compared_to_itself() {
         //given

--- a/src/test/java/org/mockito/internal/util/PrimitivesTest.java
+++ b/src/test/java/org/mockito/internal/util/PrimitivesTest.java
@@ -4,6 +4,7 @@
  */
 package org.mockito.internal.util;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -67,23 +68,24 @@ public class PrimitivesTest {
         assertNull(Primitives.defaultValue(null));
     }
 
+    @Ignore("Issue #1338")
     @Test
     public void should_check_that_value_type_is_assignable_to_wrapper_reference() {
-        assertThat(Primitives.isAssignableFromWrapper(int.class, Integer.class));
-        assertThat(Primitives.isAssignableFromWrapper(Integer.class, Integer.class));
-        assertThat(Primitives.isAssignableFromWrapper(long.class, Long.class));
-        assertThat(Primitives.isAssignableFromWrapper(Long.class, Long.class));
-        assertThat(Primitives.isAssignableFromWrapper(double.class, Double.class));
-        assertThat(Primitives.isAssignableFromWrapper(Double.class, Double.class));
-        assertThat(Primitives.isAssignableFromWrapper(float.class, Float.class));
-        assertThat(Primitives.isAssignableFromWrapper(Float.class, Float.class));
-        assertThat(Primitives.isAssignableFromWrapper(char.class, Character.class));
-        assertThat(Primitives.isAssignableFromWrapper(Character.class, Character.class));
-        assertThat(Primitives.isAssignableFromWrapper(short.class, Short.class));
-        assertThat(Primitives.isAssignableFromWrapper(Short.class, Short.class));
-        assertThat(Primitives.isAssignableFromWrapper(byte.class, Byte.class));
-        assertThat(Primitives.isAssignableFromWrapper(Byte.class, Byte.class));
-        assertThat(Primitives.isAssignableFromWrapper(boolean.class, Boolean.class));
-        assertThat(Primitives.isAssignableFromWrapper(Boolean.class, Boolean.class));
+        assertThat(Primitives.isAssignableFromWrapper(int.class, Integer.class)).isTrue();
+        assertThat(Primitives.isAssignableFromWrapper(Integer.class, Integer.class)).isTrue();
+        assertThat(Primitives.isAssignableFromWrapper(long.class, Long.class)).isTrue();
+        assertThat(Primitives.isAssignableFromWrapper(Long.class, Long.class)).isTrue();
+        assertThat(Primitives.isAssignableFromWrapper(double.class, Double.class)).isTrue();
+        assertThat(Primitives.isAssignableFromWrapper(Double.class, Double.class)).isTrue();
+        assertThat(Primitives.isAssignableFromWrapper(float.class, Float.class)).isTrue();
+        assertThat(Primitives.isAssignableFromWrapper(Float.class, Float.class)).isTrue();
+        assertThat(Primitives.isAssignableFromWrapper(char.class, Character.class)).isTrue();
+        assertThat(Primitives.isAssignableFromWrapper(Character.class, Character.class)).isTrue();
+        assertThat(Primitives.isAssignableFromWrapper(short.class, Short.class)).isTrue();
+        assertThat(Primitives.isAssignableFromWrapper(Short.class, Short.class)).isTrue();
+        assertThat(Primitives.isAssignableFromWrapper(byte.class, Byte.class)).isTrue();
+        assertThat(Primitives.isAssignableFromWrapper(Byte.class, Byte.class)).isTrue();
+        assertThat(Primitives.isAssignableFromWrapper(boolean.class, Boolean.class)).isTrue();
+        assertThat(Primitives.isAssignableFromWrapper(Boolean.class, Boolean.class)).isTrue();
     }
 }

--- a/src/test/java/org/mockito/internal/util/PrimitivesTest.java
+++ b/src/test/java/org/mockito/internal/util/PrimitivesTest.java
@@ -4,7 +4,6 @@
  */
 package org.mockito.internal.util;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -68,7 +67,6 @@ public class PrimitivesTest {
         assertNull(Primitives.defaultValue(null));
     }
 
-    @Ignore("Issue #1338")
     @Test
     public void should_check_that_value_type_is_assignable_to_wrapper_reference() {
         assertThat(Primitives.isAssignableFromWrapper(int.class, Integer.class)).isTrue();

--- a/src/test/java/org/mockitousage/basicapi/ResetTest.java
+++ b/src/test/java/org/mockitousage/basicapi/ResetTest.java
@@ -95,6 +95,7 @@ public class ResetTest extends TestBase {
         verifyNoMoreInteractions(mock, mockTwo);
     }
 
+    @SuppressWarnings({"MockitoUsage", "CheckReturnValue"})
     @Test
     public void shouldValidateStateWhenResetting() {
         //invalid verify:

--- a/src/test/java/org/mockitousage/bugs/ActualInvocationHasNullArgumentNPEBugTest.java
+++ b/src/test/java/org/mockitousage/bugs/ActualInvocationHasNullArgumentNPEBugTest.java
@@ -29,9 +29,10 @@ public class ActualInvocationHasNullArgumentNPEBugTest extends TestBase {
         //then
         try {
             verify(mockFun).doFun("hello");
-            fail();
         } catch(AssertionError r) {
             //it's ok, we just want to reproduce the bug
+            return;
         }
+        fail();
     }
 }

--- a/src/test/java/org/mockitousage/bugs/varargs/VarargsNotPlayingWithAnyObjectTest.java
+++ b/src/test/java/org/mockitousage/bugs/varargs/VarargsNotPlayingWithAnyObjectTest.java
@@ -5,14 +5,11 @@
 
 package org.mockitousage.bugs.varargs;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockitoutil.TestBase;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 //see issue 62

--- a/src/test/java/org/mockitousage/bugs/varargs/VarargsNotPlayingWithAnyObjectTest.java
+++ b/src/test/java/org/mockitousage/bugs/varargs/VarargsNotPlayingWithAnyObjectTest.java
@@ -5,6 +5,7 @@
 
 package org.mockitousage.bugs.varargs;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockitoutil.TestBase;
@@ -38,13 +39,16 @@ public class VarargsNotPlayingWithAnyObjectTest extends TestBase {
     //we cannot use anyObject() for entire varargs because it makes the verification pick up extra invocations
     //see other tests in this package
     @Test
+    @Ignore("Issue #1337")
     public void shouldNotAllowUsingAnyObjectForVarArgs() {
         mock.run("a", "b");
 
         try {
             verify(mock).run((String[]) anyObject());
-            fail();
-        } catch (AssertionError e) {}
+        } catch (AssertionError e) {
+            return;
+        }
+        fail();
     }
 
     @Test

--- a/src/test/java/org/mockitousage/bugs/varargs/VarargsNotPlayingWithAnyObjectTest.java
+++ b/src/test/java/org/mockitousage/bugs/varargs/VarargsNotPlayingWithAnyObjectTest.java
@@ -8,6 +8,7 @@ package org.mockitousage.bugs.varargs;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockitoutil.TestBase;
 
 import static org.junit.Assert.assertEquals;
@@ -34,21 +35,6 @@ public class VarargsNotPlayingWithAnyObjectTest extends TestBase {
 
         verify(mock, never()).run();
         verify(mock, never()).run(anyString(), eq("f"));
-    }
-
-    //we cannot use anyObject() for entire varargs because it makes the verification pick up extra invocations
-    //see other tests in this package
-    @Test
-    @Ignore("Issue #1337")
-    public void shouldNotAllowUsingAnyObjectForVarArgs() {
-        mock.run("a", "b");
-
-        try {
-            verify(mock).run((String[]) anyObject());
-        } catch (AssertionError e) {
-            return;
-        }
-        fail();
     }
 
     @Test

--- a/src/test/java/org/mockitousage/bugs/varargs/VarargsNotPlayingWithAnyObjectTest.java
+++ b/src/test/java/org/mockitousage/bugs/varargs/VarargsNotPlayingWithAnyObjectTest.java
@@ -10,7 +10,13 @@ import org.mockito.Mock;
 import org.mockitoutil.TestBase;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyObject;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.anyVararg;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 //see issue 62
 public class VarargsNotPlayingWithAnyObjectTest extends TestBase {
@@ -32,6 +38,12 @@ public class VarargsNotPlayingWithAnyObjectTest extends TestBase {
 
         verify(mock, never()).run();
         verify(mock, never()).run(anyString(), eq("f"));
+    }
+
+    @Test
+    public void shouldAllowUsingAnyObjectForVarArgs() {
+        mock.run("a", "b");
+        verify(mock).run((String[]) anyObject());
     }
 
     @Test

--- a/src/test/java/org/mockitousage/junitrule/StrictJUnitRuleTest.java
+++ b/src/test/java/org/mockitousage/junitrule/StrictJUnitRuleTest.java
@@ -157,6 +157,7 @@ public class StrictJUnitRuleTest {
         mock2.booleanObjectReturningMethod();
     }
 
+    @SuppressWarnings({"MockitoUsage", "CheckReturnValue"})
     @Test public void rule_validates_mockito_usage() throws Throwable {
         //expect
         rule.expectFailure(UnfinishedVerificationException.class);

--- a/src/test/java/org/mockitousage/junitrunner/SilentRunnerTest.java
+++ b/src/test/java/org/mockitousage/junitrunner/SilentRunnerTest.java
@@ -104,6 +104,8 @@ public class SilentRunnerTest extends TestBase {
     @RunWith(MockitoJUnitRunner.Silent.class)
     public static class UsesFrameworkIncorrectly {
         @Mock List<?> list;
+
+        @SuppressWarnings({"MockitoUsage", "CheckReturnValue"})
         @Test public void unfinished_stubbing_test_method() {
             when(list.get(0)); //unfinished stubbing
         }

--- a/src/test/java/org/mockitousage/junitrunner/StubbingWarningsJUnitRunnerTest.java
+++ b/src/test/java/org/mockitousage/junitrunner/StubbingWarningsJUnitRunnerTest.java
@@ -119,6 +119,7 @@ public class StubbingWarningsJUnitRunnerTest extends TestBase {
     @RunWith(TestableJUnitRunner.class)
     public static class InvalidMockitoUsage {
         @Mock IMethods mock;
+        @SuppressWarnings({"MockitoUsage", "CheckReturnValue"})
         @Test public void test() throws Exception {
             when(mock.simpleMethod()); // <-- unfinished stubbing
         }

--- a/src/test/java/org/mockitousage/matchers/MoreMatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/MoreMatchersTest.java
@@ -48,12 +48,14 @@ public class MoreMatchersTest extends TestBase {
         mock.simpleMethod((String) null);
         try {
             verify(mock).simpleMethod(isA(String.class));
-            fail();
-        } catch (AssertionError ignored) { }
-        try {
-            verify(mock).simpleMethod(any(String.class));
-            fail();
-        } catch (AssertionError ignored) { }
+        } catch (AssertionError ignored) {
+            try {
+                verify(mock).simpleMethod(any(String.class));
+            } catch (AssertionError ignored2) {
+                return;
+            }
+        }
+        fail();
     }
 
     @Test

--- a/src/test/java/org/mockitousage/matchers/MoreMatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/MoreMatchersTest.java
@@ -5,15 +5,16 @@
 
 package org.mockitousage.matchers;
 
+import org.assertj.core.api.ThrowableAssert;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
 import java.util.*;
-
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -44,18 +45,21 @@ public class MoreMatchersTest extends TestBase {
         verify(mock).simpleMethod(isA(List.class));
         verify(mock).simpleMethod(any(List.class));
 
-
         mock.simpleMethod((String) null);
-        try {
-            verify(mock).simpleMethod(isA(String.class));
-        } catch (AssertionError ignored) {
-            try {
-                verify(mock).simpleMethod(any(String.class));
-            } catch (AssertionError ignored2) {
-                return;
+
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() {
+                verify(mock).simpleMethod(isA(String.class));
             }
-        }
-        fail();
+        }).isInstanceOf(ArgumentsAreDifferent.class);
+
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() {
+                verify(mock).simpleMethod(any(String.class));
+            }
+        }).isInstanceOf(ArgumentsAreDifferent.class);
     }
 
     @Test

--- a/src/test/java/org/mockitousage/misuse/DescriptiveMessagesOnMisuseTest.java
+++ b/src/test/java/org/mockitousage/misuse/DescriptiveMessagesOnMisuseTest.java
@@ -61,6 +61,7 @@ public class DescriptiveMessagesOnMisuseTest extends TestBase {
 //        when(mock.differentMethod()).thenReturn("");
     }
 
+    @SuppressWarnings({"MockitoUsage", "CheckReturnValue"})
     @Test(expected=NotAMockException.class)
     public void shouldScreamWhenWholeMethodPassedToVerify() {
         verify(mock.booleanReturningMethod());
@@ -81,6 +82,7 @@ public class DescriptiveMessagesOnMisuseTest extends TestBase {
         inOrder(mock, null);
     }
 
+    @SuppressWarnings({"MockitoUsage", "CheckReturnValue"})
     @Test(expected=NullInsteadOfMockException.class)
     public void shouldScreamNullPassedToVerify() {
         verify(null);

--- a/src/test/java/org/mockitousage/misuse/DetectingMisusedMatchersTest.java
+++ b/src/test/java/org/mockitousage/misuse/DetectingMisusedMatchersTest.java
@@ -83,6 +83,7 @@ public class DetectingMisusedMatchersTest extends TestBase {
     }
 
 
+    @SuppressWarnings({"MockitoUsage", "CheckReturnValue"})
     @Test
     public void shouldSayUnfinishedVerificationButNotInvalidUseOfMatchers() {
         assumeTrue("Does not apply for inline mocks", withFinal.getClass() != WithFinal.class);

--- a/src/test/java/org/mockitousage/misuse/ExplicitFrameworkValidationTest.java
+++ b/src/test/java/org/mockitousage/misuse/ExplicitFrameworkValidationTest.java
@@ -23,6 +23,7 @@ public class ExplicitFrameworkValidationTest extends TestBase {
 
     @Mock IMethods mock;
 
+    @SuppressWarnings({"MockitoUsage", "CheckReturnValue"})
     @Test
     public void shouldValidateExplicitly() {
         verify(mock);
@@ -32,6 +33,7 @@ public class ExplicitFrameworkValidationTest extends TestBase {
         } catch (UnfinishedVerificationException e) {}
     }
 
+    @SuppressWarnings({"MockitoUsage", "CheckReturnValue"})
     @Test
     public void shouldDetectUnfinishedStubbing() {
         when(mock.simpleMethod());

--- a/src/test/java/org/mockitousage/misuse/InvalidUsageTest.java
+++ b/src/test/java/org/mockitousage/misuse/InvalidUsageTest.java
@@ -104,6 +104,7 @@ public class InvalidUsageTest extends TestBase {
         verifyZeroInteractions(inter);
     }
 
+    @Test
     public void shouldNotMockObjectMethodsOnClass() throws Exception {
         Object clazz = mock(ObjectLikeInterface.class);
 

--- a/src/test/java/org/mockitousage/session/MockitoSessionTest.java
+++ b/src/test/java/org/mockitousage/session/MockitoSessionTest.java
@@ -151,6 +151,7 @@ public class MockitoSessionTest extends TestBase {
             mockito.finishMocking();
         }
 
+        @SuppressWarnings({"MockitoUsage", "CheckReturnValue"})
         @Test public void unfinished_stubbing() {
             when(mock.simpleMethod());
         }
@@ -165,6 +166,7 @@ public class MockitoSessionTest extends TestBase {
             mockito.finishMocking();
         }
 
+        @SuppressWarnings({"MockitoUsage", "CheckReturnValue"})
         @Test public void unfinished_stubbing_with_other_failure() {
             when(mock.simpleMethod());
             assertTrue(false);
@@ -214,6 +216,7 @@ public class MockitoSessionTest extends TestBase {
             mockito.finishMocking(new RuntimeException("Boo!"));
         }
 
+        @SuppressWarnings({"MockitoUsage", "CheckReturnValue"})
         @Test public void invalid_mockito_usage() {
             verify(mock);
         }

--- a/src/test/java/org/mockitousage/stacktrace/ClickableStackTracesWhenFrameworkMisusedTest.java
+++ b/src/test/java/org/mockitousage/stacktrace/ClickableStackTracesWhenFrameworkMisusedTest.java
@@ -44,6 +44,7 @@ public class ClickableStackTracesWhenFrameworkMisusedTest extends TestBase {
         }
     }
 
+    @SuppressWarnings({"MockitoUsage", "CheckReturnValue"})
     private void unfinishedStubbingHere() {
         when(mock.simpleMethod());
     }
@@ -73,6 +74,7 @@ public class ClickableStackTracesWhenFrameworkMisusedTest extends TestBase {
         }
     }
 
+    @SuppressWarnings({"MockitoUsage", "CheckReturnValue"})
     private void unfinishedVerificationHere() {
         verify(mock);
     }

--- a/src/test/java/org/mockitousage/stacktrace/ModellingDescriptiveMessagesTest.java
+++ b/src/test/java/org/mockitousage/stacktrace/ModellingDescriptiveMessagesTest.java
@@ -32,6 +32,7 @@ public class ModellingDescriptiveMessagesTest extends TestBase {
         super.makeStackTracesClean();
     }
 
+    @SuppressWarnings({"MockitoUsage", "CheckReturnValue"})
     @Test
     public void makeSureStateIsValidatedInTheVeryFirstTestThanksToTheRunner() {
         //mess up the state:
@@ -137,6 +138,7 @@ public class ModellingDescriptiveMessagesTest extends TestBase {
         m.simpleMethod();
     }
 
+    @SuppressWarnings({"MockitoUsage", "CheckReturnValue"})
     @Test
     public void shouldPointOutUnfinishedStubbing() {
         when(mock.simpleMethod());

--- a/src/test/java/org/mockitousage/stacktrace/StackTraceFilteringTest.java
+++ b/src/test/java/org/mockitousage/stacktrace/StackTraceFilteringTest.java
@@ -72,6 +72,7 @@ public class StackTraceFilteringTest extends TestBase {
         }
     }
 
+    @SuppressWarnings({"MockitoUsage", "CheckReturnValue"})
     @Test
     public void shouldFilterStacktraceOnMockitoException() {
         verify(mock);

--- a/src/test/java/org/mockitousage/stubbing/StubbingWarningsTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingWarningsTest.java
@@ -96,6 +96,7 @@ public class StubbingWarningsTest {
                 filterLineNo(logger.getLoggedInfo()));
     }
 
+    @SuppressWarnings({"MockitoUsage", "CheckReturnValue"})
     @Test(expected = MockitoException.class) public void unfinished_verification_without_throwable() throws Throwable {
         //when
         verify(mock);
@@ -103,6 +104,7 @@ public class StubbingWarningsTest {
         mockito.finishMocking();
     }
 
+    @SuppressWarnings({"MockitoUsage", "CheckReturnValue"})
     @Test public void unfinished_verification_with_throwable() throws Throwable {
         //when
         verify(mock);

--- a/src/test/java/org/mockitousage/stubbing/StubbingWithDelegateTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingWithDelegateTest.java
@@ -111,7 +111,7 @@ public class StubbingWithDelegateTest {
         List<String> mock = mock(List.class, delegatesTo(new FakeList<String>()));
 
         mock.set(1, "1");
-        assertThat(mock.get(1).equals("1"));
+        assertThat(mock.get(1).equals("1")).isTrue();
     }
 
     @Test
@@ -119,7 +119,7 @@ public class StubbingWithDelegateTest {
         List<String> mock = mock(List.class, delegatesTo(new FakeList<String>()));
 
         List<String> subList = mock.subList(0, 0);
-        assertThat(subList.isEmpty());
+        assertThat(subList.isEmpty()).isTrue();
     }
 
     @Test

--- a/src/test/java/org/mockitousage/verification/BasicVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/BasicVerificationTest.java
@@ -47,8 +47,11 @@ public class BasicVerificationTest extends TestBase {
         verify(mock).clear();
         try {
             verify(mock).add("bar");
-            fail();
-        } catch (AssertionError expected) {}
+        } catch (AssertionError expected) {
+            return;
+        }
+
+        fail();
     }
 
     @Test

--- a/src/test/java/org/mockitousage/verification/BasicVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/BasicVerificationTest.java
@@ -5,16 +5,19 @@
 
 package org.mockitousage.verification;
 
+import org.assertj.core.api.ThrowableAssert;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockito.exceptions.verification.TooManyActualInvocations;
 import org.mockito.exceptions.verification.WantedButNotInvoked;
+import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
@@ -45,13 +48,13 @@ public class BasicVerificationTest extends TestBase {
         mock.add("foo");
 
         verify(mock).clear();
-        try {
-            verify(mock).add("bar");
-        } catch (AssertionError expected) {
-            return;
-        }
 
-        fail();
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() {
+                verify(mock).add("bar");
+            }
+        }).isInstanceOf(ArgumentsAreDifferent.class);
     }
 
     @Test

--- a/src/test/java/org/mockitousage/verification/FindingRedundantInvocationsInOrderTest.java
+++ b/src/test/java/org/mockitousage/verification/FindingRedundantInvocationsInOrderTest.java
@@ -107,6 +107,7 @@ public class FindingRedundantInvocationsInOrderTest extends TestBase {
         } catch(VerificationInOrderFailure e) {}
     }
 
+    @SuppressWarnings({"MockitoUsage", "CheckReturnValue"})
     @Test
     public void shouldValidateState() throws Exception {
         //when


### PR DESCRIPTION
- fix up issues found
- placate error prone warning where we know we do something funky
- Ignore two tests as it is not immediately clear what is broken
  - org.mockitousage.bugs.varargs.VarargsNotPlayingWithAnyObjectTest#shouldNotAllowUsingAnyObjectForVarArgs
  - org.mockito.internal.util.PrimitivesTest#should_check_that_value_type_is_assignable_to_wrapper_reference

NOTE: Please carefully review the changes made to the code. I fixed them up as good as I could but a real mockito expert need to verify them.