### PR TITLE
junit jupiter extension dependencies

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -5,10 +5,12 @@ ext {
 def versions = [:]
 
 versions.bytebuddy = '1.8.0'
+versions.junitJupiter = '5.1.0'
 
 libraries.junit4 = 'junit:junit:4.12'
-libraries.junitJupiterLauncher = 'org.junit.platform:junit-platform-launcher:1.1.0'
-libraries.junitJupiterEngine = 'org.junit.jupiter:junit-jupiter-engine:5.1.0'
+libraries.junitJupiterApi = "org.junit.jupiter:junit-jupiter-api:${versions.junitJupiter}"
+libraries.junitPlatformLauncher = 'org.junit.platform:junit-platform-launcher:1.1.0'
+libraries.junitJupiterEngine = "org.junit.jupiter:junit-jupiter-engine:${versions.junitJupiter}"
 libraries.assertj = 'org.assertj:assertj-core:2.9.0'
 libraries.hamcrest = 'org.hamcrest:hamcrest-core:1.3'
 libraries.testng = 'org.testng:testng:6.3.1'

--- a/subprojects/junit-jupiter/junit-jupiter.gradle
+++ b/subprojects/junit-jupiter/junit-jupiter.gradle
@@ -7,9 +7,10 @@ targetCompatibility = 1.8
 
 dependencies {
     compile project.rootProject
+    implementation libraries.junitJupiterApi
     testCompile libraries.assertj
-    testCompile libraries.junitJupiterLauncher
-    implementation libraries.junitJupiterEngine
+    testCompile libraries.junitPlatformLauncher
+    testRuntime libraries.junitJupiterEngine
 }
 
 test {


### PR DESCRIPTION
 - we should be fine with the api for implementing the extension, therefore let's only depend on junitJupiterApi
 - change junitJupiterEngine dependency to testRuntime
 - rename junitJupiterLauncher to junitPlatformLauncher