### PR TITLE
Fix #1346 - Different mocks are used for @Mock and @InjectMock in the same test class with JUnit 5 extension

### DIFF
--- a/subprojects/junit-jupiter/src/main/java/org/mockito/junit/jupiter/MockitoExtension.java
+++ b/subprojects/junit-jupiter/src/main/java/org/mockito/junit/jupiter/MockitoExtension.java
@@ -5,6 +5,9 @@
 package org.mockito.junit.jupiter;
 
 
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -14,10 +17,6 @@ import org.mockito.Mockito;
 import org.mockito.MockitoSession;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.quality.Strictness;
-
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.extension.ExtensionContext.Namespace.create;
 import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
@@ -101,7 +100,7 @@ public class MockitoExtension implements TestInstancePostProcessor,BeforeEachCal
      */
     @Override
     public void beforeEach(final ExtensionContext context) {
-        List<Object> testInstances = new LinkedList<>();
+        Set<Object> testInstances = new LinkedHashSet<>();
         testInstances.add(context.getRequiredTestInstance());
 
         this.collectParentTestInstances(context, testInstances);
@@ -135,7 +134,7 @@ public class MockitoExtension implements TestInstancePostProcessor,BeforeEachCal
         return annotation;
     }
 
-    private void collectParentTestInstances(ExtensionContext context, List<Object> testInstances) {
+    private void collectParentTestInstances(ExtensionContext context, Set<Object> testInstances) {
         Optional<ExtensionContext> parent = context.getParent();
 
         while (parent.isPresent() && parent.get() != context.getRoot()) {

--- a/subprojects/junit-jupiter/src/test/java/org/mockitousage/JunitJupiterTest.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockitousage/JunitJupiterTest.java
@@ -4,14 +4,14 @@
  */
 package org.mockitousage;
 
+import java.util.function.Function;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -20,6 +20,9 @@ class JunitJupiterTest {
 
     @Mock
     private Function<Integer, String> rootMock;
+
+    @InjectMocks
+    private ClassWithDependency classWithDependency;
 
     @Test
     void ensureMockCreationWorks() {
@@ -68,6 +71,19 @@ class JunitJupiterTest {
         // mock is initialized by mockito session
         void shouldWeCreateMocksInTheParentContext() {
             assertThat(rootMock).isNotNull();
+        }
+    }
+
+    @Test
+    void should_be_injected_correct_instance_of_mock() {
+        assertThat(classWithDependency.dependency).isSameAs(rootMock);
+    }
+
+    private static class ClassWithDependency {
+        private final Function<Integer, String> dependency;
+
+        private ClassWithDependency(Function<Integer, String> dependency) {
+            this.dependency = dependency;
         }
     }
 }


### PR DESCRIPTION
Fix #1346 - fix `MockitoExtension` which has init mocks with two identical test instances which cause the mock to be initialized and injected two times