### PR TITLE
Update Byte Buddy and ASM for bug fix releases

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -4,7 +4,7 @@ ext {
 
 def versions = [:]
 
-versions.bytebuddy = '1.8.0'
+versions.bytebuddy = '1.8.1'
 versions.junitJupiter = '5.1.0'
 
 libraries.junit4 = 'junit:junit:4.12'
@@ -21,7 +21,7 @@ libraries.bytebuddyandroid = "net.bytebuddy:byte-buddy-android:${versions.bytebu
 
 libraries.objenesis = 'org.objenesis:objenesis:2.6'
 
-libraries.asm = 'org.ow2.asm:asm:6.1'
+libraries.asm = 'org.ow2.asm:asm:6.1.1'
 
 def kotlinVersion = '1.2.10'
 libraries.kotlin = [


### PR DESCRIPTION
This updates a few minor regressions that came with the updates of ASM and Byte Buddy.

In particular, this fixes a bug with the processing of parameter annotations caused by an API change in ASM. This also introduces a new handling for stack map frames in advice code that is used by the inline mock maker which can now translate inconsistent frames, typically caused by non-javac compilers such as Scala and Kotlin and by code obfuscators. 