### PR TITLE
Use java.lang.MethodHandles.Lookup::defineClass 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
     env: SKIP_RELEASE=true
   - jdk: oraclejdk9
     env: SKIP_RELEASE=true MOCK_MAKER=mock-maker-inline
+  - jdk: oraclejdk9
+    env: SKIP_RELEASE=true DISABLE_REFLECTION=true
   - install: . ./install-jdk.sh -F 10 -L GPL
     env: SKIP_RELEASE=true JDK='Oracle JDK 10'
   - install: . ./install-jdk.sh -F 10 -L GPL

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
   - jdk: oraclejdk9
     env: SKIP_RELEASE=true MOCK_MAKER=mock-maker-inline
   - jdk: oraclejdk9
-    env: SKIP_RELEASE=true DISABLE_REFLECTION=true
+    env: SKIP_RELEASE=true SIMULATE_JAVA11=true
   - install: . ./install-jdk.sh -F 10 -L GPL
     env: SKIP_RELEASE=true JDK='Oracle JDK 10'
   - install: . ./install-jdk.sh -F 10 -L GPL

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -4,7 +4,7 @@ ext {
 
 def versions = [:]
 
-versions.bytebuddy = '1.8.1'
+versions.bytebuddy = '1.8.3'
 versions.junitJupiter = '5.1.0'
 
 libraries.junit4 = 'junit:junit:4.12'

--- a/gradle/mockito-core/testing.gradle
+++ b/gradle/mockito-core/testing.gradle
@@ -1,3 +1,12 @@
+task(disableReflection).doLast {
+    if (System.env.DISABLE_REFLECTION != null) {
+        logger.info("Disabling reflection: ${System.env.DISABLE_REFLECTION}")
+        test {
+            systemProperty "org.mockito.reflection.disabled", System.env.DISABLE_REFLECTION
+        }
+    }
+}
+
 task(createTestResources).doLast {
     def mockMakerFile = new File("$projectDir/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker")
     if (System.env.MOCK_MAKER != null) {
@@ -12,10 +21,11 @@ task(createTestResources).doLast {
 
 task(removeTestResources).doLast {
     def mockMakerFile = new File("$projectDir/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker")
-    if (mockMakerFile.exists()){
+    if (mockMakerFile.exists()) {
         mockMakerFile.delete()
     }
 }
 
+compileTestJava.dependsOn disableReflection
 compileTestJava.dependsOn createTestResources
 compileTestJava.finalizedBy removeTestResources

--- a/gradle/mockito-core/testing.gradle
+++ b/gradle/mockito-core/testing.gradle
@@ -1,8 +1,8 @@
 task(disableReflection).doLast {
-    if (System.env.DISABLE_REFLECTION != null) {
-        logger.info("Disabling reflection: ${System.env.DISABLE_REFLECTION}")
+    if (System.env.SIMULATE_JAVA11 != null) {
+        logger.info("Disabling reflection: ${System.env.SIMULATE_JAVA11}")
         test {
-            systemProperty "org.mockito.reflection.disabled", System.env.DISABLE_REFLECTION
+            systemProperty "org.mockito.internal.simulateJava11", System.env.SIMULATE_JAVA11
         }
     }
 }

--- a/gradle/mockito-core/testing.gradle
+++ b/gradle/mockito-core/testing.gradle
@@ -1,9 +1,8 @@
-task(disableReflection).doLast {
-    if (System.env.SIMULATE_JAVA11 != null) {
-        logger.info("Disabling reflection: ${System.env.SIMULATE_JAVA11}")
-        test {
-            systemProperty "org.mockito.internal.simulateJava11", System.env.SIMULATE_JAVA11
-        }
+def java11 = System.env.SIMULATE_JAVA11
+if (java11 != null) {
+    test {
+        logger.info("$it.path - use Java11 simluation: ${java11}")
+        systemProperty "org.mockito.internal.simulateJava11", java11
     }
 }
 
@@ -26,6 +25,5 @@ task(removeTestResources).doLast {
     }
 }
 
-compileTestJava.dependsOn disableReflection
 compileTestJava.dependsOn createTestResources
 compileTestJava.finalizedBy removeTestResources

--- a/src/main/java/org/mockito/codegen/InjectionBase.java
+++ b/src/main/java/org/mockito/codegen/InjectionBase.java
@@ -4,6 +4,10 @@
  */
 package org.mockito.codegen;
 
+/**
+ * This class is required to resolve a method handle lookup for the {@code org.mockito.codegen} package what requires a preexisting class for the package.
+ * By defining this class, the JVM (starting from Java 9) assures that this package is a part of the Mockito module such that we gain full access rights.
+ */
 public class InjectionBase {
 
     private InjectionBase() {

--- a/src/main/java/org/mockito/codegen/InjectionBase.java
+++ b/src/main/java/org/mockito/codegen/InjectionBase.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.codegen;
+
+public class InjectionBase {
+
+    private InjectionBase() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassBytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassBytecodeGenerator.java
@@ -121,7 +121,7 @@ class SubclassBytecodeGenerator implements BytecodeGenerator {
                 .or(hasParameters(whereAny(hasType(isPackagePrivate())))));
         }
         return builder.make()
-                      .load(classLoader, loader.resolveStrategy(features.mockedType, features.serializableMode, classLoader, name.startsWith(CODEGEN_PACKAGE)))
+                      .load(classLoader, loader.resolveStrategy(features.mockedType, classLoader, name.startsWith(CODEGEN_PACKAGE)))
                       .getLoaded();
     }
 

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassBytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassBytecodeGenerator.java
@@ -38,6 +38,8 @@ import static org.mockito.internal.util.StringUtil.join;
 
 class SubclassBytecodeGenerator implements BytecodeGenerator {
 
+    private static final String CODEGEN_PACKAGE = "org.mockito.codegen.";
+
     private final SubclassLoader loader;
 
     private final ByteBuddy byteBuddy;
@@ -68,9 +70,10 @@ class SubclassBytecodeGenerator implements BytecodeGenerator {
 
     @Override
     public <T> Class<? extends T> mockClass(MockFeatures<T> features) {
+        String name = nameFor(features.mockedType);
         DynamicType.Builder<T> builder =
                 byteBuddy.subclass(features.mockedType)
-                         .name(nameFor(features.mockedType))
+                         .name(name)
                          .ignoreAlso(isGroovyMethod())
                          .annotateType(features.stripAnnotations
                              ? new Annotation[0]
@@ -118,7 +121,7 @@ class SubclassBytecodeGenerator implements BytecodeGenerator {
                 .or(hasParameters(whereAny(hasType(isPackagePrivate())))));
         }
         return builder.make()
-                      .load(classLoader, loader.getStrategy(features.mockedType))
+                      .load(classLoader, loader.resolveStrategy(features.mockedType, features.serializableMode, classLoader, name.startsWith(CODEGEN_PACKAGE)))
                       .getLoaded();
     }
 
@@ -132,7 +135,7 @@ class SubclassBytecodeGenerator implements BytecodeGenerator {
         if (isComingFromJDK(type)
                 || isComingFromSignedJar(type)
                 || isComingFromSealedPackage(type)) {
-            typeName = "codegen." + typeName;
+            typeName = CODEGEN_PACKAGE + type.getSimpleName();
         }
         return String.format("%s$%s$%d", typeName, "MockitoMock", Math.abs(random.nextInt()));
     }

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassInjectionLoader.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassInjectionLoader.java
@@ -20,7 +20,7 @@ class SubclassInjectionLoader implements SubclassLoader {
     private final SubclassLoader loader;
 
     SubclassInjectionLoader() {
-        if (!Boolean.getBoolean("org.mockito.reflection.disabled") && ClassInjector.UsingReflection.isAvailable()) {
+        if (!Boolean.getBoolean("org.mockito.internal.simulateJava11") && ClassInjector.UsingReflection.isAvailable()) {
             this.loader = new WithReflection();
         } else if (ClassInjector.UsingLookup.isAvailable()) {
             this.loader = tryLookup();

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassInjectionLoader.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassInjectionLoader.java
@@ -4,12 +4,84 @@
  */
 package org.mockito.internal.creation.bytebuddy;
 
+import net.bytebuddy.dynamic.loading.ClassInjector;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+import org.mockito.codegen.InjectionBase;
+import org.mockito.exceptions.base.MockitoException;
+import org.mockito.mock.SerializableMode;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.mockito.internal.util.StringUtil.join;
 
 class SubclassInjectionLoader implements SubclassLoader {
 
+    private final boolean disableReflection;
+
+    private final Object lookup, codegenLookup;
+
+    private final Method privateLookupIn;
+
+    public SubclassInjectionLoader() {
+        disableReflection = Boolean.getBoolean("org.mockito.reflection.disabled");
+        Object lookup, codegenLookup;
+        Method privateLookupIn;
+        if (ClassInjector.UsingLookup.isAvailable()) {
+            try {
+                Class<?> methodHandles = Class.forName("java.lang.invoke.MethodHandles");
+                lookup = methodHandles.getMethod("lookup").invoke(null);
+                privateLookupIn = methodHandles.getMethod("privateLookupIn", Class.class, Class.forName("java.lang.invoke.MethodHandles$Lookup"));
+                codegenLookup = privateLookupIn.invoke(null, InjectionBase.class, lookup);
+            } catch (Exception ignored) {
+                lookup = null;
+                privateLookupIn = null;
+                codegenLookup = null;
+            }
+        } else {
+            lookup = null;
+            privateLookupIn = null;
+            codegenLookup = null;
+        }
+        this.lookup = lookup;
+        this.privateLookupIn = privateLookupIn;
+        this.codegenLookup = codegenLookup;
+    }
+
     @Override
-    public ClassLoadingStrategy<ClassLoader> getStrategy(Class<?> mockedType) {
-        return ClassLoadingStrategy.Default.INJECTION.with(mockedType.getProtectionDomain());
+    public ClassLoadingStrategy<ClassLoader> resolveStrategy(Class<?> mockedType, SerializableMode serializableMode, ClassLoader classLoader, boolean codegen) {
+        if (!disableReflection && ClassInjector.UsingReflection.isAvailable()) {
+            return ClassLoadingStrategy.Default.INJECTION.with(mockedType.getProtectionDomain());
+        } else if (ClassInjector.UsingLookup.isAvailable() && lookup != null && privateLookupIn != null && codegenLookup != null) {
+            if (codegen) {
+                return ClassLoadingStrategy.UsingLookup.of(codegenLookup);
+            } else if (classLoader != mockedType.getClassLoader()) {
+                return ClassLoadingStrategy.Default.WRAPPER.with(mockedType.getProtectionDomain());
+            } else {
+                try {
+                    Object privateLookup;
+                    try {
+                        privateLookup = privateLookupIn.invoke(null, mockedType, lookup);
+                    } catch (InvocationTargetException exception) {
+                        if (exception.getCause() instanceof IllegalAccessException) {
+                            return ClassLoadingStrategy.Default.WRAPPER.with(mockedType.getProtectionDomain());
+                        } else {
+                            throw exception.getCause();
+                        }
+                    }
+                    return ClassLoadingStrategy.UsingLookup.of(privateLookup);
+                } catch (Throwable exception) {
+                    throw new MockitoException(join(
+                        "The Java module system prevents Mockito from defining a mock class in the same package as " + mockedType,
+                        "",
+                        "To overcome this, you must open and export the mocked type to Mockito.",
+                        "Remember that you can also do so programmatically if the mocked class is defined by the same module as your test code",
+                        exception
+                    ));
+                }
+            }
+        } else {
+            throw new MockitoException("The current JVM does not support any class injection mechanism, neither by method handles or using sun.misc.Unsafe");
+        }
     }
 }

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassLoader.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassLoader.java
@@ -5,9 +5,12 @@
 package org.mockito.internal.creation.bytebuddy;
 
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+import org.mockito.mock.SerializableMode;
 
 public interface SubclassLoader {
 
-    ClassLoadingStrategy<ClassLoader> getStrategy(Class<?> mockedType);
-
+    ClassLoadingStrategy<ClassLoader> resolveStrategy(Class<?> mockedType,
+                                                      SerializableMode serializableMode,
+                                                      ClassLoader classLoader,
+                                                      boolean codegen);
 }

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassLoader.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassLoader.java
@@ -5,12 +5,19 @@
 package org.mockito.internal.creation.bytebuddy;
 
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
-import org.mockito.mock.SerializableMode;
 
+/**
+ * A subclass loader is responsible for resolving a class loading strategy for a mock that is implemented as a subclass.
+ */
 public interface SubclassLoader {
 
-    ClassLoadingStrategy<ClassLoader> resolveStrategy(Class<?> mockedType,
-                                                      SerializableMode serializableMode,
-                                                      ClassLoader classLoader,
-                                                      boolean codegen);
+    /**
+     * Resolves a class loading strategy.
+     *
+     * @param mockedType  The type being mocked.
+     * @param classLoader The class loader being used.
+     * @param codegen     {@code true} if the mock is loaded in the {@code org.mockito.codegen} package.
+     * @return An appropriate class loading strategy.
+     */
+    ClassLoadingStrategy<ClassLoader> resolveStrategy(Class<?> mockedType, ClassLoader classLoader, boolean codegen);
 }

--- a/src/test/java/org/mockitousage/basicapi/MocksSerializationForAnnotationTest.java
+++ b/src/test/java/org/mockitousage/basicapi/MocksSerializationForAnnotationTest.java
@@ -19,7 +19,6 @@ import org.mockitoutil.TestBase;
 
 import java.io.ByteArrayOutputStream;
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Observable;
@@ -254,19 +253,19 @@ public class MocksSerializationForAnnotationTest extends TestBase implements Ser
     @Test
     public void should_serialize_with_real_object_spy() throws Exception {
         // given
-        List<Object> list = new ArrayList<Object>();
-        List<Object> spy = mock(ArrayList.class, withSettings()
+        SerializableSample list = new SerializableSample();
+        SerializableSample spy = mock(SerializableSample.class, withSettings()
                         .spiedInstance(list)
                         .defaultAnswer(CALLS_REAL_METHODS)
                         .serializable());
-        when(spy.size()).thenReturn(100);
+        when(spy.foo()).thenReturn("foo");
 
         // when
         ByteArrayOutputStream serialized = serializeMock(spy);
 
         // then
-        List<?> readObject = deserializeMock(serialized, List.class);
-        assertEquals(100, readObject.size());
+        SerializableSample readObject = deserializeMock(serialized, SerializableSample.class);
+        assertEquals("foo", readObject.foo());
     }
 
     @Test
@@ -313,13 +312,9 @@ public class MocksSerializationForAnnotationTest extends TestBase implements Ser
                 .isInstanceOf(IMethods.class);
     }
 
-
-
     static class NotSerializableAndNoDefaultConstructor {
         NotSerializableAndNoDefaultConstructor(Observable o) { super(); }
     }
-
-
 
     static class SerializableAndNoDefaultConstructor implements Serializable {
         SerializableAndNoDefaultConstructor(Observable o) { super(); }
@@ -336,5 +331,12 @@ public class MocksSerializationForAnnotationTest extends TestBase implements Ser
         MockitoAnnotations.initMocks(testClass);
 
         serializeAndBack(testClass.serializableAndNoDefaultConstructor);
+    }
+
+    public static class SerializableSample implements Serializable {
+
+        public String foo() {
+            return null;
+        }
     }
 }

--- a/src/test/java/org/mockitousage/serialization/DeepStubsSerializableTest.java
+++ b/src/test/java/org/mockitousage/serialization/DeepStubsSerializableTest.java
@@ -59,31 +59,56 @@ public class DeepStubsSerializableTest {
         // then revert to the default RETURNS_DEEP_STUBS and the code will raise a ClassCastException
     }
 
-
     static class SampleClass implements Serializable {
-        SampleClass2 getSample() { return new SampleClass2(); }
+
+        SampleClass2 getSample() {
+            return new SampleClass2();
+        }
     }
 
     static class SampleClass2 implements Serializable {
-        boolean isFalse() { return false; }
-        int number() { return 100; }
+
+        boolean isFalse() {
+            return false;
+        }
+
+        int number() {
+            return 100;
+        }
     }
 
     static class Container<E> implements Iterable<E>, Serializable {
+
         private E e;
-        public Container(E e) { this.e = e; }
-        public E get() { return e; }
+
+        public Container(E e) {
+            this.e = e;
+        }
+
+        public E get() {
+            return e;
+        }
 
         public Iterator<E> iterator() {
             return new Iterator<E>() {
-                public boolean hasNext() { return true; }
-                public E next() { return e; }
-                public void remove() { }
+                public boolean hasNext() {
+                    return true;
+                }
+
+                public E next() {
+                    return e;
+                }
+
+                public void remove() {
+                }
             };
         }
     }
 
     static class ListContainer extends Container<List<String>> {
-        public ListContainer(List<String> list) { super(list); }
+
+        public ListContainer(List<String> list) {
+            super(list);
+        }
     }
 }

--- a/subprojects/android/src/main/java/org/mockito/android/internal/creation/AndroidLoadingStrategy.java
+++ b/subprojects/android/src/main/java/org/mockito/android/internal/creation/AndroidLoadingStrategy.java
@@ -4,18 +4,20 @@
  */
 package org.mockito.android.internal.creation;
 
-import static org.mockito.internal.util.StringUtil.join;
-
-import java.io.File;
 import net.bytebuddy.android.AndroidClassLoadingStrategy;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.creation.bytebuddy.SubclassLoader;
+import org.mockito.mock.SerializableMode;
+
+import java.io.File;
+
+import static org.mockito.internal.util.StringUtil.join;
 
 class AndroidLoadingStrategy implements SubclassLoader {
 
     @Override
-    public ClassLoadingStrategy<ClassLoader> getStrategy(Class<?> mockFeatures) {
+    public ClassLoadingStrategy<ClassLoader> resolveStrategy(Class<?> mockedType, SerializableMode serializableMode, ClassLoader classLoader, boolean codegen) {
         File target = AndroidTempFileLocator.target;
         if (target == null) {
             throw new MockitoException(join(

--- a/subprojects/android/src/main/java/org/mockito/android/internal/creation/AndroidLoadingStrategy.java
+++ b/subprojects/android/src/main/java/org/mockito/android/internal/creation/AndroidLoadingStrategy.java
@@ -8,7 +8,6 @@ import net.bytebuddy.android.AndroidClassLoadingStrategy;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.creation.bytebuddy.SubclassLoader;
-import org.mockito.mock.SerializableMode;
 
 import java.io.File;
 
@@ -17,7 +16,7 @@ import static org.mockito.internal.util.StringUtil.join;
 class AndroidLoadingStrategy implements SubclassLoader {
 
     @Override
-    public ClassLoadingStrategy<ClassLoader> resolveStrategy(Class<?> mockedType, SerializableMode serializableMode, ClassLoader classLoader, boolean codegen) {
+    public ClassLoadingStrategy<ClassLoader> resolveStrategy(Class<?> mockedType, ClassLoader classLoader, boolean codegen) {
         File target = AndroidTempFileLocator.target;
         if (target == null) {
             throw new MockitoException(join(


### PR DESCRIPTION
Use java.lang.MethodHandles.Lookup::defineClass if this mechanism is available on the current JVM. This might not work when interoperating with foreign modules, if those modules do not open and export their types, most prominently, the Java core modules where there are introduced issues with serialization.

This introduces a change in behavior for Mockito when using Java 9+. Unfortunately, I think that this is necessary for Mockito to continue to function after introduction of the JPMS. For now, it seems like this limitation only affects working with serializability in combination with platform types what is not too bad but there is a chance that we will discover issues once this new mechanism is picked up by the community.