### PR TITLE
Make use of shipkit v2.0.15

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.4.3' //for 'java-compatibility-check.gradle'
 
         //Using buildscript.classpath so that we can resolve shipkit from maven local, during local testing
-        classpath 'org.shipkit:shipkit:2.0.13'
+        classpath 'org.shipkit:shipkit:2.0.15'
     }
 }
 


### PR DESCRIPTION
We actually got rid of unnecessary hits to GitHub REST API during non-release builds (see https://github.com/mockito/shipkit/issues/345 for details).

I did some manual testing using 'testRelease' in mockito project and it did work.

