### PR TITLE
Apply errorprone to all java projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     dependencies {
         classpath 'gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.14.0'
         classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.4.3' //for 'java-compatibility-check.gradle'
-        classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.13"
+        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.13'
 
         //Using buildscript.classpath so that we can resolve shipkit from maven local, during local testing
         classpath 'org.shipkit:shipkit:2.0.13'

--- a/build.gradle
+++ b/build.gradle
@@ -45,11 +45,13 @@ apply from: 'gradle/dependencies.gradle'
 
 archivesBaseName = "mockito-core"
 
-allprojects {
+allprojects { proj ->
     repositories {
         jcenter()
     }
-    apply plugin: 'net.ltgt.errorprone'
+    plugins.withId('java') {
+        proj.apply plugin: 'net.ltgt.errorprone'
+    }
     tasks.withType(JavaCompile) {
         //I don't believe those warnings add value given modern IDEs
         options.warnings = false

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
     dependencies {
         classpath 'gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.14.0'
         classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.4.3' //for 'java-compatibility-check.gradle'
+        classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.13"
 
         //Using buildscript.classpath so that we can resolve shipkit from maven local, during local testing
         classpath 'org.shipkit:shipkit:2.0.13'
@@ -16,7 +17,6 @@ buildscript {
 
 plugins {
     id 'com.gradle.build-scan' version '1.12.1'
-    id 'net.ltgt.errorprone' version '0.0.13' apply false
 }
 
 description = 'Mockito mock objects library core API and implementation'
@@ -52,7 +52,7 @@ allprojects { proj ->
     plugins.withId('java') {
         proj.apply plugin: 'net.ltgt.errorprone'
         proj.dependencies {
-            errorprone 'com.google.errorprone:error_prone_core:2.2.0'
+            errorprone libraries.errorprone
         }
     }
     tasks.withType(JavaCompile) {

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 
 plugins {
     id 'com.gradle.build-scan' version '1.12.1'
-    id 'net.ltgt.errorprone' version '0.0.13'
+    id 'net.ltgt.errorprone' version '0.0.13' apply false
 }
 
 description = 'Mockito mock objects library core API and implementation'
@@ -49,6 +49,7 @@ allprojects {
     repositories {
         jcenter()
     }
+    apply plugin: 'net.ltgt.errorprone'
     tasks.withType(JavaCompile) {
         //I don't believe those warnings add value given modern IDEs
         options.warnings = false

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,9 @@ allprojects { proj ->
     }
     plugins.withId('java') {
         proj.apply plugin: 'net.ltgt.errorprone'
+        proj.dependencies {
+            errorprone 'com.google.errorprone:error_prone_core:2.2.0'
+        }
     }
     tasks.withType(JavaCompile) {
         //I don't believe those warnings add value given modern IDEs

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,6 +19,8 @@ libraries.bytebuddy = "net.bytebuddy:byte-buddy:${versions.bytebuddy}"
 libraries.bytebuddyagent = "net.bytebuddy:byte-buddy-agent:${versions.bytebuddy}"
 libraries.bytebuddyandroid = "net.bytebuddy:byte-buddy-android:${versions.bytebuddy}"
 
+libraries.errorprone = 'com.google.errorprone:error_prone_core:2.2.0'
+
 libraries.objenesis = 'org.objenesis:objenesis:2.6'
 
 libraries.asm = 'org.ow2.asm:asm:6.1.1'

--- a/subprojects/deprecatedPluginsTest/deprecatedPluginsTest.gradle
+++ b/subprojects/deprecatedPluginsTest/deprecatedPluginsTest.gradle
@@ -3,6 +3,8 @@ apply from: "$rootDir/gradle/dependencies.gradle"
 apply plugin: 'java'
 description = "End-to-end tests for deprecated Mockito plugins."
 
+sourceCompatibility = 1.8
+
 dependencies {
     testCompile project(":")
     testCompile libraries.junit4

--- a/subprojects/deprecatedPluginsTest/src/test/java/org/mockitousage/plugins/DeprecatedInstantiatorProviderTest.java
+++ b/subprojects/deprecatedPluginsTest/src/test/java/org/mockitousage/plugins/DeprecatedInstantiatorProviderTest.java
@@ -24,6 +24,7 @@ public class DeprecatedInstantiatorProviderTest {
         assertNotNull(plugin);
     }
 
+    @SuppressWarnings("CheckReturnValue")
     @Test
     public void uses_custom_instantiator_provider() {
         MyDeprecatedInstantiatorProvider.invokedFor.remove();
@@ -31,6 +32,7 @@ public class DeprecatedInstantiatorProviderTest {
         assertEquals(MyDeprecatedInstantiatorProvider.invokedFor.get(), asList(DeprecatedInstantiatorProviderTest.class));
     }
 
+    @SuppressWarnings("CheckReturnValue")
     @Test(expected = InstantiationException.class)
     public void exception_while_instantiating() throws Throwable {
         MyDeprecatedInstantiatorProvider.shouldExcept.set(true);

--- a/subprojects/extTest/extTest.gradle
+++ b/subprojects/extTest/extTest.gradle
@@ -3,6 +3,8 @@ apply from: "$rootDir/gradle/dependencies.gradle"
 apply plugin: 'java'
 description = "End-to-end tests for Mockito and its extensions."
 
+sourceCompatibility = 1.8
+
 //so that we can depend on locally published mockito
 //and test end-to-end mockito jar resolution (for example, flesh out missing dependencies in pom file)
 [compileTestJava, ideaModule].each {

--- a/subprojects/extTest/src/test/java/org/mockitousage/plugins/instantiator/InstantiatorProviderTest.java
+++ b/subprojects/extTest/src/test/java/org/mockitousage/plugins/instantiator/InstantiatorProviderTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.mock;
 
 public class InstantiatorProviderTest {
 
+    @SuppressWarnings("CheckReturnValue")
     @Test
     public void uses_custom_instantiator_provider() {
         //given mocking works:

--- a/subprojects/extTest/src/test/java/org/mockitousage/plugins/switcher/PluginSwitchTest.java
+++ b/subprojects/extTest/src/test/java/org/mockitousage/plugins/switcher/PluginSwitchTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.mock;
 
 public class PluginSwitchTest {
 
+    @SuppressWarnings("CheckReturnValue")
     @Test
     public void plugin_switcher_is_used() {
         mock(List.class);

--- a/subprojects/inline/src/test/java/org/mockitoinline/FinalClassMockingTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/FinalClassMockingTest.java
@@ -9,6 +9,7 @@ import org.mockito.Mockito;
 
 public class FinalClassMockingTest {
 
+    @SuppressWarnings("CheckReturnValue")
     @Test
     public void no_exception_while_mocking_final_class() throws Exception {
         Mockito.mock(FinalClass.class);

--- a/subprojects/testng/src/test/java/org/mockitousage/testng/failuretests/FailingOnPurposeBecauseIncorrectStubbingSyntax.java
+++ b/subprojects/testng/src/test/java/org/mockitousage/testng/failuretests/FailingOnPurposeBecauseIncorrectStubbingSyntax.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mock;
 @Test(description = "Always failing, shouldn't be listed in 'mockito-testng.xml'")
 public class FailingOnPurposeBecauseIncorrectStubbingSyntax {
 
+    @SuppressWarnings("CheckReturnValue")
     @Test(expectedExceptions = InvalidUseOfMatchersException.class)
     public void incorrect_stubbing_syntax_in_test() throws Exception {
         mock(PrintStream.class);

--- a/subprojects/testng/testng.gradle
+++ b/subprojects/testng/testng.gradle
@@ -2,6 +2,8 @@ apply plugin: 'java'
 apply plugin: 'maven'
 description = "Mockito for TestNG"
 
+sourceCompatibility = 1.8
+
 //TODO SF ensure this one is released, too (ensure source and target compatibility, too).
 
 Properties props = new Properties()


### PR DESCRIPTION
I thought it might be a good idea to apply the errorprone plugin to all projects using the java plugin.
Furthermore, I think it is a good idea to specify the version of errorprone in the gradle file instead of always using the latest one (since this might break the build e.g. due to new checks).

@TimvdLippe, @mockitoguy what do you think? 