### PR TITLE
Performance improvements

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -4,7 +4,7 @@ ext {
 
 def versions = [:]
 
-versions.bytebuddy = '1.8.3'
+versions.bytebuddy = '1.8.5'
 versions.junitJupiter = '5.1.0'
 
 libraries.junit4 = 'junit:junit:4.12'

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
@@ -15,6 +15,7 @@ import net.bytebuddy.description.method.MethodList;
 import net.bytebuddy.description.method.ParameterDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.ClassFileLocator;
+import net.bytebuddy.dynamic.scaffold.MethodGraph;
 import net.bytebuddy.dynamic.scaffold.TypeValidation;
 import net.bytebuddy.implementation.Implementation;
 import net.bytebuddy.jar.asm.ClassVisitor;
@@ -74,7 +75,8 @@ public class InlineBytecodeGenerator implements BytecodeGenerator, ClassFileTran
         this.instrumentation = instrumentation;
         byteBuddy = new ByteBuddy()
                 .with(TypeValidation.DISABLED)
-                .with(Implementation.Context.Disabled.Factory.INSTANCE);
+                .with(Implementation.Context.Disabled.Factory.INSTANCE)
+                .with(MethodGraph.Compiler.ForDeclaredMethods.INSTANCE);
         mocked = new WeakConcurrentSet<Class<?>>(WeakConcurrentSet.Cleaner.INLINE);
         identifier = RandomString.make();
         advice = new MockMethodAdvice(mocks, identifier);

--- a/subprojects/junit-jupiter/src/main/java/org/mockito/junit/jupiter/MockitoExtension.java
+++ b/subprojects/junit-jupiter/src/main/java/org/mockito/junit/jupiter/MockitoExtension.java
@@ -77,8 +77,8 @@ public class MockitoExtension implements TestInstancePostProcessor,BeforeEachCal
     }
 
     /**
-     * Callback for post-processing the supplied test instance.
-     * <p>
+     * <p>Callback for post-processing the supplied test instance.
+     *
      * <p><strong>Note</strong>: the {@code ExtensionContext} supplied to a
      * {@code TestInstancePostProcessor} will always return an empty
      * {@link Optional} value from {@link ExtensionContext#getTestInstance()


### PR DESCRIPTION
Use less expensive method graph compiler for inline mock maker. Update Byte Buddy for general performance improvements and bug fixes. Fixes #1364. Also fixes javadoc warning.