### PR TITLE
 Fixes #1371 : Adding Suppliers to Returns object

### DIFF
--- a/gradle/java-library.gradle
+++ b/gradle/java-library.gradle
@@ -4,8 +4,8 @@ group = 'org.mockito'
 archivesBaseName = "mockito-" + project.name
 bintrayUpload.enabled = true
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 test {
     include "**/*Test.class"

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -2507,6 +2507,12 @@ public class Mockito extends ArgumentMatchers {
         return MOCKITO_CORE.stubber().doReturn(toBeReturned, toBeReturnedNext);
     }
 
+    // TODO: 4/16/18  
+    @CheckReturnValue
+    public static Stubber doReturn(SerializableSupplier returnSupplier, Class typeHint) {
+        return MOCKITO_CORE.stubber().doReturn(returnSupplier, typeHint);
+    }
+
     /**
      * Creates {@link org.mockito.InOrder} object that allows verifying mocks in order.
      *

--- a/src/main/java/org/mockito/SerializableSupplier.java
+++ b/src/main/java/org/mockito/SerializableSupplier.java
@@ -1,0 +1,12 @@
+package org.mockito;
+
+import org.mockito.internal.util.Supplier;
+
+import java.io.Serializable;
+
+/**
+ * An interface to make Suppliers serializable.
+ * @param <T>
+ */
+public interface SerializableSupplier<T> extends Serializable, Supplier<T> {
+}

--- a/src/main/java/org/mockito/internal/stubbing/BaseStubbing.java
+++ b/src/main/java/org/mockito/internal/stubbing/BaseStubbing.java
@@ -8,6 +8,7 @@ import static org.mockito.internal.exceptions.Reporter.notAnException;
 import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
 import static org.objenesis.ObjenesisHelper.newInstance;
 
+import org.mockito.SerializableSupplier;
 import org.mockito.internal.stubbing.answers.CallsRealMethods;
 import org.mockito.internal.stubbing.answers.Returns;
 import org.mockito.internal.stubbing.answers.ThrowsException;
@@ -32,6 +33,11 @@ public abstract class BaseStubbing<T> implements OngoingStubbing<T> {
             stubbing = stubbing.thenReturn(v);
         }
         return stubbing;
+    }
+
+    @Override
+    public OngoingStubbing<T> thenReturn(SerializableSupplier<T> tSupplier, Class<T> returnType) {
+        return thenAnswer(new Returns(tSupplier, returnType));
     }
 
     private OngoingStubbing<T> thenThrow(Throwable throwable) {

--- a/src/main/java/org/mockito/internal/stubbing/StubberImpl.java
+++ b/src/main/java/org/mockito/internal/stubbing/StubberImpl.java
@@ -4,6 +4,7 @@
  */
 package org.mockito.internal.stubbing;
 
+import org.mockito.SerializableSupplier;
 import org.mockito.internal.stubbing.answers.CallsRealMethods;
 import org.mockito.internal.stubbing.answers.Returns;
 import org.mockito.internal.stubbing.answers.ThrowsException;
@@ -49,6 +50,13 @@ public class StubberImpl implements Stubber {
     @Override
     public Stubber doReturn(Object toBeReturned, Object... nextToBeReturned) {
         return doReturnValues(toBeReturned).doReturnValues(nextToBeReturned);
+    }
+
+    @Override
+    public Stubber doReturn(SerializableSupplier returnSupplier, Class typeHint) {
+        // TODO: 4/16/18
+        answers.add(new Returns(returnSupplier, typeHint));
+        return this;
     }
 
     private StubberImpl doReturnValues(Object... toBeReturned) {

--- a/src/main/java/org/mockito/stubbing/OngoingStubbing.java
+++ b/src/main/java/org/mockito/stubbing/OngoingStubbing.java
@@ -5,6 +5,7 @@
 package org.mockito.stubbing;
 
 import org.mockito.Mockito;
+import org.mockito.SerializableSupplier;
 
 /**
  * Simply put: "<b>When</b> the x method is called <b>then</b> return y". E.g:
@@ -65,6 +66,20 @@ public interface OngoingStubbing<T> {
     // Additional method helps users of JDK7+ to hide heap pollution / unchecked generics array creation warnings (on call site)
     @SuppressWarnings ({"unchecked", "varargs"})
     OngoingStubbing<T> thenReturn(T value, T... values);
+
+    /**
+     * Seta a supplier that will evaluated every time the method is called. E.g.:
+     * <pre class="code"><code class="java">
+     * when(mock.someMethod()).thenReturn(MyClass::new)
+     * </code></pre>
+     *
+     * The Return value for each call will be the output of running Supplier.get()
+     *
+     * @param tSupplier
+     * @param returnType
+     * @return
+     */
+    OngoingStubbing<T> thenReturn(SerializableSupplier<T> tSupplier, Class<T> returnType);
 
     /**
      * Sets Throwable objects to be thrown when the method is called. E.g:

--- a/src/main/java/org/mockito/stubbing/Stubber.java
+++ b/src/main/java/org/mockito/stubbing/Stubber.java
@@ -5,6 +5,7 @@
 package org.mockito.stubbing;
 
 import org.mockito.Mockito;
+import org.mockito.SerializableSupplier;
 
 /**
  * Allows to choose a method when stubbing in doThrow()|doAnswer()|doNothing()|doReturn() style
@@ -168,6 +169,9 @@ public interface Stubber {
      */
     @SuppressWarnings({"unchecked", "varargs"})
     Stubber doReturn(Object toBeReturned, Object... nextToBeReturned);
+
+    // TODO: 4/16/18  
+    Stubber doReturn(SerializableSupplier returnSupplier, Class typeHint);
 
     /**
      * Use it for stubbing consecutive calls in {@link Mockito#doCallRealMethod()} style.

--- a/src/test/java/org/mockito/MockitoTest.java
+++ b/src/test/java/org/mockito/MockitoTest.java
@@ -6,10 +6,14 @@
 package org.mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
 import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
 
 import java.util.List;
+import java.util.Random;
+
 import org.junit.Test;
 import org.mockito.exceptions.misusing.NotAMockException;
 import org.mockito.internal.creation.MockSettingsImpl;
@@ -60,6 +64,32 @@ public class MockitoTest {
 
         //then
         assertThat(Mockito.RETURNS_DEFAULTS).isEqualTo(settings.getDefaultAnswer());
+    }
+
+    @Test
+    public void shouldProduceDifferentNumbers() {
+        Random random = new Random();
+        List<String> stringList = Mockito.mock(List.class);
+
+        SerializableSupplier<Integer> supplier = () -> random.nextInt(100);
+        when(stringList.size()).thenReturn(supplier, Integer.class);
+
+        for(int i = 0; i < 10; i ++) {
+            assertThat(stringList.size()).isBetween(0, 100);
+        }
+    }
+
+    @Test
+    public void shouldProduceDifferentNumbers_mockitoStubber() {
+        Random random = new Random();
+        List<String> stringList = Mockito.mock(List.class);
+
+        SerializableSupplier<Integer> supplier = () -> random.nextInt(100);
+        Mockito.doReturn(supplier, Integer.class).when(stringList).size();
+
+        for(int i = 0; i < 10; i ++) {
+            assertThat(stringList.size()).isBetween(0, 100);
+        }
     }
 
 }

--- a/src/test/java/org/mockito/internal/stubbing/answers/ReturnsTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/answers/ReturnsTest.java
@@ -48,4 +48,27 @@ public class ReturnsTest {
     public void should_fail_on_null_with_primitive() throws Throwable {
         new Returns(null).validateFor(new InvocationBuilder().method("booleanReturningMethod").toInvocation());
     }
+
+    @Test
+    public void should_return_incrementing_number() throws Throwable {
+        Returns returns = new Returns(MyClass::new, MyClass.class);
+
+        for(int i = 1; i < 10; i++) {
+            MyClass myClass = (MyClass) returns.answer(new InvocationBuilder().simpleMethod().toInvocation());
+            assertThat(myClass.getValue()).isEqualTo(i);
+        }
+
+    }
+
+    private static class MyClass {
+        private static int value = 0;
+
+        public MyClass() {
+            value++;
+        }
+
+        public int getValue() {
+            return value;
+        }
+    }
 }

--- a/src/test/java/org/mockitousage/matchers/MatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/MatchersTest.java
@@ -286,7 +286,7 @@ public class MatchersTest extends TestBase {
         when(mock.oneArg(anyLong())).thenReturn("6");
         when(mock.oneArg(anyShort())).thenReturn("7");
         when(mock.oneArg((String) anyObject())).thenReturn("8");
-        when(mock.oneArg(anyObject())).thenReturn("9");
+        when(mock.oneArg((Object) anyObject())).thenReturn("9");
         when(mock.oneArg(any(RandomAccess.class))).thenReturn("10");
 
         assertEquals("0", mock.oneArg(true));
@@ -594,14 +594,14 @@ public class MatchersTest extends TestBase {
     public void eq_matcher_and_nulls() {
         mock.simpleMethod((Object) null);
 
-        verify(mock).simpleMethod(eq(null));
+        verify(mock).simpleMethod((Object) eq(null));
     }
 
     @Test
     public void same_matcher_and_nulls() {
         mock.simpleMethod((Object) null);
 
-        verify(mock).simpleMethod(same(null));
+        verify(mock).simpleMethod((Object) same(null));
     }
 
     @Test

--- a/src/test/java/org/mockitousage/matchers/MoreMatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/MoreMatchersTest.java
@@ -34,8 +34,8 @@ public class MoreMatchersTest extends TestBase {
     public void any_should_be_actual_alias_to_anyObject() {
         mock.simpleMethod((Object) null);
 
-        verify(mock).simpleMethod(any());
-        verify(mock).simpleMethod(anyObject());
+        verify(mock).simpleMethod((Object) any());
+        verify(mock).simpleMethod((Object) anyObject());
     }
 
     @Test


### PR DESCRIPTION
Fixes #1371 

This pull request allows Mockito to use some of Java 8 features.  Users can now provide a Supplier to the Returns functionality.  With this, users can test Streams and large batch processing style tests were data is partially generated prior to running and is mutated during processing.

Documentation and testing is weak: these will be improved in the next commit following general discussion with core dev team.

