### PR TITLE
Update Byte Buddy and cache some expensive values

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -4,7 +4,7 @@ ext {
 
 def versions = [:]
 
-versions.bytebuddy = '1.8.5'
+versions.bytebuddy = '1.8.8'
 versions.junitJupiter = '5.1.0'
 
 libraries.junit4 = 'junit:junit:4.12'


### PR DESCRIPTION
This avoids the reallocation of certain objects that are expensive to compute. Also, Byte Buddy is updated.