### PR TITLE
Avoid circularity: avoid endless loop during mock creation

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -4,7 +4,7 @@ ext {
 
 def versions = [:]
 
-versions.bytebuddy = '1.8.8'
+versions.bytebuddy = '1.8.10'
 versions.junitJupiter = '5.1.0'
 
 libraries.junit4 = 'junit:junit:4.12'

--- a/subprojects/kotlinTest/src/test/kotlin/org/mockito/kotlin/CircularityTest.kt
+++ b/subprojects/kotlinTest/src/test/kotlin/org/mockito/kotlin/CircularityTest.kt
@@ -1,0 +1,20 @@
+package org.mockito.kotlin
+
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito
+
+class MyClass
+
+class MyTest {
+
+    private lateinit var myClassMock: MyClass
+
+    @Before
+    fun `before each`() {
+        myClassMock = Mockito.mock(MyClass::class.java)
+    }
+
+    @Test
+    fun `some test`() { }
+}


### PR DESCRIPTION
If certain types a type for the first time during instrumentation while our mocking engine relies on the same types, this can cause a circularity as checking if an instance is a mock requires instances of the latter types what again returns to the latter mock checking routine what causes an endless loop. (Described in comment.) Fixes #1240.

It is a bit difficult to reproduce this issue in our tests. It mainly happens with classes generated by Kotlin or Scala and requires the inline mock maker and a JDK 9 or older. If we want to add such a test, we can copy the test from https://github.com/guenhter/mockito-final-class-kotlin-problem
