### PR TITLE
Make MockitoExtension constructor public

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,7 @@ include 'extTest'
 include 'kotlinTest'
 include 'android'
 include 'junit-jupiter'
+include 'junitJupiterExtensionTest'
 
 rootProject.name = 'mockito'
 

--- a/subprojects/junit-jupiter/src/main/java/org/mockito/junit/jupiter/MockitoExtension.java
+++ b/subprojects/junit-jupiter/src/main/java/org/mockito/junit/jupiter/MockitoExtension.java
@@ -66,9 +66,9 @@ public class MockitoExtension implements TestInstancePostProcessor,BeforeEachCal
 
     private final Strictness strictness;
 
-    // This constructor is invoked by JUnit Jupiter via reflection
+    // This constructor is invoked by JUnit Jupiter via reflection or ServiceLoader
     @SuppressWarnings("unused")
-    private MockitoExtension() {
+    public MockitoExtension() {
         this(Strictness.STRICT_STUBS);
     }
 

--- a/subprojects/junitJupiterExtensionTest/junitJupiterExtensionTest.gradle
+++ b/subprojects/junitJupiterExtensionTest/junitJupiterExtensionTest.gradle
@@ -1,0 +1,18 @@
+apply from: "$rootDir/gradle/dependencies.gradle"
+
+apply plugin: 'java'
+description = "End-to-end tests for automatic registration of MockitoExtension."
+
+sourceCompatibility = 1.8
+
+dependencies {
+    testCompile project(":junit-jupiter")
+    testCompile libraries.assertj
+    testCompile libraries.junitPlatformLauncher
+    testCompile libraries.junitJupiterApi
+    testRuntime libraries.junitJupiterEngine
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/subprojects/junitJupiterExtensionTest/src/test/java/org/mockitousage/NoExtendsTest.java
+++ b/subprojects/junitJupiterExtensionTest/src/test/java/org/mockitousage/NoExtendsTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2018 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage;
+
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+class NoExtendsTest {
+
+    @Mock
+    private List<String> mock;
+
+    @Test
+    void runs() {
+        when(mock.get(0)).thenReturn("foo");
+        assertThat(mock.get(0)).isEqualTo("foo");
+    }
+}

--- a/subprojects/junitJupiterExtensionTest/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/subprojects/junitJupiterExtensionTest/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+org.mockito.junit.jupiter.MockitoExtension

--- a/subprojects/junitJupiterExtensionTest/src/test/resources/junit-platform.properties
+++ b/subprojects/junitJupiterExtensionTest/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.extensions.autodetection.enabled = true


### PR DESCRIPTION
It is possible to register an extension for automatic use using Java's `ServiceLoader` mechanism.

https://junit.org/junit5/docs/current/user-guide/#extensions-registration-automatic

Some projects may want to provide their own `META-INF` file to avoid tediously adding `MockitoExtension` to tests since it is very common. However, `ServiceLoader` requires the class to have a no-args *public* constructor, so the current extension cannot be used with the `ServiceLoader` mechanism.

Fixes #1390

check list

 - [X] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/2.x/.github/CONTRIBUTING.md)
 - [X] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [X] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [X] Avoid other runtime dependencies
 - [X] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [X] The pull request follows coding style
 - [X] Mention `Fixes #<issue number>` in the description _if relevant_
 - [X] At least one commit should mention `Fixes #<issue number>` _if relevant_

