### PR TITLE
Fix wrong artifact name in javadoc, and link to proper javadoc page

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -1510,8 +1510,8 @@ import org.mockito.verification.VerificationWithTimeout;
  *
  * <h3 id="45">45. (**new**) <a class="meaningful_link" href="#junit5_mockito" name="junit5_mockito">New JUnit Jupiter (JUnit5+) extension</a></h3>
  *
- * For integration with JUnit Jupiter (JUnit5+), use the `org.mockito.junit-jupiter` artifact.
- * For more information about the usage of the integration, see the JavaDoc of <code>MockitoExtension</code>.
+ * For integration with JUnit Jupiter (JUnit5+), use the `org.mockito:mockito-junit-jupiter` artifact.
+ * For more information about the usage of the integration, see <a href="http://javadoc.io/page/org.mockito/mockito-junit-jupiter/latest/org/mockito/junit/jupiter/MockitoExtension.html">the JavaDoc of <code>MockitoExtension</code></a>.
  */
 @SuppressWarnings("unchecked")
 public class Mockito extends ArgumentMatchers {


### PR DESCRIPTION
## motivation

1. Current javadoc in `Mockito.java` uses wrong artifact name 'org.mockito.junit-jupiter', but it should be [org.mockito:mockito-junit-jupiter](https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter). To avoid user's confusion, fix it with correct name.
2. The `MockitoExtension` isn't contained in `mockito-core`, so we cannot use hyper link generated by `{@link ...}`. Instead, we can use `<a>` tag to guide users to proper javadoc page.

## check list

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/2.x/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

Thanks for your great product that really helps our daily hacking :)