### PR TITLE
mockito on Java 11-ea+21

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -4,7 +4,7 @@ ext {
 
 def versions = [:]
 
-versions.bytebuddy = '1.8.10'
+versions.bytebuddy = '1.8.13'
 versions.junitJupiter = '5.1.0'
 
 libraries.junit4 = 'junit:junit:4.12'
@@ -23,7 +23,7 @@ libraries.errorprone = 'com.google.errorprone:error_prone_core:2.3.1'
 
 libraries.objenesis = 'org.objenesis:objenesis:2.6'
 
-libraries.asm = 'org.ow2.asm:asm:6.1.1'
+libraries.asm = 'org.ow2.asm:asm:6.2'
 
 def kotlinVersion = '1.2.10'
 libraries.kotlin = [

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
@@ -23,6 +23,7 @@ import net.bytebuddy.jar.asm.MethodVisitor;
 import net.bytebuddy.jar.asm.Opcodes;
 import net.bytebuddy.matcher.ElementMatchers;
 import net.bytebuddy.pool.TypePool;
+import net.bytebuddy.utility.OpenedClassReader;
 import net.bytebuddy.utility.RandomString;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.util.concurrent.WeakConcurrentMap;
@@ -247,7 +248,7 @@ public class InlineBytecodeGenerator implements BytecodeGenerator, ClassFileTran
             private final TypeDescription typeDescription;
 
             private ParameterAddingClassVisitor(ClassVisitor cv, TypeDescription typeDescription) {
-                super(Opcodes.ASM6, cv);
+                super(OpenedClassReader.ASM_API, cv);
                 this.typeDescription = typeDescription;
             }
 


### PR DESCRIPTION
Fixes #1419 

Requires `-Dnet.bytebuddy.experimental=true` system property to be set to let bytebuddy use asm API version `ASM7_EXPERMIENTAL` and use the same one in `InlineBytecodeGenerator`.
