### PR TITLE
Update gradle plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,8 @@ buildscript {
 
     dependencies {
         classpath 'gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.14.0'
-        classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.4.3' //for 'java-compatibility-check.gradle'
-        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.13'
+        classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.4.4' //for 'java-compatibility-check.gradle'
+        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.15'
 
         //Using buildscript.classpath so that we can resolve shipkit from maven local, during local testing
         classpath 'org.shipkit:shipkit:2.0.15'
@@ -16,7 +16,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.gradle.build-scan' version '1.12.1'
+    id 'com.gradle.build-scan' version '1.15.1'
 }
 
 description = 'Mockito mock objects library core API and implementation'


### PR DESCRIPTION
 - gradle-animalsniffer-plugin (v1.4.4)
 - gradle-errorprone-plugin (v0.0.15)
 - build-scan-plugin (v1.15.1)

I will provide another pr about updating shipkit to the latest version soon (which we'd need in order to be able to use gradle 4.8/4.9).
