### PR TITLE
Fixed Travis build

### DIFF
--- a/src/main/java/org/mockito/internal/matchers/Any.java
+++ b/src/main/java/org/mockito/internal/matchers/Any.java
@@ -9,12 +9,9 @@ import java.io.Serializable;
 
 import org.mockito.ArgumentMatcher;
 
-public class Any implements ArgumentMatcher<Object>, VarargMatcher ,Serializable {
+public class Any implements ArgumentMatcher<Object>, VarargMatcher, Serializable {
 
     public static final Any ANY = new Any();
-
-    private Any() {
-    }
 
     public boolean matches(Object actual) {
         return true;


### PR DESCRIPTION
We don't need private constructor on an 'internal' class. Internal classes can be changed at any time based on our compatibility policy.