### PR TITLE
Javadoc: Update code example (ignoreStubs)

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -2580,11 +2580,11 @@ public class Mockito extends ArgumentMatchers {
      * Ignoring stubs can be used with <b>verification in order</b>:
      * <pre class="code"><code class="java">
      *  List list = mock(List.class);
-     *  when(mock.get(0)).thenReturn("foo");
+     *  when(list.get(0)).thenReturn("foo");
      *
      *  list.add(0);
-     *  System.out.println(list.get(0)); //we don't want to verify this
      *  list.clear();
+     *  System.out.println(list.get(0)); //we don't want to verify this
      *
      *  InOrder inOrder = inOrder(ignoreStubs(list));
      *  inOrder.verify(list).add(0);


### PR DESCRIPTION
It updates the code example of `ignoreStubs` in Javadoc.
- Correct wrong variable
: From `mock` to `list`
- Change call sequence
: The existing one doesn't clearly describe the use of `ignoreStubs` with `inOrder`.