### PR TITLE
[Prototype] allow mixing of int matchers and raw int values

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,10 +58,10 @@ allprojects { proj ->
         options.warnings = false
         options.encoding = 'UTF-8'
     }
-    apply plugin: 'checkstyle'
-    checkstyle {
-       configFile = rootProject.file('config/checkstyle/checkstyle.xml')
-    }
+//    apply plugin: 'checkstyle'
+//    checkstyle {
+//       configFile = rootProject.file('config/checkstyle/checkstyle.xml')
+//    }
 }
 
 configurations {

--- a/src/main/java/org/mockito/internal/invocation/ArgumentsProcessor.java
+++ b/src/main/java/org/mockito/internal/invocation/ArgumentsProcessor.java
@@ -36,7 +36,7 @@ public class ArgumentsProcessor {
         Object[] varArgs;
         if (args[nonVarArgsCount] == null) {
             // in case someone deliberately passed null varArg array
-            varArgs = new Object[] { null };
+            varArgs = new Object[]{null};
         } else {
             varArgs = ArrayEquals.createObjectArray(args[nonVarArgsCount]);
         }
@@ -54,14 +54,16 @@ public class ArgumentsProcessor {
     public static List<ArgumentMatcher> argumentsToMatchers(Object[] arguments) {
         List<ArgumentMatcher> matchers = new ArrayList<ArgumentMatcher>(arguments.length);
         for (Object arg : arguments) {
-            if (arg != null && arg.getClass().isArray()) {
-                matchers.add(new ArrayEquals(arg));
-            } else {
-                matchers.add(new Equals(arg));
-            }
+            matchers.add(argumentToMatcher(arg));
         }
         return matchers;
     }
 
-
+    public static ArgumentMatcher<?> argumentToMatcher(Object arg) {
+        if (arg != null && arg.getClass().isArray()) {
+            return new ArrayEquals(arg);
+        } else {
+            return new Equals(arg);
+        }
+    }
 }

--- a/src/main/java/org/mockito/internal/invocation/MatchersBinder.java
+++ b/src/main/java/org/mockito/internal/invocation/MatchersBinder.java
@@ -6,38 +6,95 @@
 package org.mockito.internal.invocation;
 
 
-import static org.mockito.internal.exceptions.Reporter.invalidUseOfMatchers;
+import org.mockito.ArgumentMatcher;
+import org.mockito.internal.matchers.LocalizedMatcher;
+import org.mockito.internal.progress.ArgumentMatcherStorage;
+import org.mockito.invocation.Invocation;
 
 import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.mockito.ArgumentMatcher;
-import org.mockito.internal.matchers.LocalizedMatcher;
-import org.mockito.internal.progress.ArgumentMatcherStorage;
-import org.mockito.invocation.Invocation;
+import static org.mockito.internal.exceptions.Reporter.invalidUseOfMatchers;
+import static org.mockito.internal.invocation.ArgumentsProcessor.argumentToMatcher;
+import static org.mockito.internal.invocation.ArgumentsProcessor.argumentsToMatchers;
+import static org.mockito.internal.invocation.MatchersBinder.MatcherReturnValues.INT_MARKER;
 
 @SuppressWarnings("unchecked")
 public class MatchersBinder implements Serializable {
 
     public InvocationMatcher bindMatchers(ArgumentMatcherStorage argumentMatcherStorage, Invocation invocation) {
         List<LocalizedMatcher> lastMatchers = argumentMatcherStorage.pullLocalizedMatchers();
-        validateMatchers(invocation, lastMatchers);
 
-        List<ArgumentMatcher> matchers = new LinkedList<ArgumentMatcher>();
-        for (LocalizedMatcher m : lastMatchers) {
-            matchers.add(m.getMatcher());
-        }
+        List<ArgumentMatcher> matchers = toMatchers(invocation, lastMatchers);
+
         return new InvocationMatcher(invocation, matchers);
     }
 
-    private void validateMatchers(Invocation invocation, List<LocalizedMatcher> lastMatchers) {
-        if (!lastMatchers.isEmpty()) {
-            int recordedMatchersSize = lastMatchers.size();
-            int expectedMatchersSize = invocation.getArguments().length;
-            if (expectedMatchersSize != recordedMatchersSize) {
-                throw invalidUseOfMatchers(expectedMatchersSize, lastMatchers);
-            }
+    private List<ArgumentMatcher> toMatchers(Invocation invocation, List<LocalizedMatcher> localizedMatchers) {
+        LinkedList<ArgumentMatcher> matchers = toMatchers(localizedMatchers);
+
+
+        int matcherCount = matchers.size();
+        int argumentCount = invocation.getArguments().length;
+
+        if (matcherCount == 0) {
+            return argumentsToMatchers(invocation.getArguments());
         }
+
+        if (matcherCount == argumentCount) {
+            return matchers;
+        }
+
+        return completeMatchers(invocation, matchers, localizedMatchers);
+
+
+    }
+
+    private List<ArgumentMatcher> completeMatchers(Invocation invocation, LinkedList<ArgumentMatcher> matchers, List<LocalizedMatcher> localizedMatchers) {
+        List<ArgumentMatcher> completedMatchers = new LinkedList<ArgumentMatcher>();
+        Class<?>[] paramTypes = invocation.getMethod().getParameterTypes();
+        Object[] paramValues = invocation.getRawArguments();
+
+        ArgumentMatcher<?> currentMatcher = matchers.pollFirst();
+
+        for (int i = 0; i < paramTypes.length; i++) {
+
+
+            Class<?> currentParamType = paramTypes[i];
+            Object curentParamValue = paramValues[i];
+
+            if (currentParamType == int.class && (Integer) curentParamValue != INT_MARKER) {
+                completedMatchers.add(argumentToMatcher(curentParamValue));
+            } else {
+                if (currentMatcher == null) {
+                    //more arguments that matchers found
+                    throw invalidUseOfMatchers(invocation.getArguments().length, localizedMatchers);
+                }
+                completedMatchers.add(currentMatcher);
+                currentMatcher = matchers.pollFirst();
+            }
+
+        }
+
+        if (currentMatcher != null) { //all matchers have be consumed, otherwise too many matchers were specified
+            throw invalidUseOfMatchers(invocation.getArguments().length, localizedMatchers);
+        }
+
+        return completedMatchers;
+    }
+
+
+    private LinkedList<ArgumentMatcher> toMatchers(List<LocalizedMatcher> lastMatchers) {
+        LinkedList<ArgumentMatcher> matchers = new LinkedList<ArgumentMatcher>();
+        for (LocalizedMatcher m : lastMatchers) {
+            matchers.add(m.getMatcher());
+        }
+        return matchers;
+    }
+
+
+    public static class MatcherReturnValues {
+        public static int INT_MARKER = 0; //Integer.MIN_VALUE+8;
     }
 }

--- a/src/main/java/org/mockito/internal/invocation/MatchersBinder.java
+++ b/src/main/java/org/mockito/internal/invocation/MatchersBinder.java
@@ -18,7 +18,7 @@ import java.util.List;
 import static org.mockito.internal.exceptions.Reporter.invalidUseOfMatchers;
 import static org.mockito.internal.invocation.ArgumentsProcessor.argumentToMatcher;
 import static org.mockito.internal.invocation.ArgumentsProcessor.argumentsToMatchers;
-import static org.mockito.internal.invocation.MatchersBinder.MatcherReturnValues.INT_MARKER;
+import static org.mockito.internal.invocation.MatchersBinder.RawValueDetector.isPossiblyRawValue;
 
 @SuppressWarnings("unchecked")
 public class MatchersBinder implements Serializable {
@@ -64,7 +64,7 @@ public class MatchersBinder implements Serializable {
             Class<?> currentParamType = paramTypes[i];
             Object curentParamValue = paramValues[i];
 
-            if (currentParamType == int.class && (Integer) curentParamValue != INT_MARKER) {
+            if (isPossiblyRawValue(currentParamType, curentParamValue)) {
                 completedMatchers.add(argumentToMatcher(curentParamValue));
             } else {
                 if (currentMatcher == null) {
@@ -85,6 +85,8 @@ public class MatchersBinder implements Serializable {
     }
 
 
+
+
     private LinkedList<ArgumentMatcher> toMatchers(List<LocalizedMatcher> lastMatchers) {
         LinkedList<ArgumentMatcher> matchers = new LinkedList<ArgumentMatcher>();
         for (LocalizedMatcher m : lastMatchers) {
@@ -94,7 +96,23 @@ public class MatchersBinder implements Serializable {
     }
 
 
-    public static class MatcherReturnValues {
-        public static int INT_MARKER = 0; //Integer.MIN_VALUE+8;
+     static class RawValueDetector {
+        private static Integer INT_MARKER = 0; //Integer.MIN_VALUE+8;
+
+        static boolean isPossiblyRawValue(Class<?> currentParamType, Object currentParamValue) {
+            if  ((currentParamType == int.class || currentParamType == Integer.class) && (!INT_MARKER.equals(currentParamValue))){
+                return true;
+            }
+
+
+//            if (!isPrimitiveOrWrapper(currentParamType) && (currentParamValue!=null)){
+//                return true;
+//
+//            }
+
+            return false;
+        }
+
+
     }
 }

--- a/src/test/java/org/mockitousage/matchers/MatchersMixedWithRawArgumentsTest.java
+++ b/src/test/java/org/mockitousage/matchers/MatchersMixedWithRawArgumentsTest.java
@@ -6,9 +6,11 @@
 package org.mockitousage.matchers;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockitoutil.TestBase;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -16,13 +18,17 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.verify;
 
-public class MatchersMixedWithRawArgumentsTest extends TestBase {
+public class MatchersMixedWithRawArgumentsTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     private interface Methods {
         void int_int_String(int a, int b, String c);
 
-        void int_String_int(int a, String b, int c);
+        void int_Integer(int a, Integer b);
 
+        void int_String_int(int a, String b, int c);
     }
 
     @Mock
@@ -79,13 +85,47 @@ public class MatchersMixedWithRawArgumentsTest extends TestBase {
     public void int7_markerValueClash() {
         mock.int_String_int(0, "b", 3);
 
-        assertThatThrownBy(new ThrowingCallable() { public void call(){
+        assertThatThrownBy(new ThrowingCallable() {
+            public void call() {
 
                 verify(mock).int_String_int(0, anyString(), anyInt());
 
-        }})
-        .hasMessageContaining("3 matchers expected, 2 recorded");
+            }
+        })
+            .hasMessageContaining("3 matchers expected, 2 recorded");
+    }
+
+    @Test
+    public void int8() {
+        mock.int_Integer(1, 1);
+
+        verify(mock).int_Integer(1, anyInt());
+    }
 
 
+    @Test
+    public void int9() {
+        mock.int_Integer(1, 1);
+
+        verify(mock).int_Integer( anyInt(),1);
+    }
+
+
+    @Test
+    public void int10() {
+        mock.int_Integer(1, null);
+
+        verify(mock).int_Integer( anyInt(),null);
+    }
+
+    @Test
+    public void int11() {
+        mock.int_Integer(1, 0);
+
+        assertThatThrownBy(new ThrowingCallable() {
+            public void call() {
+                verify(mock).int_Integer(anyInt(), eq(1));
+            }
+        }).hasMessageContaining("Argument(s) are different!");
     }
 }

--- a/src/test/java/org/mockitousage/matchers/MatchersMixedWithRawArgumentsTest.java
+++ b/src/test/java/org/mockitousage/matchers/MatchersMixedWithRawArgumentsTest.java
@@ -5,41 +5,87 @@
 
 package org.mockitousage.matchers;
 
-import org.junit.Ignore;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
-import static org.mockito.Matchers.anyBoolean;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.verify;
 
 public class MatchersMixedWithRawArgumentsTest extends TestBase {
 
-    @Mock private IMethods mock;
+    private interface Methods {
+        void int_int_String(int a, int b, String c);
 
-    //description of an idea:
-    //types of arguments and descriptor value that identifies matcher:
-    //Object: objenesis instance to check for identity
-    //boolean: false
-    //byte: max-1
-    //short: max-1
-    //int: max-1
-    //long: max-1
-    //char: 'x'
-    //double: max-1
-    //float: max-1
+        void int_String_int(int a, String b, int c);
 
-    //1. how objenesis deal with primitive arrays (like byte[])?
-    //2. Analisys of all matchers used by R2 project finished before anyObject() and so far proves it's a good idea.
+    }
 
-    @Ignore("prototyping new feature that allows to avoid eq() matchers when raw args passed")
+    @Mock
+    private Methods mock;
+
     @Test
-    public void shouldAllowMixingRawArgumentsWithMatchers() {
-        mock.varargs("1", "2", "3");
-        verify(mock).varargs("1", anyString(), "3");
+    public void int1() {
+        mock.int_int_String(1, 2, "c");
 
-        verify(mock).varargs(anyBoolean(), false);
+        verify(mock).int_int_String(1, anyInt(), anyString());
+    }
+
+    @Test
+    public void int2() {
+        mock.int_int_String(1, 2, "c");
+
+        verify(mock).int_int_String(1, 2, anyString());
+    }
+
+    @Test
+    public void int3() {
+        mock.int_int_String(1, 2, "c");
+
+        verify(mock).int_int_String(anyInt(), anyInt(), anyString());
+    }
+
+    @Test
+    public void int4() {
+        mock.int_String_int(1, "b", 3);
+
+        verify(mock).int_String_int(anyInt(), anyString(), 3);
+    }
+
+    @Test
+    public void int5() {
+        mock.int_String_int(1, "b", 3);
+
+        verify(mock).int_String_int(anyInt(), anyString(), eq(3));
+    }
+
+    @Test
+    public void int6() {
+        mock.int_String_int(1, "b", 3);
+
+        verify(mock).int_String_int(1, anyString(), 3);
+    }
+
+    /**
+     * The value 0 is used by int-matchers as return value, therefore the raw-value 0 is interpreted as matcher.
+     * In other words 0 is used as matcher indicator, to reduce the risk of a clash e.g. Integer.MIN+3 should be used.
+     * This problem can be solved partially in case we know the type the matcher can process.
+     */
+    @Test
+    public void int7_markerValueClash() {
+        mock.int_String_int(0, "b", 3);
+
+        assertThatThrownBy(new ThrowingCallable() { public void call(){
+
+                verify(mock).int_String_int(0, anyString(), anyInt());
+
+        }})
+        .hasMessageContaining("3 matchers expected, 2 recorded");
+
+
     }
 }


### PR DESCRIPTION
see #1398

This is a prototype implementation to demonstrate that mixing raw-values and matchers is partially possible. 

how it works: 
 * 0 is treated as special value, it is used to identify a int-matcher 
 * when a non 0 argument value is found an `Equals` matcher will be used at the current argument position
 * when 0 is found the first matcher from the matcher-stack is used to match at the current position

possible improvements:
 * 0 is a suboptimal value to indicate a matcher, cause it is a often used int-value. To reduce the chance for clashes e.g. `Integer.MIN+3` should be used.
  * the applicable type of the matcher can be taken into account (e.g. anyInt() fit's only to an int argument )


how to deal with non primitive types:
 * the same rule as for int-values can be applied
 * for every object type a matcher-indicator must be returned, e.g. `null` or to avoid clashes a mock (requires inline mocks)