### PR TITLE
Updates Byte Buddy to add preliminary support for Java 12.

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -4,7 +4,7 @@ ext {
 
 def versions = [:]
 
-versions.bytebuddy = '1.8.13'
+versions.bytebuddy = '1.8.15'
 versions.junitJupiter = '5.1.0'
 
 libraries.junit4 = 'junit:junit:4.12'


### PR DESCRIPTION
Adds support for Java 12 version constant. This allows to run Mockito on Java 11 and 12 when the `net.bytebuddy.experimental` property is set to `true`.