### PR TITLE
Added validation of artifact IDs

### DIFF
--- a/gradle/java-library.gradle
+++ b/gradle/java-library.gradle
@@ -6,6 +6,13 @@ if (!archivesBaseName.startsWith("mockito-")) {
     archivesBaseName = "mockito-" + project.name
 }
 
+generatePomFileForJavaLibraryPublication.doLast {
+    //validates the the pom has correct artifact id to avoid issues like #1444
+    def pom = new XmlSlurper().parse(destination)
+    assert pom.artifactId == archivesBaseName
+    assert pom.name == archivesBaseName
+}
+
 bintrayUpload.enabled = true
 
 sourceCompatibility = 1.6


### PR DESCRIPTION
This will prevent problems such as unintentional change to artifact ids (#1444)

Tested by removing the workaround and running "./gradlew generatePomFileForJavaLibraryPublication" task. The assertions were failing.