### PR TITLE
Prevent stubOnly() from being verified (#1460)

### DIFF
--- a/src/main/java/org/mockito/internal/MockitoCore.java
+++ b/src/main/java/org/mockito/internal/MockitoCore.java
@@ -35,16 +35,7 @@ import org.mockito.verification.VerificationMode;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.mockito.internal.exceptions.Reporter.missingMethodInvocation;
-import static org.mockito.internal.exceptions.Reporter.mocksHaveToBePassedToVerifyNoMoreInteractions;
-import static org.mockito.internal.exceptions.Reporter.mocksHaveToBePassedWhenCreatingInOrder;
-import static org.mockito.internal.exceptions.Reporter.notAMockPassedToVerify;
-import static org.mockito.internal.exceptions.Reporter.notAMockPassedToVerifyNoMoreInteractions;
-import static org.mockito.internal.exceptions.Reporter.notAMockPassedWhenCreatingInOrder;
-import static org.mockito.internal.exceptions.Reporter.nullPassedToVerify;
-import static org.mockito.internal.exceptions.Reporter.nullPassedToVerifyNoMoreInteractions;
-import static org.mockito.internal.exceptions.Reporter.nullPassedWhenCreatingInOrder;
-import static org.mockito.internal.exceptions.Reporter.stubPassedToVerify;
+import static org.mockito.internal.exceptions.Reporter.*;
 import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
 import static org.mockito.internal.util.MockUtil.createMock;
 import static org.mockito.internal.util.MockUtil.getInvocationContainer;
@@ -93,7 +84,7 @@ public class MockitoCore {
         if (!mockingDetails.isMock()) {
             throw notAMockPassedToVerify(mock.getClass());
         }
-        assertVerifiableMock(mock);
+        assertNotStubOnlyMock(mock);
         MockHandler handler = mockingDetails.getMockHandler();
         mock = (T) VerificationStartedNotifier.notifyVerificationStarted(
             handler.getMockSettings().getVerificationStartedListeners(), mockingDetails);
@@ -135,7 +126,7 @@ public class MockitoCore {
                     throw nullPassedToVerifyNoMoreInteractions();
                 }
                 InvocationContainerImpl invocations = getInvocationContainer(mock);
-                assertVerifiableMock(mock);
+                assertNotStubOnlyMock(mock);
                 VerificationDataImpl data = new VerificationDataImpl(invocations, null);
                 noMoreInteractions().verify(data);
             } catch (NotAMockException e) {
@@ -156,7 +147,7 @@ public class MockitoCore {
         }
     }
 
-    private void assertVerifiableMock(Object mock) {
+    private void assertNotStubOnlyMock(Object mock) {
         if (getMockHandler(mock).getMockSettings().isStubOnly()) {
             throw stubPassedToVerify(mock);
         }
@@ -173,7 +164,7 @@ public class MockitoCore {
             if (!isMock(mock)) {
                 throw notAMockPassedWhenCreatingInOrder();
             }
-            assertVerifiableMock(mock);
+            assertNotStubOnlyMock(mock);
         }
         return new InOrderImpl(Arrays.asList(mocks));
     }

--- a/src/main/java/org/mockito/internal/exceptions/Reporter.java
+++ b/src/main/java/org/mockito/internal/exceptions/Reporter.java
@@ -278,8 +278,8 @@ public class Reporter {
 
     public static MockitoException stubPassedToVerify(Object mock) {
         return new CannotVerifyStubOnlyMock(join(
-                "Argument \"" + MockUtil.getMockName(mock) + "\" passed to verify is a stubOnly() mock, not a full blown mock!",
-                "If you intend to verify invocations on a mock, don't use stubOnly() in its MockSettings."
+                "Argument \"" + MockUtil.getMockName(mock) + "\" passed to verify is a stubOnly() mock which cannot be verified.",
+                "If you intend to verify invocations on this mock, don't use stubOnly() in its MockSettings."
         ));
     }
 

--- a/src/main/java/org/mockito/internal/exceptions/Reporter.java
+++ b/src/main/java/org/mockito/internal/exceptions/Reporter.java
@@ -277,9 +277,9 @@ public class Reporter {
         ));
     }
 
-    public static MockitoException stubPassedToVerify() {
+    public static MockitoException stubPassedToVerify(Object mock) {
         return new CannotVerifyStubOnlyMock(join(
-                "Argument passed to verify() is a stubOnly() mock, not a full blown mock!",
+                "Argument \"" + safelyGetMockName(mock) + "\" passed to verify is a stubOnly() mock, not a full blown mock!",
                 "If you intend to verify invocations on a mock, don't use stubOnly() in its MockSettings."
         ));
     }

--- a/src/main/java/org/mockito/internal/exceptions/Reporter.java
+++ b/src/main/java/org/mockito/internal/exceptions/Reporter.java
@@ -26,7 +26,6 @@ import org.mockito.invocation.Invocation;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.invocation.Location;
 import org.mockito.listeners.InvocationListener;
-import org.mockito.mock.MockName;
 import org.mockito.mock.SerializableMode;
 
 import java.lang.reflect.Field;
@@ -279,7 +278,7 @@ public class Reporter {
 
     public static MockitoException stubPassedToVerify(Object mock) {
         return new CannotVerifyStubOnlyMock(join(
-                "Argument \"" + safelyGetMockName(mock) + "\" passed to verify is a stubOnly() mock, not a full blown mock!",
+                "Argument \"" + MockUtil.getMockName(mock) + "\" passed to verify is a stubOnly() mock, not a full blown mock!",
                 "If you intend to verify invocations on a mock, don't use stubOnly() in its MockSettings."
         ));
     }
@@ -437,7 +436,7 @@ public class Reporter {
         return new NoInteractionsWanted(join(
                 "No interactions wanted here:",
                 new LocationImpl(),
-                "But found this interaction on mock '" + safelyGetMockName(undesired.getMock()) + "':",
+                "But found this interaction on mock '" + MockUtil.getMockName(undesired.getMock()) + "':",
                 undesired.getLocation(),
                 scenario
         ));
@@ -447,7 +446,7 @@ public class Reporter {
         return new VerificationInOrderFailure(join(
                 "No interactions wanted here:",
                 new LocationImpl(),
-                "But found this interaction on mock '" + safelyGetMockName(undesired.getMock()) + "':",
+                "But found this interaction on mock '" + MockUtil.getMockName(undesired.getMock()) + "':",
                 undesired.getLocation()
         ));
     }
@@ -513,7 +512,7 @@ public class Reporter {
                 actualType + " cannot be returned by " + methodName + "()",
                 methodName + "() should return " + expectedType,
                 "",
-                "The default answer of " + safelyGetMockName(mock) + " that was configured on the mock is probably incorrectly implemented.",
+                "The default answer of " + MockUtil.getMockName(mock) + " that was configured on the mock is probably incorrectly implemented.",
                 ""
         ));
     }
@@ -697,7 +696,7 @@ public class Reporter {
 
     public static MockitoException cannotInjectDependency(Field field, Object matchingMock, Exception details) {
         return new MockitoException(join(
-                "Mockito couldn't inject mock dependency '" + safelyGetMockName(matchingMock) + "' on field ",
+                "Mockito couldn't inject mock dependency '" + MockUtil.getMockName(matchingMock) + "' on field ",
                 "'" + field + "'",
                 "whose type '" + field.getDeclaringClass().getCanonicalName() + "' was annotated by @InjectMocks in your test.",
                 "Also I failed because: " + exceptionCauseMessageIfAvailable(details),
@@ -740,7 +739,7 @@ public class Reporter {
     public static MockitoException invalidArgumentPositionRangeAtInvocationTime(InvocationOnMock invocation, boolean willReturnLastParameter, int argumentIndex) {
         return new MockitoException(join(
                 "Invalid argument index for the current invocation of method : ",
-                " -> " + safelyGetMockName(invocation.getMock()) + "." + invocation.getMethod().getName() + "()",
+                " -> " + MockUtil.getMockName(invocation.getMock()) + "." + invocation.getMethod().getName() + "()",
                 "",
                 (willReturnLastParameter ?
                         "Last parameter wanted" :
@@ -774,7 +773,7 @@ public class Reporter {
         return new WrongTypeOfReturnValue(join(
                 "The argument of type '" + actualType.getSimpleName() + "' cannot be returned because the following ",
                 "method should return the type '" + expectedType + "'",
-                " -> " + safelyGetMockName(invocation.getMock()) + "." + invocation.getMethod().getName() + "()",
+                " -> " + MockUtil.getMockName(invocation.getMock()) + "." + invocation.getMethod().getName() + "()",
                 "",
                 "The reason for this error can be :",
                 "1. The wanted argument position is incorrect.",
@@ -811,7 +810,7 @@ public class Reporter {
     public static MockitoException delegatedMethodHasWrongReturnType(Method mockMethod, Method delegateMethod, Object mock, Object delegate) {
         return new MockitoException(join(
                 "Methods called on delegated instance must have compatible return types with the mock.",
-                "When calling: " + mockMethod + " on mock: " + safelyGetMockName(mock),
+                "When calling: " + mockMethod + " on mock: " + MockUtil.getMockName(mock),
                 "return type should be: " + mockMethod.getReturnType().getSimpleName() + ", but was: " + delegateMethod.getReturnType().getSimpleName(),
                 "Check that the instance passed to delegatesTo() is of the correct type or contains compatible methods",
                 "(delegate instance had type: " + delegate.getClass().getSimpleName() + ")"
@@ -821,7 +820,7 @@ public class Reporter {
     public static MockitoException delegatedMethodDoesNotExistOnDelegate(Method mockMethod, Object mock, Object delegate) {
         return new MockitoException(join(
                 "Methods called on mock must exist in delegated instance.",
-                "When calling: " + mockMethod + " on mock: " + safelyGetMockName(mock),
+                "When calling: " + mockMethod + " on mock: " + MockUtil.getMockName(mock),
                 "no such method was found.",
                 "Check that the instance passed to delegatesTo() is of the correct type or contains compatible methods",
                 "(delegate instance had type: " + delegate.getClass().getSimpleName() + ")"
@@ -847,10 +846,6 @@ public class Reporter {
         return new MockitoException(join(
                 "Exception type cannot be null.",
                 "This may happen with doThrow(Class)|thenThrow(Class) family of methods if passing null parameter."));
-    }
-
-    private static MockName safelyGetMockName(Object mock) {
-        return MockUtil.getMockName(mock);
     }
 
     public static UnnecessaryStubbingException formatUnncessaryStubbingException(Class<?> testClass, Collection<Invocation> unnecessaryStubbings) {

--- a/src/test/java/org/mockitousage/stubbing/BasicStubbingTest.java
+++ b/src/test/java/org/mockitousage/stubbing/BasicStubbingTest.java
@@ -10,13 +10,12 @@ import org.junit.Test;
 import org.mockito.exceptions.misusing.CannotVerifyStubOnlyMock;
 import org.mockito.exceptions.misusing.MissingMethodInvocationException;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
-import org.mockito.internal.util.MockUtil;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 public class BasicStubbingTest extends TestBase {
@@ -126,7 +125,9 @@ public class BasicStubbingTest extends TestBase {
             verify(localMock); // throws exception before method invocation
             fail();
         } catch (CannotVerifyStubOnlyMock e) {
-            assertThat(e.getMessage()).contains(MockUtil.getMockName(localMock).toString());
+            assertEquals("\n" +
+                "Argument \"iMethods\" passed to verify is a stubOnly() mock which cannot be verified.\n" +
+                "If you intend to verify invocations on this mock, don't use stubOnly() in its MockSettings.", e.getMessage());
         }
     }
 
@@ -137,9 +138,7 @@ public class BasicStubbingTest extends TestBase {
         try {
             verifyNoMoreInteractions(localMock);
             fail();
-        } catch (CannotVerifyStubOnlyMock e) {
-            assertThat(e.getMessage()).contains(MockUtil.getMockName(localMock).toString());
-        }
+        } catch (CannotVerifyStubOnlyMock e) {}
     }
 
     @Test
@@ -149,8 +148,6 @@ public class BasicStubbingTest extends TestBase {
         try {
             inOrder(localMock);
             fail();
-        } catch (CannotVerifyStubOnlyMock e) {
-            assertThat(e.getMessage()).contains(MockUtil.getMockName(localMock).toString());
-        }
+        } catch (CannotVerifyStubOnlyMock e) {}
     }
 }

--- a/src/test/java/org/mockitousage/stubbing/BasicStubbingTest.java
+++ b/src/test/java/org/mockitousage/stubbing/BasicStubbingTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import org.mockito.exceptions.misusing.CannotVerifyStubOnlyMock;
 import org.mockito.exceptions.misusing.MissingMethodInvocationException;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
+import org.mockito.internal.util.MockUtil;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
@@ -124,6 +125,32 @@ public class BasicStubbingTest extends TestBase {
         try {
             verify(localMock); // throws exception before method invocation
             fail();
-        } catch (CannotVerifyStubOnlyMock e) {}
+        } catch (CannotVerifyStubOnlyMock e) {
+            assertThat(e.getMessage()).contains(MockUtil.getMockName(localMock).toString());
+        }
+    }
+
+    @Test
+    public void test_stub_only_not_verifiable_verify_no_more_interactions() {
+        IMethods localMock = mock(IMethods.class, withSettings().stubOnly());
+
+        try {
+            verifyNoMoreInteractions(localMock);
+            fail();
+        } catch (CannotVerifyStubOnlyMock e) {
+            assertThat(e.getMessage()).contains(MockUtil.getMockName(localMock).toString());
+        }
+    }
+
+    @Test
+    public void test_stub_only_not_verifiable_in_order() {
+        IMethods localMock = mock(IMethods.class, withSettings().stubOnly());
+
+        try {
+            inOrder(localMock);
+            fail();
+        } catch (CannotVerifyStubOnlyMock e) {
+            assertThat(e.getMessage()).contains(MockUtil.getMockName(localMock).toString());
+        }
     }
 }


### PR DESCRIPTION
This PR adds assertion to verification methods to prevent stub-only mock from being verified (#1460)
- `verify()`
- `verifyNoMoreInteractions()`
- `inOrder()`