### PR TITLE
Expose StubbingLookupListener publicly (#793)

### DIFF
--- a/src/main/java/org/mockito/MockSettings.java
+++ b/src/main/java/org/mockito/MockSettings.java
@@ -9,6 +9,7 @@ import org.mockito.exceptions.misusing.UnnecessaryStubbingException;
 import org.mockito.invocation.InvocationFactory;
 import org.mockito.invocation.MockHandler;
 import org.mockito.listeners.InvocationListener;
+import org.mockito.listeners.MockObjectListener;
 import org.mockito.listeners.VerificationStartedListener;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.mock.SerializableMode;
@@ -204,6 +205,23 @@ public interface MockSettings extends Serializable {
     MockSettings verboseLogging();
 
     /**
+     * Add listener to mock object.
+     * For a list of supported listeners, see the interfaces that extend {@link MockObjectListener}.
+     *
+     * Multiple listeners may be added and they will be notified in the order they were supplied.
+     *
+     * Example:
+     * <pre class="code"><code class="java">
+     *  List mockWithListener = mock(List.class, withSettings().addListeners(new YourInvocationListener()));
+     *  List mockWithListener = mock(List.class, withSettings().addListeners(new YourStubbingLookupListener()));
+     * </code></pre>
+     *
+     * @param listeners The mock object listeners to add. May not be null.
+     * @return settings instance so that you can fluently specify other settings
+     */
+    MockSettings addListeners(MockObjectListener... listeners);
+
+    /**
      * Registers a listener for method invocations on this mock. The listener is
      * notified every time a method on this mock is called.
      * <p>
@@ -218,7 +236,9 @@ public interface MockSettings extends Serializable {
      *
      * @param listeners The invocation listeners to add. May not be null.
      * @return settings instance so that you can fluently specify other settings
+     * @deprecated - please use {@link #addListeners(MockObjectListener...)} instead.
      */
+    @Deprecated
     MockSettings invocationListeners(InvocationListener... listeners);
 
     /**

--- a/src/main/java/org/mockito/internal/MockitoCore.java
+++ b/src/main/java/org/mockito/internal/MockitoCore.java
@@ -67,7 +67,7 @@ public class MockitoCore {
         MockSettingsImpl impl = MockSettingsImpl.class.cast(settings);
         MockCreationSettings<T> creationSettings = impl.build(typeToMock);
         T mock = createMock(creationSettings);
-        mockingProgress().mockingStarted(mock, creationSettings);
+        mockingProgress().mockingStarted(mock, impl);
         return mock;
     }
 

--- a/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
+++ b/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
@@ -4,8 +4,9 @@
  */
 package org.mockito.internal.creation.settings;
 
-import org.mockito.internal.listeners.StubbingLookupListener;
+import org.mockito.listeners.StubbingLookupListener;
 import org.mockito.listeners.InvocationListener;
+import org.mockito.listeners.MockObjectListener;
 import org.mockito.listeners.VerificationStartedListener;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.mock.MockName;
@@ -29,8 +30,7 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
     protected Answer<Object> defaultAnswer;
     protected MockName mockName;
     protected SerializableMode serializableMode = SerializableMode.NONE;
-    protected List<InvocationListener> invocationListeners = new ArrayList<InvocationListener>();
-    protected final List<StubbingLookupListener> stubbingLookupListeners = new ArrayList<StubbingLookupListener>();
+    protected List<MockObjectListener> mockObjectListeners = new ArrayList<MockObjectListener>();
     protected List<VerificationStartedListener> verificationStartedListeners = new LinkedList<VerificationStartedListener>();
     protected boolean stubOnly;
     protected boolean stripAnnotations;
@@ -50,7 +50,7 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
         this.defaultAnswer = copy.defaultAnswer;
         this.mockName = copy.mockName;
         this.serializableMode = copy.serializableMode;
-        this.invocationListeners = copy.invocationListeners;
+        this.mockObjectListeners = copy.mockObjectListeners;
         this.verificationStartedListeners = copy.verificationStartedListeners;
         this.stubOnly = copy.stubOnly;
         this.useConstructor = copy.isUsingConstructor();
@@ -119,6 +119,12 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
 
     @Override
     public List<InvocationListener> getInvocationListeners() {
+        final List<InvocationListener> invocationListeners = new ArrayList<InvocationListener>();
+        for (MockObjectListener listener : mockObjectListeners) {
+            if (listener instanceof InvocationListener) {
+                invocationListeners.add((InvocationListener) listener);
+            }
+        }
         return invocationListeners;
     }
 
@@ -128,6 +134,12 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
     }
 
     public List<StubbingLookupListener> getStubbingLookupListeners() {
+        final List<StubbingLookupListener> stubbingLookupListeners = new ArrayList<StubbingLookupListener>();
+        for (MockObjectListener listener : mockObjectListeners) {
+            if (listener instanceof StubbingLookupListener) {
+                stubbingLookupListeners.add((StubbingLookupListener) listener);
+            }
+        }
         return stubbingLookupListeners;
     }
 

--- a/src/main/java/org/mockito/internal/exceptions/Reporter.java
+++ b/src/main/java/org/mockito/internal/exceptions/Reporter.java
@@ -685,6 +685,10 @@ public class Reporter {
         return new MockitoException(method + "() does not accept " + parameter + " See the Javadoc.");
     }
 
+    public static MockitoException addListenersRequiresAtLeastOneListener() {
+        return new MockitoException("addListeners() requires at least one listener");
+    }
+
     public static MockitoException invocationListenersRequiresAtLeastOneListener() {
         return new MockitoException("invocationListeners() requires at least one listener");
     }

--- a/src/main/java/org/mockito/internal/handler/MockHandlerImpl.java
+++ b/src/main/java/org/mockito/internal/handler/MockHandlerImpl.java
@@ -4,7 +4,6 @@
  */
 package org.mockito.internal.handler;
 
-import org.mockito.internal.creation.settings.CreationSettings;
 import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockito.internal.invocation.MatchersBinder;
 import org.mockito.internal.stubbing.InvocationContainerImpl;
@@ -85,9 +84,7 @@ public class MockHandlerImpl<T> implements MockHandler<T> {
 
         // look for existing answer for this invocation
         StubbedInvocationMatcher stubbing = invocationContainer.findAnswerFor(invocation);
-        // TODO #793 - when completed, we should be able to get rid of the casting below
-        notifyStubbedAnswerLookup(invocation, stubbing, invocationContainer.getStubbingsAscending(),
-                                  (CreationSettings) mockSettings);
+        notifyStubbedAnswerLookup(invocation, stubbing, invocationContainer.getStubbingsAscending(), mockSettings);
 
         if (stubbing != null) {
             stubbing.captureArgumentsFrom(invocation);

--- a/src/main/java/org/mockito/internal/junit/DefaultStubbingLookupListener.java
+++ b/src/main/java/org/mockito/internal/junit/DefaultStubbingLookupListener.java
@@ -5,8 +5,8 @@
 package org.mockito.internal.junit;
 
 import org.mockito.internal.exceptions.Reporter;
-import org.mockito.internal.listeners.StubbingLookupEvent;
-import org.mockito.internal.listeners.StubbingLookupListener;
+import org.mockito.listeners.StubbingLookupEvent;
+import org.mockito.listeners.StubbingLookupListener;
 import org.mockito.internal.stubbing.UnusedStubbingReporting;
 import org.mockito.invocation.Invocation;
 import org.mockito.quality.Strictness;

--- a/src/main/java/org/mockito/internal/junit/MismatchReportingTestListener.java
+++ b/src/main/java/org/mockito/internal/junit/MismatchReportingTestListener.java
@@ -4,8 +4,8 @@
  */
 package org.mockito.internal.junit;
 
+import org.mockito.MockSettings;
 import org.mockito.internal.util.MockitoLogger;
-import org.mockito.mock.MockCreationSettings;
 
 import java.util.Collection;
 import java.util.LinkedList;
@@ -35,7 +35,7 @@ public class MismatchReportingTestListener implements MockitoTestListener {
         }
     }
 
-    public void onMockCreated(Object mock, MockCreationSettings settings) {
+    public void onMockCreated(Object mock, MockSettings settings) {
         this.mocks.add(mock);
     }
 }

--- a/src/main/java/org/mockito/internal/junit/NoOpTestListener.java
+++ b/src/main/java/org/mockito/internal/junit/NoOpTestListener.java
@@ -4,11 +4,11 @@
  */
 package org.mockito.internal.junit;
 
-import org.mockito.mock.MockCreationSettings;
+import org.mockito.MockSettings;
 
 public class NoOpTestListener implements MockitoTestListener {
 
     public void testFinished(TestFinishedEvent event) {}
 
-    public void onMockCreated(Object mock, MockCreationSettings settings) {}
+    public void onMockCreated(Object mock, MockSettings settings) {}
 }

--- a/src/main/java/org/mockito/internal/junit/StrictStubsRunnerTestListener.java
+++ b/src/main/java/org/mockito/internal/junit/StrictStubsRunnerTestListener.java
@@ -4,8 +4,7 @@
  */
 package org.mockito.internal.junit;
 
-import org.mockito.internal.creation.settings.CreationSettings;
-import org.mockito.mock.MockCreationSettings;
+import org.mockito.MockSettings;
 import org.mockito.quality.Strictness;
 
 /**
@@ -19,11 +18,7 @@ public class StrictStubsRunnerTestListener implements MockitoTestListener {
     public void testFinished(TestFinishedEvent event) {}
 
     @Override
-    public void onMockCreated(Object mock, MockCreationSettings settings) {
-        //It is not ideal that we modify the state of MockCreationSettings object
-        //MockCreationSettings is intended to be an immutable view of the creation settings
-        //In future, we should start passing MockSettings object to the creation listener
-        //TODO #793 - when completed, we should be able to get rid of the CreationSettings casting below
-        ((CreationSettings) settings).getStubbingLookupListeners().add(stubbingLookupListener);
+    public void onMockCreated(Object mock, MockSettings settings) {
+        settings.addListeners(stubbingLookupListener);
     }
 }

--- a/src/main/java/org/mockito/internal/junit/UnnecessaryStubbingsReporter.java
+++ b/src/main/java/org/mockito/internal/junit/UnnecessaryStubbingsReporter.java
@@ -7,10 +7,10 @@ package org.mockito.internal.junit;
 import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunNotifier;
+import org.mockito.MockSettings;
 import org.mockito.internal.exceptions.Reporter;
 import org.mockito.invocation.Invocation;
 import org.mockito.listeners.MockCreationListener;
-import org.mockito.mock.MockCreationSettings;
 
 import java.util.Collection;
 import java.util.LinkedList;
@@ -36,7 +36,7 @@ public class UnnecessaryStubbingsReporter implements MockCreationListener {
     }
 
     @Override
-    public void onMockCreated(Object mock, MockCreationSettings settings) {
+    public void onMockCreated(Object mock, MockSettings settings) {
         mocks.add(mock);
     }
 }

--- a/src/main/java/org/mockito/internal/listeners/StubbingLookupNotifier.java
+++ b/src/main/java/org/mockito/internal/listeners/StubbingLookupNotifier.java
@@ -4,8 +4,9 @@
  */
 package org.mockito.internal.listeners;
 
-import org.mockito.internal.creation.settings.CreationSettings;
 import org.mockito.invocation.Invocation;
+import org.mockito.listeners.StubbingLookupEvent;
+import org.mockito.listeners.StubbingLookupListener;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.stubbing.Stubbing;
 
@@ -15,7 +16,7 @@ import java.util.List;
 public class StubbingLookupNotifier {
 
     public static void notifyStubbedAnswerLookup(Invocation invocation, Stubbing stubbingFound,
-                                                 Collection<Stubbing> allStubbings, CreationSettings creationSettings) {
+                                                 Collection<Stubbing> allStubbings, MockCreationSettings creationSettings) {
         List<StubbingLookupListener> listeners = creationSettings.getStubbingLookupListeners();
         if (listeners.isEmpty()) {
             return;

--- a/src/main/java/org/mockito/internal/progress/MockingProgress.java
+++ b/src/main/java/org/mockito/internal/progress/MockingProgress.java
@@ -6,9 +6,10 @@
 package org.mockito.internal.progress;
 
 import java.util.Set;
+
+import org.mockito.MockSettings;
 import org.mockito.listeners.MockitoListener;
 import org.mockito.listeners.VerificationListener;
-import org.mockito.mock.MockCreationSettings;
 import org.mockito.stubbing.OngoingStubbing;
 import org.mockito.verification.VerificationMode;
 import org.mockito.verification.VerificationStrategy;
@@ -41,7 +42,7 @@ public interface MockingProgress {
 
     ArgumentMatcherStorage getArgumentMatcherStorage();
 
-    void mockingStarted(Object mock, MockCreationSettings settings);
+    void mockingStarted(Object mock, MockSettings settings);
 
     void addListener(MockitoListener listener);
 

--- a/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
+++ b/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
@@ -5,6 +5,7 @@
 
 package org.mockito.internal.progress;
 
+import org.mockito.MockSettings;
 import org.mockito.internal.configuration.GlobalConfiguration;
 import org.mockito.internal.debugging.Localized;
 import org.mockito.internal.debugging.LocationImpl;
@@ -13,7 +14,6 @@ import org.mockito.invocation.Location;
 import org.mockito.listeners.MockCreationListener;
 import org.mockito.listeners.MockitoListener;
 import org.mockito.listeners.VerificationListener;
-import org.mockito.mock.MockCreationSettings;
 import org.mockito.stubbing.OngoingStubbing;
 import org.mockito.verification.VerificationMode;
 import org.mockito.verification.VerificationStrategy;
@@ -144,7 +144,7 @@ public class MockingProgressImpl implements MockingProgress {
         return argumentMatcherStorage;
     }
 
-    public void mockingStarted(Object mock, MockCreationSettings settings) {
+    public void mockingStarted(Object mock, MockSettings settings) {
         for (MockitoListener listener : listeners) {
             if (listener instanceof MockCreationListener) {
                 ((MockCreationListener) listener).onMockCreated(mock, settings);

--- a/src/main/java/org/mockito/listeners/InvocationListener.java
+++ b/src/main/java/org/mockito/listeners/InvocationListener.java
@@ -9,9 +9,9 @@ import org.mockito.MockSettings;
 /**
  * This listener can be notified of method invocations on a mock.
  *
- * For this to happen, it must be registered using {@link MockSettings#invocationListeners(InvocationListener...)}.
+ * For this to happen, it must be registered using {@link MockSettings#addListeners(MockObjectListener...)}.
  */
-public interface InvocationListener {
+public interface InvocationListener extends MockObjectListener {
 
     /**
      * Called after the invocation of the listener's mock if it returned normally.

--- a/src/main/java/org/mockito/listeners/MockCreationListener.java
+++ b/src/main/java/org/mockito/listeners/MockCreationListener.java
@@ -4,7 +4,7 @@
  */
 package org.mockito.listeners;
 
-import org.mockito.mock.MockCreationSettings;
+import org.mockito.MockSettings;
 
 /**
  * Notified when mock object is created.
@@ -16,7 +16,7 @@ public interface MockCreationListener extends MockitoListener {
      * Mock object was just created.
      *
      * @param mock created mock object
-     * @param settings the settings used for creation
+     * @param settings the settings of the mock object
      */
-    void onMockCreated(Object mock, MockCreationSettings settings);
+    void onMockCreated(Object mock, MockSettings settings);
 }

--- a/src/main/java/org/mockito/listeners/MockObjectListener.java
+++ b/src/main/java/org/mockito/listeners/MockObjectListener.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2018 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.listeners;
+
+/**
+ * Marker interface for all types of Mock object listeners.
+ * For more information, see {@link org.mockito.MockSettings#addListeners(MockObjectListener...)}.
+ */
+public interface MockObjectListener {
+}

--- a/src/main/java/org/mockito/listeners/StubbingLookupEvent.java
+++ b/src/main/java/org/mockito/listeners/StubbingLookupEvent.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2018 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-package org.mockito.internal.listeners;
+package org.mockito.listeners;
 
 import org.mockito.invocation.Invocation;
 import org.mockito.mock.MockCreationSettings;

--- a/src/main/java/org/mockito/listeners/StubbingLookupListener.java
+++ b/src/main/java/org/mockito/listeners/StubbingLookupListener.java
@@ -2,10 +2,15 @@
  * Copyright (c) 2017 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-package org.mockito.internal.listeners;
+package org.mockito.listeners;
+
+import org.mockito.MockSettings;
 
 /**
- * Listens to attempts to look up stubbing answer for given mocks. This class is internal for now.
+ * This listener can be notified of looking up stubbing answer for a given mock.
+ *
+ * For this to happen, it must be registered using {@link MockSettings#addListeners(MockObjectListener...)}.
+ *
  * <p>
  * How does it work?
  * When method is called on the mock object, Mockito looks for any answer (stubbing) declared on that mock.
@@ -13,18 +18,15 @@ package org.mockito.internal.listeners;
  * If the answer is not found (e.g. that invocation was not stubbed on the mock), mock's default answer is used.
  * This listener implementation is notified when Mockito looked up an answer for invocation on a mock.
  * <p>
- * If we make this interface a part of public API (and we should):
- *  - make the implementation unified with InvocationListener (for example: common parent, marker interface MockObjectListener
- *  single method for adding listeners so long they inherit from the parent)
- *  - make the error handling strict
- * so that Mockito provides decent message when listener fails due to poor implementation.
  */
-public interface StubbingLookupListener {
+public interface StubbingLookupListener extends MockObjectListener {
 
     /**
      * Called by the framework when Mockito looked up an answer for invocation on a mock.
      *
      * @param stubbingLookupEvent - Information about the looked up stubbing
+     *
+     * @see StubbingLookupEvent
      */
     void onStubbingLookup(StubbingLookupEvent stubbingLookupEvent);
 }

--- a/src/main/java/org/mockito/mock/MockCreationSettings.java
+++ b/src/main/java/org/mockito/mock/MockCreationSettings.java
@@ -8,6 +8,7 @@ package org.mockito.mock;
 import org.mockito.Incubating;
 import org.mockito.MockSettings;
 import org.mockito.NotExtensible;
+import org.mockito.listeners.StubbingLookupListener;
 import org.mockito.listeners.InvocationListener;
 import org.mockito.listeners.VerificationStartedListener;
 import org.mockito.quality.Strictness;
@@ -70,7 +71,12 @@ public interface MockCreationSettings<T> {
     boolean isStripAnnotations();
 
     /**
-     * {@link InvocationListener} instances attached to this mock, see {@link org.mockito.MockSettings#invocationListeners}.
+     * {@link StubbingLookupListener} instances attached to this mock, see {@link org.mockito.MockSettings#addListeners}.
+     */
+    List<StubbingLookupListener> getStubbingLookupListeners();
+
+    /**
+     * {@link InvocationListener} instances attached to this mock, see {@link org.mockito.MockSettings#addListeners}.
      */
     List<InvocationListener> getInvocationListeners();
 

--- a/src/test/java/org/mockito/internal/framework/DefaultMockitoFrameworkTest.java
+++ b/src/test/java/org/mockito/internal/framework/DefaultMockitoFrameworkTest.java
@@ -12,7 +12,6 @@ import org.mockito.StateMaster;
 import org.mockito.exceptions.misusing.RedundantListenerException;
 import org.mockito.listeners.MockCreationListener;
 import org.mockito.listeners.MockitoListener;
-import org.mockito.mock.MockCreationSettings;
 import org.mockitoutil.TestBase;
 
 import java.util.List;
@@ -69,8 +68,8 @@ public class DefaultMockitoFrameworkTest extends TestBase {
         Set mock2 = mock(Set.class);
 
         //then
-        verify(listener).onMockCreated(eq(mock), any(MockCreationSettings.class));
-        verify(listener).onMockCreated(eq(mock2), any(MockCreationSettings.class));
+        verify(listener).onMockCreated(eq(mock), any(MockSettings.class));
+        verify(listener).onMockCreated(eq(mock2), any(MockSettings.class));
         verifyNoMoreInteractions(listener);
     }
 
@@ -83,7 +82,7 @@ public class DefaultMockitoFrameworkTest extends TestBase {
 
         //and hooked up correctly
         mock(List.class);
-        verify(listener).onMockCreated(ArgumentMatchers.any(), any(MockCreationSettings.class));
+        verify(listener).onMockCreated(ArgumentMatchers.any(), any(MockSettings.class));
 
         //when
         framework.removeListener(listener);

--- a/src/test/java/org/mockito/internal/listeners/StubbingLookupNotifierTest.java
+++ b/src/test/java/org/mockito/internal/listeners/StubbingLookupNotifierTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.internal.creation.settings.CreationSettings;
 import org.mockito.invocation.Invocation;
+import org.mockito.listeners.StubbingLookupListener;
 import org.mockito.stubbing.Stubbing;
 import org.mockitoutil.TestBase;
 

--- a/src/test/java/org/mockitousage/debugging/StubbingLookupListenerCallbackTest.java
+++ b/src/test/java/org/mockitousage/debugging/StubbingLookupListenerCallbackTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2018 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage.debugging;
+
+import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.InOrder;
+import org.mockito.invocation.Invocation;
+import org.mockito.listeners.StubbingLookupEvent;
+import org.mockito.listeners.StubbingLookupListener;
+import org.mockito.mock.MockCreationSettings;
+import org.mockito.stubbing.Stubbing;
+import org.mockitoutil.TestBase;
+
+import java.util.Collection;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class StubbingLookupListenerCallbackTest extends TestBase {
+
+    @Test
+    public void should_call_listener_when_mock_return_normally_with_stubbed_answer() {
+        // given
+        final AnswerListener listener = spy(AnswerListener.class);
+        Foo foo = mock(Foo.class, withSettings().addListeners(listener));
+        doReturn("coke").when(foo).giveMeSomeString("soda");
+        doReturn("java").when(foo).giveMeSomeString("coffee");
+
+        // when
+        foo.giveMeSomeString("soda");
+
+        // then
+        verify(listener).onStubbingLookup(argThat(new ArgumentMatcher<StubbingLookupEvent>() {
+            @Override
+            public boolean matches(StubbingLookupEvent argument) {
+                assertEquals("soda", argument.getInvocation().getArgument(0));
+                assertEquals("foo", argument.getMockSettings().getMockName().toString());
+                assertEquals(2, argument.getAllStubbings().size());
+                assertNotNull(argument.getStubbingFound());
+                return true;
+            }
+        }));
+    }
+
+    @Test
+    public void should_call_listener_when_mock_return_normally_with_default_answer() {
+        // given
+        AnswerListener listener = spy(AnswerListener.class);
+        Foo foo = mock(Foo.class, withSettings().addListeners(listener));
+        doReturn("java").when(foo).giveMeSomeString("coffee");
+
+        // when
+        foo.giveMeSomeString("soda");
+
+        // then
+        verify(listener).onStubbingLookup(argThat(new ArgumentMatcher<StubbingLookupEvent>() {
+            @Override
+            public boolean matches(StubbingLookupEvent argument) {
+                assertEquals("soda", argument.getInvocation().getArgument(0));
+                assertEquals("foo", argument.getMockSettings().getMockName().toString());
+                assertEquals(1, argument.getAllStubbings().size());
+                assertNull(argument.getStubbingFound());
+                return true;
+            }
+        }));
+    }
+
+    @Test
+    public void should_not_call_listener_when_mock_is_not_called() {
+        // given
+        AnswerListener listener = spy(AnswerListener.class);
+        Foo foo = mock(Foo.class, withSettings().addListeners(listener));
+        doReturn("java").when(foo).giveMeSomeString("coffee");
+
+        // when nothing
+
+        // then
+        verifyZeroInteractions(listener);
+    }
+
+    @Test
+    public void should_allow_same_listener() {
+        // given
+        AnswerListener listener = mock(AnswerListener.class);
+        Foo foo = mock(Foo.class, withSettings().addListeners(listener, listener));
+
+        // when
+        foo.giveMeSomeString("tea");
+        foo.giveMeSomeString("coke");
+
+        // then each listener was notified 2 times (notified 4 times in total)
+        verify(listener, times(4)).onStubbingLookup(any(StubbingLookupEvent.class));
+    }
+
+    @Test
+    public void should_call_all_listeners_in_order() {
+        // given
+        AnswerListener listener1 = mock(AnswerListener.class);
+        AnswerListener listener2 = mock(AnswerListener.class);
+        Foo foo = mock(Foo.class, withSettings().addListeners(listener1, listener2));
+        doReturn("sprite").when(foo).giveMeSomeString("soda");
+
+        // when
+        foo.giveMeSomeString("soda");
+
+        // then
+        InOrder inOrder = inOrder(listener1, listener2);
+        inOrder.verify(listener1).onStubbingLookup(any(StubbingLookupEvent.class));
+        inOrder.verify(listener2).onStubbingLookup(any(StubbingLookupEvent.class));
+    }
+
+    @Test
+    public void should_call_all_listeners_when_mock_throws_exception() {
+        // given
+        AnswerListener listener1 = mock(AnswerListener.class);
+        AnswerListener listener2 = mock(AnswerListener.class);
+        Foo foo = mock(Foo.class, withSettings().addListeners(listener1, listener2));
+        doThrow(new NoWater()).when(foo).giveMeSomeString("tea");
+
+        // when
+        try {
+            foo.giveMeSomeString("tea");
+            fail();
+        } catch (NoWater e) {
+            // then
+            verify(listener1).onStubbingLookup(any(StubbingLookupEvent.class));
+            verify(listener2).onStubbingLookup(any(StubbingLookupEvent.class));
+        }
+    }
+
+    private static class AnswerListener implements StubbingLookupListener {
+        private Invocation invocation;
+        private Stubbing stubbing;
+        private Collection<Stubbing> allStubbings;
+        private MockCreationSettings mockSettings;
+
+        public AnswerListener() {}
+
+        public void onStubbingLookup(StubbingLookupEvent event) {
+            this.invocation = event.getInvocation();
+            this.stubbing = event.getStubbingFound();
+            this.allStubbings = event.getAllStubbings();
+            this.mockSettings = event.getMockSettings();
+        }
+    }
+
+    private static class NoWater extends RuntimeException {}
+}


### PR DESCRIPTION
This PR makes `StubbingLookupListener` public and adds `MockObjectListener` as parent of `InvocationListener` and `StubbingLookupListener`. (#793)