### PR TITLE
MockitoSession API does not clean up listener when initMocks fails

### DIFF
--- a/src/main/java/org/mockito/exceptions/misusing/InjectMocksException.java
+++ b/src/main/java/org/mockito/exceptions/misusing/InjectMocksException.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2018 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.exceptions.misusing;
+
+import org.mockito.exceptions.base.MockitoException;
+
+/**
+ * Thrown when creation of test subject annotated with InjectMocks fails.
+ */
+public class InjectMocksException extends MockitoException {
+    public InjectMocksException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/mockito/internal/exceptions/Reporter.java
+++ b/src/main/java/org/mockito/internal/exceptions/Reporter.java
@@ -673,7 +673,7 @@ public class Reporter {
     }
 
     public static MockitoException fieldInitialisationThrewException(Field field, Throwable details) {
-        return new MockitoException(join(
+        return new InjectMocksException(join(
                 "Cannot instantiate @InjectMocks field named '" + field.getName() + "' of type '" + field.getType() + "'.",
                 "You haven't provided the instance at field declaration so I tried to construct the instance.",
                 "However the constructor or the initialization block threw an exception : " + details.getMessage(),

--- a/src/main/java/org/mockito/internal/framework/DefaultMockitoSession.java
+++ b/src/main/java/org/mockito/internal/framework/DefaultMockitoSession.java
@@ -18,12 +18,10 @@ import java.util.List;
 
 public class DefaultMockitoSession implements MockitoSession {
 
-    private final List<Object> testClassInstances;
     private final String name;
     private final UniversalTestListener listener;
 
     public DefaultMockitoSession(List<Object> testClassInstances, String name, Strictness strictness, MockitoLogger logger) {
-        this.testClassInstances = testClassInstances;
         this.name = name;
         listener = new UniversalTestListener(strictness, logger);
         try {

--- a/src/main/java/org/mockito/internal/framework/DefaultMockitoSession.java
+++ b/src/main/java/org/mockito/internal/framework/DefaultMockitoSession.java
@@ -32,8 +32,14 @@ public class DefaultMockitoSession implements MockitoSession {
         } catch (RedundantListenerException e) {
             Reporter.unfinishedMockingSession();
         }
-        for (Object testClassInstance : testClassInstances) {
-            MockitoAnnotations.initMocks(testClassInstance);
+        try {
+            for (Object testClassInstance : testClassInstances) {
+                MockitoAnnotations.initMocks(testClassInstance);
+            }
+        } catch (RuntimeException e) {
+            //clean up in case 'initMocks' fails
+            listener.setListenerDirty();
+            throw e;
         }
     }
 

--- a/src/main/java/org/mockito/internal/junit/UniversalTestListener.java
+++ b/src/main/java/org/mockito/internal/junit/UniversalTestListener.java
@@ -88,11 +88,17 @@ public class UniversalTestListener implements MockitoTestListener, AutoCleanable
         this.stubbingLookupListener.setCurrentStrictness(strictness);
     }
 
+    /**
+     * See {@link AutoCleanableListener#isListenerDirty()}
+     */
     @Override
     public boolean isListenerDirty() {
         return listenerDirty;
     }
 
+    /**
+     * Marks listener as dirty, scheduled for cleanup when the next session starts
+     */
     public void setListenerDirty() {
         this.listenerDirty = true;
     }

--- a/src/main/java/org/mockito/internal/junit/UniversalTestListener.java
+++ b/src/main/java/org/mockito/internal/junit/UniversalTestListener.java
@@ -5,6 +5,7 @@
 package org.mockito.internal.junit;
 
 import org.mockito.internal.creation.settings.CreationSettings;
+import org.mockito.internal.listeners.AutoCleanableListener;
 import org.mockito.internal.util.MockitoLogger;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.quality.Strictness;
@@ -18,13 +19,14 @@ import java.util.Map;
  * Will come handy when we offer tweaking strictness at the method level with annotation.
  * Should be relatively easy to improve and offer tweaking strictness per mock.
  */
-public class UniversalTestListener implements MockitoTestListener {
+public class UniversalTestListener implements MockitoTestListener, AutoCleanableListener {
 
     private Strictness currentStrictness;
     private final MockitoLogger logger;
 
     private Map<Object, MockCreationSettings> mocks = new IdentityHashMap<Object, MockCreationSettings>();
     private DefaultStubbingLookupListener stubbingLookupListener;
+    private boolean listenerDirty;
 
     public UniversalTestListener(Strictness initialStrictness, MockitoLogger logger) {
         this.currentStrictness = initialStrictness;
@@ -84,5 +86,14 @@ public class UniversalTestListener implements MockitoTestListener {
     public void setStrictness(Strictness strictness) {
         this.currentStrictness = strictness;
         this.stubbingLookupListener.setCurrentStrictness(strictness);
+    }
+
+    @Override
+    public boolean isListenerDirty() {
+        return listenerDirty;
+    }
+
+    public void setListenerDirty() {
+        this.listenerDirty = true;
     }
 }

--- a/src/main/java/org/mockito/internal/listeners/AutoCleanableListener.java
+++ b/src/main/java/org/mockito/internal/listeners/AutoCleanableListener.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2018 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.listeners;
+
+/**
+ * Listener that is automatically cleaned up (removed from the the global list of subscribers).
+ * For now, we don't intend to make this interface public.
+ */
+public interface AutoCleanableListener {
+
+    /**
+     * Indicates that the listener is dirty and should be removed from the subscribers
+     */
+    boolean isListenerDirty();
+}

--- a/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
+++ b/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
@@ -165,12 +165,16 @@ public class MockingProgressImpl implements MockingProgress {
         for (MockitoListener existing : listeners) {
             if (existing.getClass().equals(listener.getClass())) {
                 if (existing instanceof AutoCleanableListener && ((AutoCleanableListener) existing).isListenerDirty()) {
+                    //dirty listener means that there was an exception even before the test started
+                    //if we fail here with redundant mockito listener exception there will be multiple failures causing confusion
+                    //so we simply remove the existing listener and move on
                     delete.add(existing);
                 } else {
                     Reporter.redundantMockitoListener(listener.getClass().getSimpleName());
                 }
             }
         }
+        //delete dirty listeners so they don't occupy state/memory and don't receive notifications
         for (MockitoListener toDelete : delete) {
             listeners.remove(toDelete);
         }

--- a/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
+++ b/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
@@ -9,6 +9,7 @@ import org.mockito.internal.configuration.GlobalConfiguration;
 import org.mockito.internal.debugging.Localized;
 import org.mockito.internal.debugging.LocationImpl;
 import org.mockito.internal.exceptions.Reporter;
+import org.mockito.internal.listeners.AutoCleanableListener;
 import org.mockito.invocation.Location;
 import org.mockito.listeners.MockCreationListener;
 import org.mockito.listeners.MockitoListener;
@@ -19,6 +20,8 @@ import org.mockito.verification.VerificationMode;
 import org.mockito.verification.VerificationStrategy;
 
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Set;
 
 import static org.mockito.internal.exceptions.Reporter.unfinishedStubbing;
@@ -154,12 +157,24 @@ public class MockingProgressImpl implements MockingProgress {
     }
 
     public void addListener(MockitoListener listener) {
+        addListener(listener, listeners);
+    }
+
+    static void addListener(MockitoListener listener, Set<MockitoListener> listeners) {
+        List<MockitoListener> delete = new LinkedList<MockitoListener>();
         for (MockitoListener existing : listeners) {
             if (existing.getClass().equals(listener.getClass())) {
-                Reporter.redundantMockitoListener(listener.getClass().getSimpleName());
+                if (existing instanceof AutoCleanableListener && ((AutoCleanableListener) existing).isListenerDirty()) {
+                    delete.add(existing);
+                } else {
+                    Reporter.redundantMockitoListener(listener.getClass().getSimpleName());
+                }
             }
         }
-        this.listeners.add(listener);
+        for (MockitoListener toDelete : delete) {
+            listeners.remove(toDelete);
+        }
+        listeners.add(listener);
     }
 
     public void removeListener(MockitoListener listener) {

--- a/src/test/java/org/mockito/internal/session/DefaultMockitoSessionBuilderTest.java
+++ b/src/test/java/org/mockito/internal/session/DefaultMockitoSessionBuilderTest.java
@@ -97,6 +97,16 @@ public class DefaultMockitoSessionBuilderTest {
         }).throwsException(UnfinishedMockingSessionException.class);
     }
 
+    @Test public void auto_cleans_dirty_listeners() {
+        new DefaultMockitoSessionBuilder().startMocking();
+
+        ThrowableAssert.assertThat(new Runnable() {
+            public void run() {
+                new DefaultMockitoSessionBuilder().startMocking();
+            }
+        }).throwsException(UnfinishedMockingSessionException.class);
+    }
+
     class TestClass {
 
         @Mock public Set<Object> set;


### PR DESCRIPTION
When initMocks() fails we did not clean up the session listener. This led to a confusing error message on the next attempt to create a session (next test method run). I stumbled upon this problem when attempting to configure TestNG to use strict stubbing (https://github.com/mockito/mockito-testng/issues/1).

In order to fix this cleanly I need to keep the existing functionality that protects the user from forgetting to use 'finishMocking()'. Hence, I still need to throw an exception if the user adds the same listener multiple times. However, in the event that the listener is dirty, I clean it up automatically instead of failing.