### PR TITLE
support core functional interfaces of java 8

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -4,6 +4,11 @@
  */
 package org.mockito;
 
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
 import org.mockito.exceptions.misusing.PotentialStubbingProblem;
 import org.mockito.exceptions.misusing.UnnecessaryStubbingException;
 import org.mockito.internal.InternalMockHandler;
@@ -12,6 +17,10 @@ import org.mockito.internal.creation.MockSettingsImpl;
 import org.mockito.internal.debugging.MockitoDebuggerImpl;
 import org.mockito.internal.framework.DefaultMockitoFramework;
 import org.mockito.internal.session.DefaultMockitoSessionBuilder;
+import org.mockito.internal.stubbing.answers.AppliesBiFunction;
+import org.mockito.internal.stubbing.answers.AppliesConsumer;
+import org.mockito.internal.stubbing.answers.AppliesFunction;
+import org.mockito.internal.stubbing.answers.AppliesSupplier;
 import org.mockito.internal.verification.VerificationModeFactory;
 import org.mockito.invocation.Invocation;
 import org.mockito.invocation.InvocationFactory;
@@ -2376,6 +2385,25 @@ public class Mockito extends ArgumentMatchers {
     @CheckReturnValue
     public static Stubber doAnswer(Answer answer) {
         return MOCKITO_CORE.stubber().doAnswer(answer);
+    }
+
+    @CheckReturnValue
+    public static <T, R> Stubber doApply(Function<T, R> function) {
+        return doAnswer(new AppliesFunction<T, R>(function));
+    }
+
+    @CheckReturnValue
+    public static <T, U, R> Stubber doApplyBi(BiFunction<T, U, R> function) {
+        return doAnswer(new AppliesBiFunction<T, U, R>(function));
+    }
+
+    @CheckReturnValue
+    public static <T> Stubber doSupply(Supplier<T> supplier) {
+        return doAnswer(new AppliesSupplier(supplier));
+    }
+
+    public static <T> Stubber doConsume(Consumer<T> consumer) {
+        return doAnswer(new AppliesConsumer<T>(consumer));
     }
 
     /**

--- a/src/main/java/org/mockito/internal/stubbing/answers/AppliesBiFunction.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/AppliesBiFunction.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.stubbing.answers;
+
+import java.io.Serializable;
+import java.util.function.BiFunction;
+
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+public class AppliesBiFunction<T, U, R> implements Answer<Object>, Serializable {
+    private static final long serialVersionUID = -2320854589863776136L;
+
+    private final BiFunction<T, U, R> func;
+
+    public AppliesBiFunction(BiFunction<T, U, R> func) {
+        this.func = func;
+    }
+
+    @Override
+    public Object answer(InvocationOnMock invocation) throws Throwable {
+        T t = invocation.getArgument(0);
+        U u = invocation.getArgument(1);
+        return func.apply(t, u);
+    }
+
+}

--- a/src/main/java/org/mockito/internal/stubbing/answers/AppliesConsumer.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/AppliesConsumer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.stubbing.answers;
+
+import java.io.Serializable;
+import java.util.function.Consumer;
+
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+public class AppliesConsumer<T> implements Answer<Object>, Serializable {
+    private static final long serialVersionUID = 3515432710365798383L;
+
+    private final Consumer<T> cons;
+
+    public AppliesConsumer(Consumer<T> cons) {
+        this.cons = cons;
+    }
+
+    @Override
+    public Object answer(InvocationOnMock invocation) throws Throwable {
+        T t = invocation.getArgument(0);
+        cons.accept(t);
+        return null;
+    }
+
+}

--- a/src/main/java/org/mockito/internal/stubbing/answers/AppliesFunction.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/AppliesFunction.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.stubbing.answers;
+
+import java.io.Serializable;
+import java.util.function.Function;
+
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+public class AppliesFunction<T, R> implements Answer<Object>, Serializable {
+    private static final long serialVersionUID = 4105249304302118590L;
+
+    private final Function<T, R> func;
+
+    public AppliesFunction(Function<T, R> func) {
+        this.func = func;
+    }
+
+    @Override
+    public Object answer(InvocationOnMock invocation) throws Throwable {
+        T t = invocation.getArgument(0);
+        return func.apply(t);
+    }
+
+}

--- a/src/main/java/org/mockito/internal/stubbing/answers/AppliesSupplier.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/AppliesSupplier.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.stubbing.answers;
+
+import java.io.Serializable;
+import java.util.function.Supplier;
+
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+public class AppliesSupplier implements Answer<Object>, Serializable {
+    private static final long serialVersionUID = -7877552016409403742L;
+
+    private final Supplier<?> supp;
+
+    public AppliesSupplier(Supplier<?> supp) {
+        this.supp = supp;
+    }
+
+    @Override
+    public Object answer(InvocationOnMock invocation) throws Throwable {
+        return supp.get();
+    }
+
+}


### PR DESCRIPTION
Add useful ``Answer`` and ``InvocationOnMock`` wrappers around java 8 functional interfaces to allow writing compact and meaningful lambda-based mocks. Examples:

Funtion
``Mockito.doApply(ArgType::getSomething).when(myob).callMe(any())``

Consumer
``Mockito.doApply(ArgType::doSomething).when(myob).callMe(any())``
``Mockito.doApply(arg -> arg.smash(123)).when(myob).callMe(any())``
