### PR TITLE
Try to mock all constructor dependencies if possible.

### DIFF
--- a/src/test/java/org/mockito/internal/configuration/injection/SimpleArgumentResolverTest.java
+++ b/src/test/java/org/mockito/internal/configuration/injection/SimpleArgumentResolverTest.java
@@ -29,7 +29,7 @@ public class SimpleArgumentResolverTest {
     }
 
     @Test
-    public void should_return_null_when_match_is_not_possible_on_given_types() throws Exception {
+    public void should_return_noname_mock_when_match_is_not_possible_on_given_types() throws Exception {
         ConstructorInjection.SimpleArgumentResolver resolver =
                 new ConstructorInjection.SimpleArgumentResolver(newSetOf(new HashSet<Float>(), new ByteArrayOutputStream()));
 
@@ -37,7 +37,7 @@ public class SimpleArgumentResolverTest {
 
         assertEquals(3, resolvedInstance.length);
         assertTrue(resolvedInstance[0] instanceof Set);
-        assertNull(resolvedInstance[1]);
+        assertTrue(resolvedInstance[1] instanceof Map);
         assertTrue(resolvedInstance[2] instanceof OutputStream);
     }
 


### PR DESCRIPTION
Although I couldn't find any relevant issue for this change, I think it will help a lot of people that need to test legacy or flat out bad code.

What I have come across very regularly is test classes that have a lot or `@Mock` fields that are not used for testing, but just to wire the component under test. If the `@InjectMocks` tried to mock needed constructor dependencies, most of the `@Mock` unused field could be eliminated and thus have fewer distractions in the test classes.

I also spotted a [ `TODO`](https://github.com/mockito/mockito/blob/release/2.x/src/main/java/org/mockito/internal/configuration/injection/ConstructorInjection.java#L30) in `ConstructorInjection` with the same idea. So, I thought I would give it a try.