### PR TITLE
Updates Byte Buddy to next version for Java 11 support.

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -4,7 +4,7 @@ ext {
 
 def versions = [:]
 
-versions.bytebuddy = '1.8.21'
+versions.bytebuddy = '1.9.0'
 versions.junitJupiter = '5.1.1'
 
 libraries.junit4 = 'junit:junit:4.12'


### PR DESCRIPTION
Does no longer require the experimental flag to be set.