### PR TITLE
Added 'lenient' annotation toggle

### DIFF
--- a/src/main/java/org/mockito/Mock.java
+++ b/src/main/java/org/mockito/Mock.java
@@ -76,4 +76,6 @@ public @interface Mock {
     Class<?>[] extraInterfaces() default {};
 
     boolean serializable() default false;
+
+    boolean lenient() default false;
 }

--- a/src/main/java/org/mockito/Mock.java
+++ b/src/main/java/org/mockito/Mock.java
@@ -9,6 +9,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.PARAMETER;
@@ -67,15 +68,41 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Documented
 public @interface Mock {
 
+    /**
+     * Mock will have custom answer, see {@link MockSettings#defaultAnswer(Answer)}.
+     * For examples how to use 'Mock' annotation and parameters see {@link Mock}.
+     */
     Answers answer() default Answers.RETURNS_DEFAULTS;
 
+    /**
+     * Mock will be 'stubOnly', see {@link MockSettings#stubOnly()}.
+     * For examples how to use 'Mock' annotation and parameters see {@link Mock}.
+     */
     boolean stubOnly() default false;
 
+    /**
+     * Mock will have custom name (shown in verification errors), see {@link MockSettings#name(String)}.
+     * For examples how to use 'Mock' annotation and parameters see {@link Mock}.
+     */
     String name() default "";
 
+    /**
+     * Mock will have extra interfaces, see {@link MockSettings#extraInterfaces(Class[])}.
+     * For examples how to use 'Mock' annotation and parameters see {@link Mock}.
+     */
     Class<?>[] extraInterfaces() default {};
 
+    /**
+     * Mock will be serializable, see {@link MockSettings#serializable()}.
+     * For examples how to use 'Mock' annotation and parameters see {@link Mock}.
+     */
     boolean serializable() default false;
 
+    /**
+     * Mock will be lenient, see {@link MockSettings#lenient()}.
+     * For examples how to use 'Mock' annotation and parameters see {@link Mock}.
+     *
+     * @since 2.23.3
+     */
     boolean lenient() default false;
 }

--- a/src/main/java/org/mockito/internal/configuration/MockAnnotationProcessor.java
+++ b/src/main/java/org/mockito/internal/configuration/MockAnnotationProcessor.java
@@ -35,6 +35,9 @@ public class MockAnnotationProcessor implements FieldAnnotationProcessor<Mock> {
         if(annotation.stubOnly()){
             mockSettings.stubOnly();
         }
+        if(annotation.lenient()){
+            mockSettings.lenient();
+        }
 
         // see @Mock answer default value
         mockSettings.defaultAnswer(annotation.answer());

--- a/src/test/java/org/mockitousage/strictness/LenientMockAnnotationTest.java
+++ b/src/test/java/org/mockitousage/strictness/LenientMockAnnotationTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockitousage.strictness;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.exceptions.misusing.PotentialStubbingProblem;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
+import org.mockitousage.IMethods;
+
+import static org.mockito.Mockito.when;
+
+public class LenientMockAnnotationTest {
+
+    public @Rule MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+    @Mock(lenient = true) IMethods lenientMock;
+    @Mock IMethods regularMock;
+
+    @Test
+    public void mock_is_lenient() {
+        when(lenientMock.simpleMethod("1")).thenReturn("1");
+        when(regularMock.simpleMethod("2")).thenReturn("2");
+
+        //then lenient mock does not throw:
+        lenientMock.simpleMethod("3");
+
+        //but regular mock throws:
+        Assertions.assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            public void call() {
+                regularMock.simpleMethod("4");
+            }
+        }).isInstanceOf(PotentialStubbingProblem.class);
+    }
+}


### PR DESCRIPTION
This way we can conveniently configure an existing 'lenient' setting via an annotation. See the unit test that describes the feature.

```Java
@Mock(lenient = true) SomeClass mock;
```