### PR TITLE
Allow delegating to non-public methods for AdditionalAnswers#delegatesTo

### DIFF
--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ForwardsInvocations.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ForwardsInvocations.java
@@ -40,6 +40,7 @@ public class ForwardsInvocations implements Answer<Object>, Serializable {
             }
 
             Object[] rawArguments = ((Invocation) invocation).getRawArguments();
+            delegateMethod.setAccessible(true);
             return delegateMethod.invoke(delegatedObject, rawArguments);
         } catch (NoSuchMethodException e) {
             throw delegatedMethodDoesNotExistOnDelegate(mockMethod, invocation.getMock(), delegatedObject);

--- a/src/test/java/org/mockito/internal/stubbing/defaultanswers/ForwardsInvocationsTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/defaultanswers/ForwardsInvocationsTest.java
@@ -33,4 +33,10 @@ public class ForwardsInvocationsTest extends TestBase {
         ForwardsInvocations forwardsInvocations = new ForwardsInvocations(new FooImpl());
         assertEquals(1, forwardsInvocations.answer(invocationOf(Foo.class, "bar", "b", new Object[] {})));
     }
+    
+    @Test
+    public void should_call_anonymous_class_method() throws Throwable {
+        ForwardsInvocations forwardsInvocations = new ForwardsInvocations(new FooImpl() {});
+        assertEquals(1, forwardsInvocations.answer(invocationOf(Foo.class, "bar", "b")));
+    }
 }


### PR DESCRIPTION
Fixes an issue where doing "delegatesTo(new AnonymousClass() {})" would cause an IllegalAccessException, and other access-related issues.

