### PR TITLE
Improved sensitivity of potential stubbing problem

### DIFF
--- a/src/main/java/org/mockito/internal/debugging/LocationImpl.java
+++ b/src/main/java/org/mockito/internal/debugging/LocationImpl.java
@@ -16,6 +16,7 @@ public class LocationImpl implements Location, Serializable {
 
     private final Throwable stackTraceHolder;
     private final StackTraceFilter stackTraceFilter;
+    private final String sourceFile;
 
     public LocationImpl() {
         this(defaultStackTraceFilter);
@@ -32,6 +33,13 @@ public class LocationImpl implements Location, Serializable {
     private LocationImpl(StackTraceFilter stackTraceFilter, Throwable stackTraceHolder) {
         this.stackTraceFilter = stackTraceFilter;
         this.stackTraceHolder = stackTraceHolder;
+        if (stackTraceHolder.getStackTrace() == null || stackTraceHolder.getStackTrace().length == 0) {
+            //there are corner cases where exception can have a null or empty stack trace
+            //for example, a custom exception can override getStackTrace() method
+            this.sourceFile = "<unknown source file>";
+        } else {
+            this.sourceFile = stackTraceFilter.findSourceFile(stackTraceHolder.getStackTrace(), "<unknown source file>");
+        }
     }
 
     @Override
@@ -42,5 +50,10 @@ public class LocationImpl implements Location, Serializable {
             return "-> at <<unknown line>>";
         }
         return "-> at " + filtered[0].toString();
+    }
+
+    @Override
+    public String getSourceFile() {
+        return sourceFile;
     }
 }

--- a/src/main/java/org/mockito/internal/exceptions/stacktrace/StackTraceFilter.java
+++ b/src/main/java/org/mockito/internal/exceptions/stacktrace/StackTraceFilter.java
@@ -37,4 +37,17 @@ public class StackTraceFilter implements Serializable {
         StackTraceElement[] result = new StackTraceElement[filtered.size()];
         return filtered.toArray(result);
     }
+
+    /**
+     * Finds the source file of the target stack trace.
+     * Returns the default value if source file cannot be found.
+     */
+    public String findSourceFile(StackTraceElement[] target, String defaultValue) {
+        for (StackTraceElement e : target) {
+            if (CLEANER.isIn(e)) {
+                return e.getFileName();
+            }
+        }
+        return defaultValue;
+    }
 }

--- a/src/main/java/org/mockito/internal/junit/DefaultStubbingLookupListener.java
+++ b/src/main/java/org/mockito/internal/junit/DefaultStubbingLookupListener.java
@@ -57,8 +57,11 @@ class DefaultStubbingLookupListener implements StubbingLookupListener {
         List<Invocation> matchingStubbings = new LinkedList<Invocation>();
         for (Stubbing s : stubbings) {
             if (UnusedStubbingReporting.shouldBeReported(s)
-                && s.getInvocation().getMethod().getName().equals(invocation.getMethod().getName())) {
-                matchingStubbings.add(s.getInvocation());
+                && s.getInvocation().getMethod().getName().equals(invocation.getMethod().getName())
+                //If stubbing and invocation are in the same source file we assume they are in the test code,
+                // and we don't flag it as mismatch:
+                && !s.getInvocation().getLocation().getSourceFile().equals(invocation.getLocation().getSourceFile())) {
+                    matchingStubbings.add(s.getInvocation());
             }
         }
         return matchingStubbings;

--- a/src/main/java/org/mockito/invocation/Location.java
+++ b/src/main/java/org/mockito/invocation/Location.java
@@ -4,14 +4,26 @@
  */
 package org.mockito.invocation;
 
+import org.mockito.NotExtensible;
+
 /**
  * Describes the location of something in the source code.
  */
+@NotExtensible
 public interface Location {
 
     /**
-     * @return the location
+     * Human readable location in the source code, see {@link Invocation#getLocation()}
+     *
+     * @return location
      */
     String toString();
 
+    /**
+     * Source file of this location
+     *
+     * @return source file
+     * @since 2.23.4
+     */
+    String getSourceFile();
 }

--- a/src/main/java/org/mockito/invocation/Location.java
+++ b/src/main/java/org/mockito/invocation/Location.java
@@ -23,7 +23,7 @@ public interface Location {
      * Source file of this location
      *
      * @return source file
-     * @since 2.23.4
+     * @since 2.23.5
      */
     String getSourceFile();
 }

--- a/src/test/java/org/mockito/internal/invocation/InvocationBuilder.java
+++ b/src/test/java/org/mockito/internal/invocation/InvocationBuilder.java
@@ -130,6 +130,9 @@ public class InvocationBuilder {
             public String toString() {
                 return location;
             }
+            public String getSourceFile() {
+                return "SomeClass";
+            }
         };
         return this;
     }

--- a/src/test/java/org/mockitousage/internal/debugging/LocationImplTest.java
+++ b/src/test/java/org/mockitousage/internal/debugging/LocationImplTest.java
@@ -4,13 +4,15 @@
  */
 package org.mockitousage.internal.debugging;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.junit.Test;
 import org.mockito.internal.debugging.LocationImpl;
 import org.mockito.internal.exceptions.stacktrace.StackTraceFilter;
 import org.mockitoutil.TestBase;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 @SuppressWarnings("serial")
@@ -36,5 +38,19 @@ public class LocationImplTest extends TestBase {
 
         //then
         assertEquals("-> at <<unknown line>>", loc);
+    }
+
+    @Test
+    public void provides_location_class() {
+        //when
+        final List<String> files = new ArrayList<String>();
+        new Runnable() { //anonymous inner class adds stress to the check
+            public void run() {
+                files.add(new LocationImpl().getSourceFile());
+            }
+        }.run();
+
+        //then
+        assertEquals("LocationImplTest.java", files.get(0));
     }
 }

--- a/src/test/java/org/mockitousage/junitrule/StrictJUnitRuleTest.java
+++ b/src/test/java/org/mockitousage/junitrule/StrictJUnitRuleTest.java
@@ -14,6 +14,7 @@ import org.mockito.exceptions.misusing.UnnecessaryStubbingException;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.quality.Strictness;
 import org.mockitousage.IMethods;
+import org.mockitousage.strictness.ProductionCode;
 import org.mockitoutil.SafeJUnitRule;
 
 import static org.junit.Assert.assertEquals;
@@ -75,7 +76,7 @@ public class StrictJUnitRuleTest {
 
         //when
         when(mock.simpleMethod(10)).thenReturn("10");
-        when(mock.simpleMethod(20)).thenReturn("20");
+        ProductionCode.simpleMethod(mock, 20);
     }
 
     @Test public void fails_fast_when_stubbing_invoked_with_different_argument() throws Throwable {
@@ -87,7 +88,7 @@ public class StrictJUnitRuleTest {
                                 "Strict stubbing argument mismatch. Please check:\n" +
                                 " - this invocation of 'simpleMethod' method:\n" +
                                 "    mock.simpleMethod(15);\n" +
-                                "    -> at org.mockitousage.junitrule.StrictJUnitRuleTest.fails_fast_when_stubbing_invoked_with_different_argument(StrictJUnitRuleTest.java:0)\n" +
+                                "    -> at org.mockitousage.strictness.ProductionCode.simpleMethod(ProductionCode.java:0)\n" +
                                 " - has following stubbing(s) with different arguments:\n" +
                                 "    1. mock.simpleMethod(20);\n" +
                                 "      -> at org.mockitousage.junitrule.StrictJUnitRuleTest.fails_fast_when_stubbing_invoked_with_different_argument(StrictJUnitRuleTest.java:0)\n" +
@@ -116,7 +117,7 @@ public class StrictJUnitRuleTest {
 
         //invocation in the code under test uses different argument and should fail immediately
         //this helps with debugging and is essential for Mockito strictness
-        mock.simpleMethod(15);
+        ProductionCode.simpleMethod(mock, 15);
     }
 
     @Test public void verify_no_more_interactions_ignores_stubs() throws Throwable {

--- a/src/test/java/org/mockitousage/junitrunner/StrictStubsRunnerTest.java
+++ b/src/test/java/org/mockitousage/junitrunner/StrictStubsRunnerTest.java
@@ -13,6 +13,7 @@ import org.mockito.exceptions.misusing.PotentialStubbingProblem;
 import org.mockito.exceptions.misusing.UnnecessaryStubbingException;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockitousage.IMethods;
+import org.mockitousage.strictness.ProductionCode;
 import org.mockitoutil.JUnitResultAssert;
 import org.mockitoutil.TestBase;
 
@@ -65,7 +66,7 @@ public class StrictStubsRunnerTest extends TestBase {
         }
         @Test public void argument_mismatch() {
             when(mock.simpleMethod(10)).thenReturn("");
-            mock.simpleMethod(20);
+            ProductionCode.simpleMethod(mock, 20);
         }
     }
 }

--- a/src/test/java/org/mockitousage/strictness/LenientMockAnnotationTest.java
+++ b/src/test/java/org/mockitousage/strictness/LenientMockAnnotationTest.java
@@ -30,12 +30,12 @@ public class LenientMockAnnotationTest {
         when(regularMock.simpleMethod("2")).thenReturn("2");
 
         //then lenient mock does not throw:
-        lenientMock.simpleMethod("3");
+        ProductionCode.simpleMethod(lenientMock, "3");
 
         //but regular mock throws:
         Assertions.assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
             public void call() {
-                regularMock.simpleMethod("4");
+                ProductionCode.simpleMethod(regularMock,"4");
             }
         }).isInstanceOf(PotentialStubbingProblem.class);
     }

--- a/src/test/java/org/mockitousage/strictness/PotentialStubbingSensitivityTest.java
+++ b/src/test/java/org/mockitousage/strictness/PotentialStubbingSensitivityTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockitousage.strictness;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.exceptions.misusing.PotentialStubbingProblem;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
+import org.mockitousage.IMethods;
+
+import static org.mockito.Mockito.when;
+
+public class PotentialStubbingSensitivityTest {
+
+    @Rule public MockitoRule mockito = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+    @Mock IMethods mock;
+
+    @Before
+    public void setup() {
+        when(mock.simpleMethod("1")).thenReturn("1");
+    }
+
+    @Test
+    public void allows_stubbing_with_different_arg_in_test_code() {
+        //although we are calling 'simpleMethod' with different argument
+        //Mockito understands that this is stubbing in the test code and does not trigger PotentialStubbingProblem
+        when(mock.simpleMethod("2")).thenReturn("2");
+
+        //methods in anonymous inner classes are ok, too
+        new Runnable() {
+            public void run() {
+                when(mock.simpleMethod("3")).thenReturn("3");
+            }
+        }.run();
+
+        //avoiding unnecessary stubbing failures:
+        mock.simpleMethod("1");
+        mock.simpleMethod("2");
+        mock.simpleMethod("3");
+    }
+
+    @Test
+    public void reports_potential_stubbing_problem_in_production_code() {
+        //when
+        Assertions.assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            public void call() throws Throwable {
+                ProductionCode.simpleMethod(mock, "2");
+            }
+        }).isInstanceOf(PotentialStubbingProblem.class);
+    }
+}

--- a/src/test/java/org/mockitousage/strictness/ProductionCode.java
+++ b/src/test/java/org/mockitousage/strictness/ProductionCode.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockitousage.strictness;
+
+import org.mockitousage.IMethods;
+
+/**
+ * Test utility class that simulates invocation of mock in production code.
+ * In certain tests, the production code needs to be invoked in a different class/source file than the test.
+ */
+public class ProductionCode {
+
+    public static void simpleMethod(IMethods mock, String argument) {
+        mock.simpleMethod(argument);
+    }
+
+    public static void simpleMethod(IMethods mock, int argument) {
+        mock.simpleMethod(argument);
+    }
+}

--- a/src/test/java/org/mockitousage/strictness/StrictnessPerMockTest.java
+++ b/src/test/java/org/mockitousage/strictness/StrictnessPerMockTest.java
@@ -60,9 +60,8 @@ public class StrictnessPerMockTest {
 
         //and on strict stub mock (created by session), we cannot call stubbed method with different arg:
         Assertions.assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
-            @Override
             public void call() throws Throwable {
-                strictStubsMock.simpleMethod(200);
+                ProductionCode.simpleMethod(strictStubsMock, 200);
             }
         }).isInstanceOf(PotentialStubbingProblem.class);
     }

--- a/src/test/java/org/mockitousage/strictness/StrictnessPerStubbingTest.java
+++ b/src/test/java/org/mockitousage/strictness/StrictnessPerStubbingTest.java
@@ -51,7 +51,7 @@ public class StrictnessPerStubbingTest {
         assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
             @Override
             public void call() throws Throwable {
-                mock.simpleMethod("100");
+                ProductionCode.simpleMethod(mock, "100");
             }
         }).isInstanceOf(PotentialStubbingProblem.class);
     }

--- a/src/test/java/org/mockitousage/strictness/StrictnessPerStubbingWithRunnerTest.java
+++ b/src/test/java/org/mockitousage/strictness/StrictnessPerStubbingWithRunnerTest.java
@@ -33,9 +33,8 @@ public class StrictnessPerStubbingWithRunnerTest {
 
         //but on strict stubbing, we cannot:
         assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
-            @Override
-            public void call() throws Throwable {
-                mock.simpleMethod("100");
+            public void call() {
+                ProductionCode.simpleMethod(mock, "100");
             }
         }).isInstanceOf(PotentialStubbingProblem.class);
 

--- a/src/test/java/org/mockitousage/strictness/StrictnessWhenRuleStrictnessIsUpdatedTest.java
+++ b/src/test/java/org/mockitousage/strictness/StrictnessWhenRuleStrictnessIsUpdatedTest.java
@@ -34,9 +34,8 @@ public class StrictnessWhenRuleStrictnessIsUpdatedTest {
         //then previous mock is strict:
         when(mock.simpleMethod(1)).thenReturn("1");
         assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
-            @Override
-            public void call() throws Throwable {
-                mock.simpleMethod(2);
+            public void call() {
+                ProductionCode.simpleMethod(mock, 2);
             }
         }).isInstanceOf(PotentialStubbingProblem.class);
 
@@ -54,9 +53,8 @@ public class StrictnessWhenRuleStrictnessIsUpdatedTest {
         //then previous mock is strict:
         when(mock.simpleMethod(1)).thenReturn("1");
         assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
-            @Override
-            public void call() throws Throwable {
-                mock.simpleMethod(2);
+            public void call() {
+                ProductionCode.simpleMethod(mock, 2);
             }
         }).isInstanceOf(PotentialStubbingProblem.class);
 

--- a/src/test/java/org/mockitousage/strictness/StrictnessWithRulesTest.java
+++ b/src/test/java/org/mockitousage/strictness/StrictnessWithRulesTest.java
@@ -35,9 +35,8 @@ public class StrictnessWithRulesTest {
 
         //but on strict stubbing, we cannot:
         assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
-            @Override
-            public void call() throws Throwable {
-                mock.simpleMethod("100");
+            public void call() {
+                ProductionCode.simpleMethod(mock, "100");
             }
         }).isInstanceOf(PotentialStubbingProblem.class);
 

--- a/src/test/java/org/mockitousage/stubbing/StrictStubbingEndToEndTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StrictStubbingEndToEndTest.java
@@ -17,6 +17,7 @@ import org.mockito.exceptions.misusing.UnfinishedMockingSessionException;
 import org.mockito.exceptions.misusing.UnnecessaryStubbingException;
 import org.mockito.quality.Strictness;
 import org.mockitousage.IMethods;
+import org.mockitousage.strictness.ProductionCode;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -102,7 +103,7 @@ public class StrictStubbingEndToEndTest {
 
         @Test public void mismatch() {
             given(mock.simpleMethod(1)).willReturn("");
-            mock.simpleMethod(2);
+            ProductionCode.simpleMethod(mock, 2);
         }
     }
 

--- a/src/test/java/org/mockitousage/stubbing/StrictStubbingTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StrictStubbingTest.java
@@ -14,6 +14,7 @@ import org.mockito.exceptions.misusing.UnnecessaryStubbingException;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockito.quality.Strictness;
 import org.mockitousage.IMethods;
+import org.mockitousage.strictness.ProductionCode;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -82,7 +83,7 @@ public class StrictStubbingTest {
         //stubbing argument mismatch is detected
         assertThat(new Runnable() {
             public void run() {
-                mock.simpleMethod(200);
+                ProductionCode.simpleMethod(mock, 200);
             }
         }).throwsException(PotentialStubbingProblem.class);
     }


### PR DESCRIPTION
This change improves the developer experience with strict stubbing. It is now possible to stub the same method with different argument multiple times in the test. Previously, we threw PotentialStubbingProblem exception in this scenario:

```java
when(mock.foo(1)).thenReturn(1);
when(mock.foo(2)).thenReturn(2); // <- no longer throws PotentialStubbingProblem (false negative)
```

This reduces the number of false negatives reported by strict stubbing.

Fixes #1522, #1496, partially #769, #720