### PR TITLE
Exposed new API - StubbingLookupListener

### DIFF
--- a/src/main/java/org/mockito/MockSettings.java
+++ b/src/main/java/org/mockito/MockSettings.java
@@ -218,7 +218,7 @@ public interface MockSettings extends Serializable {
      *
      * @param listeners The stubbing lookup listeners to add. May not be null.
      * @return settings instance so that you can fluently specify other settings
-     * @since TODO x here and everywhere else
+     * @since 2.23.5
      */
     MockSettings stubbingLookupListeners(StubbingLookupListener... listeners);
 

--- a/src/main/java/org/mockito/MockSettings.java
+++ b/src/main/java/org/mockito/MockSettings.java
@@ -207,9 +207,9 @@ public interface MockSettings extends Serializable {
     /**
      * Add stubbing lookup listener to the mock object.
      *
-     * Multiple listeners may be added and they will be notified in the order they were supplied.
+     * Multiple listeners may be added and they will be notified orderly.
      *
-     * For use cases and more info see {@link StubbingLookupListener}
+     * For use cases and more info see {@link StubbingLookupListener}.
      *
      * Example:
      * <pre class="code"><code class="java">

--- a/src/main/java/org/mockito/MockSettings.java
+++ b/src/main/java/org/mockito/MockSettings.java
@@ -9,6 +9,7 @@ import org.mockito.exceptions.misusing.UnnecessaryStubbingException;
 import org.mockito.invocation.InvocationFactory;
 import org.mockito.invocation.MockHandler;
 import org.mockito.listeners.InvocationListener;
+import org.mockito.listeners.StubbingLookupListener;
 import org.mockito.listeners.VerificationStartedListener;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.mock.SerializableMode;
@@ -202,6 +203,24 @@ public interface MockSettings extends Serializable {
      * @return settings instance so that you can fluently specify other settings
      */
     MockSettings verboseLogging();
+
+    /**
+     * Add stubbing lookup listener to the mock object.
+     *
+     * Multiple listeners may be added and they will be notified in the order they were supplied.
+     *
+     * For use cases and more info see {@link StubbingLookupListener}
+     *
+     * Example:
+     * <pre class="code"><code class="java">
+     *  List mockWithListener = mock(List.class, withSettings().stubbingLookupListeners(new YourStubbingLookupListener()));
+     * </code></pre>
+     *
+     * @param listeners The stubbing lookup listeners to add. May not be null.
+     * @return settings instance so that you can fluently specify other settings
+     * @since TODO x here and everywhere else
+     */
+    MockSettings stubbingLookupListeners(StubbingLookupListener... listeners);
 
     /**
      * Registers a listener for method invocations on this mock. The listener is

--- a/src/main/java/org/mockito/MockSettings.java
+++ b/src/main/java/org/mockito/MockSettings.java
@@ -218,7 +218,7 @@ public interface MockSettings extends Serializable {
      *
      * @param listeners The stubbing lookup listeners to add. May not be null.
      * @return settings instance so that you can fluently specify other settings
-     * @since 2.23.5
+     * @since 2.24.6
      */
     MockSettings stubbingLookupListeners(StubbingLookupListener... listeners);
 

--- a/src/main/java/org/mockito/internal/creation/MockSettingsImpl.java
+++ b/src/main/java/org/mockito/internal/creation/MockSettingsImpl.java
@@ -11,6 +11,7 @@ import org.mockito.internal.util.Checks;
 import org.mockito.internal.util.MockCreationValidator;
 import org.mockito.internal.util.MockNameImpl;
 import org.mockito.listeners.InvocationListener;
+import org.mockito.listeners.StubbingLookupListener;
 import org.mockito.listeners.VerificationStartedListener;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.mock.MockName;
@@ -19,17 +20,17 @@ import org.mockito.stubbing.Answer;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static java.util.Arrays.asList;
 import static org.mockito.internal.exceptions.Reporter.defaultAnswerDoesNotAcceptNullParameter;
 import static org.mockito.internal.exceptions.Reporter.extraInterfacesAcceptsOnlyInterfaces;
 import static org.mockito.internal.exceptions.Reporter.extraInterfacesDoesNotAcceptNullParameters;
 import static org.mockito.internal.exceptions.Reporter.extraInterfacesRequiresAtLeastOneInterface;
-import static org.mockito.internal.exceptions.Reporter.invocationListenersRequiresAtLeastOneListener;
 import static org.mockito.internal.exceptions.Reporter.methodDoesNotAcceptParameter;
+import static org.mockito.internal.exceptions.Reporter.requiresAtLeastOneListener;
 import static org.mockito.internal.util.collections.Sets.newSet;
 
 @SuppressWarnings("unchecked")
@@ -154,7 +155,7 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
         }
         List<Object> resultArgs = new ArrayList<Object>(constructorArgs.length + 1);
         resultArgs.add(outerClassInstance);
-        resultArgs.addAll(Arrays.asList(constructorArgs));
+        resultArgs.addAll(asList(constructorArgs));
         return resultArgs.toArray(new Object[constructorArgs.length + 1]);
     }
 
@@ -173,16 +174,23 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
 
     @Override
     public MockSettings invocationListeners(InvocationListener... listeners) {
-        if (listeners == null || listeners.length == 0) {
-            throw invocationListenersRequiresAtLeastOneListener();
-        }
         addListeners(listeners, invocationListeners, "invocationListeners");
         return this;
     }
 
+    @Override
+    public MockSettings stubbingLookupListeners(StubbingLookupListener... listeners) {
+        addListeners(listeners, stubbingLookupListeners, "stubbingLookupListeners");
+        return this;
+    }
+
+    //TODO X dedicated unit tests
     private static <T> void addListeners(T[] listeners, List<T> container, String method) {
         if (listeners == null) {
             throw methodDoesNotAcceptParameter(method, "null vararg array.");
+        }
+        if (listeners.length == 0) {
+            throw requiresAtLeastOneListener(method);
         }
         for (T listener : listeners) {
             if (listener == null) {
@@ -207,13 +215,8 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
         return false;
     }
 
-    @Override
-    public List<InvocationListener> getInvocationListeners() {
-        return this.invocationListeners;
-    }
-
     public boolean hasInvocationListeners() {
-        return !invocationListeners.isEmpty();
+        return !getInvocationListeners().isEmpty();
     }
 
     @Override

--- a/src/main/java/org/mockito/internal/creation/MockSettingsImpl.java
+++ b/src/main/java/org/mockito/internal/creation/MockSettingsImpl.java
@@ -184,8 +184,7 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
         return this;
     }
 
-    //TODO X dedicated unit tests
-    private static <T> void addListeners(T[] listeners, List<T> container, String method) {
+    static <T> void addListeners(T[] listeners, List<T> container, String method) {
         if (listeners == null) {
             throw methodDoesNotAcceptParameter(method, "null vararg array.");
         }

--- a/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
+++ b/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
@@ -18,6 +18,7 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public class CreationSettings<T> implements MockCreationSettings<T>, Serializable {
     private static final long serialVersionUID = -6789800638070123629L;
@@ -31,8 +32,9 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
     protected SerializableMode serializableMode = SerializableMode.NONE;
     protected List<InvocationListener> invocationListeners = new ArrayList<InvocationListener>();
 
-    //TODO X - concurrent scenario?
-    protected List<StubbingLookupListener> stubbingLookupListeners = new ArrayList<StubbingLookupListener>();
+    //Other listeners in this class may also need concurrency-safe implementation
+    //However, no issue was reported yet, so we only protect stubbing lookup listeners (new code)
+    protected List<StubbingLookupListener> stubbingLookupListeners = new CopyOnWriteArrayList<StubbingLookupListener>();
 
     protected List<VerificationStartedListener> verificationStartedListeners = new LinkedList<VerificationStartedListener>();
     protected boolean stubOnly;

--- a/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
+++ b/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
@@ -32,8 +32,8 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
     protected SerializableMode serializableMode = SerializableMode.NONE;
     protected List<InvocationListener> invocationListeners = new ArrayList<InvocationListener>();
 
-    //Other listeners in this class may also need concurrency-safe implementation
-    //However, no issue was reported yet, so we only protect stubbing lookup listeners (new code)
+    //Other listeners in this class may also need concurrency-safe implementation. However, no issue was reported about it.
+    // If we do it, we need to understand usage patterns and choose the right concurrent implementation.
     protected List<StubbingLookupListener> stubbingLookupListeners = new CopyOnWriteArrayList<StubbingLookupListener>();
 
     protected List<VerificationStartedListener> verificationStartedListeners = new LinkedList<VerificationStartedListener>();

--- a/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
+++ b/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
@@ -46,6 +46,7 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
 
     @SuppressWarnings("unchecked")
     public CreationSettings(CreationSettings copy) {
+        //TODO x can we have a reflection test here?
         this.typeToMock = copy.typeToMock;
         this.extraInterfaces = copy.extraInterfaces;
         this.name = copy.name;

--- a/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
+++ b/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
@@ -48,7 +48,7 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
 
     @SuppressWarnings("unchecked")
     public CreationSettings(CreationSettings copy) {
-        //TODO x can we have a reflection test here?
+        //TODO can we have a reflection test here? We had a couple of bugs here in the past.
         this.typeToMock = copy.typeToMock;
         this.extraInterfaces = copy.extraInterfaces;
         this.name = copy.name;

--- a/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
+++ b/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
@@ -4,8 +4,8 @@
  */
 package org.mockito.internal.creation.settings;
 
-import org.mockito.internal.listeners.StubbingLookupListener;
 import org.mockito.listeners.InvocationListener;
+import org.mockito.listeners.StubbingLookupListener;
 import org.mockito.listeners.VerificationStartedListener;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.mock.MockName;
@@ -30,7 +30,10 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
     protected MockName mockName;
     protected SerializableMode serializableMode = SerializableMode.NONE;
     protected List<InvocationListener> invocationListeners = new ArrayList<InvocationListener>();
-    protected final List<StubbingLookupListener> stubbingLookupListeners = new ArrayList<StubbingLookupListener>();
+
+    //TODO X - concurrent scenario?
+    protected List<StubbingLookupListener> stubbingLookupListeners = new ArrayList<StubbingLookupListener>();
+
     protected List<VerificationStartedListener> verificationStartedListeners = new LinkedList<VerificationStartedListener>();
     protected boolean stubOnly;
     protected boolean stripAnnotations;
@@ -51,6 +54,7 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
         this.mockName = copy.mockName;
         this.serializableMode = copy.serializableMode;
         this.invocationListeners = copy.invocationListeners;
+        this.stubbingLookupListeners = copy.stubbingLookupListeners;
         this.verificationStartedListeners = copy.verificationStartedListeners;
         this.stubOnly = copy.stubOnly;
         this.useConstructor = copy.isUsingConstructor();

--- a/src/main/java/org/mockito/internal/exceptions/Reporter.java
+++ b/src/main/java/org/mockito/internal/exceptions/Reporter.java
@@ -684,8 +684,8 @@ public class Reporter {
         return new MockitoException(method + "() does not accept " + parameter + " See the Javadoc.");
     }
 
-    public static MockitoException invocationListenersRequiresAtLeastOneListener() {
-        return new MockitoException("invocationListeners() requires at least one listener");
+    public static MockitoException requiresAtLeastOneListener(String method) {
+        return new MockitoException(method + "() requires at least one listener");
     }
 
     public static MockitoException invocationListenerThrewException(InvocationListener listener, Throwable listenerThrowable) {

--- a/src/main/java/org/mockito/internal/junit/DefaultStubbingLookupListener.java
+++ b/src/main/java/org/mockito/internal/junit/DefaultStubbingLookupListener.java
@@ -5,8 +5,8 @@
 package org.mockito.internal.junit;
 
 import org.mockito.internal.exceptions.Reporter;
-import org.mockito.internal.listeners.StubbingLookupEvent;
-import org.mockito.internal.listeners.StubbingLookupListener;
+import org.mockito.listeners.StubbingLookupEvent;
+import org.mockito.listeners.StubbingLookupListener;
 import org.mockito.internal.stubbing.UnusedStubbingReporting;
 import org.mockito.invocation.Invocation;
 import org.mockito.quality.Strictness;

--- a/src/main/java/org/mockito/internal/junit/DefaultStubbingLookupListener.java
+++ b/src/main/java/org/mockito/internal/junit/DefaultStubbingLookupListener.java
@@ -5,10 +5,10 @@
 package org.mockito.internal.junit;
 
 import org.mockito.internal.exceptions.Reporter;
-import org.mockito.listeners.StubbingLookupEvent;
-import org.mockito.listeners.StubbingLookupListener;
 import org.mockito.internal.stubbing.UnusedStubbingReporting;
 import org.mockito.invocation.Invocation;
+import org.mockito.listeners.StubbingLookupEvent;
+import org.mockito.listeners.StubbingLookupListener;
 import org.mockito.quality.Strictness;
 import org.mockito.stubbing.Stubbing;
 

--- a/src/main/java/org/mockito/internal/junit/StrictStubsRunnerTestListener.java
+++ b/src/main/java/org/mockito/internal/junit/StrictStubsRunnerTestListener.java
@@ -21,7 +21,6 @@ public class StrictStubsRunnerTestListener implements MockitoTestListener {
     public void onMockCreated(Object mock, MockCreationSettings settings) {
         //It is not ideal that we modify the state of MockCreationSettings object
         //MockCreationSettings is intended to be an immutable view of the creation settings
-        //In future, we should start passing MockSettings object to the creation listener
         settings.getStubbingLookupListeners().add(stubbingLookupListener);
     }
 }

--- a/src/main/java/org/mockito/internal/junit/StrictStubsRunnerTestListener.java
+++ b/src/main/java/org/mockito/internal/junit/StrictStubsRunnerTestListener.java
@@ -4,7 +4,6 @@
  */
 package org.mockito.internal.junit;
 
-import org.mockito.internal.creation.settings.CreationSettings;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.quality.Strictness;
 
@@ -23,7 +22,6 @@ public class StrictStubsRunnerTestListener implements MockitoTestListener {
         //It is not ideal that we modify the state of MockCreationSettings object
         //MockCreationSettings is intended to be an immutable view of the creation settings
         //In future, we should start passing MockSettings object to the creation listener
-        //TODO #793 - when completed, we should be able to get rid of the CreationSettings casting below
-        ((CreationSettings) settings).getStubbingLookupListeners().add(stubbingLookupListener);
+        settings.getStubbingLookupListeners().add(stubbingLookupListener);
     }
 }

--- a/src/main/java/org/mockito/internal/junit/StrictStubsRunnerTestListener.java
+++ b/src/main/java/org/mockito/internal/junit/StrictStubsRunnerTestListener.java
@@ -21,6 +21,8 @@ public class StrictStubsRunnerTestListener implements MockitoTestListener {
     public void onMockCreated(Object mock, MockCreationSettings settings) {
         //It is not ideal that we modify the state of MockCreationSettings object
         //MockCreationSettings is intended to be an immutable view of the creation settings
+        //However, we our previous listeners work this way and it hasn't backfired.
+        //Since it is simple and pragmatic, we'll keep it for now.
         settings.getStubbingLookupListeners().add(stubbingLookupListener);
     }
 }

--- a/src/main/java/org/mockito/internal/listeners/StubbingLookupNotifier.java
+++ b/src/main/java/org/mockito/internal/listeners/StubbingLookupNotifier.java
@@ -6,6 +6,8 @@ package org.mockito.internal.listeners;
 
 import org.mockito.internal.creation.settings.CreationSettings;
 import org.mockito.invocation.Invocation;
+import org.mockito.listeners.StubbingLookupEvent;
+import org.mockito.listeners.StubbingLookupListener;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.stubbing.Stubbing;
 

--- a/src/main/java/org/mockito/invocation/Location.java
+++ b/src/main/java/org/mockito/invocation/Location.java
@@ -23,7 +23,7 @@ public interface Location {
      * Source file of this location
      *
      * @return source file
-     * @since 2.23.5
+     * @since 2.24.6
      */
     String getSourceFile();
 }

--- a/src/main/java/org/mockito/listeners/StubbingLookupEvent.java
+++ b/src/main/java/org/mockito/listeners/StubbingLookupEvent.java
@@ -12,25 +12,32 @@ import java.util.Collection;
 
 /**
  * Represent an information about the looked up stubbing
+ *
+ * @since 2.23.5
  */
 public interface StubbingLookupEvent {
+
     /**
      * @return The invocation that causes stubbing lookup
+     * @since 2.23.5
      */
     Invocation getInvocation();
 
     /**
      * @return Looked up stubbing. It can be <code>null</code>, which indicates that the invocation was not stubbed
+     * @since 2.23.5
      */
     Stubbing getStubbingFound();
 
     /**
      * @return All stubbings declared on the mock object that we are invoking
+     * @since 2.23.5
      */
     Collection<Stubbing> getAllStubbings();
 
     /**
      * @return Settings of the mock object that we are invoking
+     * @since 2.23.5
      */
     MockCreationSettings getMockSettings();
 }

--- a/src/main/java/org/mockito/listeners/StubbingLookupEvent.java
+++ b/src/main/java/org/mockito/listeners/StubbingLookupEvent.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2018 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-package org.mockito.internal.listeners;
+package org.mockito.listeners;
 
 import org.mockito.invocation.Invocation;
 import org.mockito.mock.MockCreationSettings;

--- a/src/main/java/org/mockito/listeners/StubbingLookupEvent.java
+++ b/src/main/java/org/mockito/listeners/StubbingLookupEvent.java
@@ -13,31 +13,31 @@ import java.util.Collection;
 /**
  * Represent an information about the looked up stubbing
  *
- * @since 2.23.5
+ * @since 2.24.6
  */
 public interface StubbingLookupEvent {
 
     /**
      * @return The invocation that causes stubbing lookup
-     * @since 2.23.5
+     * @since 2.24.6
      */
     Invocation getInvocation();
 
     /**
      * @return Looked up stubbing. It can be <code>null</code>, which indicates that the invocation was not stubbed
-     * @since 2.23.5
+     * @since 2.24.6
      */
     Stubbing getStubbingFound();
 
     /**
      * @return All stubbings declared on the mock object that we are invoking
-     * @since 2.23.5
+     * @since 2.24.6
      */
     Collection<Stubbing> getAllStubbings();
 
     /**
      * @return Settings of the mock object that we are invoking
-     * @since 2.23.5
+     * @since 2.24.6
      */
     MockCreationSettings getMockSettings();
 }

--- a/src/main/java/org/mockito/listeners/StubbingLookupListener.java
+++ b/src/main/java/org/mockito/listeners/StubbingLookupListener.java
@@ -5,21 +5,23 @@
 package org.mockito.listeners;
 
 import org.mockito.MockSettings;
+import org.mockito.mock.MockCreationSettings;
 
 /**
- * This listener can be notified of looking up stubbing answer for a given mock.
- *
- * For this to happen, it must be registered using {@link MockSettings#stubbingLookupListeners(StubbingLookupListener...)}.
- *
- * TODO x use case, mutability
- *
+ * When a method is called on a mock object Mockito looks up any stubbings recorded on that mock.
+ * This listener gets notified on stubbing lookup.
+ * Register listener via {@link MockSettings#stubbingLookupListeners(StubbingLookupListener...)}.
+ * This API is used by Mockito to implement {@link org.mockito.exceptions.misusing.PotentialStubbingProblem}
+ * (part of Mockito {@link org.mockito.quality.Strictness}.
  * <p>
- * How does it work?
- * When method is called on the mock object, Mockito looks for any answer (stubbing) declared on that mock.
+ * Details: When method is called on the mock object, Mockito looks for any answer (stubbing) declared on that mock.
  * If the stubbed answer is found, that answer is invoked (value returned, thrown exception, etc.).
  * If the answer is not found (e.g. that invocation was not stubbed on the mock), mock's default answer is used.
- * This listener implementation is notified when Mockito looked up an answer for invocation on a mock.
+ * This listener implementation is notified when Mockito attempted to find an answer for invocation on a mock.
  * <p>
+ * The listeners can be accessed via {@link MockCreationSettings#getStubbingLookupListeners()}.
+ *
+ * @since 2.23.5
  */
 public interface StubbingLookupListener {
 
@@ -27,6 +29,7 @@ public interface StubbingLookupListener {
      * Called by the framework when Mockito looked up an answer for invocation on a mock.
      *
      * @param stubbingLookupEvent - Information about the looked up stubbing
+     * @since 2.23.5
      */
     void onStubbingLookup(StubbingLookupEvent stubbingLookupEvent);
 }

--- a/src/main/java/org/mockito/listeners/StubbingLookupListener.java
+++ b/src/main/java/org/mockito/listeners/StubbingLookupListener.java
@@ -2,10 +2,17 @@
  * Copyright (c) 2017 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-package org.mockito.internal.listeners;
+package org.mockito.listeners;
+
+import org.mockito.MockSettings;
 
 /**
- * Listens to attempts to look up stubbing answer for given mocks. This class is internal for now.
+ * This listener can be notified of looking up stubbing answer for a given mock.
+ *
+ * For this to happen, it must be registered using {@link MockSettings#stubbingLookupListeners(StubbingLookupListener...)}.
+ *
+ * TODO x use case, mutability
+ *
  * <p>
  * How does it work?
  * When method is called on the mock object, Mockito looks for any answer (stubbing) declared on that mock.
@@ -13,11 +20,6 @@ package org.mockito.internal.listeners;
  * If the answer is not found (e.g. that invocation was not stubbed on the mock), mock's default answer is used.
  * This listener implementation is notified when Mockito looked up an answer for invocation on a mock.
  * <p>
- * If we make this interface a part of public API (and we should):
- *  - make the implementation unified with InvocationListener (for example: common parent, marker interface MockObjectListener
- *  single method for adding listeners so long they inherit from the parent)
- *  - make the error handling strict
- * so that Mockito provides decent message when listener fails due to poor implementation.
  */
 public interface StubbingLookupListener {
 
@@ -25,6 +27,8 @@ public interface StubbingLookupListener {
      * Called by the framework when Mockito looked up an answer for invocation on a mock.
      *
      * @param stubbingLookupEvent - Information about the looked up stubbing
+     *
+     * @see StubbingLookupEvent
      */
     void onStubbingLookup(StubbingLookupEvent stubbingLookupEvent);
 }

--- a/src/main/java/org/mockito/listeners/StubbingLookupListener.java
+++ b/src/main/java/org/mockito/listeners/StubbingLookupListener.java
@@ -27,8 +27,6 @@ public interface StubbingLookupListener {
      * Called by the framework when Mockito looked up an answer for invocation on a mock.
      *
      * @param stubbingLookupEvent - Information about the looked up stubbing
-     *
-     * @see StubbingLookupEvent
      */
     void onStubbingLookup(StubbingLookupEvent stubbingLookupEvent);
 }

--- a/src/main/java/org/mockito/listeners/StubbingLookupListener.java
+++ b/src/main/java/org/mockito/listeners/StubbingLookupListener.java
@@ -12,12 +12,12 @@ import org.mockito.mock.MockCreationSettings;
  * This listener gets notified on stubbing lookup.
  * Register listener via {@link MockSettings#stubbingLookupListeners(StubbingLookupListener...)}.
  * This API is used by Mockito to implement {@link org.mockito.exceptions.misusing.PotentialStubbingProblem}
- * (part of Mockito {@link org.mockito.quality.Strictness}.
+ * (part of Mockito {@link org.mockito.quality.Strictness}).
  * <p>
  * Details: When method is called on the mock object, Mockito looks for any answer (stubbing) declared on that mock.
- * If the stubbed answer is found, that answer is invoked (value returned, thrown exception, etc.).
+ * If the stubbed answer is found, that answer is then invoked (value returned, thrown exception, etc.).
  * If the answer is not found (e.g. that invocation was not stubbed on the mock), mock's default answer is used.
- * This listener implementation is notified when Mockito attempted to find an answer for invocation on a mock.
+ * This listener implementation is notified when Mockito attempts to find an answer for invocation on a mock.
  * <p>
  * The listeners can be accessed via {@link MockCreationSettings#getStubbingLookupListeners()}.
  *
@@ -27,6 +27,7 @@ public interface StubbingLookupListener {
 
     /**
      * Called by the framework when Mockito looked up an answer for invocation on a mock.
+     * For details, see {@link StubbingLookupListener}.
      *
      * @param stubbingLookupEvent - Information about the looked up stubbing
      * @since 2.23.5

--- a/src/main/java/org/mockito/listeners/StubbingLookupListener.java
+++ b/src/main/java/org/mockito/listeners/StubbingLookupListener.java
@@ -21,7 +21,7 @@ import org.mockito.mock.MockCreationSettings;
  * <p>
  * The listeners can be accessed via {@link MockCreationSettings#getStubbingLookupListeners()}.
  *
- * @since 2.23.5
+ * @since 2.24.6
  */
 public interface StubbingLookupListener {
 
@@ -30,7 +30,7 @@ public interface StubbingLookupListener {
      * For details, see {@link StubbingLookupListener}.
      *
      * @param stubbingLookupEvent - Information about the looked up stubbing
-     * @since 2.23.5
+     * @since 2.24.6
      */
     void onStubbingLookup(StubbingLookupEvent stubbingLookupEvent);
 }

--- a/src/main/java/org/mockito/mock/MockCreationSettings.java
+++ b/src/main/java/org/mockito/mock/MockCreationSettings.java
@@ -77,7 +77,7 @@ public interface MockCreationSettings<T> {
     List<StubbingLookupListener> getStubbingLookupListeners();
 
     /**
-     * {@link InvocationListener} instances attached to this mock, see {@link org.mockito.MockSettings#addListeners}.
+     * {@link InvocationListener} instances attached to this mock, see {@link org.mockito.MockSettings#invocationListeners(InvocationListener...)}.
      */
     List<InvocationListener> getInvocationListeners();
 

--- a/src/main/java/org/mockito/mock/MockCreationSettings.java
+++ b/src/main/java/org/mockito/mock/MockCreationSettings.java
@@ -8,8 +8,8 @@ package org.mockito.mock;
 import org.mockito.Incubating;
 import org.mockito.MockSettings;
 import org.mockito.NotExtensible;
-import org.mockito.listeners.StubbingLookupListener;
 import org.mockito.listeners.InvocationListener;
+import org.mockito.listeners.StubbingLookupListener;
 import org.mockito.listeners.VerificationStartedListener;
 import org.mockito.quality.Strictness;
 import org.mockito.stubbing.Answer;
@@ -71,8 +71,12 @@ public interface MockCreationSettings<T> {
     boolean isStripAnnotations();
 
     /**
-     * TODO x document mutability
-     * {@link StubbingLookupListener} instances attached to this mock via {@link MockSettings#stubbingLookupListeners(StubbingLookupListener...)}.
+     * Returns {@link StubbingLookupListener} instances attached to this mock via {@link MockSettings#stubbingLookupListeners(StubbingLookupListener...)}.
+     * The resulting list is mutable, you can add/remove listeners even after the mock was created.
+     * <p>
+     * For more details see {@link StubbingLookupListener}.
+     *
+     * @since 2.23.5
      */
     List<StubbingLookupListener> getStubbingLookupListeners();
 

--- a/src/main/java/org/mockito/mock/MockCreationSettings.java
+++ b/src/main/java/org/mockito/mock/MockCreationSettings.java
@@ -8,6 +8,7 @@ package org.mockito.mock;
 import org.mockito.Incubating;
 import org.mockito.MockSettings;
 import org.mockito.NotExtensible;
+import org.mockito.listeners.StubbingLookupListener;
 import org.mockito.listeners.InvocationListener;
 import org.mockito.listeners.VerificationStartedListener;
 import org.mockito.quality.Strictness;
@@ -70,7 +71,13 @@ public interface MockCreationSettings<T> {
     boolean isStripAnnotations();
 
     /**
-     * {@link InvocationListener} instances attached to this mock, see {@link org.mockito.MockSettings#invocationListeners}.
+     * TODO x document mutability
+     * {@link StubbingLookupListener} instances attached to this mock via {@link MockSettings#stubbingLookupListeners(StubbingLookupListener...)}.
+     */
+    List<StubbingLookupListener> getStubbingLookupListeners();
+
+    /**
+     * {@link InvocationListener} instances attached to this mock, see {@link org.mockito.MockSettings#addListeners}.
      */
     List<InvocationListener> getInvocationListeners();
 

--- a/src/main/java/org/mockito/mock/MockCreationSettings.java
+++ b/src/main/java/org/mockito/mock/MockCreationSettings.java
@@ -76,7 +76,7 @@ public interface MockCreationSettings<T> {
      * <p>
      * For more details see {@link StubbingLookupListener}.
      *
-     * @since 2.23.5
+     * @since 2.24.6
      */
     List<StubbingLookupListener> getStubbingLookupListeners();
 

--- a/src/test/java/org/mockito/internal/creation/MockSettingsImplTest.java
+++ b/src/test/java/org/mockito/internal/creation/MockSettingsImplTest.java
@@ -18,6 +18,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -169,53 +170,45 @@ public class MockSettingsImplTest extends TestBase {
 
     @Test
     public void validates_listeners() {
-        Assertions.assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
             public void call() {
                 mockSettingsImpl.addListeners(new Object[] {}, new LinkedList<Object>(), "myListeners");
             }
         }).hasMessageContaining("myListeners() requires at least one listener");
 
-        Assertions.assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
             public void call() {
                 mockSettingsImpl.addListeners(null, new LinkedList<Object>(), "myListeners");
             }
         }).hasMessageContaining("myListeners() does not accept null vararg array");
 
-        Assertions.assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
             public void call() {
                 mockSettingsImpl.addListeners(new Object[] {null}, new LinkedList<Object>(), "myListeners");
             }
         }).hasMessageContaining("myListeners() does not accept null listeners");
     }
 
-    @Test
-    public void addListeners_shouldNotAllowNullListener() {
-        try {
-            mockSettingsImpl.stubbingLookupListeners((StubbingLookupListener[])null);
-            fail();
-        } catch (MockitoException e) {
-            assertThat(e.getMessage()).contains("null vararg array");
-        }
-    }
 
     @Test
-    public void addListeners_shouldNotAllowEmptyListener() {
-        try {
-            mockSettingsImpl.stubbingLookupListeners();
-            fail();
-        } catch (MockitoException e) {
-            assertThat(e.getMessage()).contains("at least one listener");
-        }
-    }
+    public void validates_stubbing_lookup_listeners() {
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            public void call() {
+                mockSettingsImpl.stubbingLookupListeners(new StubbingLookupListener[] {});
+            }
+        }).hasMessageContaining("stubbingLookupListeners() requires at least one listener");
 
-    @Test
-    public void addListeners_shouldReportErrorWhenAddingANullListener() {
-        try {
-            mockSettingsImpl.stubbingLookupListeners(stubbingLookupListener, null);
-            fail();
-        } catch (Exception e) {
-            assertThat(e.getMessage()).contains("does not accept null");
-        }
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            public void call() {
+                mockSettingsImpl.stubbingLookupListeners(null);
+            }
+        }).hasMessageContaining("stubbingLookupListeners() does not accept null vararg array");
+
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            public void call() {
+                mockSettingsImpl.stubbingLookupListeners(new StubbingLookupListener[] {null});
+            }
+        }).hasMessageContaining("stubbingLookupListeners() does not accept null listeners");
     }
 
     @Test

--- a/src/test/java/org/mockito/internal/creation/MockSettingsImplTest.java
+++ b/src/test/java/org/mockito/internal/creation/MockSettingsImplTest.java
@@ -18,9 +18,11 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class MockSettingsImplTest extends TestBase {
 

--- a/src/test/java/org/mockito/internal/creation/MockSettingsImplTest.java
+++ b/src/test/java/org/mockito/internal/creation/MockSettingsImplTest.java
@@ -116,12 +116,6 @@ public class MockSettingsImplTest extends TestBase {
         Assertions.assertThat(mockSettingsImpl.getInvocationListeners()).hasSize(1);
     }
 
-    @SuppressWarnings("unchecked")
-    @Test(expected=MockitoException.class)
-    public void shouldNotAllowNullListener() {
-        mockSettingsImpl.invocationListeners((InvocationListener[])null);
-    }
-
     @Test
     @SuppressWarnings("unchecked")
     public void shouldAddInvocationListener() {
@@ -146,26 +140,6 @@ public class MockSettingsImplTest extends TestBase {
 
         //then
         Assertions.assertThat(mockSettingsImpl.getInvocationListeners()).containsSequence(invocationListener, invocationListener, invocationListener);
-    }
-
-    @Test
-    public void shouldReportErrorWhenAddingNoInvocationListeners() throws Exception {
-        try {
-            mockSettingsImpl.invocationListeners();
-            fail();
-        } catch (Exception e) {
-            Assertions.assertThat(e.getMessage()).contains("at least one listener");
-        }
-    }
-
-    @Test
-    public void shouldReportErrorWhenAddingANullInvocationListener() throws Exception {
-        try {
-            mockSettingsImpl.invocationListeners(invocationListener, null);
-            fail();
-        } catch (Exception e) {
-            Assertions.assertThat(e.getMessage()).contains("does not accept null");
-        }
     }
 
     @Test
@@ -209,6 +183,27 @@ public class MockSettingsImplTest extends TestBase {
                 mockSettingsImpl.stubbingLookupListeners(new StubbingLookupListener[] {null});
             }
         }).hasMessageContaining("stubbingLookupListeners() does not accept null listeners");
+    }
+
+    @Test
+    public void validates_invocation_listeners() {
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            public void call() {
+                mockSettingsImpl.invocationListeners(new InvocationListener[] {});
+            }
+        }).hasMessageContaining("invocationListeners() requires at least one listener");
+
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            public void call() {
+                mockSettingsImpl.invocationListeners(null);
+            }
+        }).hasMessageContaining("invocationListeners() does not accept null vararg array");
+
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            public void call() {
+                mockSettingsImpl.invocationListeners(new InvocationListener[] {null});
+            }
+        }).hasMessageContaining("invocationListeners() does not accept null listeners");
     }
 
     @Test

--- a/src/test/java/org/mockito/internal/creation/MockSettingsImplTest.java
+++ b/src/test/java/org/mockito/internal/creation/MockSettingsImplTest.java
@@ -5,6 +5,7 @@
 package org.mockito.internal.creation;
 
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ThrowableAssert;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.exceptions.base.MockitoException;
@@ -164,6 +165,27 @@ public class MockSettingsImplTest extends TestBase {
         } catch (Exception e) {
             Assertions.assertThat(e.getMessage()).contains("does not accept null");
         }
+    }
+
+    @Test
+    public void validates_listeners() {
+        Assertions.assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            public void call() {
+                mockSettingsImpl.addListeners(new Object[] {}, new LinkedList<Object>(), "myListeners");
+            }
+        }).hasMessageContaining("myListeners() requires at least one listener");
+
+        Assertions.assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            public void call() {
+                mockSettingsImpl.addListeners(null, new LinkedList<Object>(), "myListeners");
+            }
+        }).hasMessageContaining("myListeners() does not accept null vararg array");
+
+        Assertions.assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            public void call() {
+                mockSettingsImpl.addListeners(new Object[] {null}, new LinkedList<Object>(), "myListeners");
+            }
+        }).hasMessageContaining("myListeners() does not accept null listeners");
     }
 
     @Test

--- a/src/test/java/org/mockito/internal/creation/MockSettingsImplTest.java
+++ b/src/test/java/org/mockito/internal/creation/MockSettingsImplTest.java
@@ -197,11 +197,13 @@ public class MockSettingsImplTest extends TestBase {
     }
 
     @Test
-    public void addListeners_shouldAddMockObjectListeners() {
-        //given
+    public void addListeners_has_empty_listeners_by_default() {
         assertTrue(mockSettingsImpl.getInvocationListeners().isEmpty());
         assertTrue(mockSettingsImpl.getStubbingLookupListeners().isEmpty());
+    }
 
+    @Test
+    public void addListeners_shouldAddMockObjectListeners() {
         //when
         mockSettingsImpl.invocationListeners(invocationListener);
         mockSettingsImpl.stubbingLookupListeners(stubbingLookupListener);
@@ -215,10 +217,6 @@ public class MockSettingsImplTest extends TestBase {
 
     @Test
     public void addListeners_canAddDuplicateMockObjectListeners_ItsNotOurBusinessThere() {
-        //given
-        assertTrue(mockSettingsImpl.getInvocationListeners().isEmpty());
-        assertTrue(mockSettingsImpl.getStubbingLookupListeners().isEmpty());
-
         //when
         mockSettingsImpl.stubbingLookupListeners(stubbingLookupListener)
                         .stubbingLookupListeners(stubbingLookupListener)

--- a/src/test/java/org/mockito/internal/creation/MockSettingsImplTest.java
+++ b/src/test/java/org/mockito/internal/creation/MockSettingsImplTest.java
@@ -211,8 +211,6 @@ public class MockSettingsImplTest extends TestBase {
         //then
         assertThat(mockSettingsImpl.getInvocationListeners()).contains(invocationListener);
         assertThat(mockSettingsImpl.getStubbingLookupListeners()).contains(stubbingLookupListener);
-
-        //TODO x add test that we can remove listeners
     }
 
     @Test

--- a/src/test/java/org/mockito/internal/listeners/StubbingLookupNotifierTest.java
+++ b/src/test/java/org/mockito/internal/listeners/StubbingLookupNotifierTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.internal.creation.settings.CreationSettings;
 import org.mockito.invocation.Invocation;
+import org.mockito.listeners.StubbingLookupListener;
 import org.mockito.stubbing.Stubbing;
 import org.mockitoutil.TestBase;
 

--- a/src/test/java/org/mockitousage/debugging/StubbingLookupListenerCallbackTest.java
+++ b/src/test/java/org/mockitousage/debugging/StubbingLookupListenerCallbackTest.java
@@ -7,37 +7,33 @@ package org.mockitousage.debugging;
 import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.InOrder;
-import org.mockito.invocation.Invocation;
 import org.mockito.listeners.StubbingLookupEvent;
 import org.mockito.listeners.StubbingLookupListener;
-import org.mockito.mock.MockCreationSettings;
-import org.mockito.stubbing.Stubbing;
 import org.mockitoutil.TestBase;
-
-import java.util.Collection;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 public class StubbingLookupListenerCallbackTest extends TestBase {
 
+    final StubbingLookupListener listener = mock(StubbingLookupListener.class);
+    Foo mock = mock(Foo.class, withSettings().stubbingLookupListeners(listener));
+
     @Test
     public void should_call_listener_when_mock_return_normally_with_stubbed_answer() {
         // given
-        final AnswerListener listener = spy(AnswerListener.class);
-        Foo foo = mock(Foo.class, withSettings().stubbingLookupListeners(listener));
-        doReturn("coke").when(foo).giveMeSomeString("soda");
-        doReturn("java").when(foo).giveMeSomeString("coffee");
+        doReturn("coke").when(mock).giveMeSomeString("soda");
+        doReturn("java").when(mock).giveMeSomeString("coffee");
 
         // when
-        foo.giveMeSomeString("soda");
+        mock.giveMeSomeString("soda");
 
         // then
         verify(listener).onStubbingLookup(argThat(new ArgumentMatcher<StubbingLookupEvent>() {
             @Override
             public boolean matches(StubbingLookupEvent argument) {
                 assertEquals("soda", argument.getInvocation().getArgument(0));
-                assertEquals("foo", argument.getMockSettings().getMockName().toString());
+                assertEquals("mock", argument.getMockSettings().getMockName().toString());
                 assertEquals(2, argument.getAllStubbings().size());
                 assertNotNull(argument.getStubbingFound());
                 return true;
@@ -48,19 +44,17 @@ public class StubbingLookupListenerCallbackTest extends TestBase {
     @Test
     public void should_call_listener_when_mock_return_normally_with_default_answer() {
         // given
-        AnswerListener listener = spy(AnswerListener.class);
-        Foo foo = mock(Foo.class, withSettings().stubbingLookupListeners(listener));
-        doReturn("java").when(foo).giveMeSomeString("coffee");
+        doReturn("java").when(mock).giveMeSomeString("coffee");
 
         // when
-        foo.giveMeSomeString("soda");
+        mock.giveMeSomeString("soda");
 
         // then
         verify(listener).onStubbingLookup(argThat(new ArgumentMatcher<StubbingLookupEvent>() {
             @Override
             public boolean matches(StubbingLookupEvent argument) {
                 assertEquals("soda", argument.getInvocation().getArgument(0));
-                assertEquals("foo", argument.getMockSettings().getMockName().toString());
+                assertEquals("mock", argument.getMockSettings().getMockName().toString());
                 assertEquals(1, argument.getAllStubbings().size());
                 assertNull(argument.getStubbingFound());
                 return true;
@@ -70,12 +64,8 @@ public class StubbingLookupListenerCallbackTest extends TestBase {
 
     @Test
     public void should_not_call_listener_when_mock_is_not_called() {
-        // given
-        AnswerListener listener = spy(AnswerListener.class);
-        Foo foo = mock(Foo.class, withSettings().stubbingLookupListeners(listener));
-        doReturn("java").when(foo).giveMeSomeString("coffee");
-
-        // when nothing
+        // when stubbing is recorded
+        doReturn("java").when(mock).giveMeSomeString("coffee");
 
         // then
         verifyZeroInteractions(listener);
@@ -84,12 +74,11 @@ public class StubbingLookupListenerCallbackTest extends TestBase {
     @Test
     public void should_allow_same_listener() {
         // given
-        AnswerListener listener = mock(AnswerListener.class);
-        Foo foo = mock(Foo.class, withSettings().stubbingLookupListeners(listener, listener));
+        Foo mock = mock(Foo.class, withSettings().stubbingLookupListeners(listener, listener));
 
         // when
-        foo.giveMeSomeString("tea");
-        foo.giveMeSomeString("coke");
+        mock.giveMeSomeString("tea");
+        mock.giveMeSomeString("coke");
 
         // then each listener was notified 2 times (notified 4 times in total)
         verify(listener, times(4)).onStubbingLookup(any(StubbingLookupEvent.class));
@@ -98,13 +87,13 @@ public class StubbingLookupListenerCallbackTest extends TestBase {
     @Test
     public void should_call_all_listeners_in_order() {
         // given
-        AnswerListener listener1 = mock(AnswerListener.class);
-        AnswerListener listener2 = mock(AnswerListener.class);
-        Foo foo = mock(Foo.class, withSettings().stubbingLookupListeners(listener1, listener2));
-        doReturn("sprite").when(foo).giveMeSomeString("soda");
+        StubbingLookupListener listener1 = mock(StubbingLookupListener.class);
+        StubbingLookupListener listener2 = mock(StubbingLookupListener.class);
+        Foo mock = mock(Foo.class, withSettings().stubbingLookupListeners(listener1, listener2));
+        doReturn("sprite").when(mock).giveMeSomeString("soda");
 
         // when
-        foo.giveMeSomeString("soda");
+        mock.giveMeSomeString("soda");
 
         // then
         InOrder inOrder = inOrder(listener1, listener2);
@@ -115,14 +104,14 @@ public class StubbingLookupListenerCallbackTest extends TestBase {
     @Test
     public void should_call_all_listeners_when_mock_throws_exception() {
         // given
-        AnswerListener listener1 = mock(AnswerListener.class);
-        AnswerListener listener2 = mock(AnswerListener.class);
-        Foo foo = mock(Foo.class, withSettings().stubbingLookupListeners(listener1, listener2));
-        doThrow(new NoWater()).when(foo).giveMeSomeString("tea");
+        StubbingLookupListener listener1 = mock(StubbingLookupListener.class);
+        StubbingLookupListener listener2 = mock(StubbingLookupListener.class);
+        Foo mock = mock(Foo.class, withSettings().stubbingLookupListeners(listener1, listener2));
+        doThrow(new NoWater()).when(mock).giveMeSomeString("tea");
 
         // when
         try {
-            foo.giveMeSomeString("tea");
+            mock.giveMeSomeString("tea");
             fail();
         } catch (NoWater e) {
             // then
@@ -132,22 +121,6 @@ public class StubbingLookupListenerCallbackTest extends TestBase {
     }
 
     //TODO x deleted listener
-
-    private static class AnswerListener implements StubbingLookupListener {
-        private Invocation invocation;
-        private Stubbing stubbing;
-        private Collection<Stubbing> allStubbings;
-        private MockCreationSettings mockSettings;
-
-        public AnswerListener() {}
-
-        public void onStubbingLookup(StubbingLookupEvent event) {
-            this.invocation = event.getInvocation();
-            this.stubbing = event.getStubbingFound();
-            this.allStubbings = event.getAllStubbings();
-            this.mockSettings = event.getMockSettings();
-        }
-    }
 
     private static class NoWater extends RuntimeException {}
 }

--- a/src/test/java/org/mockitousage/debugging/StubbingLookupListenerCallbackTest.java
+++ b/src/test/java/org/mockitousage/debugging/StubbingLookupListenerCallbackTest.java
@@ -17,7 +17,10 @@ import org.mockitoutil.TestBase;
 import java.util.LinkedList;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 public class StubbingLookupListenerCallbackTest extends TestBase {

--- a/src/test/java/org/mockitousage/debugging/StubbingLookupListenerCallbackTest.java
+++ b/src/test/java/org/mockitousage/debugging/StubbingLookupListenerCallbackTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2018 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage.debugging;
+
+import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.InOrder;
+import org.mockito.invocation.Invocation;
+import org.mockito.listeners.StubbingLookupEvent;
+import org.mockito.listeners.StubbingLookupListener;
+import org.mockito.mock.MockCreationSettings;
+import org.mockito.stubbing.Stubbing;
+import org.mockitoutil.TestBase;
+
+import java.util.Collection;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class StubbingLookupListenerCallbackTest extends TestBase {
+
+    @Test
+    public void should_call_listener_when_mock_return_normally_with_stubbed_answer() {
+        // given
+        final AnswerListener listener = spy(AnswerListener.class);
+        Foo foo = mock(Foo.class, withSettings().stubbingLookupListeners(listener));
+        doReturn("coke").when(foo).giveMeSomeString("soda");
+        doReturn("java").when(foo).giveMeSomeString("coffee");
+
+        // when
+        foo.giveMeSomeString("soda");
+
+        // then
+        verify(listener).onStubbingLookup(argThat(new ArgumentMatcher<StubbingLookupEvent>() {
+            @Override
+            public boolean matches(StubbingLookupEvent argument) {
+                assertEquals("soda", argument.getInvocation().getArgument(0));
+                assertEquals("foo", argument.getMockSettings().getMockName().toString());
+                assertEquals(2, argument.getAllStubbings().size());
+                assertNotNull(argument.getStubbingFound());
+                return true;
+            }
+        }));
+    }
+
+    @Test
+    public void should_call_listener_when_mock_return_normally_with_default_answer() {
+        // given
+        AnswerListener listener = spy(AnswerListener.class);
+        Foo foo = mock(Foo.class, withSettings().stubbingLookupListeners(listener));
+        doReturn("java").when(foo).giveMeSomeString("coffee");
+
+        // when
+        foo.giveMeSomeString("soda");
+
+        // then
+        verify(listener).onStubbingLookup(argThat(new ArgumentMatcher<StubbingLookupEvent>() {
+            @Override
+            public boolean matches(StubbingLookupEvent argument) {
+                assertEquals("soda", argument.getInvocation().getArgument(0));
+                assertEquals("foo", argument.getMockSettings().getMockName().toString());
+                assertEquals(1, argument.getAllStubbings().size());
+                assertNull(argument.getStubbingFound());
+                return true;
+            }
+        }));
+    }
+
+    @Test
+    public void should_not_call_listener_when_mock_is_not_called() {
+        // given
+        AnswerListener listener = spy(AnswerListener.class);
+        Foo foo = mock(Foo.class, withSettings().stubbingLookupListeners(listener));
+        doReturn("java").when(foo).giveMeSomeString("coffee");
+
+        // when nothing
+
+        // then
+        verifyZeroInteractions(listener);
+    }
+
+    @Test
+    public void should_allow_same_listener() {
+        // given
+        AnswerListener listener = mock(AnswerListener.class);
+        Foo foo = mock(Foo.class, withSettings().stubbingLookupListeners(listener, listener));
+
+        // when
+        foo.giveMeSomeString("tea");
+        foo.giveMeSomeString("coke");
+
+        // then each listener was notified 2 times (notified 4 times in total)
+        verify(listener, times(4)).onStubbingLookup(any(StubbingLookupEvent.class));
+    }
+
+    @Test
+    public void should_call_all_listeners_in_order() {
+        // given
+        AnswerListener listener1 = mock(AnswerListener.class);
+        AnswerListener listener2 = mock(AnswerListener.class);
+        Foo foo = mock(Foo.class, withSettings().stubbingLookupListeners(listener1, listener2));
+        doReturn("sprite").when(foo).giveMeSomeString("soda");
+
+        // when
+        foo.giveMeSomeString("soda");
+
+        // then
+        InOrder inOrder = inOrder(listener1, listener2);
+        inOrder.verify(listener1).onStubbingLookup(any(StubbingLookupEvent.class));
+        inOrder.verify(listener2).onStubbingLookup(any(StubbingLookupEvent.class));
+    }
+
+    @Test
+    public void should_call_all_listeners_when_mock_throws_exception() {
+        // given
+        AnswerListener listener1 = mock(AnswerListener.class);
+        AnswerListener listener2 = mock(AnswerListener.class);
+        Foo foo = mock(Foo.class, withSettings().stubbingLookupListeners(listener1, listener2));
+        doThrow(new NoWater()).when(foo).giveMeSomeString("tea");
+
+        // when
+        try {
+            foo.giveMeSomeString("tea");
+            fail();
+        } catch (NoWater e) {
+            // then
+            verify(listener1).onStubbingLookup(any(StubbingLookupEvent.class));
+            verify(listener2).onStubbingLookup(any(StubbingLookupEvent.class));
+        }
+    }
+
+    //TODO x deleted listener
+
+    private static class AnswerListener implements StubbingLookupListener {
+        private Invocation invocation;
+        private Stubbing stubbing;
+        private Collection<Stubbing> allStubbings;
+        private MockCreationSettings mockSettings;
+
+        public AnswerListener() {}
+
+        public void onStubbingLookup(StubbingLookupEvent event) {
+            this.invocation = event.getInvocation();
+            this.stubbing = event.getStubbingFound();
+            this.allStubbings = event.getAllStubbings();
+            this.mockSettings = event.getMockSettings();
+        }
+    }
+
+    private static class NoWater extends RuntimeException {}
+}


### PR DESCRIPTION
Exposed new public API based on an internal API - StubbingLookupListener - #793.

As a rule of a thumb we try to expose the internal APIs that the top level features are built upon. Since StubbingLookupListener is useful for us to implement strictness, let's get the former exposed as public API. This way we build stronger framework with the concept of "onion skin API".

This PR replaces #1466 - very nice PR from @marchpig. Due to number of changes I needed to do, I decided to reimplement the feature, rather than use the original PR. @marchpig, thank you for understanding!