### PR TITLE
Fixes #1541: Prevent premature garbage collection of mock objects

### DIFF
--- a/src/main/java/org/mockito/internal/stubbing/BaseStubbing.java
+++ b/src/main/java/org/mockito/internal/stubbing/BaseStubbing.java
@@ -4,15 +4,15 @@
  */
 package org.mockito.internal.stubbing;
 
-import static org.mockito.internal.exceptions.Reporter.notAnException;
-import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
-import static org.objenesis.ObjenesisHelper.newInstance;
-
 import org.mockito.internal.stubbing.answers.CallsRealMethods;
 import org.mockito.internal.stubbing.answers.Returns;
 import org.mockito.internal.stubbing.answers.ThrowsException;
 import org.mockito.stubbing.Answer;
 import org.mockito.stubbing.OngoingStubbing;
+
+import static org.mockito.internal.exceptions.Reporter.notAnException;
+import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
+import static org.objenesis.ObjenesisHelper.newInstance;
 
 public abstract class BaseStubbing<T> implements OngoingStubbing<T> {
 
@@ -20,8 +20,8 @@ public abstract class BaseStubbing<T> implements OngoingStubbing<T> {
     // Keep strong ref to mock preventing premature garbage collection when using 'One-liner stubs'. See #1541.
     private final Object strongMockRef;
 
-    public BaseStubbing(InvocationContainerImpl invocationContainer) {
-        this.strongMockRef = invocationContainer.invokedMock();
+    BaseStubbing(Object mock) {
+        this.strongMockRef = mock;
     }
 
     @Override

--- a/src/main/java/org/mockito/internal/stubbing/BaseStubbing.java
+++ b/src/main/java/org/mockito/internal/stubbing/BaseStubbing.java
@@ -11,9 +11,23 @@ import static org.objenesis.ObjenesisHelper.newInstance;
 import org.mockito.internal.stubbing.answers.CallsRealMethods;
 import org.mockito.internal.stubbing.answers.Returns;
 import org.mockito.internal.stubbing.answers.ThrowsException;
+import org.mockito.stubbing.Answer;
 import org.mockito.stubbing.OngoingStubbing;
 
 public abstract class BaseStubbing<T> implements OngoingStubbing<T> {
+
+
+    // Keep strong ref to mock preventing premature garbage collection when using 'One-liner stubs'. See #1541.
+    private final Object strongMockRef;
+
+    public BaseStubbing(InvocationContainerImpl invocationContainer) {
+        this.strongMockRef = invocationContainer.invokedMock();
+    }
+
+    @Override
+    public OngoingStubbing<T> then(Answer<?> answer) {
+        return thenAnswer(answer);
+    }
 
     @Override
     public OngoingStubbing<T> thenReturn(T value) {
@@ -78,6 +92,12 @@ public abstract class BaseStubbing<T> implements OngoingStubbing<T> {
     @Override
     public OngoingStubbing<T> thenCallRealMethod() {
         return thenAnswer(new CallsRealMethods());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <M> M getMock() {
+        return (M) this.strongMockRef;
     }
 }
 

--- a/src/main/java/org/mockito/internal/stubbing/ConsecutiveStubbing.java
+++ b/src/main/java/org/mockito/internal/stubbing/ConsecutiveStubbing.java
@@ -8,23 +8,17 @@ import org.mockito.stubbing.Answer;
 import org.mockito.stubbing.OngoingStubbing;
 
 public class ConsecutiveStubbing<T> extends BaseStubbing<T> {
-    private final InvocationContainerImpl invocationContainerImpl;
 
-    public ConsecutiveStubbing(InvocationContainerImpl invocationContainerImpl) {
-        this.invocationContainerImpl = invocationContainerImpl;
+    private final InvocationContainerImpl invocationContainer;
+
+    public ConsecutiveStubbing(InvocationContainerImpl invocationContainer) {
+        super(invocationContainer);
+        this.invocationContainer = invocationContainer;
     }
 
     public OngoingStubbing<T> thenAnswer(Answer<?> answer) {
-        invocationContainerImpl.addConsecutiveAnswer(answer);
+        invocationContainer.addConsecutiveAnswer(answer);
         return this;
     }
 
-    public OngoingStubbing<T> then(Answer<?> answer) {
-        return thenAnswer(answer);
-    }
-
-    @SuppressWarnings("unchecked")
-    public <M> M getMock() {
-        return (M) invocationContainerImpl.invokedMock();
-    }
 }

--- a/src/main/java/org/mockito/internal/stubbing/ConsecutiveStubbing.java
+++ b/src/main/java/org/mockito/internal/stubbing/ConsecutiveStubbing.java
@@ -11,8 +11,8 @@ public class ConsecutiveStubbing<T> extends BaseStubbing<T> {
 
     private final InvocationContainerImpl invocationContainer;
 
-    public ConsecutiveStubbing(InvocationContainerImpl invocationContainer) {
-        super(invocationContainer);
+    ConsecutiveStubbing(InvocationContainerImpl invocationContainer) {
+        super(invocationContainer.invokedMock());
         this.invocationContainer = invocationContainer;
     }
 

--- a/src/main/java/org/mockito/internal/stubbing/OngoingStubbingImpl.java
+++ b/src/main/java/org/mockito/internal/stubbing/OngoingStubbingImpl.java
@@ -19,7 +19,7 @@ public class OngoingStubbingImpl<T> extends BaseStubbing<T> {
     private Strictness strictness;
 
     public OngoingStubbingImpl(InvocationContainerImpl invocationContainer) {
-        super(invocationContainer);
+        super(invocationContainer.invokedMock());
         this.invocationContainer = invocationContainer;
     }
 

--- a/src/main/java/org/mockito/internal/stubbing/OngoingStubbingImpl.java
+++ b/src/main/java/org/mockito/internal/stubbing/OngoingStubbingImpl.java
@@ -19,6 +19,7 @@ public class OngoingStubbingImpl<T> extends BaseStubbing<T> {
     private Strictness strictness;
 
     public OngoingStubbingImpl(InvocationContainerImpl invocationContainer) {
+        super(invocationContainer);
         this.invocationContainer = invocationContainer;
     }
 
@@ -32,20 +33,9 @@ public class OngoingStubbingImpl<T> extends BaseStubbing<T> {
         return new ConsecutiveStubbing<T>(invocationContainer);
     }
 
-    @Override
-    public OngoingStubbing<T> then(Answer<?> answer) {
-        return thenAnswer(answer);
-    }
-
     public List<Invocation> getRegisteredInvocations() {
         //TODO interface for tests
         return invocationContainer.getInvocations();
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public <M> M getMock() {
-        return (M) invocationContainer.invokedMock();
     }
 
     public void setStrictness(Strictness strictness) {

--- a/subprojects/inline/inline.gradle
+++ b/subprojects/inline/inline.gradle
@@ -9,5 +9,6 @@ dependencies {
 
 tasks.javadoc.enabled = false
 
-//required by the "StressTest.java"
+//required by the "StressTest.java" and "OneLinerStubStressTest.java"
 test.maxHeapSize = "256m"
+retryTest.maxHeapSize = "256m"

--- a/subprojects/inline/src/test/java/org/mockitoinline/OneLinerStubStressTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/OneLinerStubStressTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2018 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitoinline;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class OneLinerStubStressTest {
+
+    public class OneLinerStubTestClass {
+        public String getStuff() {
+            return "A";
+        }
+    }
+
+    private static String generateLargeString() {
+        final int length = 1000000;
+        final StringBuilder stringBuilder = new StringBuilder(length);
+        for (int i = 0; i <= length; i++) {
+            stringBuilder.append("B");
+        }
+        return stringBuilder.toString();
+    }
+
+    @Test
+    public void call_a_lot_of_mocks_using_one_line_stubbing() {
+        //This requires smaller heap set for the test process, see "inline.gradle"
+        final String returnValue = generateLargeString();
+        for (int i = 0; i < 50000; i++) {
+            // make sure that mock object does not get cleaned up prematurely
+            final OneLinerStubTestClass mock =
+                when(mock(OneLinerStubTestClass.class).getStuff()).thenReturn(returnValue).getMock();
+            assertEquals(returnValue, mock.getStuff());
+        }
+    }
+}

--- a/subprojects/inline/src/test/java/org/mockitoinline/OneLinerStubStressTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/OneLinerStubStressTest.java
@@ -19,7 +19,7 @@ public class OneLinerStubStressTest {
     }
 
     private static String generateLargeString() {
-        final int length = 1000000;
+        final int length = 2000000;
         final StringBuilder stringBuilder = new StringBuilder(length);
         for (int i = 0; i <= length; i++) {
             stringBuilder.append("B");


### PR DESCRIPTION
Fixes #1541.

If using 'One-liner stubs' (https://static.javadoc.io/org.mockito/mockito-core/2.23.4/org/mockito/Mockito.html#one_liner_stub) the mock object may be premature cleaned up and returning the mock fails with an exception. This occurs because there is no strong reference to the mock itself.

Therefore we need to maintain a strong reference to the mock until we've returned it, while making sure that the GC can still cleanup the mock correctly when needed.

Cause implementations of `BaseStubbing` are intended to be cleaned up after usage, we can store a strong ref to the mock there. `getMock` then uses the strong ref (instead of the weak ref provided by the invocation). After cleaning up the implementations of  `BaseStubbing` there is no strong ref to the mock itself anymore (except the one in the test class).

I tried some alternative solutions but I believe this is the only way it works.

----

Bind last mock creation to mockingProgress does not work because of this:
```
when(mock(TestClass2.class).getTestClass()).thenReturn(mock(TestClass.class)).getMock();
```

Bind mock of last invocation for stubbing to mockingProgress does not work because of this:
```
when(mock(TestClass.class).getStuff()).thenReturn("X").thenReturn(
    when(mock(TestClass.class).getStuff()).thenReturn("XXX").<TestClass>getMock().getStuff()
).getMock();
```