### PR TITLE
Enable gradle build cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ bin/
 
 # Gradle & builds
 build
+build-cache
 target
 out
 .gradle

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.daemon=true
 org.gradle.parallel=true
+org.gradle.caching=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,9 +20,7 @@ rootProject.children.each { project ->
 enableFeaturePreview('STABLE_PUBLISHING')
 
 buildCache {
-    local(DirectoryBuildCache) {
+    local {
         enabled = !System.getenv().containsKey("CI")
-        directory = new File(rootDir, 'build-cache')
-        removeUnusedEntriesAfterDays = 30
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,6 +21,7 @@ enableFeaturePreview('STABLE_PUBLISHING')
 
 buildCache {
     local(DirectoryBuildCache) {
+        enabled = !System.getenv().containsKey("CI")
         directory = new File(rootDir, 'build-cache')
         removeUnusedEntriesAfterDays = 30
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,3 +18,10 @@ rootProject.children.each { project ->
 }
 
 enableFeaturePreview('STABLE_PUBLISHING')
+
+buildCache {
+    local(DirectoryBuildCache) {
+        directory = new File(rootDir, 'build-cache')
+        removeUnusedEntriesAfterDays = 30
+    }
+}


### PR DESCRIPTION
This pr fixes #1545.

I was not entirely sure about the settings to choose for the local build cache.
Let's discuss if we should go for a local folder and if keeping cache entries for 30 days is ok. 

check list

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/2.x/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [ ] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [ ] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [ ] At least one commit should mention `Fixes #<issue number>` _if relevant_

