### PR TITLE
Bumped Gradle to last 4.x

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,2 @@
 org.gradle.daemon=true
 org.gradle.parallel=true
-org.gradle.caching=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.daemon=true
 org.gradle.parallel=true
+org.gradle.caching=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=e66e69dce8173dd2004b39ba93586a184628bc6c28461bc771d6835f7f9b0d28
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Let's stick to 4.x for now. We will use Gradle 5 after we verify that all our plugins work with 5.x.