### PR TITLE
Fixed issue with leftover state when stubbing with bad throwables

### DIFF
--- a/src/main/java/org/mockito/internal/stubbing/StubberImpl.java
+++ b/src/main/java/org/mockito/internal/stubbing/StubberImpl.java
@@ -87,12 +87,16 @@ public class StubberImpl implements Stubber {
             mockingProgress().reset();
             throw notAnException();
         }
-        Throwable e;
+        Throwable e = null;
         try {
             e = newInstance(toBeThrown);
-        } catch (RuntimeException instantiationError) {
-            mockingProgress().reset();
-            throw instantiationError;
+        } finally {
+            if (e == null) {
+                //this means that an exception or error was thrown when trying to create new instance
+                //we don't want 'catch' statement here because we want the exception to be thrown to the user
+                //however, we do want to clean up state (e.g. "stubbing started").
+                mockingProgress().reset();
+            }
         }
         return doThrow(e);
     }

--- a/src/test/java/org/mockitousage/stubbing/StubbingWithBadThrowablesTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingWithBadThrowablesTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage.stubbing;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockitoutil.TestBase;
+
+import java.util.List;
+
+import static org.mockito.Mockito.doThrow;
+
+//issue 1514
+@SuppressWarnings({ "serial", "unchecked", "rawtypes" })
+public class StubbingWithBadThrowablesTest extends TestBase {
+
+    @Mock List mock;
+
+    @Test
+    public void handles_bad_exception() {
+        Assertions.assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            public void call() {
+                doThrow(UninstantiableException.class).when(mock).clear();
+            }
+        }).isInstanceOf(InstantiationError.class); //because the exception cannot be instantiated
+
+        //ensure that the state is cleaned
+        Mockito.validateMockitoUsage();
+    }
+
+    abstract static class UninstantiableException extends RuntimeException {}
+}

--- a/subprojects/junit-jupiter/src/test/java/org/mockitousage/UninstantiableThrowableTest.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockitousage/UninstantiableThrowableTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.RepetitionInfo;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+//issue 1514
+class UninstantiableThrowableTest {
+
+    @RepeatedTest(2)
+    void should_behave_consistently(RepetitionInfo i) {
+        List mock = Mockito.mock(List.class);
+        if (i.getCurrentRepetition() == 1) {
+            Assertions.assertThatThrownBy(
+                () -> Mockito.doThrow(UninstantiableException.class).when(mock).clear())
+                .isInstanceOf(InstantiationError.class);
+        }
+
+        // The following operation results in "UnfinishedStubbing"
+        Mockito.doThrow(RuntimeException.class).when(mock).clear();
+    }
+
+    abstract static class UninstantiableException extends RuntimeException { }
+}


### PR DESCRIPTION
Fixed issue with leftover state when stubbing with bad throwables. Fixes #1514