### PR TITLE
Fixes #1553: Fix error when JUnit 3 is in the classpath.

### DIFF
--- a/src/main/java/org/mockito/internal/junit/ExceptionFactory.java
+++ b/src/main/java/org/mockito/internal/junit/ExceptionFactory.java
@@ -33,6 +33,8 @@ public class ExceptionFactory {
             JUnitArgsAreDifferent.create("message", "wanted", "actual");
         } catch (NoClassDefFoundError onlyIfJUnitIsNotAvailable) {
             return false;
+        } catch (VerifyError onlyIfJUnitIsIncompatible) {
+            return false;
         }
         return true;
     }

--- a/src/main/java/org/mockito/internal/junit/ExceptionFactory.java
+++ b/src/main/java/org/mockito/internal/junit/ExceptionFactory.java
@@ -31,9 +31,7 @@ public class ExceptionFactory {
     private static boolean canLoadJunitClass() {
         try {
             JUnitArgsAreDifferent.create("message", "wanted", "actual");
-        } catch (NoClassDefFoundError onlyIfJUnitIsNotAvailable) {
-            return false;
-        } catch (VerifyError onlyIfJUnitIsIncompatible) {
+        } catch (Throwable onlyIfJUnitIsNotAvailable) {
             return false;
         }
         return true;


### PR DESCRIPTION
Mockito will throw VerifyError during its JUnit detection when JUnit 3
is in the classpath, because the code only supports JUnit 4 and later.
This change will catch this error and pretend that JUnit is not there.
