### PR TITLE
Fixed JaCoCo build cache issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,5 +58,5 @@ script:
 
 after_success:
   #Generates coverage report:
-  - ./gradlew --stacktrace coverageReport && cp build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml jacoco.xml || echo "Code coverage failed"
+  - ./gradlew coverageReport -Pjacoco -s && cp build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml jacoco.xml || echo "Code coverage failed"
   - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,5 +58,5 @@ script:
 
 after_success:
   #Generates coverage report:
-  - ./gradlew coverageReport -Pjacoco -s && cp build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml jacoco.xml || echo "Code coverage failed"
+  - ./gradlew coverageReport -Pjacoco -s --scan && cp build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml jacoco.xml || echo "Code coverage failed"
   - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.gradle.build-scan' version '1.15.1'
+    id 'com.gradle.build-scan' version '1.16'
 }
 
 description = 'Mockito mock objects library core API and implementation'

--- a/gradle/root/coverage.gradle
+++ b/gradle/root/coverage.gradle
@@ -1,3 +1,11 @@
+if (!project.hasProperty("jacoco")) {
+    //JaCoCo plugin prevents using Build Cache. We will enable jacoco configuration only when specific property is supplied
+    logger.info "JaCoCo code coverage will not be configured because 'jacoco' project property is not present."
+    return //don't evaluate this Gradle file any further
+} else {
+    logger.lifecycle "Configuring JaCoCo code coverage because 'jacoco' project property is present."
+}
+
 //TODO: Standard JaCoCo coverage doesn't work in Android module
 task mockitoCoverage(type: JacocoReport) {
 

--- a/gradle/root/coverage.gradle
+++ b/gradle/root/coverage.gradle
@@ -1,5 +1,6 @@
 if (!project.hasProperty("jacoco")) {
     //JaCoCo plugin prevents using Build Cache. We will enable jacoco configuration only when specific property is supplied
+    //TODO remove this workaround when we migrate to Gradle 5.0 (https://github.com/gradle/gradle/issues/5269)
     logger.info "JaCoCo code coverage will not be configured because 'jacoco' project property is not present."
     return //don't evaluate this Gradle file any further
 } else {


### PR DESCRIPTION
Jacoco Gradle plugin breaks cacheability, hence we only configure the plugin on demand.

Bumped Build Scans plugin so that it is easier to debug build cache issues.

This PR is needed for #1546