### PR TITLE
Fixes Issue #1542: When verify fails show all method invocations

### DIFF
--- a/src/main/java/org/mockito/internal/exceptions/Reporter.java
+++ b/src/main/java/org/mockito/internal/exceptions/Reporter.java
@@ -307,20 +307,21 @@ public class Reporter {
 
         StringBuilder actualBuilder = new StringBuilder();
         StringBuilder messageBuilder = new StringBuilder();
-        messageBuilder.append("\n");
-        messageBuilder.append("Argument(s) are different! Wanted:\n");
-        messageBuilder.append(wanted);
-        messageBuilder.append("\n");
-        messageBuilder.append(new LocationImpl());
-        messageBuilder.append("\n");
-        messageBuilder.append("Actual invocations have different arguments:\n");
+        messageBuilder.append("\n")
+        .append("Argument(s) are different! Wanted:\n")
+        .append(wanted)
+        .append("\n")
+        .append(new LocationImpl())
+        .append("\n")
+        .append("Actual invocations have different arguments:\n");
         for (int i = 0; i < actualCalls.size(); i++) {
-            actualBuilder.append(actualCalls.get(i));
+            actualBuilder.append(actualCalls.get(i))
+                .append("\n");
 
-            messageBuilder.append(actualCalls.get(i));
-            messageBuilder.append("\n");
-            messageBuilder.append(actualLocations.get(i));
-            messageBuilder.append("\n");
+            messageBuilder.append(actualCalls.get(i))
+            .append("\n")
+            .append(actualLocations.get(i))
+            .append("\n");
         }
 
         return ExceptionFactory.createArgumentsAreDifferentException(messageBuilder.toString(), wanted, actualBuilder.toString());

--- a/src/main/java/org/mockito/internal/exceptions/Reporter.java
+++ b/src/main/java/org/mockito/internal/exceptions/Reporter.java
@@ -299,17 +299,31 @@ public class Reporter {
         return join(description.toArray());
     }
 
-    public static AssertionError argumentsAreDifferent(String wanted, String actual, Location actualLocation) {
-        String message = join("Argument(s) are different! Wanted:",
-                              wanted,
-                              new LocationImpl(),
-                              "Actual invocation has different arguments:",
-                              actual,
-                              actualLocation,
-                              ""
-        );
+    public static AssertionError argumentsAreDifferent(String wanted, List<String> actualCalls, List<Location> actualLocations) {
+        if (actualCalls == null || actualLocations == null || actualCalls.size() != actualLocations.size()) {
+            throw new IllegalArgumentException("actualCalls and actualLocations list must match");
+        }
 
-        return ExceptionFactory.createArgumentsAreDifferentException(message, wanted, actual);
+
+        StringBuilder actualBuilder = new StringBuilder();
+        StringBuilder messageBuilder = new StringBuilder();
+        messageBuilder.append("\n");
+        messageBuilder.append("Argument(s) are different! Wanted:\n");
+        messageBuilder.append(wanted);
+        messageBuilder.append("\n");
+        messageBuilder.append(new LocationImpl());
+        messageBuilder.append("\n");
+        messageBuilder.append("Actual invocations have different arguments:\n");
+        for (int i = 0; i < actualCalls.size(); i++) {
+            actualBuilder.append(actualCalls.get(i));
+
+            messageBuilder.append(actualCalls.get(i));
+            messageBuilder.append("\n");
+            messageBuilder.append(actualLocations.get(i));
+            messageBuilder.append("\n");
+        }
+
+        return ExceptionFactory.createArgumentsAreDifferentException(messageBuilder.toString(), wanted, actualBuilder.toString());
     }
 
     public static MockitoAssertionError wantedButNotInvoked(DescribedInvocation wanted) {

--- a/src/main/java/org/mockito/internal/verification/checkers/MissingInvocationChecker.java
+++ b/src/main/java/org/mockito/internal/verification/checkers/MissingInvocationChecker.java
@@ -17,8 +17,10 @@ import static org.mockito.internal.verification.argumentmatching.ArgumentMatchin
 import java.util.List;
 
 import org.mockito.internal.reporting.SmartPrinter;
+import org.mockito.internal.util.collections.ListUtil;
 import org.mockito.internal.verification.api.InOrderContext;
 import org.mockito.invocation.Invocation;
+import org.mockito.invocation.Location;
 import org.mockito.invocation.MatchableInvocation;
 
 public class MissingInvocationChecker {
@@ -39,8 +41,15 @@ public class MissingInvocationChecker {
         }
 
         Integer[] indexesOfSuspiciousArgs = getSuspiciouslyNotMatchingArgsIndexes(wanted.getMatchers(), similar.getArguments());
-        SmartPrinter smartPrinter = new SmartPrinter(wanted, similar, indexesOfSuspiciousArgs);
-        throw argumentsAreDifferent(smartPrinter.getWanted(), smartPrinter.getActual(), similar.getLocation());
+        SmartPrinter smartPrinter = new SmartPrinter(wanted, invocations, indexesOfSuspiciousArgs);
+        List<Location> actualLocations = ListUtil.convert(invocations, new ListUtil.Converter<Invocation, Location>() {
+            @Override
+            public Location convert(Invocation invocation) {
+                return invocation.getLocation();
+            }
+        });
+
+        throw argumentsAreDifferent(smartPrinter.getWanted(), smartPrinter.getActuals(), actualLocations);
 
     }
 

--- a/src/test/java/org/mockito/internal/verification/SmartPrinterTest.java
+++ b/src/test/java/org/mockito/internal/verification/SmartPrinterTest.java
@@ -36,7 +36,9 @@ public class SmartPrinterTest extends TestBase {
 
         //then
         assertThat(printer.getWanted()).contains("\n");
-        assertThat(printer.getActual()).contains("\n");
+        for (String actual : printer.getActuals()) {
+            assertThat(actual).contains("\n");
+        }
     }
 
     @Test
@@ -46,7 +48,9 @@ public class SmartPrinterTest extends TestBase {
 
         //then
         assertThat(printer.getWanted()).contains("\n");
-        assertThat(printer.getActual()).contains("\n");
+        for (String actual : printer.getActuals()) {
+            assertThat(actual).contains("\n");
+        }
     }
 
     @Test
@@ -56,7 +60,9 @@ public class SmartPrinterTest extends TestBase {
 
         //then
         assertThat(printer.getWanted()).contains("\n");
-        assertThat(printer.getActual()).contains("\n");
+        for (String actual : printer.getActuals()) {
+            assertThat(actual).contains("\n");
+        }
     }
 
     @Test
@@ -66,6 +72,8 @@ public class SmartPrinterTest extends TestBase {
 
         //then
         assertThat(printer.getWanted()).doesNotContain("\n");
-        assertThat(printer.getActual()).doesNotContain("\n");
+        for (String actual : printer.getActuals()) {
+            assertThat(actual).doesNotContain("\n");
+        }
     }
 }

--- a/src/test/java/org/mockito/internal/verification/checkers/MissingInvocationCheckerTest.java
+++ b/src/test/java/org/mockito/internal/verification/checkers/MissingInvocationCheckerTest.java
@@ -62,7 +62,7 @@ public class MissingInvocationCheckerTest extends TestBase {
 
 		exception.expectMessage("Argument(s) are different! Wanted:");
 		exception.expectMessage("mock.intArgumentMethod(2222);");
-		exception.expectMessage("Actual invocation has different arguments:");
+		exception.expectMessage("Actual invocations have different arguments:");
 		exception.expectMessage("mock.intArgumentMethod(1111);");
 
 		MissingInvocationChecker.checkMissingInvocation(invocations, wanted);

--- a/src/test/java/org/mockito/internal/verification/checkers/MissingInvocationInOrderCheckerTest.java
+++ b/src/test/java/org/mockito/internal/verification/checkers/MissingInvocationInOrderCheckerTest.java
@@ -77,7 +77,7 @@ public class MissingInvocationInOrderCheckerTest  {
 
 		exception.expectMessage("Argument(s) are different! Wanted:");
 		exception.expectMessage("mock.intArgumentMethod(2222);");
-		exception.expectMessage("Actual invocation has different arguments:");
+		exception.expectMessage("Actual invocations have different arguments:");
 		exception.expectMessage("mock.intArgumentMethod(1111);");
 
     	checkMissingInvocation(invocations, wanted, context);

--- a/src/test/java/org/mockitousage/verification/DescriptiveMessagesOnVerificationInOrderErrorsTest.java
+++ b/src/test/java/org/mockitousage/verification/DescriptiveMessagesOnVerificationInOrderErrorsTest.java
@@ -97,7 +97,7 @@ public class DescriptiveMessagesOnVerificationInOrderErrorsTest extends TestBase
             inOrder.verify(one).simpleMethod(999);
             fail();
         } catch (org.mockito.exceptions.verification.junit.ArgumentsAreDifferent e) {
-            assertThat(e).hasMessageContaining("has different arguments");
+            assertThat(e).hasMessageContaining("have different arguments");
         }
     }
 

--- a/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
+++ b/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
@@ -82,7 +82,7 @@ public class DescriptiveMessagesWhenVerificationFailsTest extends TestBase {
 
             String actual =
                     "\n" +
-                    "Actual invocation has different arguments:" +
+                    "Actual invocations have different arguments:" +
                     "\n" +
                     "iMethods.varargs(1, 2);";
 
@@ -116,7 +116,7 @@ public class DescriptiveMessagesWhenVerificationFailsTest extends TestBase {
 
             String actual =
                     "\n" +
-                    "Actual invocation has different arguments:" +
+                    "Actual invocations have different arguments:" +
                     "\n" +
                     "iMethods.varargs(" +
                     "\n" +

--- a/src/test/java/org/mockitousage/verification/VerifyPrintsAllInvocationsOnErrorTest.java
+++ b/src/test/java/org/mockitousage/verification/VerifyPrintsAllInvocationsOnErrorTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage.verification;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+
+public class VerifyPrintsAllInvocationsOnErrorTest {
+
+    @Test
+    public void shouldPrintAllInvocationsOnError() {
+        ExampleBuilder mockBuilder = Mockito.mock(ExampleBuilder.class);
+        mockBuilder.with("key1", "val1");
+        mockBuilder.with("key2", "val2");
+        try {
+            Mockito.verify(mockBuilder).with("key1", "wrongValue");
+            fail();
+        }
+        catch (ArgumentsAreDifferent e) {
+            assertThat(e).hasMessageContaining("exampleBuilder.with(\"key1\", \"val1\")");
+            assertThat(e).hasMessageContaining("exampleBuilder.with(\"key2\", \"val2\"");
+        }
+    }
+
+
+    private static class ExampleBuilder {
+        public ExampleBuilder with(String key, String val) {
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes issue #1542 (when mock is called multiple times, and verify fails, the error message reports only the first invocation). From the issue, the idea is that showing all invocation would make it easier to see why something failed.

I have changed the behavior of the exception thrown and it's message now contains all method invocations instead of only the first one.
New format: 
```
Argument(s) are different! Wanted:
exampleBuilder.with("key1", "wrongValue");
-> at org.mockitousage.verification.VerifyPrintsAllInvocationsOnErrorTest.shouldPrintAllInvocationsOnError(VerifyPrintsAllInvocationsOnErrorTest.java:23)
Actual invocations have different arguments:
exampleBuilder.with("key1", "val1");
-> at org.mockitousage.verification.VerifyPrintsAllInvocationsOnErrorTest.shouldPrintAllInvocationsOnError(VerifyPrintsAllInvocationsOnErrorTest.java:20)
exampleBuilder.with("key2", "val2");
-> at org.mockitousage.verification.VerifyPrintsAllInvocationsOnErrorTest.shouldPrintAllInvocationsOnError(VerifyPrintsAllInvocationsOnErrorTest.java:21)
```