### PR TITLE
Use errorprone gradle plugin v0.6 and extract errorprone config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     dependencies {
         classpath 'gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.14.0'
         classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.4.4' //for 'java-compatibility-check.gradle'
-        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.15'
+        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.6'
 
         //Using buildscript.classpath so that we can resolve shipkit from maven local, during local testing
         classpath 'org.shipkit:shipkit:2.0.28'
@@ -51,10 +51,7 @@ allprojects { proj ->
         jcenter()
     }
     plugins.withId('java') {
-        proj.apply plugin: 'net.ltgt.errorprone'
-        proj.dependencies {
-            errorprone libraries.errorprone
-        }
+        proj.apply from: "$rootDir/gradle/errorprone.gradle"
     }
     tasks.withType(JavaCompile) {
         //I don't believe those warnings add value given modern IDEs

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -18,7 +18,7 @@ libraries.bytebuddy = "net.bytebuddy:byte-buddy:${versions.bytebuddy}"
 libraries.bytebuddyagent = "net.bytebuddy:byte-buddy-agent:${versions.bytebuddy}"
 libraries.bytebuddyandroid = "net.bytebuddy:byte-buddy-android:${versions.bytebuddy}"
 
-libraries.errorprone = 'com.google.errorprone:error_prone_core:2.3.1'
+libraries.errorprone = 'com.google.errorprone:error_prone_core:2.3.2'
 
 // objenesis 3.x with full Java 11 support requires Java 8, bump version when Java 7 support is dropped
 libraries.objenesis = 'org.objenesis:objenesis:2.6'

--- a/gradle/errorprone.gradle
+++ b/gradle/errorprone.gradle
@@ -1,0 +1,12 @@
+
+apply plugin: "net.ltgt.errorprone"
+
+if (JavaVersion.current() == JavaVersion.VERSION_1_8) {
+    dependencies {
+        errorproneJavac("com.google.errorprone:javac:9+181-r4173-1")
+    }
+}
+
+dependencies {
+    errorprone libraries.errorprone
+}


### PR DESCRIPTION
let's use latest errorprone plugin and extract errorprone configuration.

This should also make the build java11 ready.