### PR TITLE
Use jacoco 0.8.2

### DIFF
--- a/gradle/root/coverage.gradle
+++ b/gradle/root/coverage.gradle
@@ -17,7 +17,7 @@ task mockitoCoverage(type: JacocoReport) {
             apply plugin: "jacoco"
 
             jacoco {
-                toolVersion = '0.8.1' //Gradle 4.2.1 uses 0.7.8 by default
+                toolVersion = '0.8.2'
 
                 if (currentProject != rootProject) {   //already automatically enhanced in mockito main project as "java" plugin was applied before
                     applyTo test


### PR DESCRIPTION
jacoco 0.8.2 has experimental java 11 support.

see https://github.com/jacoco/jacoco/releases/tag/v0.8.2 for details

