### PR TITLE
Prevent StackOverflowError when processing reversed generics

### DIFF
--- a/src/main/java/org/mockito/internal/util/reflection/GenericMetadataSupport.java
+++ b/src/main/java/org/mockito/internal/util/reflection/GenericMetadataSupport.java
@@ -116,6 +116,12 @@ public abstract class GenericMetadataSupport {
             TypeVariable<?> typeParameter = typeParameters[i];
             Type actualTypeArgument = actualTypeArguments[i];
 
+            // Prevent registration of a cycle of TypeVariables. This can happen when we are processing
+            // type parameters in a Method, while we already processed the type parameters of a class.
+            if (actualTypeArgument instanceof TypeVariable && contextualActualTypeParameters.containsKey(typeParameter)) {
+                continue;
+            }
+
             if (actualTypeArgument instanceof WildcardType) {
                 contextualActualTypeParameters.put(typeParameter, boundsOf((WildcardType) actualTypeArgument));
             } else if (typeParameter != actualTypeArgument) {


### PR DESCRIPTION
When processing the reverse method, the type parameters are actually
reversed compared to the type parameters in the class. This subsequently
confuses GenericMetadataSupport, as it creates a cycle in
`contextualActualTypeParameters`. In that case A resolves to B, while B
resolves to A.

The root cause is that we are processing type parameters of methods,
while we already processed them in the class declaration. Therefore,
ignore any type parameters if we already derived the appropriate
contextual type parameter.