### PR TITLE
Add warning to inline mock maker when running on a JRE

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
@@ -25,6 +25,8 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.JarOutputStream;
 
+import javax.tools.ToolProvider;
+
 import static org.mockito.internal.creation.bytebuddy.InlineBytecodeGenerator.EXCLUDES;
 import static org.mockito.internal.util.StringUtil.join;
 
@@ -170,7 +172,7 @@ public class InlineByteBuddyMockMaker implements ClassCreatingMockMaker {
         if (INITIALIZATION_ERROR != null) {
             throw new MockitoInitializationException(join(
                     "Could not initialize inline Byte Buddy mock maker. (This mock maker is not supported on Android.)",
-                    "",
+                    ToolProvider.getSystemJavaCompiler() == null ? "Are you running a JRE instead of a JDK? The inline mock maker needs to be run on a JDK.\n" : "",
                     Platform.describe()), INITIALIZATION_ERROR);
         }
         bytecodeGenerator = new TypeCachingBytecodeGenerator(new InlineBytecodeGenerator(INSTRUMENTATION, mocks), true);


### PR DESCRIPTION
I made a topic about this in the [mailing list](https://groups.google.com/forum/#!topic/mockito/vKhx3R4_doQ).

Long story short: the inline mock maker doesn't work when running on just a JRE, so I added a warning in the error message if that's that case. This would've saved me a lot of headache, so I figured I'd maybe help a poor soul that encounters this in the future.