### PR TITLE
Improve eclipse project setup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ buildscript {
 
 plugins {
     id 'com.gradle.build-scan' version '1.16'
+    id 'eclipse'
 }
 
 description = 'Mockito mock objects library core API and implementation'
@@ -98,6 +99,12 @@ buildScan {
 
 //workaround for #1444, delete when Shipkit bug is fixed
 subprojects {
+	eclipse {
+		project {
+			name = rootProject.name + '-' + project.name
+		}
+	}
+	
     afterEvaluate {
         def lib = publishing.publications.javaLibrary
         if(lib && !lib.artifactId.startsWith("mockito-")) {

--- a/subprojects/extTest/extTest.gradle
+++ b/subprojects/extTest/extTest.gradle
@@ -5,18 +5,12 @@ description = "End-to-end tests for Mockito and its extensions."
 
 sourceCompatibility = 1.8
 
-//so that we can depend on locally published mockito
-//and test end-to-end mockito jar resolution (for example, flesh out missing dependencies in pom file)
-[compileTestJava, ideaModule].each {
-    it.dependsOn ":publishToMavenLocal"
-}
-
 repositories {
     mavenLocal() //we depend on locally published mockito
 }
 
 dependencies {
-    testCompile "org.mockito:mockito-core:$version"
+    testCompile project.rootProject
     testCompile project(path: ':', configuration: 'testUtil')
     testCompile libraries.junit4
     testCompile libraries.assertj


### PR DESCRIPTION
A work in progress for #1568.
Sadly eclipse doesn't honor encoding setting in the gradle build file, so I can't fix that.
There's also still the problem with the `java.nio.file.Path` reference by `assertj-core`. My theory is that animal sniffer doesn't check dependencies properly, because `assertj-core` explicitly states that it requires at least java 7.