### PR TITLE
Fix/bug 1551 cce on smart not null answers

### DIFF
--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNulls.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNulls.java
@@ -72,8 +72,9 @@ public class ReturnsSmartNulls implements Answer<Object>, Serializable {
     }
 
     /**
-     * Try to resolve a given type using {@link ReturnsEmptyValues} and {@link ReturnsMoreEmptyValues}. This will also
-     * try to invoke interface on the current class and all it's superclass.
+     * Try to resolve the result value using {@link ReturnsEmptyValues} and {@link ReturnsMoreEmptyValues}.
+     *
+     * This will try to use all parent class (superclass & interfaces) to retrieve the value..
      *
      * @param type the return type of the method
      * @return a non-null instance if the type has been resolve. Null otherwise.
@@ -81,6 +82,7 @@ public class ReturnsSmartNulls implements Answer<Object>, Serializable {
     private Object delegateChains(final Class<?> type) {
         final ReturnsEmptyValues returnsEmptyValues = new ReturnsEmptyValues();
         Object result = returnsEmptyValues.returnValueFor(type);
+
         if (result == null) {
             Class<?> emptyValueForClass = type;
             while (emptyValueForClass != null && result == null) {
@@ -106,6 +108,7 @@ public class ReturnsSmartNulls implements Answer<Object>, Serializable {
      * Retrieve the expected type when it came from a primitive. If the type cannot be retrieve, return null.
      *
      * @param invocation the current invocation
+     * @param returnType the expected return type
      * @return the type or null if not found
      */
     private Class<?> findTypeFromGeneric(final InvocationOnMock invocation, final TypeVariable returnType) {
@@ -127,6 +130,7 @@ public class ReturnsSmartNulls implements Answer<Object>, Serializable {
      * Find a return type using generic arguments provided by the calling method.
      *
      * @param invocation the current invocation
+     * @param returnType the expected return type
      * @return the return type or null if the return type cannot be found
      */
     private Class<?> findTypeFromGenericInArguments(final InvocationOnMock invocation, final TypeVariable returnType) {

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNulls.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNulls.java
@@ -9,11 +9,16 @@ import static org.mockito.internal.util.ObjectMethodsGuru.isToStringMethod;
 
 import java.io.Serializable;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 
 import org.mockito.Mockito;
 import org.mockito.internal.debugging.LocationImpl;
+import org.mockito.internal.util.MockUtil;
+import org.mockito.internal.util.reflection.GenericMetadataSupport;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.invocation.Location;
+import org.mockito.mock.MockCreationSettings;
 import org.mockito.stubbing.Answer;
 
 /**
@@ -46,15 +51,98 @@ public class ReturnsSmartNulls implements Answer<Object>, Serializable {
             return defaultReturnValue;
         }
         Class<?> type = invocation.getMethod().getReturnType();
-        if (!type.isPrimitive() && !Modifier.isFinal(type.getModifiers())) {
+
+        final Type returnType = invocation.getMethod().getGenericReturnType();
+        if (returnType instanceof TypeVariable) {
+            type = findTypeFromGeneric(invocation);
+            if (type != null) {
+                defaultReturnValue = delegateChains(type);
+            }
+        }
+        if (defaultReturnValue != null) {
+            return defaultReturnValue;
+        }
+
+        if (type != null && !type.isPrimitive() && !Modifier.isFinal(type.getModifiers())) {
             final Location location = new LocationImpl();
             return Mockito.mock(type, new ThrowsSmartNullPointer(invocation, location));
         }
         return null;
     }
 
+    /**
+     * Try to resolve a given type using {@link ReturnsEmptyValues} and {@link ReturnsMoreEmptyValues}. This will also
+     * try to invoke interface on the current class and all it's superclass.
+     *
+     * @param type the return type of the method
+     * @return a non-null instance if the type has been resolve. Null otherwise.
+     */
+    private Object delegateChains(final Class<?> type) {
+        final ReturnsEmptyValues returnsEmptyValues = new ReturnsEmptyValues();
+        Object result = returnsEmptyValues.returnValueFor(type);
+        if (result == null) {
+            Class<?> emptyValueForClass = type;
+            while (emptyValueForClass != null && result == null) {
+                final Class<?>[] classes = emptyValueForClass.getInterfaces();
+                for (Class<?> clazz : classes) {
+                    result = returnsEmptyValues.returnValueFor(clazz);
+                    if (result != null) {
+                        break;
+                    }
+                }
+                emptyValueForClass = emptyValueForClass.getSuperclass();
+            }
+        }
+
+        if (result == null) {
+            result = new ReturnsMoreEmptyValues().returnValueFor(type);
+        }
+
+        return result;
+    }
+
+    /**
+     * Retrieve the expected type when it came from a primitive. If the type cannot be retrieve, return null.
+     *
+     * @param invocation the current invocation
+     * @return the type or null if not found
+     */
+    private Class<?> findTypeFromGeneric(final InvocationOnMock invocation) {
+        // Class level
+        final MockCreationSettings mockSettings = MockUtil.getMockHandler(invocation.getMock()).getMockSettings();
+        final GenericMetadataSupport returnType = GenericMetadataSupport
+            .inferFrom(mockSettings.getTypeToMock())
+            .resolveGenericReturnType(invocation.getMethod());
+        final Class<?> rawType = returnType.rawType();
+
+        // Method level
+        if (rawType == Object.class) {
+            return findTypeFromGenericInArguments(invocation);
+        }
+        return rawType;
+    }
+
+    /**
+     * Find a return type using generic arguments provided by the calling method.
+     *
+     * @param invocation the current invocation
+     * @return the return type or null if the return type cannot be found
+     */
+    private Class<?> findTypeFromGenericInArguments(final InvocationOnMock invocation) {
+        final Type returnType = invocation.getMethod().getGenericReturnType();
+        final Type[] parameterTypes = invocation.getMethod().getGenericParameterTypes();
+        for (int i = 0; i < parameterTypes.length; i++) {
+            if (parameterTypes[i] instanceof TypeVariable && returnType.equals(parameterTypes[i])) {
+                return invocation.getArgument(i).getClass();
+            }
+        }
+        return null;
+    }
+
     private static class ThrowsSmartNullPointer implements Answer {
+
         private final InvocationOnMock unstubbedInvocation;
+
         private final Location location;
 
         public ThrowsSmartNullPointer(InvocationOnMock unstubbedInvocation, Location location) {
@@ -65,7 +153,7 @@ public class ReturnsSmartNulls implements Answer<Object>, Serializable {
         public Object answer(InvocationOnMock currentInvocation) throws Throwable {
             if (isToStringMethod(currentInvocation.getMethod())) {
                 return "SmartNull returned by this unstubbed method call on a mock:\n" +
-                        unstubbedInvocation.toString();
+                    unstubbedInvocation.toString();
             }
 
             throw smartNullPointerException(unstubbedInvocation.toString(), location);

--- a/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNullsTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNullsTest.java
@@ -4,21 +4,26 @@
  */
 package org.mockito.internal.stubbing.defaultanswers;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ThrowableAssert;
 import org.junit.Test;
 import org.mockito.exceptions.verification.SmartNullPointerException;
 import org.mockito.internal.debugging.LocationImpl;
 import org.mockito.internal.invocation.InterceptedInvocation;
 import org.mockito.internal.invocation.SerializableMethod;
 import org.mockito.internal.invocation.mockref.MockStrongReference;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.mockitoutil.TestBase;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
@@ -44,16 +49,6 @@ public class ReturnsSmartNullsTest extends TestBase {
         Foo withArgs(String oneArg, String otherArg);
     }
 
-    interface GenericFoo<T> {
-        T get();
-    }
-
-    interface GenericFooBar extends GenericFoo<Foo> {
-        <I> I method();
-        <I> I methodWithArgs(int firstArg, I secondArg);
-        <I> I methodWithVarArgs(int firstArg, I... secondArg);
-    }
-
     @Test
     public void should_return_an_object_that_fails_on_any_method_invocation_for_non_primitives() throws Throwable {
         Answer<Object> answer = new ReturnsSmartNulls();
@@ -75,109 +70,6 @@ public class ReturnsSmartNullsTest extends TestBase {
         assertThat(smartNull.toString())
             .contains("SmartNull returned by")
             .contains("foo.get()");
-    }
-
-    @Test
-    public void should_return_an_object_when_it_came_from_a_generic_defined_on_class() throws Throwable {
-        Answer<Object> answer = new ReturnsSmartNulls();
-
-        Foo smartNull = (Foo) answer.answer(invocationOf(GenericFooBar.class, "get"));
-
-        assertThat(smartNull.toString())
-            .contains("SmartNull returned by")
-            .contains("genericFooBar.get()");
-    }
-
-    @Test
-    public void should_return_an_object_when_it_came_from_a_generic_defined_on_method_without_infer() throws Throwable {
-
-        Answer<Object> answer = new ReturnsSmartNulls();
-
-        String smartNull = (String) answer.answer(invocationOf(GenericFooBar.class, "method"));
-
-        assertThat(smartNull).isNull();
-    }
-
-    @Test
-    public void should_return_an_object_when_it_came_from_a_generic_method() throws Throwable {
-
-        Answer<Object> answer = new ReturnsSmartNulls();
-
-        InvocationOnMock invocation = new InterceptedInvocation(
-            new MockStrongReference<Object>(mock(GenericFooBar.class), false),
-            new SerializableMethod(GenericFooBar.class.getMethod("methodWithArgs", int.class, Object.class)),
-            new Object[]{1, "secondArg"},
-            InterceptedInvocation.NO_OP,
-            new LocationImpl(),
-            1);
-
-        Object smartNull = answer.answer(invocation);
-
-        assertThat(smartNull)
-            .isNotNull()
-            .isInstanceOf(String.class)
-            .asString()
-            .isEmpty();
-    }
-
-    @Test
-    public void should_return_a_list_when_it_came_from_a_generic_method() throws Throwable {
-
-        Answer<Object> answer = new ReturnsSmartNulls();
-
-        InvocationOnMock invocation = new InterceptedInvocation(
-            new MockStrongReference<Object>(mock(GenericFooBar.class), false),
-            new SerializableMethod(GenericFooBar.class.getMethod("methodWithArgs", int.class, Object.class)),
-            new Object[]{1, Collections.singletonList("secondArg")},
-            InterceptedInvocation.NO_OP,
-            new LocationImpl(),
-            1);
-
-        Object smartNull = answer.answer(invocation);
-
-        assertThat(smartNull)
-            .isNotNull()
-            .isInstanceOf(List.class);
-    }
-
-    @Test
-    public void should_return_an_object_when_it_came_from_a_generic_method_using_a_mock_as_type() throws Throwable {
-
-        Answer<Object> answer = new ReturnsSmartNulls();
-
-        InvocationOnMock invocation = new InterceptedInvocation(
-            new MockStrongReference<Object>(mock(GenericFooBar.class), false),
-            new SerializableMethod(GenericFooBar.class.getMethod("methodWithArgs", int.class, Object.class)),
-            new Object[]{1, mock(GenericFooBar.class)},
-            InterceptedInvocation.NO_OP,
-            new LocationImpl(),
-            1);
-
-        Object smartNull = answer.answer(invocation);
-
-        assertThat(smartNull.toString())
-            .contains("SmartNull returned by")
-            .contains("genericFooBar.methodWithArgs(");
-    }
-
-    @Test
-    public void should_return_an_object_when_it_came_from_a_generic_method_using_Object_as_type() throws Throwable {
-
-        Answer<Object> answer = new ReturnsSmartNulls();
-
-        InvocationOnMock invocation = new InterceptedInvocation(
-            new MockStrongReference<Object>(mock(GenericFooBar.class), false),
-            new SerializableMethod(GenericFooBar.class.getMethod("methodWithArgs", int.class, Object.class)),
-            new Object[]{1, new Object() {}},
-            InterceptedInvocation.NO_OP,
-            new LocationImpl(),
-            1);
-
-        Object smartNull = answer.answer(invocation);
-
-        assertThat(smartNull.toString())
-            .contains("SmartNull returned by")
-            .contains("genericFooBar.methodWithArgs(");
     }
 
     @Test
@@ -207,4 +99,274 @@ public class ReturnsSmartNullsTest extends TestBase {
                 .hasMessageContaining("lumpa");
         }
     }
+
+    interface GenericFoo<T> {
+        T get();
+    }
+
+    interface GenericFooBar extends GenericFoo<Foo> {
+        <I> I method();
+        <I> I methodWithArgs(int firstArg, I secondArg);
+        <I> I methodWithVarArgs(int firstArg, I... secondArg);
+    }
+
+    @Test
+    public void should_return_an_object_that_has_been_defined_with_class_generic() throws Throwable {
+        Answer<Object> answer = new ReturnsSmartNulls();
+
+        Foo smartNull = (Foo) answer.answer(invocationOf(GenericFooBar.class, "get"));
+
+        assertThat(smartNull.toString())
+            .contains("SmartNull returned by")
+            .contains("genericFooBar.get()");
+    }
+
+    @Test
+    public void should_return_an_object_that_has_been_defined_with_method_generic() throws Throwable {
+
+        Answer<Object> answer = new ReturnsSmartNulls();
+
+        String smartNull = (String) answer.answer(invocationOf(GenericFooBar.class, "method"));
+
+        assertThat(smartNull)
+            .isNull();
+    }
+
+    private static <T> InterceptedInvocation invocationMethodWithArgs(final T obj) throws NoSuchMethodException {
+        return new InterceptedInvocation(
+            new MockStrongReference<Object>(mock(GenericFooBar.class), false),
+            new SerializableMethod(GenericFooBar.class.getMethod("methodWithArgs", int.class, Object.class)),
+            new Object[]{1, obj},
+            InterceptedInvocation.NO_OP,
+            new LocationImpl(),
+            1);
+    }
+
+    @Test
+    public void should_return_a_String_that_has_been_defined_with_method_generic_and_provided_in_argument() throws Throwable {
+
+        Answer<Object> answer = new ReturnsSmartNulls();
+
+        Object smartNull = answer.answer(invocationMethodWithArgs("secondArg"));
+
+        assertThat(smartNull)
+            .isNotNull()
+            .isInstanceOf(String.class)
+            .asString()
+            .isEmpty();
+    }
+
+    @Test
+    public void should_return_a_empty_list_that_has_been_defined_with_method_generic_and_provided_in_argument() throws Throwable {
+
+        final List<String> list = Collections.singletonList("String");
+        Answer<Object> answer = new ReturnsSmartNulls();
+
+        Object smartNull = answer.answer(invocationMethodWithArgs(list));
+
+        assertThat(smartNull)
+            .isNotNull()
+            .isInstanceOf(List.class);
+        assertThat((List) smartNull)
+            .isEmpty();
+    }
+
+    @Test
+    public void should_return_a_empty_map_that_has_been_defined_with_method_generic_and_provided_in_argument() throws Throwable {
+
+        final Map<String, String> map = new HashMap<String, String>();
+        map.put("key-1", "value-1");
+        map.put("key-2", "value-2");
+        Answer<Object> answer = new ReturnsSmartNulls();
+
+        Object smartNull = answer.answer(invocationMethodWithArgs(map));
+
+        assertThat(smartNull)
+            .isNotNull()
+            .isInstanceOf(Map.class);
+        assertThat((Map) smartNull)
+            .isEmpty();
+    }
+
+    @Test
+    public void should_return_a_empty_set_that_has_been_defined_with_method_generic_and_provided_in_argument() throws Throwable {
+
+        Answer<Object> answer = new ReturnsSmartNulls();
+
+        Object smartNull =
+            answer.answer(invocationMethodWithArgs(new HashSet<String>(Arrays.asList("set-1", "set-2"))));
+
+        assertThat(smartNull)
+            .isNotNull()
+            .isInstanceOf(Set.class);
+        assertThat((Set) smartNull)
+            .isEmpty();
+    }
+
+    @Test
+    public void should_return_a_new_mock_that_has_been_defined_with_method_generic_and_provided_in_argument() throws Throwable {
+
+        Answer<Object> answer = new ReturnsSmartNulls();
+        final Foo mock = mock(Foo.class);
+
+        Object smartNull = answer.answer(invocationMethodWithArgs(mock));
+
+        assertThat(smartNull)
+            .isNotNull()
+            .isNotSameAs(mock);
+        assertThat(smartNull.toString())
+            .contains("SmartNull returned by")
+            .contains("genericFooBar.methodWithArgs(");
+    }
+
+    @Test
+    public void should_return_an_Object_that_has_been_defined_with_method_generic_and_provided_in_argument() throws Throwable {
+
+        Answer<Object> answer = new ReturnsSmartNulls();
+
+        Object smartNull = answer.answer(invocationMethodWithArgs(new Object() {
+        }));
+
+        assertThat(smartNull.toString())
+            .contains("SmartNull returned by")
+            .contains("genericFooBar.methodWithArgs(");
+    }
+
+    @Test
+    public void should_throw_a_error_on_invocation_of_returned_mock() throws Throwable {
+
+        final Answer<Object> answer = new ReturnsSmartNulls();
+        final Foo mock = mock(Foo.class);
+
+        final Throwable throwable = Assertions.catchThrowable(new ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() throws Throwable {
+                ((Foo) answer.answer(invocationMethodWithArgs(mock))).get();
+            }
+        });
+
+        Assertions.assertThat(throwable)
+            .isInstanceOf(SmartNullPointerException.class)
+            .hasMessageContaining("genericFooBar.methodWithArgs(")
+            .hasMessageContaining("1")
+            .hasMessageContaining(mock.toString());
+    }
+
+    private static <T> InterceptedInvocation invocationMethodWithVarArgs(final T[] obj) throws NoSuchMethodException {
+        return new InterceptedInvocation(
+            new MockStrongReference<Object>(mock(GenericFooBar.class), false),
+            new SerializableMethod(GenericFooBar.class.getMethod("methodWithVarArgs", int.class, Object[].class)),
+            new Object[]{1, obj},
+            InterceptedInvocation.NO_OP,
+            new LocationImpl(),
+            1);
+    }
+
+    @Test
+    public void should_return_a_String_that_has_been_defined_with_method_generic_and_provided_in_var_args()
+        throws Throwable {
+
+        Answer<Object> answer = new ReturnsSmartNulls();
+
+        Object smartNull = answer.answer(invocationMethodWithVarArgs(new String[]{"varArg-1", "varArg-2"}));
+
+        assertThat(smartNull)
+            .isNotNull()
+            .isInstanceOf(String.class)
+            .asString()
+            .isEmpty();
+    }
+
+    @Test
+    public void should_return_a_empty_list_that_has_been_defined_with_method_generic_and_provided_in_var_args()
+        throws Throwable {
+
+        final List<String> arg1 = Collections.singletonList("String");
+        final List<String> arg2 = Arrays.asList("str-1", "str-2");
+        Answer<Object> answer = new ReturnsSmartNulls();
+
+        Object smartNull = answer.answer(invocationMethodWithVarArgs(new List[]{arg1, arg2}));
+
+        assertThat(smartNull)
+            .isNotNull()
+            .isInstanceOf(List.class);
+        assertThat((List) smartNull)
+            .isEmpty();
+    }
+
+    @Test
+    public void should_return_a_empty_map_that_has_been_defined_with_method_generic_and_provided_in_var_args()
+        throws Throwable {
+
+        final Map<String, String> map1 = new HashMap<String, String>() {{
+            put("key-1", "value-1");
+            put("key-2", "value-2");
+        }};
+        final Map<String, String> map2 = new HashMap<String, String>() {{
+            put("key-3", "value-1");
+            put("key-4", "value-2");
+        }};
+        Answer<Object> answer = new ReturnsSmartNulls();
+
+        Object smartNull = answer.answer(invocationMethodWithVarArgs(new Map[]{map1, map2}));
+
+        assertThat(smartNull)
+            .isNotNull()
+            .isInstanceOf(Map.class);
+        assertThat((Map) smartNull)
+            .isEmpty();
+    }
+
+    @Test
+    public void should_return_a_empty_set_that_has_been_defined_with_method_generic_and_provided_in_var_args()
+        throws Throwable {
+
+        final HashSet<String> set1 = new HashSet<String>(Arrays.asList("set-1", "set-2"));
+        final HashSet<String> set2 = new HashSet<String>(Arrays.asList("set-1", "set-2"));
+        Answer<Object> answer = new ReturnsSmartNulls();
+
+        Object smartNull =
+            answer.answer(invocationMethodWithVarArgs(new HashSet[]{set1, set2}));
+
+        assertThat(smartNull)
+            .isNotNull()
+            .isInstanceOf(Set.class);
+        assertThat((Set) smartNull)
+            .isEmpty();
+    }
+
+    @Test
+    public void should_return_a_new_mock_that_has_been_defined_with_method_generic_and_provided_in_var_args()
+        throws Throwable {
+
+        Answer<Object> answer = new ReturnsSmartNulls();
+        final Foo mock1 = mock(Foo.class);
+        final Foo mock2 = mock(Foo.class);
+
+        Object smartNull = answer.answer(invocationMethodWithVarArgs(new Foo[]{mock1, mock2}));
+
+        assertThat(smartNull)
+            .isNotNull()
+            .isNotSameAs(mock1)
+            .isNotSameAs(mock2);
+        assertThat(smartNull.toString())
+            .contains("SmartNull returned by")
+            .contains("genericFooBar.methodWithVarArgs(");
+    }
+
+    @Test
+    public void should_return_an_Object_that_has_been_defined_with_method_generic_and_provided_in_var_args()
+        throws Throwable {
+
+        Answer<Object> answer = new ReturnsSmartNulls();
+
+        Object smartNull = answer.answer(invocationMethodWithVarArgs(new Object[]{new Object() {
+        }, new Object() {
+        }}));
+
+        assertThat(smartNull.toString())
+            .contains("SmartNull returned by")
+            .contains("genericFooBar.methodWithVarArgs(");
+    }
+
 }

--- a/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNullsTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNullsTest.java
@@ -8,11 +8,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.mockito.exceptions.verification.SmartNullPointerException;
+import org.mockito.internal.debugging.LocationImpl;
+import org.mockito.internal.invocation.InterceptedInvocation;
+import org.mockito.internal.invocation.SerializableMethod;
+import org.mockito.internal.invocation.mockref.MockStrongReference;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.mockitoutil.TestBase;
 
+import java.util.Collections;
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 public class ReturnsSmartNullsTest extends TestBase {
 
@@ -33,6 +42,16 @@ public class ReturnsSmartNullsTest extends TestBase {
     interface Foo {
         Foo get();
         Foo withArgs(String oneArg, String otherArg);
+    }
+
+    interface GenericFoo<T> {
+        T get();
+    }
+
+    interface GenericFooBar extends GenericFoo<Foo> {
+        <I> I method();
+        <I> I methodWithArgs(int firstArg, I secondArg);
+        <I> I methodWithVarArgs(int firstArg, I... secondArg);
     }
 
     @Test
@@ -56,6 +75,109 @@ public class ReturnsSmartNullsTest extends TestBase {
         assertThat(smartNull.toString())
             .contains("SmartNull returned by")
             .contains("foo.get()");
+    }
+
+    @Test
+    public void should_return_an_object_when_it_came_from_a_generic_defined_on_class() throws Throwable {
+        Answer<Object> answer = new ReturnsSmartNulls();
+
+        Foo smartNull = (Foo) answer.answer(invocationOf(GenericFooBar.class, "get"));
+
+        assertThat(smartNull.toString())
+            .contains("SmartNull returned by")
+            .contains("genericFooBar.get()");
+    }
+
+    @Test
+    public void should_return_an_object_when_it_came_from_a_generic_defined_on_method_without_infer() throws Throwable {
+
+        Answer<Object> answer = new ReturnsSmartNulls();
+
+        String smartNull = (String) answer.answer(invocationOf(GenericFooBar.class, "method"));
+
+        assertThat(smartNull).isNull();
+    }
+
+    @Test
+    public void should_return_an_object_when_it_came_from_a_generic_method() throws Throwable {
+
+        Answer<Object> answer = new ReturnsSmartNulls();
+
+        InvocationOnMock invocation = new InterceptedInvocation(
+            new MockStrongReference<Object>(mock(GenericFooBar.class), false),
+            new SerializableMethod(GenericFooBar.class.getMethod("methodWithArgs", int.class, Object.class)),
+            new Object[]{1, "secondArg"},
+            InterceptedInvocation.NO_OP,
+            new LocationImpl(),
+            1);
+
+        Object smartNull = answer.answer(invocation);
+
+        assertThat(smartNull)
+            .isNotNull()
+            .isInstanceOf(String.class)
+            .asString()
+            .isEmpty();
+    }
+
+    @Test
+    public void should_return_a_list_when_it_came_from_a_generic_method() throws Throwable {
+
+        Answer<Object> answer = new ReturnsSmartNulls();
+
+        InvocationOnMock invocation = new InterceptedInvocation(
+            new MockStrongReference<Object>(mock(GenericFooBar.class), false),
+            new SerializableMethod(GenericFooBar.class.getMethod("methodWithArgs", int.class, Object.class)),
+            new Object[]{1, Collections.singletonList("secondArg")},
+            InterceptedInvocation.NO_OP,
+            new LocationImpl(),
+            1);
+
+        Object smartNull = answer.answer(invocation);
+
+        assertThat(smartNull)
+            .isNotNull()
+            .isInstanceOf(List.class);
+    }
+
+    @Test
+    public void should_return_an_object_when_it_came_from_a_generic_method_using_a_mock_as_type() throws Throwable {
+
+        Answer<Object> answer = new ReturnsSmartNulls();
+
+        InvocationOnMock invocation = new InterceptedInvocation(
+            new MockStrongReference<Object>(mock(GenericFooBar.class), false),
+            new SerializableMethod(GenericFooBar.class.getMethod("methodWithArgs", int.class, Object.class)),
+            new Object[]{1, mock(GenericFooBar.class)},
+            InterceptedInvocation.NO_OP,
+            new LocationImpl(),
+            1);
+
+        Object smartNull = answer.answer(invocation);
+
+        assertThat(smartNull.toString())
+            .contains("SmartNull returned by")
+            .contains("genericFooBar.methodWithArgs(");
+    }
+
+    @Test
+    public void should_return_an_object_when_it_came_from_a_generic_method_using_Object_as_type() throws Throwable {
+
+        Answer<Object> answer = new ReturnsSmartNulls();
+
+        InvocationOnMock invocation = new InterceptedInvocation(
+            new MockStrongReference<Object>(mock(GenericFooBar.class), false),
+            new SerializableMethod(GenericFooBar.class.getMethod("methodWithArgs", int.class, Object.class)),
+            new Object[]{1, new Object() {}},
+            InterceptedInvocation.NO_OP,
+            new LocationImpl(),
+            1);
+
+        Object smartNull = answer.answer(invocation);
+
+        assertThat(smartNull.toString())
+            .contains("SmartNull returned by")
+            .contains("genericFooBar.methodWithArgs(");
     }
 
     @Test

--- a/src/test/java/org/mockitousage/stubbing/SmartNullsGenericBugTest.java
+++ b/src/test/java/org/mockitousage/stubbing/SmartNullsGenericBugTest.java
@@ -19,12 +19,13 @@ public class SmartNullsGenericBugTest {
     public void smart_nulls_generic_bug() {
         final ConcreteDao concreteDao = mock(ConcreteDao.class, withSettings().defaultAnswer(Answers.RETURNS_SMART_NULLS));
 
-        Assertions.assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+        final Throwable throwable = Assertions.catchThrowable(new ThrowableAssert.ThrowingCallable() {
             public void call() {
                 concreteDao.findById();
             }
-        }).isInstanceOf(ClassCastException.class);
-        //TODO: can we avoid CCE here? Can we make the exception message better? See issue #1551
+        });
+
+        Assertions.assertThat(throwable).as("Issume #1551 - Avoid CCE").isNull();
     }
 
     static class AbstractDao<T> {

--- a/src/test/java/org/mockitousage/stubbing/SmartNullsGenericBugTest.java
+++ b/src/test/java/org/mockitousage/stubbing/SmartNullsGenericBugTest.java
@@ -5,7 +5,6 @@
 package org.mockitousage.stubbing;
 
 import org.assertj.core.api.Assertions;
-import org.assertj.core.api.ThrowableAssert;
 import org.junit.Test;
 import org.mockito.Answers;
 
@@ -16,22 +15,56 @@ import static org.mockito.Mockito.withSettings;
 public class SmartNullsGenericBugTest {
 
     @Test
-    public void smart_nulls_generic_bug() {
-        final ConcreteDao concreteDao = mock(ConcreteDao.class, withSettings().defaultAnswer(Answers.RETURNS_SMART_NULLS));
+    public void smart_nulls_generic_bug_generic_T() {
+        ConcreteDao concreteDao = mock(ConcreteDao.class, withSettings().defaultAnswer(Answers.RETURNS_SMART_NULLS));
 
-        final Throwable throwable = Assertions.catchThrowable(new ThrowableAssert.ThrowingCallable() {
-            public void call() {
-                concreteDao.findById();
-            }
-        });
+        final Entity result = concreteDao.findById();
 
-        Assertions.assertThat(throwable).as("Issume #1551 - Avoid CCE").isNull();
+        Assertions.assertThat(result)
+            .as("Issume #1551 - Avoid CCE")
+            .isNotNull();
+    }
+
+    @Test
+    public void smart_nulls_generic_bug_generic_M() {
+        ConcreteDao concreteDao = mock(ConcreteDao.class, withSettings().defaultAnswer(Answers.RETURNS_SMART_NULLS));
+
+        final String other = concreteDao.find();
+
+        Assertions.assertThat(other)
+            .as("Issume #1551 - Avoid CCE")
+            .isNull();
+    }
+
+    @Test
+    public void smart_nulls_generic_bug_generic_M_provided_in_args() {
+        ConcreteDao concreteDao = mock(ConcreteDao.class, withSettings().defaultAnswer(Answers.RETURNS_SMART_NULLS));
+
+        final String other = concreteDao.findArgs(1, "plop");
+
+        Assertions.assertThat(other)
+            .as("Issume #1551 - Avoid CCE")
+            .isEqualTo("");
+    }
+
+    @Test
+    public void smart_nulls_generic_bug_generic_M_provided_as_varargs() {
+        ConcreteDao concreteDao = mock(ConcreteDao.class, withSettings().defaultAnswer(Answers.RETURNS_SMART_NULLS));
+
+        final String other = concreteDao.findVarargs(42, "plip", "plop");
+
+        Assertions.assertThat(other)
+            .as("Issume #1551 - Avoid CCE")
+            .isEqualTo("");
     }
 
     static class AbstractDao<T> {
         T findById() {
             return null;
         }
+        <M> M find() { return null; }
+        <M> M findArgs(int idx, M arg) { return null; }
+        <M> M findVarargs(int idx, M... args) { return null; }
     }
 
     static class Entity { }

--- a/src/test/java/org/mockitousage/stubbing/SmartNullsGenericBugTest.java
+++ b/src/test/java/org/mockitousage/stubbing/SmartNullsGenericBugTest.java
@@ -21,7 +21,7 @@ public class SmartNullsGenericBugTest {
         final Entity result = concreteDao.findById();
 
         Assertions.assertThat(result)
-            .as("Issume #1551 - Avoid CCE")
+            .as("#1551")
             .isNotNull();
     }
 
@@ -32,7 +32,7 @@ public class SmartNullsGenericBugTest {
         final String other = concreteDao.find();
 
         Assertions.assertThat(other)
-            .as("Issume #1551 - Avoid CCE")
+            .as("#1551 - CCannot resolve type")
             .isNull();
     }
 
@@ -43,7 +43,7 @@ public class SmartNullsGenericBugTest {
         final String other = concreteDao.findArgs(1, "plop");
 
         Assertions.assertThat(other)
-            .as("Issume #1551 - Avoid CCE")
+            .as("#1551")
             .isEqualTo("");
     }
 
@@ -54,7 +54,7 @@ public class SmartNullsGenericBugTest {
         final String other = concreteDao.findVarargs(42, "plip", "plop");
 
         Assertions.assertThat(other)
-            .as("Issume #1551 - Avoid CCE")
+            .as("#1551")
             .isEqualTo("");
     }
 


### PR DESCRIPTION
This PR intends to fix #1551. For fix it, the `ReturnsSmartNulls` answer use now some reflection to find the correct return type instead of the `java.util.Object`.

When the return type can be found, it will start to retrieve empty values using the answer `ReturnsMoreEmptyValues` & `ReturnsEmptyValues` before creating a new mock instance.

As you may notice in tests, there is still one case where the return type cannot be found. In this case, the `Answer` will return a `null` instead of `Object` mock.

I think, it may be possible to improve this code. Any suggestion will be welcome !