### PR TITLE
Fixes #1578: outer class mocks unavailable from inner class

### DIFF
--- a/src/main/java/org/mockito/internal/junit/JUnitRule.java
+++ b/src/main/java/org/mockito/internal/junit/JUnitRule.java
@@ -7,6 +7,7 @@ package org.mockito.internal.junit;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 import org.mockito.MockitoSession;
 import org.mockito.internal.session.MockitoSessionLoggerAdapter;
 import org.mockito.plugins.MockitoLogger;
@@ -34,12 +35,16 @@ public class JUnitRule implements MockitoRule {
 	public Statement apply(final Statement base, final FrameworkMethod method, final Object target) {
         return new Statement() {
             public void evaluate() throws Throwable {
-                session = Mockito.mockitoSession()
-                    .name(target.getClass().getSimpleName() + "." + method.getName())
-                    .strictness(strictness)
-                    .logger(new MockitoSessionLoggerAdapter(logger))
-                    .initMocks(target)
-                    .startMocking();
+                if (session == null) {
+                    session = Mockito.mockitoSession()
+                                     .name(target.getClass().getSimpleName() + "." + method.getName())
+                                     .strictness(strictness)
+                                     .logger(new MockitoSessionLoggerAdapter(logger))
+                                     .initMocks(target)
+                                     .startMocking();
+                } else {
+                    MockitoAnnotations.initMocks(target);
+                }
                 Throwable testFailure = evaluateSafely(base);
                 session.finishMocking(testFailure);
                 if (testFailure != null) {

--- a/src/test/java/org/mockitousage/junitrule/MockitoJUnitRuleTest.java
+++ b/src/test/java/org/mockitousage/junitrule/MockitoJUnitRuleTest.java
@@ -19,6 +19,10 @@ public class MockitoJUnitRuleTest {
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
 
+    // Fixes #1578: Protect against multiple execution.
+    @Rule
+    public MockitoRule mockitoRule2 = mockitoRule;
+
     @Mock
     private Injected injected;
 


### PR DESCRIPTION
I opened issue #1578 a few weeks ago that went without an correspondence, so I apologize if submitting a PR isn't the ideal method of moving this issue forward.  However I am hoping I can get this fix incorporated into an official version without implementing temporary workarounds.

The PR should clearly show the issue I am trying to fix, but I had to introduce a testCompile snapshot dependency.  The dependent project has a fix required to demonstrate the issue within Mockito but it unfortunately has not been incorporated into an official release, and I can't think of another way to reproduce the issue.  I have contacted the owner of the dependent project but I haven't received a response from them either.

I am looking for guidance on next steps for what I believe to be regression (reported to be working in #353).  The only other solution I can think of is to merge this without a unit test but I highly doubt that is desirable.

_Git Commit Message_
- problem - JUnitRule detects an unfinished mocking session when an inner class is detected
- fix - if a MockitoSession has been established for JUnitRule, then use that and init mocks of the inner class.
- tests - within an inner class ... ensure mocks are accessible, override outer class values when desired, retain original values if not overwritten
- demonstrated with de.bechte.junit:junit-hierarchicalcontextrunner:4.12.2-SNAPSHOT