### PR TITLE
Return null instead of causing a CCE

### DIFF
--- a/gradle/errorprone.gradle
+++ b/gradle/errorprone.gradle
@@ -10,3 +10,7 @@ if (JavaVersion.current() == JavaVersion.VERSION_1_8) {
 dependencies {
     errorprone libraries.errorprone
 }
+
+tasks.named("compileTestJava").configure {
+    options.errorprone.errorproneArgs << "-Xep:MockitoCast:OFF"
+}

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsDeepStubs.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsDeepStubs.java
@@ -53,6 +53,15 @@ public class ReturnsDeepStubs implements Answer<Object>, Serializable {
             return delegate().returnValueFor(rawType);
         }
 
+        // When dealing with erasured generics, we only receive the Object type as rawType. At this
+        // point, there is nothing to salvage for Mockito. Instead of trying to be smart and generate
+        // a mock that would potentially match the return signature, instead return `null`. This
+        // is valid per the CheckCast JVM instruction and is better than causing a ClassCastException
+        // on runtime.
+        if (rawType.equals(Object.class)) {
+            return null;
+        }
+
         return deepStub(invocation, returnTypeGenericMetadata);
     }
 

--- a/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsGenericDeepStubsTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsGenericDeepStubsTest.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unused")
 public class ReturnsGenericDeepStubsTest {
@@ -109,5 +110,27 @@ public class ReturnsGenericDeepStubsTest {
         // following assignment needed to create a ClassCastException on the call site (i.e. : here)
         StringBuilder stringBuilder_assignment_that_should_throw_a_CCE =
                 mock.twoTypeParams(new StringBuilder()).append(2).append(3);
+    }
+
+    class WithGenerics<T> {
+        T execute() {
+            throw new IllegalArgumentException();
+        }
+    }
+    class SubClass<S> extends WithGenerics<S> {}
+
+    class UserOfSubClass {
+        SubClass<String> generate() {
+            return null;
+        }
+    }
+
+    @Test
+    public void can_handle_deep_stubs_with_generics_at_end_of_deep_invocation() {
+        UserOfSubClass mock = mock(UserOfSubClass.class, RETURNS_DEEP_STUBS);
+
+        when(mock.generate().execute()).thenReturn("sub");
+
+        assertThat(mock.generate().execute()).isEqualTo("sub");
     }
 }

--- a/src/test/java/org/mockitousage/serialization/DeepStubsSerializableTest.java
+++ b/src/test/java/org/mockitousage/serialization/DeepStubsSerializableTest.java
@@ -45,7 +45,7 @@ public class DeepStubsSerializableTest {
         assertThat(deserialized_deep_stub.iterator().next().add("yes")).isEqualTo(true);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = NullPointerException.class)
     public void should_discard_generics_metadata_when_serialized_then_disabling_deep_stubs_with_generics() throws Exception {
         // given
         ListContainer deep_stubbed = mock(ListContainer.class, withSettings().defaultAnswer(RETURNS_DEEP_STUBS).serializable());


### PR DESCRIPTION
This solves a large number of edge-cases where `null` will actually
remove the runtime ClassCastException. This essentially negates the
whole MockitoCast ErrorProne check. We can still not support every use
case, but causing a NPE instead of a CCE does not seem to make this
worse.

I am still running internal tests within Google to see if there are any
regressions, but I already saw that some of the test failures we had
with ByteBuddy were resolved with this particular patch.

Note that this now fully closes #357. A previous PR resolved the same
issue with ReturnsSmartNulls: #1576.

Fixes #357