### PR TITLE
Add test that mocks an interface with a finalize method

### DIFF
--- a/src/test/java/org/mockitousage/stubbing/StubbingFinalizeTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingFinalizeTest.java
@@ -1,0 +1,20 @@
+package org.mockitousage.stubbing;
+
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+
+public class StubbingFinalizeTest {
+
+    interface FinalizeInterface {
+        void finalize();
+    }
+
+    @Test
+    public void should_not_throw_illegal_access_error_when_stubbing_finalize() {
+        FinalizeInterface finalized = mock(FinalizeInterface.class);
+
+        finalized.finalize();
+    }
+
+}


### PR DESCRIPTION
This is a regression compared to the CGLibMockmaker, for which an interface with a method named "finalize" can not be mock. The call here to `finalized.finalize()` throws `java.lang.IllegalAccessError: org.mockitousage.stubbing.StubbingFinalizeTest$FinalizeInterface$MockitoMock$809502244.finalize()V`

I think this is a bug with ByteBuddy or a bug in how we define the type in `SubclassBytecodeGenerator`?