### PR TITLE
Add test for dealing with generics created in method

### DIFF
--- a/src/main/java/org/mockito/internal/creation/MockSettingsImpl.java
+++ b/src/main/java/org/mockito/internal/creation/MockSettingsImpl.java
@@ -239,7 +239,17 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
 
         validator.validateType(typeToMock);
         validator.validateExtraInterfaces(typeToMock, source.getExtraInterfaces());
-        validator.validateMockedType(typeToMock, source.getSpiedInstance());
+
+        // This is only the case if we are spying a real object. In that case, anonymous classes
+        // do not allow us to override methods. However, since the interface of an anonymous class
+        // is the same as the "first interface" it implements, we can use that as the type instead.
+        // The validator should not be run in this case, as we are intentionally using a different
+        // class to define our mock class with.
+        if (typeToMock.isAnonymousClass() && source.getSpiedInstance() != null) {
+            typeToMock = (Class<T>) typeToMock.getInterfaces()[0];
+        } else {
+            validator.validateMockedType(typeToMock, source.getSpiedInstance());
+        }
 
         //TODO SF - add this validation and also add missing coverage
 //        validator.validateDelegatedInstance(classToMock, settings.getDelegatedInstance());

--- a/src/test/java/org/mockitousage/spies/SpyWithVariableGenericsTest.java
+++ b/src/test/java/org/mockitousage/spies/SpyWithVariableGenericsTest.java
@@ -1,0 +1,30 @@
+package org.mockitousage.spies;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class SpyWithVariableGenericsTest {
+
+    @Test
+    public void can_spy_anonymous_class_created_in_method() {
+        Mockito.spy(SpyWithVariableGenericsTest.<Integer>createPublisher());
+    }
+
+    private static <T> Publisher<T> createPublisher() {
+        return new Publisher<T>() {
+            @Override
+            public void subscribe(Subscriber<? super T> subscribe) {
+
+            }
+        };
+    }
+
+    interface Publisher<T> {
+        void subscribe(Subscriber<? super T> subscribe);
+    }
+
+    interface Subscriber<T> {
+        void onNext(T next);
+    }
+
+}

--- a/src/test/java/org/mockitousage/spies/SpyWithVariableGenericsTest.java
+++ b/src/test/java/org/mockitousage/spies/SpyWithVariableGenericsTest.java
@@ -1,5 +1,13 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
 package org.mockitousage.spies;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -7,20 +15,42 @@ public class SpyWithVariableGenericsTest {
 
     @Test
     public void can_spy_anonymous_class_created_in_method() {
-        Mockito.spy(SpyWithVariableGenericsTest.<Integer>createPublisher());
+        Publisher<Integer> spy = Mockito
+            .spy(SpyWithVariableGenericsTest.<Integer>createPublisher());
+
+        final AtomicBoolean called = new AtomicBoolean(false);
+
+        spy.subscribe(new Subscriber<Integer>() {
+            @Override
+            public void onNext(Integer next) {
+                called.set(true);
+                assertThat(next).isEqualTo(5);
+            }
+        });
+
+        spy.publish(5);
+        assertThat(called.get()).isTrue();
     }
 
     private static <T> Publisher<T> createPublisher() {
         return new Publisher<T>() {
-            @Override
-            public void subscribe(Subscriber<? super T> subscribe) {
+            private Subscriber<? super T> subscriber;
 
+            @Override
+            public void subscribe(Subscriber<? super T> subscriber) {
+                this.subscriber = subscriber;
+            }
+
+            @Override
+            public void publish(T object) {
+                this.subscriber.onNext(object);
             }
         };
     }
 
     interface Publisher<T> {
         void subscribe(Subscriber<? super T> subscribe);
+        void publish(T object);
     }
 
     interface Subscriber<T> {


### PR DESCRIPTION
This currently fails with the below stacktrace:

```
org.mockito.exceptions.base.MockitoException: 
Mockito cannot mock this class: class org.mockitousage.spies.SpyWithVariableGenericsTest$1.

Mockito can only mock non-private & non-final classes.
If you're not sure why you're getting this error, please report to the mailing list.


Java               : 9
JVM vendor name    : Oracle Corporation
JVM vendor version : 9.0.4+11-google-release-215426676
JVM name           : OpenJDK 64-Bit Server VM
JVM version        : 9.0.4+11-google-release-215426676
JVM info           : mixed mode
OS name            : Linux
OS version         : 4.19.16-1rodete1-amd64


Underlying exception : java.lang.IllegalArgumentException: Cannot attach undefined variable: T

	at org.mockito.internal.creation.bytebuddy.SubclassByteBuddyMockMaker.prettifyFailure(SubclassByteBuddyMockMaker.java:104)
	at org.mockito.internal.creation.bytebuddy.SubclassByteBuddyMockMaker.createMockType(SubclassByteBuddyMockMaker.java:78)
	at org.mockito.internal.creation.bytebuddy.SubclassByteBuddyMockMaker.createMock(SubclassByteBuddyMockMaker.java:42)
	at org.mockito.internal.creation.bytebuddy.ByteBuddyMockMaker.createMock(ByteBuddyMockMaker.java:25)
	at org.mockito.internal.util.MockUtil.createMock(MockUtil.java:35)
	at org.mockito.internal.MockitoCore.mock(MockitoCore.java:62)
	at org.mockito.Mockito.spy(Mockito.java:1980)
	at org.mockitousage.spies.SpyWithVariableGenericsTest.should_not_fail(SpyWithVariableGenericsTest.java:10)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:564)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
Caused by: java.lang.IllegalArgumentException: Cannot attach undefined variable: T
	at net.bytebuddy.dynamic.Transformer$ForMethod$TransformedMethod$AttachmentVisitor.onTypeVariable(Transformer.java:592)
	at net.bytebuddy.dynamic.Transformer$ForMethod$TransformedMethod$AttachmentVisitor.onTypeVariable(Transformer.java:580)
	at net.bytebuddy.description.type.TypeDescription$Generic$OfTypeVariable$Symbolic.accept(TypeDescription.java:5757)
	at net.bytebuddy.description.type.TypeList$Generic$AbstractBase.accept(TypeList.java:276)
	at net.bytebuddy.description.type.TypeDescription$Generic$Visitor$Substitutor.onWildcard(TypeDescription.java:1838)
	at net.bytebuddy.description.type.TypeDescription$Generic$Visitor$Substitutor$WithoutTypeSubstitution.onWildcard(TypeDescription.java:1861)
	at net.bytebuddy.description.type.TypeDescription$Generic$OfWildcardType.accept(TypeDescription.java:4565)
	at net.bytebuddy.description.type.TypeDescription$Generic$Visitor$Substitutor.onParameterizedType(TypeDescription.java:1817)
	at net.bytebuddy.description.type.TypeDescription$Generic$Visitor$Substitutor$WithoutTypeSubstitution.onParameterizedType(TypeDescription.java:1861)
	at net.bytebuddy.description.type.TypeDescription$Generic$OfParameterizedType.accept(TypeDescription.java:4991)
	at net.bytebuddy.dynamic.Transformer$ForMethod$TransformedMethod$TransformedParameter.getType(Transformer.java:511)
	at net.bytebuddy.description.method.ParameterList$AbstractBase.asTypeList(ParameterList.java:109)
	at net.bytebuddy.description.method.MethodDescription$AbstractBase.asTypeToken(MethodDescription.java:837)
	at net.bytebuddy.dynamic.scaffold.MethodRegistry$Default$Prepared$Entry.resolveBridgeTypes(MethodRegistry.java:868)
	at net.bytebuddy.dynamic.scaffold.MethodRegistry$Default$Prepared.compile(MethodRegistry.java:746)
	at net.bytebuddy.dynamic.scaffold.subclass.SubclassDynamicTypeBuilder.make(SubclassDynamicTypeBuilder.java:199)
	at net.bytebuddy.dynamic.scaffold.subclass.SubclassDynamicTypeBuilder.make(SubclassDynamicTypeBuilder.java:189)
	at net.bytebuddy.dynamic.DynamicType$Builder$AbstractBase.make(DynamicType.java:3397)
	at net.bytebuddy.dynamic.DynamicType$Builder$AbstractBase$Delegator.make(DynamicType.java:3586)
	at org.mockito.internal.creation.bytebuddy.SubclassBytecodeGenerator.mockClass(SubclassBytecodeGenerator.java:172)
	at org.mockito.internal.creation.bytebuddy.TypeCachingBytecodeGenerator$1.call(TypeCachingBytecodeGenerator.java:37)
	at org.mockito.internal.creation.bytebuddy.TypeCachingBytecodeGenerator$1.call(TypeCachingBytecodeGenerator.java:34)
	at net.bytebuddy.TypeCache.findOrInsert(TypeCache.java:152)
	at net.bytebuddy.TypeCache$WithInlineExpunction.findOrInsert(TypeCache.java:365)
	at net.bytebuddy.TypeCache.findOrInsert(TypeCache.java:174)
	at net.bytebuddy.TypeCache$WithInlineExpunction.findOrInsert(TypeCache.java:376)
	at org.mockito.internal.creation.bytebuddy.TypeCachingBytecodeGenerator.mockClass(TypeCachingBytecodeGenerator.java:32)
	at org.mockito.internal.creation.bytebuddy.SubclassByteBuddyMockMaker.createMockType(SubclassByteBuddyMockMaker.java:71)
	... 28 more
```