### PR TITLE
Fixes #1618 : Fix strict stubbing profile serialization support.

### DIFF
--- a/src/main/java/org/mockito/internal/junit/DefaultStubbingLookupListener.java
+++ b/src/main/java/org/mockito/internal/junit/DefaultStubbingLookupListener.java
@@ -12,6 +12,7 @@ import org.mockito.invocation.Invocation;
 import org.mockito.quality.Strictness;
 import org.mockito.stubbing.Stubbing;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -22,7 +23,9 @@ import static org.mockito.internal.stubbing.StrictnessSelector.determineStrictne
  * Default implementation of stubbing lookup listener.
  * Fails early if stub called with unexpected arguments, but only if current strictness is set to STRICT_STUBS.
  */
-class DefaultStubbingLookupListener implements StubbingLookupListener {
+class DefaultStubbingLookupListener implements StubbingLookupListener, Serializable {
+
+    private static final long serialVersionUID = -6789800638070123629L;
 
     private Strictness currentStrictness;
     private boolean mismatchesReported;

--- a/src/test/java/org/mockitousage/serialization/StrictStubsSerializableTest.java
+++ b/src/test/java/org/mockitousage/serialization/StrictStubsSerializableTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage.serialization;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.Serializable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+import static org.mockitoutil.SimpleSerializationUtil.serializeAndBack;
+
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
+public class StrictStubsSerializableTest {
+
+    @Mock(serializable = true) private SampleClass sampleClass;
+
+    @Test
+    public void should_serialize_and_deserialize_mock_created_with_serializable_and_strict_stubs() throws Exception {
+        // given
+        when(sampleClass.isFalse()).thenReturn(true);
+
+        // when
+        SampleClass deserializedSample = serializeAndBack(sampleClass);
+        // to satisfy strict stubbing
+        deserializedSample.isFalse();
+        verify(deserializedSample).isFalse();
+        verify(sampleClass, never()).isFalse();
+
+        // then
+        assertThat(deserializedSample.isFalse()).isEqualTo(true);
+        assertThat(sampleClass.isFalse()).isEqualTo(true);
+    }
+
+    static class SampleClass implements Serializable {
+
+        boolean isFalse() {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
When strict stubs profile is enabled, mock serialization doesn't work.

This PR fixes this problem.