### PR TITLE
Handle terminal type var with bounds

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -1685,6 +1685,7 @@ public class Mockito extends ArgumentMatchers {
 
     /**
      * Optional <code>Answer</code> to be used with {@link Mockito#mock(Class, Answer)}
+     *
      * <p>
      * {@link Answer} can be used to define the return values of unstubbed invocations.
      * <p>
@@ -1716,8 +1717,11 @@ public class Mockito extends ArgumentMatchers {
      * </code></pre>
      *
      * <p>
-     * <u>Note:</u> Stubbing partial mocks using <code>when(mock.getSomething()).thenReturn(fakeValue)</code>
+     * <u>Note 1:</u> Stubbing partial mocks using <code>when(mock.getSomething()).thenReturn(fakeValue)</code>
      * syntax will call the real method. For partial mock it's recommended to use <code>doReturn</code> syntax.
+     * <p>
+     * <u>Note 2:</u> If the mock is serialized then deserialized, then this answer will not be able to understand
+     * generics metadata.
      */
     public static final Answer<Object> CALLS_REAL_METHODS = Answers.CALLS_REAL_METHODS;
 

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodInterceptor.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodInterceptor.java
@@ -46,13 +46,11 @@ public class MockMethodInterceptor implements Serializable {
                        Method invokedMethod,
                        Object[] arguments,
                        RealMethod realMethod) throws Throwable {
-        return doIntercept(
-                mock,
-                invokedMethod,
-                arguments,
-            realMethod,
-                new LocationImpl()
-        );
+        return doIntercept(mock,
+                           invokedMethod,
+                           arguments,
+                           realMethod,
+                           new LocationImpl());
     }
 
     Object doIntercept(Object mock,
@@ -108,11 +106,11 @@ public class MockMethodInterceptor implements Serializable {
                 return superCall.call();
             }
             return interceptor.doIntercept(
-                    mock,
-                    invokedMethod,
-                    arguments,
-                    new RealMethod.FromCallable(superCall)
-            );
+                mock,
+                invokedMethod,
+                arguments,
+                new RealMethod.FromCallable(superCall)
+                                          );
         }
 
         @SuppressWarnings("unused")
@@ -126,11 +124,11 @@ public class MockMethodInterceptor implements Serializable {
                 return stubValue;
             }
             return interceptor.doIntercept(
-                    mock,
-                    invokedMethod,
-                    arguments,
-                    RealMethod.IsIllegal.INSTANCE
-            );
+                mock,
+                invokedMethod,
+                arguments,
+                RealMethod.IsIllegal.INSTANCE
+                                          );
         }
     }
 }

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsDeepStubs.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsDeepStubs.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.withSettings;
 /**
  * Returning deep stub implementation.
  *
- * Will return previously created mock if the invocation matches.
+ * <p>Will return previously created mock if the invocation matches.
  *
  * <p>Supports nested generic information, with this answer you can write code like this :
  *
@@ -37,6 +37,8 @@ import static org.mockito.Mockito.withSettings;
  * </code></pre>
  * </p>
  *
+ * <p>However this answer does not support generics information when the mock has been deserialized.
+ *
  * @see org.mockito.Mockito#RETURNS_DEEP_STUBS
  * @see org.mockito.Answers#RETURNS_DEEP_STUBS
  */
@@ -46,21 +48,21 @@ public class ReturnsDeepStubs implements Answer<Object>, Serializable {
 
     public Object answer(InvocationOnMock invocation) throws Throwable {
         GenericMetadataSupport returnTypeGenericMetadata =
-                actualParameterizedType(invocation.getMock()).resolveGenericReturnType(invocation.getMethod());
+            actualParameterizedType(invocation.getMock()).resolveGenericReturnType(invocation.getMethod());
 
         Class<?> rawType = returnTypeGenericMetadata.rawType();
         if (!mockitoCore().isTypeMockable(rawType)) {
             return delegate().returnValueFor(rawType);
         }
 
-        // When dealing with erasured generics, we only receive the Object type as rawType. At this
+        // When dealing with erased generics, we only receive the Object type as rawType. At this
         // point, there is nothing to salvage for Mockito. Instead of trying to be smart and generate
         // a mock that would potentially match the return signature, instead return `null`. This
         // is valid per the CheckCast JVM instruction and is better than causing a ClassCastException
         // on runtime.
-//        if (rawType.equals(Object.class)) {
-//            return null;
-//        }
+        if (rawType.equals(Object.class) && !returnTypeGenericMetadata.hasRawExtraInterfaces()) {
+            return null;
+        }
 
         return deepStub(invocation, returnTypeGenericMetadata);
     }
@@ -78,9 +80,9 @@ public class ReturnsDeepStubs implements Answer<Object>, Serializable {
 
         // record deep stub answer
         StubbedInvocationMatcher stubbing = recordDeepStubAnswer(
-                newDeepStubMock(returnTypeGenericMetadata, invocation.getMock()),
-                container
-        );
+            newDeepStubMock(returnTypeGenericMetadata, invocation.getMock()),
+            container
+                                                                );
 
         // deep stubbing creates a stubbing and immediately uses it
         // so the stubbing is actually used by the same invocation
@@ -97,24 +99,24 @@ public class ReturnsDeepStubs implements Answer<Object>, Serializable {
      * {@link ReturnsDeepStubs} answer in which we will store the returned type generic metadata.
      *
      * @param returnTypeGenericMetadata The metadata to use to create the new mock.
-     * @param parentMock The parent of the current deep stub mock.
+     * @param parentMock                The parent of the current deep stub mock.
      * @return The mock
      */
     private Object newDeepStubMock(GenericMetadataSupport returnTypeGenericMetadata, Object parentMock) {
         MockCreationSettings parentMockSettings = MockUtil.getMockSettings(parentMock);
         return mockitoCore().mock(
-                returnTypeGenericMetadata.rawType(),
-                withSettingsUsing(returnTypeGenericMetadata, parentMockSettings)
-        );
+            returnTypeGenericMetadata.rawType(),
+            withSettingsUsing(returnTypeGenericMetadata, parentMockSettings)
+                                 );
     }
 
     private MockSettings withSettingsUsing(GenericMetadataSupport returnTypeGenericMetadata, MockCreationSettings parentMockSettings) {
         MockSettings mockSettings = returnTypeGenericMetadata.hasRawExtraInterfaces() ?
-                withSettings().extraInterfaces(returnTypeGenericMetadata.rawExtraInterfaces())
-                : withSettings();
+                                    withSettings().extraInterfaces(returnTypeGenericMetadata.rawExtraInterfaces())
+                                                                                      : withSettings();
 
         return propagateSerializationSettings(mockSettings, parentMockSettings)
-                .defaultAnswer(returnsDeepStubsAnswerUsing(returnTypeGenericMetadata));
+            .defaultAnswer(returnsDeepStubsAnswerUsing(returnTypeGenericMetadata));
     }
 
     private MockSettings propagateSerializationSettings(MockSettings mockSettings, MockCreationSettings parentMockSettings) {
@@ -148,6 +150,15 @@ public class ReturnsDeepStubs implements Answer<Object>, Serializable {
         protected GenericMetadataSupport actualParameterizedType(Object mock) {
             return returnTypeGenericMetadata;
         }
+
+        /**
+         * Generics support and serialization with deep stubs don't work together.
+         * <p>
+         * The issue is that GenericMetadataSupport is not serializable because
+         * the type elements inferred via reflection are not serializable. Supporting
+         * serialization would require to replace all types coming from the Java reflection
+         * with our own and still managing type equality with the JDK ones.
+         */
         private Object writeReplace() throws IOException {
             return Mockito.RETURNS_DEEP_STUBS;
         }
@@ -161,6 +172,7 @@ public class ReturnsDeepStubs implements Answer<Object>, Serializable {
         DeeplyStubbedAnswer(Object mock) {
             this.mock = mock;
         }
+
         public Object answer(InvocationOnMock invocation) throws Throwable {
             return mock;
         }

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsDeepStubs.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsDeepStubs.java
@@ -58,9 +58,9 @@ public class ReturnsDeepStubs implements Answer<Object>, Serializable {
         // a mock that would potentially match the return signature, instead return `null`. This
         // is valid per the CheckCast JVM instruction and is better than causing a ClassCastException
         // on runtime.
-        if (rawType.equals(Object.class)) {
-            return null;
-        }
+//        if (rawType.equals(Object.class)) {
+//            return null;
+//        }
 
         return deepStub(invocation, returnTypeGenericMetadata);
     }

--- a/src/main/java/org/mockito/internal/util/reflection/GenericMetadataSupport.java
+++ b/src/main/java/org/mockito/internal/util/reflection/GenericMetadataSupport.java
@@ -418,6 +418,7 @@ public abstract class GenericMetadataSupport {
         private final TypeVariable<?> typeVariable;
         private final TypeVariable<?>[] typeParameters;
         private Class<?> rawType;
+        private List<Type> extraInterfaces;
 
         public TypeVariableReturnType(GenericMetadataSupport source, TypeVariable<?>[] typeParameters, TypeVariable<?> typeVariable) {
             this.typeParameters = typeParameters;
@@ -450,15 +451,18 @@ public abstract class GenericMetadataSupport {
 
         @Override
         public List<Type> extraInterfaces() {
+            if (extraInterfaces != null) {
+                return extraInterfaces;
+            }
             Type type = extractActualBoundedTypeOf(typeVariable);
             if (type instanceof BoundedType) {
-                return Arrays.asList(((BoundedType) type).interfaceBounds());
+                return extraInterfaces = Arrays.asList(((BoundedType) type).interfaceBounds());
             }
             if (type instanceof ParameterizedType) {
-                return Collections.singletonList(type);
+                return extraInterfaces = Collections.singletonList(type);
             }
             if (type instanceof Class) {
-                return Collections.emptyList();
+                return extraInterfaces = Collections.emptyList();
             }
             throw new MockitoException("Cannot extract extra-interfaces from '" + typeVariable + "' : '" + type + "'");
         }

--- a/src/main/java/org/mockito/internal/util/reflection/GenericMetadataSupport.java
+++ b/src/main/java/org/mockito/internal/util/reflection/GenericMetadataSupport.java
@@ -8,8 +8,23 @@ package org.mockito.internal.util.reflection;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.util.Checks;
 
-import java.lang.reflect.*;
-import java.util.*;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
 
 
 /**
@@ -17,20 +32,20 @@ import java.util.*;
  * and accessible members.
  *
  * <p>
- *     The main idea of this code is to create a Map that will help to resolve return types.
- *     In order to actually work with nested generics, this map will have to be passed along new instances
- *     as a type context.
+ * The main idea of this code is to create a Map that will help to resolve return types.
+ * In order to actually work with nested generics, this map will have to be passed along new instances
+ * as a type context.
  * </p>
  *
  * <p>
- *     Hence :
- *     <ul>
- *         <li>A new instance representing the metadata is created using the {@link #inferFrom(Type)} method from a real
- *         <code>Class</code> or from a <code>ParameterizedType</code>, other types are not yet supported.</li>
+ * Hence :
+ * <ul>
+ * <li>A new instance representing the metadata is created using the {@link #inferFrom(Type)} method from a real
+ * <code>Class</code> or from a <code>ParameterizedType</code>, other types are not yet supported.</li>
  *
- *         <li>Then from this metadata, we can extract meta-data for a generic return type of a method, using
- *         {@link #resolveGenericReturnType(Method)}.</li>
- *     </ul>
+ * <li>Then from this metadata, we can extract meta-data for a generic return type of a method, using
+ * {@link #resolveGenericReturnType(Method)}.</li>
+ * </ul>
  * </p>
  *
  * <p>
@@ -98,19 +113,10 @@ public abstract class GenericMetadataSupport {
         if (type instanceof TypeVariable) {
             /*
              * If type is a TypeVariable, then it is needed to gather data elsewhere.
-             * Usually TypeVariables are declared on the class definition, such as
-             * such as List<E>.
-             *
-             * If the data cannot be found in the contextual map, try harder on the
-             * TypeVariable itself looking for defined bounds.
+             * Usually TypeVariables are declared on the class definition, such as such
+             * as List<E>.
              */
-            Type typeArgument = contextualActualTypeParameters.get(type);
-            if (typeArgument == null) {
-                BoundedType boundedType = boundsOf((TypeVariable<?>) type);
-                contextualActualTypeParameters.put((TypeVariable<?>) type, boundedType);
-                return extractRawTypeOf(boundedType);
-            }
-            return extractRawTypeOf(typeArgument);
+            return extractRawTypeOf(contextualActualTypeParameters.get(type));
         }
         throw new MockitoException("Raw extraction not supported for : '" + type + "'");
     }
@@ -126,10 +132,21 @@ public abstract class GenericMetadataSupport {
             TypeVariable<?> typeParameter = typeParameters[i];
             Type actualTypeArgument = actualTypeArguments[i];
 
-            // Prevent registration of a cycle of TypeVariables. This can happen when we are processing
-            // type parameters in a Method, while we already processed the type parameters of a class.
-            if (actualTypeArgument instanceof TypeVariable && contextualActualTypeParameters.containsKey(typeParameter)) {
-                continue;
+            if (actualTypeArgument instanceof TypeVariable) {
+                /*
+                 * If actualTypeArgument is a TypeVariable, and it is not present in
+                 * the context map then it is needed to try harder to gather more data
+                 * from the type argument itself. In some case the type argument do
+                 * define upper bounds, this allow to look for them if not in the
+                 * context map.
+                 */
+                registerTypeVariableIfNotPresent((TypeVariable<?>) actualTypeArgument);
+
+                // Prevent registration of a cycle of TypeVariables. This can happen when we are processing
+                // type parameters in a Method, while we already processed the type parameters of a class.
+                if (contextualActualTypeParameters.containsKey(typeParameter)) {
+                    continue;
+                }
             }
 
             if (actualTypeArgument instanceof WildcardType) {
@@ -157,7 +174,7 @@ public abstract class GenericMetadataSupport {
     /**
      * @param typeParameter The TypeVariable parameter
      * @return A {@link BoundedType} for easy bound information, if first bound is a TypeVariable
-     *         then retrieve BoundedType of this TypeVariable
+     * then retrieve BoundedType of this TypeVariable
      */
     private BoundedType boundsOf(TypeVariable<?> typeParameter) {
         if (typeParameter.getBounds()[0] instanceof TypeVariable) {
@@ -169,7 +186,7 @@ public abstract class GenericMetadataSupport {
     /**
      * @param wildCard The WildCard type
      * @return A {@link BoundedType} for easy bound information, if first bound is a TypeVariable
-     *         then retrieve BoundedType of this TypeVariable
+     * then retrieve BoundedType of this TypeVariable
      */
     private BoundedType boundsOf(WildcardType wildCard) {
         /*
@@ -255,7 +272,7 @@ public abstract class GenericMetadataSupport {
         // logger.log("Method '" + method.toGenericString() + "' has return type : " + genericReturnType.getClass().getInterfaces()[0].getSimpleName() + " : " + genericReturnType);
 
         int arity = 0;
-        while(genericReturnType instanceof GenericArrayType) {
+        while (genericReturnType instanceof GenericArrayType) {
             arity++;
             genericReturnType = ((GenericArrayType) genericReturnType).getGenericComponentType();
         }
@@ -287,8 +304,8 @@ public abstract class GenericMetadataSupport {
      * Create an new instance of {@link GenericMetadataSupport} inferred from a {@link Type}.
      *
      * <p>
-     *     At the moment <code>type</code> can only be a {@link Class} or a {@link ParameterizedType}, otherwise
-     *     it'll throw a {@link MockitoException}.
+     * At the moment <code>type</code> can only be a {@link Class} or a {@link ParameterizedType}, otherwise
+     * it'll throw a {@link MockitoException}.
      * </p>
      *
      * @param type The class from which the {@link GenericMetadataSupport} should be built.
@@ -314,7 +331,7 @@ public abstract class GenericMetadataSupport {
 
     /**
      * Generic metadata implementation for {@link Class}.
-     *
+     * <p>
      * Offer support to retrieve generic metadata on a {@link Class} by reading type parameters and type variables on
      * the class and its ancestors and interfaces.
      */
@@ -336,10 +353,10 @@ public abstract class GenericMetadataSupport {
 
     /**
      * Generic metadata implementation for "standalone" {@link ParameterizedType}.
-     *
+     * <p>
      * Offer support to retrieve generic metadata on a {@link ParameterizedType} by reading type variables of
      * the related raw type and declared type variable of this parameterized type.
-     *
+     * <p>
      * This class is not designed to work on ParameterizedType returned by {@link Method#getGenericReturnType()}, as
      * the ParameterizedType instance return in these cases could have Type Variables that refer to type declaration(s).
      * That's what meant the "standalone" word at the beginning of the Javadoc.
@@ -419,7 +436,7 @@ public abstract class GenericMetadataSupport {
             for (Type type : typeVariable.getBounds()) {
                 registerTypeVariablesOn(type);
             }
-            registerTypeParametersOn(new TypeVariable[] { typeVariable });
+            registerTypeParametersOn(new TypeVariable[]{typeVariable});
             registerTypeVariablesOn(getActualTypeArgumentFor(typeVariable));
         }
 
@@ -456,7 +473,7 @@ public abstract class GenericMetadataSupport {
             for (Type extraInterface : extraInterfaces) {
                 Class<?> rawInterface = extractRawTypeOf(extraInterface);
                 // avoid interface collision with actual raw type (with typevariables, resolution ca be quite aggressive)
-                if(!rawType().equals(rawInterface)) {
+                if (!rawType().equals(rawInterface)) {
                     rawExtraInterfaces.add(rawInterface);
                 }
             }
@@ -528,7 +545,6 @@ public abstract class GenericMetadataSupport {
     }
 
 
-
     /**
      * Type representing bounds of a type
      *
@@ -551,7 +567,7 @@ public abstract class GenericMetadataSupport {
      *
      * <p>If upper bounds are declared with SomeClass and additional interfaces, then firstBound will be SomeClass and
      * interfacesBound will be an array of the additional interfaces.
-     *
+     * <p>
      * i.e. <code>SomeClass</code>.
      * <pre class="code"><code class="java">
      *     interface UpperBoundedTypeWithClass<E extends Comparable<E> & Cloneable> {

--- a/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsGenericDeepStubsTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsGenericDeepStubsTest.java
@@ -34,7 +34,7 @@ public class ReturnsGenericDeepStubsTest {
     }
 
     @Test
-    public void generic_deep_mock_frenzy__look_at_these_chained_calls() throws Exception {
+    public void generic_deep_mock_frenzy__look_at_these_chained_calls() {
         GenericsNest<?> mock = mock(GenericsNest.class, RETURNS_DEEP_STUBS);
 
         Set<? extends Map.Entry<? extends Cloneable, Set<Number>>> entries = mock.entrySet();
@@ -50,7 +50,7 @@ public class ReturnsGenericDeepStubsTest {
     }
 
     @Test
-    public void can_create_mock_from_multiple_type_variable_bounds_when_return_type_of_parameterized_method_is_a_parameterizedtype_that_is_referencing_a_typevar_on_class() throws Exception {
+    public void can_create_mock_from_multiple_type_variable_bounds_when_return_type_of_parameterized_method_is_a_parameterizedType_that_is_referencing_a_typeVar_on_class() {
         GenericsNest<?> mock = mock(GenericsNest.class, RETURNS_DEEP_STUBS);
 
         Cloneable cloneable_bound_that_is_declared_on_typevar_K_in_the_class_which_is_referenced_by_typevar_O_declared_on_the_method =
@@ -60,7 +60,7 @@ public class ReturnsGenericDeepStubsTest {
     }
 
     @Test
-    public void can_create_mock_from_multiple_type_variable_bounds_when_method_return_type_is_referencing_a_typevar_on_class() throws Exception {
+    public void can_create_mock_from_multiple_type_variable_bounds_when_method_return_type_is_referencing_a_typeVar_on_class() {
         GenericsNest<?> mock = mock(GenericsNest.class, RETURNS_DEEP_STUBS);
 
         Cloneable cloneable_bound_of_typevar_K = mock.returningK();
@@ -68,7 +68,7 @@ public class ReturnsGenericDeepStubsTest {
     }
 
     @Test
-    public void can_create_mock_from_multiple_type_variable_bounds_when_return_type_of_parameterized_method_is_a_typevar_that_is_referencing_a_typevar_on_class() throws Exception {
+    public void can_create_mock_from_multiple_type_variable_bounds_when_return_type_of_parameterized_method_is_a_typeVar_that_is_referencing_a_typeVar_on_class() {
         GenericsNest<?> mock = mock(GenericsNest.class, RETURNS_DEEP_STUBS);
 
         Cloneable cloneable_bound_of_typevar_K_referenced_by_typevar_O = (Cloneable) mock.typeVarWithTypeParams();
@@ -76,7 +76,7 @@ public class ReturnsGenericDeepStubsTest {
     }
 
     @Test
-    public void can_create_mock_from_return_types_declared_with_a_bounded_wildcard() throws Exception {
+    public void can_create_mock_from_return_types_declared_with_a_bounded_wildcard() {
         GenericsNest<?> mock = mock(GenericsNest.class, RETURNS_DEEP_STUBS);
 
         List<? super Integer> objects = mock.returningWildcard();
@@ -85,7 +85,7 @@ public class ReturnsGenericDeepStubsTest {
     }
 
     @Test
-    public void can_still_work_with_raw_type_in_the_return_type() throws Exception {
+    public void can_still_work_with_raw_type_in_the_return_type() {
         GenericsNest<?> mock = mock(GenericsNest.class, RETURNS_DEEP_STUBS);
 
         Number the_raw_type_that_should_be_returned = mock.returnsNormalType();
@@ -93,7 +93,7 @@ public class ReturnsGenericDeepStubsTest {
     }
 
     @Test
-    public void will_return_default_value_on_non_mockable_nested_generic() throws Exception {
+    public void will_return_default_value_on_non_mockable_nested_generic() {
         GenericsNest<?> genericsNest = mock(GenericsNest.class, RETURNS_DEEP_STUBS);
         ListOfInteger listOfInteger = mock(ListOfInteger.class, RETURNS_DEEP_STUBS);
         AnotherListOfInteger anotherListOfInteger = mock(AnotherListOfInteger.class, RETURNS_DEEP_STUBS);
@@ -104,7 +104,7 @@ public class ReturnsGenericDeepStubsTest {
     }
 
     @Test(expected = ClassCastException.class)
-    public void as_expected_fail_with_a_CCE_on_callsite_when_erasure_takes_place_for_example___StringBuilder_is_subject_to_erasure() throws Exception {
+    public void as_expected_fail_with_a_CCE_on_call_site_when_erasure_takes_place_for_example___StringBuilder_is_subject_to_erasure() {
         GenericsNest<?> mock = mock(GenericsNest.class, RETURNS_DEEP_STUBS);
 
         // following assignment needed to create a ClassCastException on the call site (i.e. : here)

--- a/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsGenericDeepStubsTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsGenericDeepStubsTest.java
@@ -5,11 +5,14 @@
 package org.mockito.internal.stubbing.defaultanswers;
 
 import org.junit.Test;
+import org.mockitousage.examples.use.Article;
 
+import java.io.Closeable;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Callable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -18,18 +21,27 @@ import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unused")
 public class ReturnsGenericDeepStubsTest {
-    interface ListOfInteger extends List<Integer> {}
+    interface ListOfInteger extends List<Integer> {
+    }
 
-    interface AnotherListOfInteger extends ListOfInteger {}
+    interface AnotherListOfInteger extends ListOfInteger {
+    }
 
     interface GenericsNest<K extends Comparable<K> & Cloneable> extends Map<K, Set<Number>> {
         Set<Number> remove(Object key); // override with fixed ParameterizedType
+
         List<? super Number> returningWildcard();
+
         Map<String, K> returningNonMockableNestedGeneric();
+
         K returningK();
+
         <O extends K> List<O> paramTypeWithTypeParams();
+
         <S extends Appendable, T extends S> T twoTypeParams(S s);
+
         <O extends K> O typeVarWithTypeParams();
+
         Number returnsNormalType();
     }
 
@@ -38,7 +50,7 @@ public class ReturnsGenericDeepStubsTest {
         GenericsNest<?> mock = mock(GenericsNest.class, RETURNS_DEEP_STUBS);
 
         Set<? extends Map.Entry<? extends Cloneable, Set<Number>>> entries = mock.entrySet();
-        Iterator<? extends Map.Entry<? extends Cloneable,Set<Number>>> entriesIterator = mock.entrySet().iterator();
+        Iterator<? extends Map.Entry<? extends Cloneable, Set<Number>>> entriesIterator = mock.entrySet().iterator();
         Map.Entry<? extends Cloneable, Set<Number>> nextEntry = mock.entrySet().iterator().next();
 
         Cloneable cloneableKey = mock.entrySet().iterator().next().getKey();
@@ -54,9 +66,9 @@ public class ReturnsGenericDeepStubsTest {
         GenericsNest<?> mock = mock(GenericsNest.class, RETURNS_DEEP_STUBS);
 
         Cloneable cloneable_bound_that_is_declared_on_typevar_K_in_the_class_which_is_referenced_by_typevar_O_declared_on_the_method =
-                mock.paramTypeWithTypeParams().get(0);
+            mock.paramTypeWithTypeParams().get(0);
         Comparable<?> comparable_bound_that_is_declared_on_typevar_K_in_the_class_which_is_referenced_by_typevar_O_declared_on_the_method =
-                mock.paramTypeWithTypeParams().get(0);
+            mock.paramTypeWithTypeParams().get(0);
     }
 
     @Test
@@ -109,7 +121,7 @@ public class ReturnsGenericDeepStubsTest {
 
         // following assignment needed to create a ClassCastException on the call site (i.e. : here)
         StringBuilder stringBuilder_assignment_that_should_throw_a_CCE =
-                mock.twoTypeParams(new StringBuilder()).append(2).append(3);
+            mock.twoTypeParams(new StringBuilder()).append(2).append(3);
     }
 
     class WithGenerics<T> {
@@ -117,7 +129,9 @@ public class ReturnsGenericDeepStubsTest {
             throw new IllegalArgumentException();
         }
     }
-    class SubClass<S> extends WithGenerics<S> {}
+
+    class SubClass<S> extends WithGenerics<S> {
+    }
 
     class UserOfSubClass {
         SubClass<String> generate() {
@@ -132,5 +146,50 @@ public class ReturnsGenericDeepStubsTest {
         when(mock.generate().execute()).thenReturn("sub");
 
         assertThat(mock.generate().execute()).isEqualTo("sub");
+    }
+
+    public interface TopInterface<T> {
+        T generic();
+    }
+
+    public interface MiddleInterface<T> extends TopInterface<T> {
+    }
+
+    public class OwningClassWithDeclaredUpperBounds<T extends Iterable<Article> & Callable<Article> & Closeable> {
+        public abstract class AbstractInner implements MiddleInterface<T> {
+        }
+    }
+
+    @Test
+    public void cannot_handle_deep_stubs_with_generics_declared_upper_bounds_at_end_of_deep_invocation() throws Exception {
+        OwningClassWithDeclaredUpperBounds.AbstractInner mock =
+            mock(OwningClassWithDeclaredUpperBounds.AbstractInner.class, RETURNS_DEEP_STUBS);
+
+        // It seems that while the syntax used on OwningClassWithDeclaredUpperBounds.AbstractInner
+        // appear to be legal, the javac compiler does not follow through
+        // hence we need casting, this may also explain why GenericMetadataSupport has trouble to
+        // extract matching data as well.
+
+        assertThat(mock.generic())
+            .describedAs("mock should implement first bound : 'Iterable'")
+            .isInstanceOf(Iterable.class);
+        assertThat(((Iterable<Article>) mock.generic()).iterator())
+            .describedAs("Iterable returns Iterator").isInstanceOf(Iterator.class);
+        assertThat(((Iterable<Article>) mock.generic()).iterator().next())
+            .describedAs("Cannot yet extract Type argument 'Article' so return null instead of a mock "
+                         + "of type Object (which would raise CCE on the call-site)")
+            .isNull();
+
+        assertThat(mock.generic())
+            .describedAs("mock should implement second interface bound : 'Callable'")
+            .isInstanceOf(Callable.class);
+        assertThat(((Callable<Article>) mock.generic()).call())
+            .describedAs("Cannot yet extract Type argument 'Article' so return null instead of a mock "
+                         + "of type Object (which would raise CCE on the call-site)")
+            .isNull();
+
+        assertThat(mock.generic())
+            .describedAs("mock should implement third interface bound : 'Closeable'")
+            .isInstanceOf(Closeable.class);
     }
 }

--- a/src/test/java/org/mockito/internal/util/reflection/GenericMetadataSupportTest.java
+++ b/src/test/java/org/mockito/internal/util/reflection/GenericMetadataSupportTest.java
@@ -80,7 +80,7 @@ public class GenericMetadataSupportTest {
     }
 
     @Test
-    public void can_get_raw_type_from_ParameterizedType() throws Exception {
+    public void can_get_raw_type_from_ParameterizedType() {
         assertThat(inferFrom(ListOfAnyNumbers.class.getGenericInterfaces()[0]).rawType()).isEqualTo(List.class);
         assertThat(inferFrom(ListOfNumbers.class.getGenericInterfaces()[0]).rawType()).isEqualTo(List.class);
         assertThat(inferFrom(GenericsNest.class.getGenericInterfaces()[0]).rawType()).isEqualTo(Map.class);
@@ -88,7 +88,7 @@ public class GenericMetadataSupportTest {
     }
 
     @Test
-    public void can_get_type_variables_from_Class() throws Exception {
+    public void can_get_type_variables_from_Class() {
         assertThat(inferFrom(GenericsNest.class).actualTypeArguments().keySet()).hasSize(1).extracting("name").contains("K");
         assertThat(inferFrom(ListOfNumbers.class).actualTypeArguments().keySet()).isEmpty();
         assertThat(inferFrom(ListOfAnyNumbers.class).actualTypeArguments().keySet()).hasSize(1).extracting("name").contains("N");
@@ -105,7 +105,7 @@ public class GenericMetadataSupportTest {
     }
 
     @Test
-    public void can_get_type_variables_from_ParameterizedType() throws Exception {
+    public void can_get_type_variables_from_ParameterizedType() {
         assertThat(inferFrom(GenericsNest.class.getGenericInterfaces()[0]).actualTypeArguments().keySet()).hasSize(2).extracting("name").contains("K", "V");
         assertThat(inferFrom(ListOfAnyNumbers.class.getGenericInterfaces()[0]).actualTypeArguments().keySet()).hasSize(1).extracting("name").contains("E");
         assertThat(inferFrom(Integer.class.getGenericInterfaces()[0]).actualTypeArguments().keySet()).hasSize(1).extracting("name").contains("T");
@@ -114,7 +114,7 @@ public class GenericMetadataSupportTest {
     }
 
     @Test
-    public void typeVariable_return_type_of____iterator____resolved_to_Iterator_and_type_argument_to_String() throws Exception {
+    public void typeVariable_return_type_of____iterator____resolved_to_Iterator_and_type_argument_to_String() {
         GenericMetadataSupport genericMetadata = inferFrom(StringList.class).resolveGenericReturnType(firstNamedMethod("iterator", StringList.class));
 
         assertThat(genericMetadata.rawType()).isEqualTo(Iterator.class);
@@ -122,7 +122,7 @@ public class GenericMetadataSupportTest {
     }
 
     @Test
-    public void typeVariable_return_type_of____get____resolved_to_Set_and_type_argument_to_Number() throws Exception {
+    public void typeVariable_return_type_of____get____resolved_to_Set_and_type_argument_to_Number() {
         GenericMetadataSupport genericMetadata = inferFrom(GenericsNest.class).resolveGenericReturnType(firstNamedMethod("get", GenericsNest.class));
 
         assertThat(genericMetadata.rawType()).isEqualTo(Set.class);
@@ -130,7 +130,7 @@ public class GenericMetadataSupportTest {
     }
 
     @Test
-    public void bounded_typeVariable_return_type_of____returningK____resolved_to_Comparable_and_with_BoundedType() throws Exception {
+    public void bounded_typeVariable_return_type_of____returningK____resolved_to_Comparable_and_with_BoundedType() {
         GenericMetadataSupport genericMetadata = inferFrom(GenericsNest.class).resolveGenericReturnType(firstNamedMethod("returningK", GenericsNest.class));
 
         assertThat(genericMetadata.rawType()).isEqualTo(Comparable.class);
@@ -139,7 +139,7 @@ public class GenericMetadataSupportTest {
     }
 
     @Test
-    public void fixed_ParamType_return_type_of____remove____resolved_to_Set_and_type_argument_to_Number() throws Exception {
+    public void fixed_ParamType_return_type_of____remove____resolved_to_Set_and_type_argument_to_Number() {
         GenericMetadataSupport genericMetadata = inferFrom(GenericsNest.class).resolveGenericReturnType(firstNamedMethod("remove", GenericsNest.class));
 
         assertThat(genericMetadata.rawType()).isEqualTo(Set.class);
@@ -147,7 +147,7 @@ public class GenericMetadataSupportTest {
     }
 
     @Test
-    public void paramType_return_type_of____values____resolved_to_Collection_and_type_argument_to_Parameterized_Set() throws Exception {
+    public void paramType_return_type_of____values____resolved_to_Collection_and_type_argument_to_Parameterized_Set() {
         GenericMetadataSupport genericMetadata = inferFrom(GenericsNest.class).resolveGenericReturnType(firstNamedMethod("values", GenericsNest.class));
 
         assertThat(genericMetadata.rawType()).isEqualTo(Collection.class);
@@ -157,7 +157,7 @@ public class GenericMetadataSupportTest {
     }
 
     @Test
-    public void paramType_with_type_parameters_return_type_of____paramType_with_type_params____resolved_to_Collection_and_type_argument_to_Parameterized_Set() throws Exception {
+    public void paramType_with_type_parameters_return_type_of____paramType_with_type_params____resolved_to_Collection_and_type_argument_to_Parameterized_Set() {
         GenericMetadataSupport genericMetadata = inferFrom(GenericsNest.class).resolveGenericReturnType(firstNamedMethod("paramType_with_type_params", GenericsNest.class));
 
         assertThat(genericMetadata.rawType()).isEqualTo(List.class);
@@ -166,7 +166,7 @@ public class GenericMetadataSupportTest {
     }
 
     @Test
-    public void typeVariable_with_type_parameters_return_type_of____typeVar_with_type_params____resolved_K_hence_to_Comparable_and_with_BoundedType() throws Exception {
+    public void typeVariable_with_type_parameters_return_type_of____typeVar_with_type_params____resolved_K_hence_to_Comparable_and_with_BoundedType() {
         GenericMetadataSupport genericMetadata = inferFrom(GenericsNest.class).resolveGenericReturnType(firstNamedMethod("typeVar_with_type_params", GenericsNest.class));
 
         assertThat(genericMetadata.rawType()).isEqualTo(Comparable.class);
@@ -175,7 +175,7 @@ public class GenericMetadataSupportTest {
     }
 
     @Test
-    public void class_return_type_of____append____resolved_to_StringBuilder_and_type_arguments() throws Exception {
+    public void class_return_type_of____append____resolved_to_StringBuilder_and_type_arguments() {
         GenericMetadataSupport genericMetadata = inferFrom(StringBuilder.class).resolveGenericReturnType(firstNamedMethod("append", StringBuilder.class));
 
         assertThat(genericMetadata.rawType()).isEqualTo(StringBuilder.class);
@@ -185,7 +185,7 @@ public class GenericMetadataSupportTest {
 
 
     @Test
-    public void paramType_with_wildcard_return_type_of____returning_wildcard_with_class_lower_bound____resolved_to_List_and_type_argument_to_Integer() throws Exception {
+    public void paramType_with_wildcard_return_type_of____returning_wildcard_with_class_lower_bound____resolved_to_List_and_type_argument_to_Integer() {
         GenericMetadataSupport genericMetadata = inferFrom(GenericsNest.class).resolveGenericReturnType(firstNamedMethod("returning_wildcard_with_class_lower_bound", GenericsNest.class));
 
         assertThat(genericMetadata.rawType()).isEqualTo(List.class);
@@ -195,7 +195,7 @@ public class GenericMetadataSupportTest {
     }
 
     @Test
-    public void paramType_with_wildcard_return_type_of____returning_wildcard_with_typeVar_lower_bound____resolved_to_List_and_type_argument_to_Integer() throws Exception {
+    public void paramType_with_wildcard_return_type_of____returning_wildcard_with_typeVar_lower_bound____resolved_to_List_and_type_argument_to_Integer() {
         GenericMetadataSupport genericMetadata = inferFrom(GenericsNest.class).resolveGenericReturnType(firstNamedMethod("returning_wildcard_with_typeVar_lower_bound", GenericsNest.class));
 
         assertThat(genericMetadata.rawType()).isEqualTo(List.class);
@@ -205,7 +205,7 @@ public class GenericMetadataSupportTest {
         assertThat(boundedType.interfaceBounds()).contains(Cloneable.class);    }
 
     @Test
-    public void paramType_with_wildcard_return_type_of____returning_wildcard_with_typeVar_upper_bound____resolved_to_List_and_type_argument_to_Integer() throws Exception {
+    public void paramType_with_wildcard_return_type_of____returning_wildcard_with_typeVar_upper_bound____resolved_to_List_and_type_argument_to_Integer() {
         GenericMetadataSupport genericMetadata = inferFrom(GenericsNest.class).resolveGenericReturnType(firstNamedMethod("returning_wildcard_with_typeVar_upper_bound", GenericsNest.class));
 
         assertThat(genericMetadata.rawType()).isEqualTo(List.class);

--- a/src/test/java/org/mockitousage/serialization/DeepStubsSerializableTest.java
+++ b/src/test/java/org/mockitousage/serialization/DeepStubsSerializableTest.java
@@ -11,7 +11,11 @@ import java.util.Iterator;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 import static org.mockitoutil.SimpleSerializationUtil.serializeAndBack;
 
 public class DeepStubsSerializableTest {
@@ -45,7 +49,7 @@ public class DeepStubsSerializableTest {
         assertThat(deserialized_deep_stub.iterator().next().add("yes")).isEqualTo(true);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void should_discard_generics_metadata_when_serialized_then_disabling_deep_stubs_with_generics() throws Exception {
         // given
         ListContainer deep_stubbed = mock(ListContainer.class, withSettings().defaultAnswer(RETURNS_DEEP_STUBS).serializable());
@@ -53,10 +57,14 @@ public class DeepStubsSerializableTest {
 
         ListContainer deserialized_deep_stub = serializeAndBack(deep_stubbed);
 
-        // when stubbing on a deserialized mock
-        when(deserialized_deep_stub.iterator().next().get(42)).thenReturn("no");
-
-        // then revert to the default RETURNS_DEEP_STUBS and the code will raise a ClassCastException
+        try {
+            // when stubbing on a deserialized mock
+            // then revert to the default RETURNS_DEEP_STUBS and the code will raise a ClassCastException
+            when(deserialized_deep_stub.iterator().next().get(42)).thenReturn("no");
+            fail("Expected an exception to be thrown as deep stubs and serialization does not play well together");
+        } catch (ClassCastException e) {
+            assertThat(e).hasMessageContaining("java.util.List");
+        }
     }
 
     static class SampleClass implements Serializable {

--- a/src/test/java/org/mockitousage/serialization/DeepStubsSerializableTest.java
+++ b/src/test/java/org/mockitousage/serialization/DeepStubsSerializableTest.java
@@ -62,8 +62,8 @@ public class DeepStubsSerializableTest {
             // then revert to the default RETURNS_DEEP_STUBS and the code will raise a ClassCastException
             when(deserialized_deep_stub.iterator().next().get(42)).thenReturn("no");
             fail("Expected an exception to be thrown as deep stubs and serialization does not play well together");
-        } catch (ClassCastException e) {
-            assertThat(e).hasMessageContaining("java.util.List");
+        } catch (NullPointerException e) {
+            assertThat(e).hasMessage(null);
         }
     }
 

--- a/src/test/java/org/mockitousage/stubbing/DeepStubbingTest.java
+++ b/src/test/java/org/mockitousage/stubbing/DeepStubbingTest.java
@@ -224,7 +224,7 @@ public class DeepStubbingTest extends TestBase {
     Person person = mock(Person.class, RETURNS_DEEP_STUBS);
 
     @Test
-    public void shouldStubbingBasicallyWorkFine() throws Exception {
+    public void shouldStubbingBasicallyWorkFine() {
         //given
         given(person.getAddress().getStreet().getName()).willReturn("Norymberska");
 
@@ -236,7 +236,7 @@ public class DeepStubbingTest extends TestBase {
     }
 
     @Test
-    public void shouldVerificationBasicallyWorkFine() throws Exception {
+    public void shouldVerificationBasicallyWorkFine() {
         //given
         person.getAddress().getStreet().getName();
 
@@ -245,7 +245,7 @@ public class DeepStubbingTest extends TestBase {
     }
 
     @Test
-    public void verification_work_with_argument_Matchers_in_nested_calls() throws Exception {
+    public void verification_work_with_argument_Matchers_in_nested_calls() {
         //given
         person.getAddress("111 Mock Lane").getStreet();
         person.getAddress("111 Mock Lane").getStreet(Locale.ITALIAN).getName();
@@ -257,7 +257,7 @@ public class DeepStubbingTest extends TestBase {
     }
 
     @Test
-    public void deep_stub_return_same_mock_instance_if_invocation_matchers_matches() throws Exception {
+    public void deep_stub_return_same_mock_instance_if_invocation_matchers_matches() {
         when(person.getAddress(anyString()).getStreet().getName()).thenReturn("deep");
 
         person.getAddress("the docks").getStreet().getName();
@@ -270,7 +270,7 @@ public class DeepStubbingTest extends TestBase {
     }
 
     @Test
-    public void times_never_atLeast_atMost_verificationModes_should_work() throws Exception {
+    public void times_never_atLeast_atMost_verificationModes_should_work() {
         when(person.getAddress(anyString()).getStreet().getName()).thenReturn("deep");
 
         person.getAddress("the docks").getStreet().getName();
@@ -285,7 +285,7 @@ public class DeepStubbingTest extends TestBase {
 
 
     @Test
-    public void inOrder_only_work_on_the_very_last_mock_but_it_works() throws Exception {
+    public void inOrder_only_work_on_the_very_last_mock_but_it_works() {
         when(person.getAddress(anyString()).getStreet().getName()).thenReturn("deep");
         when(person.getAddress(anyString()).getStreet(Locale.ITALIAN).getName()).thenReturn("deep");
         when(person.getAddress(anyString()).getStreet(Locale.CHINESE).getName()).thenReturn("deep");
@@ -307,7 +307,7 @@ public class DeepStubbingTest extends TestBase {
     }
 
     @Test
-    public void verificationMode_only_work_on_the_last_returned_mock() throws Exception {
+    public void verificationMode_only_work_on_the_last_returned_mock() {
         // 1st invocation on Address mock (stubbing)
         when(person.getAddress("the docks").getStreet().getName()).thenReturn("deep");
 
@@ -328,7 +328,7 @@ public class DeepStubbingTest extends TestBase {
     }
 
     @Test
-    public void shouldFailGracefullyWhenClassIsFinal() throws Exception {
+    public void shouldFailGracefullyWhenClassIsFinal() {
         //when
         FinalClass value = new FinalClass();
         given(person.getFinalClass()).willReturn(value);


### PR DESCRIPTION
This PR aim to fix the issue described in #1621, the issue being that terminal type variable arguments were not looked up for their bounds.

Fixes #1621 