### PR TITLE
refactors BeanPropertySetter into a static utility class

### DIFF
--- a/src/main/java/org/mockito/internal/configuration/injection/filter/TerminalMockCandidateFilter.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/filter/TerminalMockCandidateFilter.java
@@ -34,7 +34,8 @@ public class TerminalMockCandidateFilter implements MockCandidateFilter {
                     try {
                         BeanPropertySetter.target = injectee;
                         BeanPropertySetter.field = candidateFieldToBeInjected;
-                        if (BeanPropertySetter.set(matchingMock)) {
+                        BeanPropertySetter.reportNoSetterFound = false;
+                        if (!BeanPropertySetter.set(matchingMock)) {
                             setField(injectee, candidateFieldToBeInjected,matchingMock);
                         }
                     } catch (RuntimeException e) {

--- a/src/main/java/org/mockito/internal/configuration/injection/filter/TerminalMockCandidateFilter.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/filter/TerminalMockCandidateFilter.java
@@ -32,7 +32,9 @@ public class TerminalMockCandidateFilter implements MockCandidateFilter {
             return new OngoingInjector() {
                 public Object thenInject() {
                     try {
-                        if (!new BeanPropertySetter(injectee, candidateFieldToBeInjected).set(matchingMock)) {
+                        BeanPropertySetter.target = injectee;
+                        BeanPropertySetter.field = candidateFieldToBeInjected;
+                        if (BeanPropertySetter.set(matchingMock)) {
                             setField(injectee, candidateFieldToBeInjected,matchingMock);
                         }
                     } catch (RuntimeException e) {

--- a/src/main/java/org/mockito/internal/creation/instance/ConstructorInstantiator.java
+++ b/src/main/java/org/mockito/internal/creation/instance/ConstructorInstantiator.java
@@ -13,7 +13,8 @@ import java.util.List;
 import org.mockito.creation.instance.Instantiator;
 import org.mockito.creation.instance.InstantiationException;
 import org.mockito.internal.util.Primitives;
-import org.mockito.internal.util.reflection.AccessibilityChanger;
+
+import static org.mockito.internal.util.reflection.AccessibilityChanger.enableAccess;
 
 import static org.mockito.internal.util.StringUtil.join;
 
@@ -61,8 +62,7 @@ public class ConstructorInstantiator implements Instantiator {
 
     @SuppressWarnings("unchecked")
     private static <T> T invokeConstructor(Constructor<?> constructor, Object... params) throws java.lang.InstantiationException, IllegalAccessException, InvocationTargetException {
-        AccessibilityChanger accessibility = new AccessibilityChanger();
-        accessibility.enableAccess(constructor);
+        enableAccess(constructor);
         return (T) constructor.newInstance(params);
     }
 

--- a/src/main/java/org/mockito/internal/util/reflection/AccessibilityChanger.java
+++ b/src/main/java/org/mockito/internal/util/reflection/AccessibilityChanger.java
@@ -6,14 +6,15 @@ package org.mockito.internal.util.reflection;
 
 import java.lang.reflect.AccessibleObject;
 
-public class AccessibilityChanger {
+public final class AccessibilityChanger {
+    public static Boolean wasAccessible = null;
 
-    private Boolean wasAccessible = null;
+    private AccessibilityChanger() {}
 
     /**
      * safely disables access
      */
-    public void safelyDisableAccess(AccessibleObject accessibleObject) {
+    public static void safelyDisableAccess(AccessibleObject accessibleObject) {
         assert wasAccessible != null : "accessibility info shall not be null";
         try {
             accessibleObject.setAccessible(wasAccessible);
@@ -25,7 +26,7 @@ public class AccessibilityChanger {
     /**
      * changes the accessibleObject accessibility and returns true if accessibility was changed
      */
-    public void enableAccess(AccessibleObject accessibleObject) {
+    public static void enableAccess(AccessibleObject accessibleObject) {
         wasAccessible = accessibleObject.isAccessible();
         accessibleObject.setAccessible(true);
     }

--- a/src/main/java/org/mockito/internal/util/reflection/BeanPropertySetter.java
+++ b/src/main/java/org/mockito/internal/util/reflection/BeanPropertySetter.java
@@ -24,10 +24,8 @@ public final class BeanPropertySetter {
      * @param propertyField The field that should be accessed with the setter
      * @param reportNoSetterFound Allow the set method to raise an Exception if the setter cannot be found
      */
-    private BeanPropertySetter(final Object target, final Field propertyField, boolean reportNoSetterFound) {
-        this.field = propertyField;
-        this.target = target;
-        this.reportNoSetterFound = reportNoSetterFound;
+    private BeanPropertySetter() {
+        throw new UnsupportedOperationException();
     }
 
     /**

--- a/src/main/java/org/mockito/internal/util/reflection/BeanPropertySetter.java
+++ b/src/main/java/org/mockito/internal/util/reflection/BeanPropertySetter.java
@@ -12,21 +12,19 @@ import java.util.Locale;
 /**
  * This utility class will call the setter of the property to inject a new value.
  */
-public class BeanPropertySetter {
+public final class BeanPropertySetter {
 
-    private static final String SET_PREFIX = "set";
-
-    private final Object target;
-    private final boolean reportNoSetterFound;
-    private final Field field;
-
+    public static final String SET_PREFIX = "set";
+    public static Object target;
+    public static Field field;
+    public static boolean reportNoSetterFound;
     /**
      * New BeanPropertySetter
      * @param target The target on which the setter must be invoked
      * @param propertyField The field that should be accessed with the setter
      * @param reportNoSetterFound Allow the set method to raise an Exception if the setter cannot be found
      */
-    public BeanPropertySetter(final Object target, final Field propertyField, boolean reportNoSetterFound) {
+    private BeanPropertySetter(final Object target, final Field propertyField, boolean reportNoSetterFound) {
         this.field = propertyField;
         this.target = target;
         this.reportNoSetterFound = reportNoSetterFound;
@@ -37,9 +35,6 @@ public class BeanPropertySetter {
      * @param target The target on which the setter must be invoked
      * @param propertyField The propertyField that must be accessed through a setter
      */
-    public BeanPropertySetter(final Object target, final Field propertyField) {
-        this(target, propertyField, false);
-    }
 
     /**
      * Set the value to the property represented by this {@link BeanPropertySetter}
@@ -48,7 +43,7 @@ public class BeanPropertySetter {
      * @throws RuntimeException Can be thrown if the setter threw an exception, if the setter is not accessible
      *          or, if <code>reportNoSetterFound</code> and setter could not be found.
      */
-    public boolean set(final Object value) {
+    public static boolean set(final Object value) {
 
         AccessibilityChanger changer = new AccessibilityChanger();
         Method writeMethod = null;
@@ -82,14 +77,14 @@ public class BeanPropertySetter {
      * @param fieldName the Field name
      * @return Setter name.
      */
-    private String setterName(String fieldName) {
+    private static String setterName(String fieldName) {
         return new StringBuilder(SET_PREFIX)
                 .append(fieldName.substring(0, 1).toUpperCase(Locale.ENGLISH))
                 .append(fieldName.substring(1))
                 .toString();
     }
 
-    private void reportNoSetterFound() {
+    private static void reportNoSetterFound() {
         if(reportNoSetterFound) {
             throw new RuntimeException("Problems setting value on object: [" + target + "] for property : [" + field.getName() + "], setter not found");
         }

--- a/src/main/java/org/mockito/internal/util/reflection/BeanPropertySetter.java
+++ b/src/main/java/org/mockito/internal/util/reflection/BeanPropertySetter.java
@@ -9,6 +9,9 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Locale;
 
+import static org.mockito.internal.util.reflection.AccessibilityChanger.enableAccess;
+import static org.mockito.internal.util.reflection.AccessibilityChanger.safelyDisableAccess;
+
 /**
  * This utility class will call the setter of the property to inject a new value.
  */
@@ -43,12 +46,11 @@ public final class BeanPropertySetter {
      */
     public static boolean set(final Object value) {
 
-        AccessibilityChanger changer = new AccessibilityChanger();
         Method writeMethod = null;
         try {
             writeMethod = target.getClass().getMethod(setterName(field.getName()), field.getType());
 
-            changer.enableAccess(writeMethod);
+            enableAccess(writeMethod);
             writeMethod.invoke(target, value);
             return true;
         } catch (InvocationTargetException e) {
@@ -59,7 +61,7 @@ public final class BeanPropertySetter {
             reportNoSetterFound();
         } finally {
             if(writeMethod != null) {
-                changer.safelyDisableAccess(writeMethod);
+                safelyDisableAccess(writeMethod);
             }
         }
 

--- a/src/main/java/org/mockito/internal/util/reflection/FieldInitializer.java
+++ b/src/main/java/org/mockito/internal/util/reflection/FieldInitializer.java
@@ -9,6 +9,8 @@ import org.mockito.internal.util.MockUtil;
 
 import static java.lang.reflect.Modifier.isStatic;
 import static org.mockito.internal.util.reflection.FieldSetter.setField;
+import static org.mockito.internal.util.reflection.AccessibilityChanger.enableAccess;
+import static org.mockito.internal.util.reflection.AccessibilityChanger.safelyDisableAccess;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -84,15 +86,14 @@ public class FieldInitializer {
      * @return Actual field instance.
      */
     public FieldInitializationReport initialize() {
-        final AccessibilityChanger changer = new AccessibilityChanger();
-        changer.enableAccess(field);
+        enableAccess(field);
 
         try {
             return acquireFieldInstance();
         } catch(IllegalAccessException e) {
             throw new MockitoException("Problems initializing field '" + field.getName() + "' of type '" + field.getType().getSimpleName() + "'", e);
         } finally {
-            changer.safelyDisableAccess(field);
+            safelyDisableAccess(field);
         }
     }
 
@@ -185,11 +186,10 @@ public class FieldInitializer {
         }
 
         public FieldInitializationReport instantiate() {
-            final AccessibilityChanger changer = new AccessibilityChanger();
             Constructor<?> constructor = null;
             try {
                 constructor = field.getType().getDeclaredConstructor();
-                changer.enableAccess(constructor);
+                enableAccess(constructor);
 
                 final Object[] noArg = new Object[0];
                 Object newFieldInstance = constructor.newInstance(noArg);
@@ -206,7 +206,7 @@ public class FieldInitializer {
                 throw new MockitoException("IllegalAccessException (see the stack trace for cause): " + e.toString(), e);
             } finally {
                 if(constructor != null) {
-                    changer.safelyDisableAccess(constructor);
+                    safelyDisableAccess(constructor);
                 }
             }
         }
@@ -259,11 +259,10 @@ public class FieldInitializer {
         }
 
         public FieldInitializationReport instantiate() {
-            final AccessibilityChanger changer = new AccessibilityChanger();
             Constructor<?> constructor = null;
             try {
                 constructor = biggestConstructor(field.getType());
-                changer.enableAccess(constructor);
+                enableAccess(constructor);
 
                 final Object[] args = argResolver.resolveTypeInstances(constructor.getParameterTypes());
                 Object newFieldInstance = constructor.newInstance(args);
@@ -280,7 +279,7 @@ public class FieldInitializer {
                 throw new MockitoException("IllegalAccessException (see the stack trace for cause): " + e.toString(), e);
             } finally {
                 if(constructor != null) {
-                    changer.safelyDisableAccess(constructor);
+                    safelyDisableAccess(constructor);
                 }
             }
         }

--- a/src/main/java/org/mockito/internal/util/reflection/FieldReader.java
+++ b/src/main/java/org/mockito/internal/util/reflection/FieldReader.java
@@ -6,18 +6,19 @@ package org.mockito.internal.util.reflection;
 
 import org.mockito.exceptions.base.MockitoException;
 
+import static org.mockito.internal.util.reflection.AccessibilityChanger.enableAccess;
+
 import java.lang.reflect.Field;
 
 public class FieldReader {
 
     final Object target;
     final Field field;
-    final AccessibilityChanger changer = new AccessibilityChanger();
 
     public FieldReader(Object target, Field field) {
         this.target = target;
         this.field = field;
-        changer.enableAccess(field);
+        enableAccess(field);
     }
 
     public boolean isNull() {

--- a/src/main/java/org/mockito/internal/util/reflection/FieldSetter.java
+++ b/src/main/java/org/mockito/internal/util/reflection/FieldSetter.java
@@ -4,6 +4,9 @@
  */
 package org.mockito.internal.util.reflection;
 
+import static org.mockito.internal.util.reflection.AccessibilityChanger.enableAccess;
+import static org.mockito.internal.util.reflection.AccessibilityChanger.safelyDisableAccess;
+
 import java.lang.reflect.Field;
 
 public class FieldSetter {
@@ -11,8 +14,8 @@ public class FieldSetter {
     private FieldSetter(){}
 
     public static void setField(Object target, Field field,Object value) {
-        AccessibilityChanger changer = new AccessibilityChanger();
-        changer.enableAccess(field);
+
+        enableAccess(field);
         try {
             field.set(target, value);
         } catch (IllegalAccessException e) {
@@ -21,6 +24,6 @@ public class FieldSetter {
             throw new RuntimeException("Wrong argument on field '" + field + "' of object '" + target + "' with value: '" + value + "', \n" +
                     "reason : " + e.getMessage(), e);
         }
-        changer.safelyDisableAccess(field);
+        safelyDisableAccess(field);
     }
 }

--- a/src/main/java/org/mockito/internal/util/reflection/LenientCopyTool.java
+++ b/src/main/java/org/mockito/internal/util/reflection/LenientCopyTool.java
@@ -4,6 +4,9 @@
  */
 package org.mockito.internal.util.reflection;
 
+import static org.mockito.internal.util.reflection.AccessibilityChanger.enableAccess;
+import static org.mockito.internal.util.reflection.AccessibilityChanger.safelyDisableAccess;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
@@ -35,14 +38,13 @@ public class LenientCopyTool {
             if (Modifier.isStatic(field.getModifiers())) {
                 continue;
             }
-            AccessibilityChanger accessibilityChanger = new AccessibilityChanger();
             try {
-                accessibilityChanger.enableAccess(field);
+                enableAccess(field);
                 fieldCopier.copyValue(from, mock, field);
             } catch (Throwable t) {
                 //Ignore - be lenient - if some field cannot be copied then let's be it
             } finally {
-                accessibilityChanger.safelyDisableAccess(field);
+                safelyDisableAccess(field);
             }
         }
     }

--- a/src/test/java/org/mockito/internal/util/reflection/AccessibilityChangerTest.java
+++ b/src/test/java/org/mockito/internal/util/reflection/AccessibilityChangerTest.java
@@ -11,23 +11,26 @@ import java.lang.reflect.Field;
 import java.util.Observable;
 
 import static org.mockitoutil.VmArgAssumptions.assumeVmArgPresent;
+import static org.mockito.internal.util.reflection.AccessibilityChanger.enableAccess;
+import static org.mockito.internal.util.reflection.AccessibilityChanger.safelyDisableAccess;
 
 public class AccessibilityChangerTest {
 
     @SuppressWarnings("unused")
     private Observable whatever;
+    public static Boolean wasAccessible = null;
 
     @Test
     public void should_enable_and_safely_disable() throws Exception {
-        AccessibilityChanger changer = new AccessibilityChanger();
-        changer.enableAccess(field("whatever"));
-        changer.safelyDisableAccess(field("whatever"));
+        enableAccess(field("whatever"));
+        safelyDisableAccess(field("whatever"));
     }
 
     @Test(expected = java.lang.AssertionError.class)
     public void safelyDisableAccess_should_fail_when_enableAccess_not_called() throws Exception {
+        AccessibilityChanger.wasAccessible = null;
         assumeVmArgPresent("-ea");
-        new AccessibilityChanger().safelyDisableAccess(field("whatever"));
+        safelyDisableAccess(field("whatever"));
     }
 
 

--- a/src/test/java/org/mockito/internal/util/reflection/BeanPropertySetterTest.java
+++ b/src/test/java/org/mockito/internal/util/reflection/BeanPropertySetterTest.java
@@ -24,8 +24,11 @@ public class BeanPropertySetterTest {
         Field theField = someBean.getClass().getDeclaredField("theField");
         File valueToInject = new File("path");
 
+        BeanPropertySetter.target = someBean;
+        BeanPropertySetter.reportNoSetterFound = true;
+        BeanPropertySetter.field = theField;
         // when
-        boolean injected = new BeanPropertySetter(someBean, theField, true).set(valueToInject);
+        boolean injected = BeanPropertySetter.set(valueToInject);
 
         // then
         assertTrue(injected);
@@ -41,7 +44,10 @@ public class BeanPropertySetterTest {
         UUID valueToInject = new UUID(0L, 0L);
 
         // when
-        boolean injected = new BeanPropertySetter(someBean, theField, true).set(valueToInject);
+        BeanPropertySetter.target = someBean;
+        BeanPropertySetter.reportNoSetterFound = true;
+        BeanPropertySetter.field = theField;
+        boolean injected = BeanPropertySetter.set(valueToInject);
 
         // then
         assertTrue(injected);
@@ -57,7 +63,10 @@ public class BeanPropertySetterTest {
         File valueToInject = new File("path");
 
         // when
-        boolean injected = new BeanPropertySetter(someBean, theField, true).set(valueToInject);
+        BeanPropertySetter.target = someBean;
+        BeanPropertySetter.reportNoSetterFound = true;
+        BeanPropertySetter.field = theField;
+        boolean injected = BeanPropertySetter.set(valueToInject);
 
         // then
         assertTrue(injected);
@@ -71,9 +80,13 @@ public class BeanPropertySetterTest {
         Field theField = bean.getClass().getDeclaredField("theField");
         File valueToInject = new File("path");
 
+        BeanPropertySetter.target = bean;
+        BeanPropertySetter.reportNoSetterFound = true;
+        BeanPropertySetter.field = theField;
+
         try {
             // when
-            new BeanPropertySetter(bean, theField, true).set(valueToInject);
+            BeanPropertySetter.set(valueToInject);
             fail();
         } catch (Exception e) {
             // then
@@ -89,7 +102,10 @@ public class BeanPropertySetterTest {
         File valueToInject = new File("path");
 
         // when
-        boolean injected = new BeanPropertySetter(bean, theField).set(valueToInject);
+        BeanPropertySetter.target = bean;
+        BeanPropertySetter.reportNoSetterFound = false;
+        BeanPropertySetter.field = theField;
+        boolean injected = BeanPropertySetter.set(valueToInject);
 
         // then
         assertFalse(injected);
@@ -103,7 +119,10 @@ public class BeanPropertySetterTest {
         File valueToInject = new File("path");
 
         // when
-        boolean injected = new BeanPropertySetter(bean, theField, false).set(valueToInject);
+        BeanPropertySetter.target = bean;
+        BeanPropertySetter.reportNoSetterFound = false;
+        BeanPropertySetter.field = theField;
+        boolean injected = BeanPropertySetter.set(valueToInject);
 
         // then
         assertFalse(injected);


### PR DESCRIPTION
It fixes issue #426 on the release/2.x branch in repository mockito/mockito, refactors BeanPropertySetter into a static utility class. On the starkelove/mockito repository it fixes issue #2.
