### PR TITLE
Refactor of LenientCopyStyle and FieldCopier to static utility classes #426

### DIFF
--- a/src/main/java/org/mockito/internal/stubbing/answers/ClonesArguments.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/ClonesArguments.java
@@ -20,7 +20,7 @@ public class ClonesArguments implements Answer<Object> {
             Object from = arguments[i];
             Instantiator instantiator = Plugins.getInstantiatorProvider().getInstantiator(null);
             Object newInstance = instantiator.newInstance(from.getClass());
-            new LenientCopyTool().copyToRealObject(from, newInstance);
+            LenientCopyTool.copyToRealObject(from, newInstance);
             arguments[i] = newInstance;
         }
         return new ReturnsEmptyValues().answer(invocation);

--- a/src/main/java/org/mockito/internal/util/MockUtil.java
+++ b/src/main/java/org/mockito/internal/util/MockUtil.java
@@ -36,7 +36,7 @@ public class MockUtil {
 
         Object spiedInstance = settings.getSpiedInstance();
         if (spiedInstance != null) {
-            new LenientCopyTool().copyToMock(spiedInstance, mock);
+            LenientCopyTool.copyToMock(spiedInstance, mock);
         }
 
         return mock;

--- a/src/main/java/org/mockito/internal/util/reflection/FieldCopier.java
+++ b/src/main/java/org/mockito/internal/util/reflection/FieldCopier.java
@@ -8,7 +8,11 @@ import java.lang.reflect.Field;
 
 public class FieldCopier {
 
-    public <T> void copyValue(T from, T to, Field field) throws IllegalAccessException {
+    private FieldCopier(){
+        throw new UnsupportedOperationException();
+    }
+
+    public static <T> void copyValue(T from, T to, Field field) throws IllegalAccessException {
         Object value = field.get(from);
         field.set(to, value);
     }

--- a/src/main/java/org/mockito/internal/util/reflection/LenientCopyTool.java
+++ b/src/main/java/org/mockito/internal/util/reflection/LenientCopyTool.java
@@ -10,8 +10,7 @@ import java.lang.reflect.Modifier;
 @SuppressWarnings("unchecked")
 public class LenientCopyTool {
 
-//    FieldCopier fieldCopier = new FieldCopier();
-    public static boolean Apa = false;
+    public static boolean disableAccessForTest = false;
 
     private LenientCopyTool(){
         throw new UnsupportedOperationException();
@@ -43,7 +42,8 @@ public class LenientCopyTool {
             AccessibilityChanger accessibilityChanger = new AccessibilityChanger();
             try {
                 accessibilityChanger.enableAccess(field);
-                if(Apa){
+                //Only used for testing, is there a better solution than this?
+                if(disableAccessForTest){
                     accessibilityChanger.safelyDisableAccess(field);
                 }
                 FieldCopier.copyValue(from, mock, field);

--- a/src/main/java/org/mockito/internal/util/reflection/LenientCopyTool.java
+++ b/src/main/java/org/mockito/internal/util/reflection/LenientCopyTool.java
@@ -10,24 +10,28 @@ import java.lang.reflect.Modifier;
 @SuppressWarnings("unchecked")
 public class LenientCopyTool {
 
-    FieldCopier fieldCopier = new FieldCopier();
+//    FieldCopier fieldCopier = new FieldCopier();
 
-    public <T> void copyToMock(T from, T mock) {
+    private LenientCopyTool(){
+        throw new UnsupportedOperationException();
+    }
+
+    public static <T> void copyToMock(T from, T mock) {
         copy(from, mock, from.getClass());
     }
 
-    public <T> void copyToRealObject(T from, T to) {
+    public static <T> void copyToRealObject(T from, T to) {
         copy(from, to, from.getClass());
     }
 
-    private <T> void copy(T from, T to, Class<?> fromClazz) {
+    private static <T> void copy(T from, T to, Class<?> fromClazz) {
         while (fromClazz != Object.class) {
             copyValues(from, to, fromClazz);
             fromClazz = fromClazz.getSuperclass();
         }
     }
 
-    private <T> void copyValues(T from, T mock, Class<?> classFrom) {
+    private static <T> void copyValues(T from, T mock, Class<?> classFrom) {
         Field[] fields = classFrom.getDeclaredFields();
 
         for (Field field : fields) {
@@ -38,7 +42,7 @@ public class LenientCopyTool {
             AccessibilityChanger accessibilityChanger = new AccessibilityChanger();
             try {
                 accessibilityChanger.enableAccess(field);
-                fieldCopier.copyValue(from, mock, field);
+                FieldCopier.copyValue(from, mock, field);
             } catch (Throwable t) {
                 //Ignore - be lenient - if some field cannot be copied then let's be it
             } finally {

--- a/src/main/java/org/mockito/internal/util/reflection/LenientCopyTool.java
+++ b/src/main/java/org/mockito/internal/util/reflection/LenientCopyTool.java
@@ -11,6 +11,7 @@ import java.lang.reflect.Modifier;
 public class LenientCopyTool {
 
 //    FieldCopier fieldCopier = new FieldCopier();
+    public static boolean Apa = false;
 
     private LenientCopyTool(){
         throw new UnsupportedOperationException();
@@ -42,6 +43,9 @@ public class LenientCopyTool {
             AccessibilityChanger accessibilityChanger = new AccessibilityChanger();
             try {
                 accessibilityChanger.enableAccess(field);
+                if(Apa){
+                    accessibilityChanger.safelyDisableAccess(field);
+                }
                 FieldCopier.copyValue(from, mock, field);
             } catch (Throwable t) {
                 //Ignore - be lenient - if some field cannot be copied then let's be it

--- a/src/test/java/org/mockito/internal/util/reflection/LenientCopyToolTest.java
+++ b/src/test/java/org/mockito/internal/util/reflection/LenientCopyToolTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.*;
 @SuppressWarnings("unchecked")
 public class LenientCopyToolTest extends TestBase {
 
-    private LenientCopyTool tool = new LenientCopyTool();
+    //private LenientCopyTool tool = new LenientCopyTool();
 
     static class InheritMe {
         protected String protectedInherited = "protected";
@@ -54,7 +54,7 @@ public class LenientCopyToolTest extends TestBase {
         assertThat(to.finalField).isNotEqualTo(100);
 
         // when
-        tool.copyToMock(from, to);
+        LenientCopyTool.copyToMock(from, to);
 
         // then
         assertEquals(100, to.finalField);
@@ -67,7 +67,7 @@ public class LenientCopyToolTest extends TestBase {
         assertThat(to.privateTransientField).isNotEqualTo(1000);
 
         // when
-        tool.copyToMock(from, to);
+        LenientCopyTool.copyToMock(from, to);
 
         // then
         assertEquals(1000, to.privateTransientField);
@@ -80,7 +80,7 @@ public class LenientCopyToolTest extends TestBase {
         LinkedList toList = mock(LinkedList.class);
 
         // when
-        tool.copyToMock(fromList, toList);
+        LenientCopyTool.copyToMock(fromList, toList);
 
         // then no exception is thrown
     }
@@ -101,7 +101,7 @@ public class LenientCopyToolTest extends TestBase {
         assertThat(to.protectedField).isNotEqualTo(from.protectedField);
 
         // when
-        tool.copyToMock(from, to);
+        LenientCopyTool.copyToMock(from, to);
 
         // then
         assertEquals(from.defaultField, to.defaultField);
@@ -120,7 +120,7 @@ public class LenientCopyToolTest extends TestBase {
         assertThat(((InheritMe) to).privateInherited).isNotEqualTo(((InheritMe) from).privateInherited);
 
         //when
-        tool.copyToMock(from, to);
+        LenientCopyTool.copyToMock(from, to);
 
         //then
         assertEquals(((InheritMe) from).privateInherited, ((InheritMe) to).privateInherited);
@@ -133,7 +133,7 @@ public class LenientCopyToolTest extends TestBase {
         assertFalse(privateField.isAccessible());
 
         //when
-        tool.copyToMock(from, to);
+        LenientCopyTool.copyToMock(from, to);
 
         //then
         privateField = SomeObject.class.getDeclaredField("privateField");
@@ -143,20 +143,21 @@ public class LenientCopyToolTest extends TestBase {
     @Test
     public void shouldContinueEvenIfThereAreProblemsCopyingSingleFieldValue() throws Exception {
         //given
-        tool.fieldCopier = mock(FieldCopier.class);
+        FieldCopier hej = mock(FieldCopier.class);
 
         doNothing().
         doThrow(new IllegalAccessException()).
         doNothing().
-        when(tool.fieldCopier).
+        when(hej).
         copyValue(anyObject(), anyObject(), any(Field.class));
 
         //when
-        tool.copyToMock(from, to);
+        LenientCopyTool.copyToMock(from, to);
 
         //then
-        verify(tool.fieldCopier, atLeast(3)).copyValue(any(), any(), any(Field.class));
+        verify(hej, atLeast(3)).copyValue(any(), any(), any(Field.class));
     }
+
 
     @Test
     public void shouldBeAbleToCopyFromRealObjectToRealObject() throws Exception {
@@ -171,7 +172,7 @@ public class LenientCopyToolTest extends TestBase {
         to = new SomeObject(0);
 
         // when
-        tool.copyToRealObject(from, to);
+        LenientCopyTool.copyToRealObject(from, to);
 
         // then
         assertEquals(from.defaultField, to.defaultField);

--- a/src/test/java/org/mockito/internal/util/reflection/LenientCopyToolTest.java
+++ b/src/test/java/org/mockito/internal/util/reflection/LenientCopyToolTest.java
@@ -141,27 +141,21 @@ public class LenientCopyToolTest extends TestBase {
 
     @Test
     public void shouldContinueEvenIfThereAreProblemsCopyingSingleFieldValue() throws Exception {
-        //given
-        FieldCopier hej = mock(FieldCopier.class);
 
-        /*
-        doNothing().
-        doThrow(new IllegalAccessException()).
-        doNothing().
-        when(hej).
-        copyValue(anyObject(), anyObject(), any(Field.class));*/
-        //when
-       // doThrow(new IllegalAccessException()).when(hej).copyToMock();
         LenientCopyTool.copyToMock(from, to);
-        LenientCopyTool.Apa = true;
+        assertEquals(from.privateField, to.privateField);
+        LenientCopyTool.disableAccessForTest = true;
+        from.defaultField = "newTest";
+        from.privateField = 12;
         LenientCopyTool.copyToMock(from, to);
-      //  assertNotEquals(from.defaultField, to.defaultField);
-        LenientCopyTool.Apa = false;
+        //With disableAccessForTest set to true it will throw a IllegalAccessException when running
+        //It will copy all fields it can access and ignore those were an exception occurred
+        assertEquals(from.defaultField, to.defaultField);
+        assertNotEquals(from.privateField, to.privateField);
+        LenientCopyTool.disableAccessForTest = false;
         LenientCopyTool.copyToMock(from, to);
-        //boolean hejja = false;
-        //assertTrue(hejja);
-        //then
-      //  verify(hej, atLeast(3)).copyValue(any(), any(), any(Field.class));
+        assertEquals(from.privateField, to.privateField);
+
     }
 
 

--- a/src/test/java/org/mockito/internal/util/reflection/LenientCopyToolTest.java
+++ b/src/test/java/org/mockito/internal/util/reflection/LenientCopyToolTest.java
@@ -10,9 +10,8 @@ import org.mockitoutil.TestBase;
 import java.lang.reflect.Field;
 import java.util.LinkedList;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 @SuppressWarnings("unchecked")
@@ -145,17 +144,24 @@ public class LenientCopyToolTest extends TestBase {
         //given
         FieldCopier hej = mock(FieldCopier.class);
 
+        /*
         doNothing().
         doThrow(new IllegalAccessException()).
         doNothing().
         when(hej).
-        copyValue(anyObject(), anyObject(), any(Field.class));
-
+        copyValue(anyObject(), anyObject(), any(Field.class));*/
         //when
+       // doThrow(new IllegalAccessException()).when(hej).copyToMock();
         LenientCopyTool.copyToMock(from, to);
-
+        LenientCopyTool.Apa = true;
+        LenientCopyTool.copyToMock(from, to);
+      //  assertNotEquals(from.defaultField, to.defaultField);
+        LenientCopyTool.Apa = false;
+        LenientCopyTool.copyToMock(from, to);
+        //boolean hejja = false;
+        //assertTrue(hejja);
         //then
-        verify(hej, atLeast(3)).copyValue(any(), any(), any(Field.class));
+      //  verify(hej, atLeast(3)).copyValue(any(), any(), any(Field.class));
     }
 
 


### PR DESCRIPTION
This pull-request refactors the classes _LenientCopyStyle_ and _FieldCopier_ to static utility classes, based on issue #426. This works with small changes to original tests in LenientCopyStyle. The only test that posed a problem was _shouldContinueEvenIfThereAreProblemsCopyingSingleFieldValue()_ which previously invoked a mocked _IllegalAccessException_, tests that the copying should not stop because of that exception. Since both LenientCopyStyle and FieldCopier now are static utility classes it is not possible to make mock objects of these. 

My current solution is to manually make an exception and check that there were no problems in the overall copying of objects, but this also forced me to change some of the code in _LenientCopyTool_ (having a boolean that disables access, which causes the exception). Do you have any suggestions on how to perform this test without doing those changes in the _LenientCopyTool_?

(NOTE: issue 4 and 5 referenced in the commit messages are local issues on our forked repo of mockito)

check list

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/2.x/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [] At least one commit should mention `Fixes #<issue number>` _if relevant_

