### PR TITLE
Refactor: made the MockCreationValidator class private static

### DIFF
--- a/src/main/java/org/mockito/internal/creation/MockSettingsImpl.java
+++ b/src/main/java/org/mockito/internal/creation/MockSettingsImpl.java
@@ -233,16 +233,14 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
     }
 
     private static <T> CreationSettings<T> validatedSettings(Class<T> typeToMock, CreationSettings<T> source) {
-        MockCreationValidator validator = new MockCreationValidator();
-
-        validator.validateType(typeToMock);
-        validator.validateExtraInterfaces(typeToMock, source.getExtraInterfaces());
-        validator.validateMockedType(typeToMock, source.getSpiedInstance());
+        MockCreationValidator.validateType(typeToMock);
+        MockCreationValidator.validateExtraInterfaces(typeToMock, source.getExtraInterfaces());
+        MockCreationValidator.validateMockedType(typeToMock, source.getSpiedInstance());
 
         //TODO SF - add this validation and also add missing coverage
 //        validator.validateDelegatedInstance(classToMock, settings.getDelegatedInstance());
 
-        validator.validateConstructorUse(source.isUsingConstructor(), source.getSerializableMode());
+        MockCreationValidator.validateConstructorUse(source.isUsingConstructor(), source.getSerializableMode());
 
         //TODO SF - I don't think we really need CreationSettings type
         //TODO do we really need to copy the entire settings every time we create mock object? it does not seem necessary.

--- a/src/main/java/org/mockito/internal/util/MockCreationValidator.java
+++ b/src/main/java/org/mockito/internal/util/MockCreationValidator.java
@@ -18,14 +18,16 @@ import org.mockito.plugins.MockMaker.TypeMockability;
 @SuppressWarnings("unchecked")
 public class MockCreationValidator {
 
-    public void validateType(Class<?> classToMock) {
+    private MockCreationValidator() {}
+
+    public static void validateType(Class<?> classToMock) {
         TypeMockability typeMockability = MockUtil.typeMockabilityOf(classToMock);
         if (!typeMockability.mockable()) {
             throw cannotMockClass(classToMock, typeMockability.nonMockableReason());
         }
     }
 
-    public void validateExtraInterfaces(Class<?> classToMock, Collection<Class<?>> extraInterfaces) {
+    public static void validateExtraInterfaces(Class<?> classToMock, Collection<Class<?>> extraInterfaces) {
         if (extraInterfaces == null) {
             return;
         }
@@ -37,7 +39,7 @@ public class MockCreationValidator {
         }
     }
 
-    public void validateMockedType(Class<?> classToMock, Object spiedInstance) {
+    public static void validateMockedType(Class<?> classToMock, Object spiedInstance) {
         if (classToMock == null || spiedInstance == null) {
             return;
         }
@@ -46,7 +48,7 @@ public class MockCreationValidator {
         }
     }
 
-    public void validateDelegatedInstance(Class<?> classToMock, Object delegatedInstance) {
+    public static void validateDelegatedInstance(Class<?> classToMock, Object delegatedInstance) {
         if (classToMock == null || delegatedInstance == null) {
             return;
         }
@@ -55,7 +57,7 @@ public class MockCreationValidator {
         }
     }
 
-    public void validateConstructorUse(boolean usingConstructor, SerializableMode mode) {
+    public static void validateConstructorUse(boolean usingConstructor, SerializableMode mode) {
         if (usingConstructor && mode == SerializableMode.ACROSS_CLASSLOADERS) {
             throw usingConstructorWithFancySerializable(mode);
         }

--- a/src/test/java/org/mockito/internal/util/MockCreationValidatorTest.java
+++ b/src/test/java/org/mockito/internal/util/MockCreationValidatorTest.java
@@ -18,14 +18,11 @@ import static org.junit.Assert.fail;
 
 @SuppressWarnings("unchecked")
 public class MockCreationValidatorTest {
-
-    MockCreationValidator validator = new MockCreationValidator();
-
     @Test
     public void should_not_allow_extra_interface_that_is_the_same_as_the_mocked_type() throws Exception {
         try {
             //when
-            validator.validateExtraInterfaces(IMethods.class, (Collection) asList(IMethods.class));
+            MockCreationValidator.validateExtraInterfaces(IMethods.class, (Collection) asList(IMethods.class));
             fail();
         } catch (MockitoException e) {
             //then
@@ -36,30 +33,30 @@ public class MockCreationValidatorTest {
     @Test(expected = MockitoException.class)
     public void should_not_allow_inconsistent_types() throws Exception {
         //when
-        validator.validateMockedType(List.class, new ArrayList());
+        MockCreationValidator.validateMockedType(List.class, new ArrayList());
         //then
     }
 
     @Test
     public void should_allow_only_consistent_types() throws Exception {
         //when
-        validator.validateMockedType(ArrayList.class, new ArrayList());
+        MockCreationValidator.validateMockedType(ArrayList.class, new ArrayList());
         //then no exception is thrown
     }
 
     @Test
     public void should_validation_be_safe_when_nulls_passed() throws Exception {
         //when
-        validator.validateMockedType(null, new ArrayList());
+        MockCreationValidator.validateMockedType(null, new ArrayList());
         //or
-        validator.validateMockedType(ArrayList.class, null);
+        MockCreationValidator.validateMockedType(ArrayList.class, null);
         //then no exception is thrown
     }
 
     @Test
     public void should_fail_when_type_not_mockable() throws Exception {
         try {
-            validator.validateType(long.class);
+            MockCreationValidator.validateType(long.class);
         } catch (MockitoException ex) {
             assertThat(ex.getMessage()).contains("primitive");
         }


### PR DESCRIPTION
This pull-request refactors the class _MockCreationValidator_ to a static utility class.  This is based on issue #426.  I have changed all functions inside of _MockCreationValidator_ to static functions and have provided a private constructor for the class to prevent the ability to generate an object of the static class.  

(NOTE: issue 3 referenced in the commit messages are local issues on our forked repo of mockito)

Check list
 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/2.x/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_