### PR TITLE
Fix handling of generics in ReturnsMocks

### DIFF
--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/RetrieveGenericsForDefaultAnswers.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/RetrieveGenericsForDefaultAnswers.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.stubbing.defaultanswers;
+
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import org.mockito.internal.util.MockUtil;
+import org.mockito.internal.util.reflection.GenericMetadataSupport;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.mock.MockCreationSettings;
+
+class RetrieveGenericsForDefaultAnswers {
+
+    static Object returnTypeForMockWithCorrectGenerics(
+        InvocationOnMock invocation, AnswerCallback answerCallback) {
+        Class<?> type = invocation.getMethod().getReturnType();
+
+        final Type returnType = invocation.getMethod().getGenericReturnType();
+
+        Object defaultReturnValue = null;
+
+        if (returnType instanceof TypeVariable) {
+            type = findTypeFromGeneric(invocation, (TypeVariable) returnType);
+            if (type != null) {
+                defaultReturnValue = delegateChains(type);
+            }
+        }
+
+        if (defaultReturnValue != null) {
+            return defaultReturnValue;
+        }
+
+        if (type != null && !type.isPrimitive() && !Modifier.isFinal(type.getModifiers())) {
+            return answerCallback.apply(type);
+        }
+
+        return answerCallback.apply(null);
+    }
+
+    /**
+     * Try to resolve the result value using {@link ReturnsEmptyValues} and {@link ReturnsMoreEmptyValues}.
+     *
+     * This will try to use all parent class (superclass & interfaces) to retrieve the value..
+     *
+     * @param type the return type of the method
+     * @return a non-null instance if the type has been resolve. Null otherwise.
+     */
+    private static Object delegateChains(final Class<?> type) {
+        final ReturnsEmptyValues returnsEmptyValues = new ReturnsEmptyValues();
+        Object result = returnsEmptyValues.returnValueFor(type);
+
+        if (result == null) {
+            Class<?> emptyValueForClass = type;
+            while (emptyValueForClass != null && result == null) {
+                final Class<?>[] classes = emptyValueForClass.getInterfaces();
+                for (Class<?> clazz : classes) {
+                    result = returnsEmptyValues.returnValueFor(clazz);
+                    if (result != null) {
+                        break;
+                    }
+                }
+                emptyValueForClass = emptyValueForClass.getSuperclass();
+            }
+        }
+
+        if (result == null) {
+            result = new ReturnsMoreEmptyValues().returnValueFor(type);
+        }
+
+        return result;
+    }
+
+    /**
+     * Retrieve the expected type when it came from a primitive. If the type cannot be retrieve, return null.
+     *
+     * @param invocation the current invocation
+     * @param returnType the expected return type
+     * @return the type or null if not found
+     */
+    private static Class<?> findTypeFromGeneric(final InvocationOnMock invocation, final TypeVariable returnType) {
+        // Class level
+        final MockCreationSettings mockSettings = MockUtil.getMockHandler(invocation.getMock()).getMockSettings();
+        final GenericMetadataSupport returnTypeSupport = GenericMetadataSupport
+            .inferFrom(mockSettings.getTypeToMock())
+            .resolveGenericReturnType(invocation.getMethod());
+        final Class<?> rawType = returnTypeSupport.rawType();
+
+        // Method level
+        if (rawType == Object.class) {
+            return findTypeFromGenericInArguments(invocation, returnType);
+        }
+        return rawType;
+    }
+
+    /**
+     * Find a return type using generic arguments provided by the calling method.
+     *
+     * @param invocation the current invocation
+     * @param returnType the expected return type
+     * @return the return type or null if the return type cannot be found
+     */
+    private static Class<?> findTypeFromGenericInArguments(final InvocationOnMock invocation, final TypeVariable returnType) {
+        final Type[] parameterTypes = invocation.getMethod().getGenericParameterTypes();
+        for (int i = 0; i < parameterTypes.length; i++) {
+            Type argType = parameterTypes[i];
+            if (returnType.equals(argType)) {
+                return invocation.getArgument(i).getClass();
+            }
+            if (argType instanceof GenericArrayType) {
+                argType = ((GenericArrayType) argType).getGenericComponentType();
+                if (returnType.equals(argType)) {
+                    return invocation.getArgument(i).getClass();
+                }
+            }
+        }
+        return null;
+    }
+
+    interface AnswerCallback {
+        Object apply(Class<?> type);
+    }
+}

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsMocks.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsMocks.java
@@ -4,33 +4,42 @@
  */
 package org.mockito.internal.stubbing.defaultanswers;
 
+import java.io.Serializable;
+import org.mockito.Mockito;
 import org.mockito.internal.MockitoCore;
 import org.mockito.internal.creation.MockSettingsImpl;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import java.io.Serializable;
-
 public class ReturnsMocks implements Answer<Object>, Serializable {
 
     private static final long serialVersionUID = -6755257986994634579L;
-    private final MockitoCore mockitoCore = new MockitoCore();
     private final Answer<Object> delegate = new ReturnsMoreEmptyValues();
+    private final MockitoCore mockitoCore = new MockitoCore();
 
-    public Object answer(InvocationOnMock invocation) throws Throwable {
-        Object ret = delegate.answer(invocation);
-        if (ret != null) {
-            return ret;
+    @Override
+    public Object answer(final InvocationOnMock invocation) throws Throwable {
+        Object defaultReturnValue = delegate.answer(invocation);
+
+        if (defaultReturnValue != null) {
+            return defaultReturnValue;
         }
 
-        return returnValueFor(invocation.getMethod().getReturnType());
-    }
+        return RetrieveGenericsForDefaultAnswers.returnTypeForMockWithCorrectGenerics(invocation,
+            new RetrieveGenericsForDefaultAnswers.AnswerCallback() {
+                @Override
+                public Object apply(Class<?> type) {
+                    if (type == null) {
+                        type = invocation.getMethod().getReturnType();
 
-    Object returnValueFor(Class<?> clazz) {
-        if (!mockitoCore.isTypeMockable(clazz)) {
-            return null;
-        }
+                        if (!mockitoCore.isTypeMockable(type)) {
+                            return null;
+                        }
+                    }
 
-        return mockitoCore.mock(clazz, new MockSettingsImpl().defaultAnswer(this));
+                    return Mockito
+                        .mock(type, new MockSettingsImpl<Object>().defaultAnswer(ReturnsMocks.this));
+                }
+            });
     }
 }

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNulls.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNulls.java
@@ -8,18 +8,10 @@ import static org.mockito.internal.exceptions.Reporter.smartNullPointerException
 import static org.mockito.internal.util.ObjectMethodsGuru.isToStringMethod;
 
 import java.io.Serializable;
-import java.lang.reflect.GenericArrayType;
-import java.lang.reflect.Modifier;
-import java.lang.reflect.Type;
-import java.lang.reflect.TypeVariable;
-
 import org.mockito.Mockito;
 import org.mockito.internal.debugging.LocationImpl;
-import org.mockito.internal.util.MockUtil;
-import org.mockito.internal.util.reflection.GenericMetadataSupport;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.invocation.Location;
-import org.mockito.mock.MockCreationSettings;
 import org.mockito.stubbing.Answer;
 
 /**
@@ -46,108 +38,25 @@ public class ReturnsSmartNulls implements Answer<Object>, Serializable {
 
     private final Answer<Object> delegate = new ReturnsMoreEmptyValues();
 
+    @Override
     public Object answer(final InvocationOnMock invocation) throws Throwable {
         Object defaultReturnValue = delegate.answer(invocation);
-        if (defaultReturnValue != null) {
-            return defaultReturnValue;
-        }
-        Class<?> type = invocation.getMethod().getReturnType();
 
-        final Type returnType = invocation.getMethod().getGenericReturnType();
-        if (returnType instanceof TypeVariable) {
-            type = findTypeFromGeneric(invocation, (TypeVariable) returnType);
-            if (type != null) {
-                defaultReturnValue = delegateChains(type);
-            }
-        }
         if (defaultReturnValue != null) {
             return defaultReturnValue;
         }
 
-        if (type != null && !type.isPrimitive() && !Modifier.isFinal(type.getModifiers())) {
-            final Location location = new LocationImpl();
-            return Mockito.mock(type, new ThrowsSmartNullPointer(invocation, location));
-        }
-        return null;
-    }
-
-    /**
-     * Try to resolve the result value using {@link ReturnsEmptyValues} and {@link ReturnsMoreEmptyValues}.
-     *
-     * This will try to use all parent class (superclass & interfaces) to retrieve the value..
-     *
-     * @param type the return type of the method
-     * @return a non-null instance if the type has been resolve. Null otherwise.
-     */
-    private Object delegateChains(final Class<?> type) {
-        final ReturnsEmptyValues returnsEmptyValues = new ReturnsEmptyValues();
-        Object result = returnsEmptyValues.returnValueFor(type);
-
-        if (result == null) {
-            Class<?> emptyValueForClass = type;
-            while (emptyValueForClass != null && result == null) {
-                final Class<?>[] classes = emptyValueForClass.getInterfaces();
-                for (Class<?> clazz : classes) {
-                    result = returnsEmptyValues.returnValueFor(clazz);
-                    if (result != null) {
-                        break;
+        return RetrieveGenericsForDefaultAnswers.returnTypeForMockWithCorrectGenerics(invocation,
+            new RetrieveGenericsForDefaultAnswers.AnswerCallback() {
+                @Override
+                public Object apply(Class<?> type) {
+                    if (type == null) {
+                        return null;
                     }
+
+                    return Mockito.mock(type, new ThrowsSmartNullPointer(invocation, new LocationImpl()));
                 }
-                emptyValueForClass = emptyValueForClass.getSuperclass();
-            }
-        }
-
-        if (result == null) {
-            result = new ReturnsMoreEmptyValues().returnValueFor(type);
-        }
-
-        return result;
-    }
-
-    /**
-     * Retrieve the expected type when it came from a primitive. If the type cannot be retrieve, return null.
-     *
-     * @param invocation the current invocation
-     * @param returnType the expected return type
-     * @return the type or null if not found
-     */
-    private Class<?> findTypeFromGeneric(final InvocationOnMock invocation, final TypeVariable returnType) {
-        // Class level
-        final MockCreationSettings mockSettings = MockUtil.getMockHandler(invocation.getMock()).getMockSettings();
-        final GenericMetadataSupport returnTypeSupport = GenericMetadataSupport
-            .inferFrom(mockSettings.getTypeToMock())
-            .resolveGenericReturnType(invocation.getMethod());
-        final Class<?> rawType = returnTypeSupport.rawType();
-
-        // Method level
-        if (rawType == Object.class) {
-            return findTypeFromGenericInArguments(invocation, returnType);
-        }
-        return rawType;
-    }
-
-    /**
-     * Find a return type using generic arguments provided by the calling method.
-     *
-     * @param invocation the current invocation
-     * @param returnType the expected return type
-     * @return the return type or null if the return type cannot be found
-     */
-    private Class<?> findTypeFromGenericInArguments(final InvocationOnMock invocation, final TypeVariable returnType) {
-        final Type[] parameterTypes = invocation.getMethod().getGenericParameterTypes();
-        for (int i = 0; i < parameterTypes.length; i++) {
-            Type argType = parameterTypes[i];
-            if (returnType.equals(argType)) {
-                return invocation.getArgument(i).getClass();
-            }
-            if (argType instanceof GenericArrayType) {
-                argType = ((GenericArrayType) argType).getGenericComponentType();
-                if (returnType.equals(argType)) {
-                    return invocation.getArgument(i).getClass();
-                }
-            }
-        }
-        return null;
+            });
     }
 
     private static class ThrowsSmartNullPointer implements Answer {
@@ -156,7 +65,7 @@ public class ReturnsSmartNulls implements Answer<Object>, Serializable {
 
         private final Location location;
 
-        public ThrowsSmartNullPointer(InvocationOnMock unstubbedInvocation, Location location) {
+        ThrowsSmartNullPointer(InvocationOnMock unstubbedInvocation, Location location) {
             this.unstubbedInvocation = unstubbedInvocation;
             this.location = location;
         }

--- a/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsMocksTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsMocksTest.java
@@ -6,14 +6,23 @@ package org.mockito.internal.stubbing.defaultanswers;
 
 import org.junit.Test;
 import org.mockito.internal.configuration.plugins.Plugins;
+import org.mockito.internal.stubbing.defaultanswers.ReturnsGenericDeepStubsTest.WithGenerics;
 import org.mockito.internal.util.MockUtil;
 import org.mockitoutil.TestBase;
 
 import static org.junit.Assert.*;
 import static org.junit.Assume.assumeFalse;
+import static org.mockito.Mockito.when;
 
 public class ReturnsMocksTest extends TestBase {
     private ReturnsMocks values = new ReturnsMocks();
+
+    interface AllInterface {
+        FooInterface getInterface();
+        BarClass getNormalClass();
+        Baz getFinalClass();
+        WithGenerics<String> withGenerics();
+    }
 
     interface FooInterface {
     }
@@ -25,21 +34,30 @@ public class ReturnsMocksTest extends TestBase {
     }
 
     @Test
-    public void should_return_mock_value_for_interface() throws Exception {
-        Object interfaceMock = values.returnValueFor(FooInterface.class);
+    public void should_return_mock_value_for_interface() throws Throwable {
+        Object interfaceMock = values.answer(invocationOf(AllInterface.class, "getInterface"));
         assertTrue(MockUtil.isMock(interfaceMock));
     }
 
     @Test
-    public void should_return_mock_value_for_class() throws Exception {
-        Object classMock = values.returnValueFor(BarClass.class);
+    public void should_return_mock_value_for_class() throws Throwable {
+        Object classMock = values.answer(invocationOf(AllInterface.class, "getNormalClass"));
         assertTrue(MockUtil.isMock(classMock));
     }
 
+    @SuppressWarnings("unchecked")
     @Test
-    public void should_return_null_for_final_class_if_unsupported() throws Exception {
+    public void should_return_mock_value_for_generic_class() throws Throwable {
+        WithGenerics<String> classMock = (WithGenerics<String>) values.answer(invocationOf(AllInterface.class, "withGenerics"));
+        assertTrue(MockUtil.isMock(classMock));
+        when(classMock.execute()).thenReturn("return");
+        assertEquals("return", classMock.execute());
+    }
+
+    @Test
+    public void should_return_null_for_final_class_if_unsupported() throws Throwable {
         assumeFalse(Plugins.getMockMaker().isTypeMockable(Baz.class).mockable());
-        assertNull(values.returnValueFor(Baz.class));
+        assertNull(values.answer(invocationOf(AllInterface.class, "getFinalClass")));
     }
 
     @Test


### PR DESCRIPTION
ReturnsMocks was exhibiting the same problems as we previously had with
ReturnsSmartNulls. Extract that common behavior into a separate class
and thus fix the issues with ReturnsMocks.