### PR TITLE
Fix returns mocks for final classes

### DIFF
--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/RetrieveGenericsForDefaultAnswers.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/RetrieveGenericsForDefaultAnswers.java
@@ -5,15 +5,17 @@
 package org.mockito.internal.stubbing.defaultanswers;
 
 import java.lang.reflect.GenericArrayType;
-import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
+import org.mockito.internal.MockitoCore;
 import org.mockito.internal.util.MockUtil;
 import org.mockito.internal.util.reflection.GenericMetadataSupport;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.mock.MockCreationSettings;
 
 class RetrieveGenericsForDefaultAnswers {
+
+    private static final MockitoCore MOCKITO_CORE = new MockitoCore();
 
     static Object returnTypeForMockWithCorrectGenerics(
         InvocationOnMock invocation, AnswerCallback answerCallback) {
@@ -34,7 +36,11 @@ class RetrieveGenericsForDefaultAnswers {
             return defaultReturnValue;
         }
 
-        if (type != null && !type.isPrimitive() && !Modifier.isFinal(type.getModifiers())) {
+        if (type != null) {
+            if (!MOCKITO_CORE.isTypeMockable(type)) {
+                return null;
+            }
+
             return answerCallback.apply(type);
         }
 

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsMocks.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsMocks.java
@@ -6,7 +6,6 @@ package org.mockito.internal.stubbing.defaultanswers;
 
 import java.io.Serializable;
 import org.mockito.Mockito;
-import org.mockito.internal.MockitoCore;
 import org.mockito.internal.creation.MockSettingsImpl;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -15,7 +14,6 @@ public class ReturnsMocks implements Answer<Object>, Serializable {
 
     private static final long serialVersionUID = -6755257986994634579L;
     private final Answer<Object> delegate = new ReturnsMoreEmptyValues();
-    private final MockitoCore mockitoCore = new MockitoCore();
 
     @Override
     public Object answer(final InvocationOnMock invocation) throws Throwable {
@@ -31,10 +29,6 @@ public class ReturnsMocks implements Answer<Object>, Serializable {
                 public Object apply(Class<?> type) {
                     if (type == null) {
                         type = invocation.getMethod().getReturnType();
-
-                        if (!mockitoCore.isTypeMockable(type)) {
-                            return null;
-                        }
                     }
 
                     return Mockito


### PR DESCRIPTION
The guard for final mocking was incorrect. It should have passed it on
to MockitoCore. Since we have the InlineMockMaker, we can actually mock,
so this check was incorrect.