### PR TITLE
VerificationCollector to handle non-matching args and other assertions

### DIFF
--- a/src/main/java/org/mockito/internal/junit/VerificationCollectorImpl.java
+++ b/src/main/java/org/mockito/internal/junit/VerificationCollectorImpl.java
@@ -75,7 +75,7 @@ public class VerificationCollectorImpl implements VerificationCollector {
         this.numberOfFailures++;
         this.builder.append('\n')
                 .append(this.numberOfFailures).append(". ")
-                .append(message.substring(1, message.length()));
+                .append(message.trim()).append('\n');
     }
 
     private class VerificationWrapper implements VerificationMode {
@@ -89,7 +89,7 @@ public class VerificationCollectorImpl implements VerificationCollector {
         public void verify(VerificationData data) {
             try {
                 this.delegate.verify(data);
-            } catch (MockitoAssertionError error) {
+            } catch (AssertionError error) {
                 VerificationCollectorImpl.this.append(error.getMessage());
             }
         }

--- a/src/test/java/org/mockitousage/junitrule/VerificationCollectorImplTest.java
+++ b/src/test/java/org/mockitousage/junitrule/VerificationCollectorImplTest.java
@@ -14,7 +14,7 @@ import org.mockito.junit.VerificationCollector;
 import org.mockitousage.IMethods;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.mockito.Mockito.*;
 
 public class VerificationCollectorImplTest {
@@ -50,7 +50,7 @@ public class VerificationCollectorImplTest {
         verify(methods).byteReturningMethod();
         try {
             collector.collectAndReport();
-            fail();
+            failBecauseExceptionWasNotThrown(MockitoAssertionError.class);
         } catch (MockitoAssertionError error) {
             assertThat(error).hasMessageContaining("1. Wanted but not invoked:");
             assertThat(error).hasMessageContaining("2. Wanted but not invoked:");
@@ -85,7 +85,7 @@ public class VerificationCollectorImplTest {
     private void assertExactlyOneFailure(VerificationCollector collector) {
         try {
             collector.collectAndReport();
-            fail();
+            failBecauseExceptionWasNotThrown(MockitoAssertionError.class);
         } catch (MockitoAssertionError error) {
             assertThat(error).hasMessageContaining("1. Wanted but not invoked:");
             assertThat(error.getMessage()).doesNotContain("2.");

--- a/src/test/java/org/mockitousage/junitrule/VerificationCollectorImplTest.java
+++ b/src/test/java/org/mockitousage/junitrule/VerificationCollectorImplTest.java
@@ -66,7 +66,7 @@ public class VerificationCollectorImplTest {
         verify(methods, never()).simpleMethod();
         verify(methods).byteReturningMethod();
 
-        this.assertAtLeastOneFailure(collector);
+        this.assertExactlyOneFailure(collector);
     }
 
     @Test
@@ -79,10 +79,10 @@ public class VerificationCollectorImplTest {
         verify(methods).byteReturningMethod();
         verify(methods).simpleMethod();
 
-        this.assertAtLeastOneFailure(collector);
+        this.assertExactlyOneFailure(collector);
     }
 
-    private void assertAtLeastOneFailure(VerificationCollector collector) {
+    private void assertExactlyOneFailure(VerificationCollector collector) {
         try {
             collector.collectAndReport();
             fail();

--- a/src/test/java/org/mockitousage/junitrule/VerificationCollectorImplTest.java
+++ b/src/test/java/org/mockitousage/junitrule/VerificationCollectorImplTest.java
@@ -8,6 +8,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
+import org.mockito.ArgumentMatcher;
 import org.mockito.exceptions.base.MockitoAssertionError;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.VerificationCollector;
@@ -46,14 +47,54 @@ public class VerificationCollectorImplTest {
 
         IMethods methods = mock(IMethods.class);
 
+        methods.intArgumentMethod(6);
+
         verify(methods).simpleMethod();
         verify(methods).byteReturningMethod();
+        verify(methods).intArgumentMethod(8);
+        verify(methods).longArg(8L);
         try {
             collector.collectAndReport();
             failBecauseExceptionWasNotThrown(MockitoAssertionError.class);
         } catch (MockitoAssertionError error) {
             assertThat(error).hasMessageContaining("1. Wanted but not invoked:");
             assertThat(error).hasMessageContaining("2. Wanted but not invoked:");
+            assertThat(error).hasMessageContaining("3. Argument(s) are different! Wanted:");
+            assertThat(error).hasMessageContaining("4. Wanted but not invoked:");
+        }
+    }
+
+    @Test
+    public void should_collect_matching_error_from_non_matching_arguments() {
+        VerificationCollector collector = MockitoJUnit.collector().assertLazily();
+
+        IMethods methods = mock(IMethods.class);
+
+        methods.intArgumentMethod(6);
+        methods.longArg(8L);
+        methods.forShort((short)6);
+
+        verify(methods).intArgumentMethod(8);
+        verify(methods).longArg(longThat(new ArgumentMatcher<Long>() {
+            @Override
+            public boolean matches(Long argument) {
+                throw new AssertionError("custom error message");
+            }
+        }));
+        verify(methods).forShort(shortThat(new ArgumentMatcher<Short>() {
+            @Override
+            public boolean matches(Short argument) {
+                return false;
+            }
+        }));
+
+        try {
+            collector.collectAndReport();
+            failBecauseExceptionWasNotThrown(MockitoAssertionError.class);
+        } catch (MockitoAssertionError error) {
+            assertThat(error).hasMessageContaining("1. Argument(s) are different! Wanted:");
+            assertThat(error).hasMessageContaining("2. custom error message");
+            assertThat(error).hasMessageContaining("3. Argument(s) are different! Wanted:");
         }
     }
 
@@ -97,8 +138,11 @@ public class VerificationCollectorImplTest {
         JUnitCore runner = new JUnitCore();
         Result result = runner.run(VerificationCollectorRuleInner.class);
 
-        assertThat(result.getFailureCount()).isEqualTo(1);
-        assertThat(result.getFailures().get(0).getMessage()).contains("1. Wanted but not invoked:");
+        assertThat(result.getFailureCount()).as("failureCount").isEqualTo(2);
+        assertThat(result.getFailures().get(0).getMessage()).as("failure1").contains("1. Wanted but not invoked:");
+        assertThat(result.getFailures().get(1).getMessage()).as("failure2")
+            .contains("1. Argument(s) are different! Wanted:")
+            .contains("2. Wanted but not invoked:");
     }
 
     // This class is picked up when running a test suite using an IDE. It fails on purpose.
@@ -120,6 +164,15 @@ public class VerificationCollectorImplTest {
             methods.simpleMethod();
 
             verify(methods).simpleMethod();
+        }
+
+        @Test
+        public void should_fail_with_args() {
+            IMethods methods = mock(IMethods.class);
+            methods.intArgumentMethod(8);
+
+            verify(methods).intArgumentMethod(9);
+            verify(methods).byteReturningMethod();
         }
     }
 }


### PR DESCRIPTION
This fix widens the catch in `VerificationCollectorImpl` so that it will catch any `AssertionError`, rather than just `MockitoAssertionError`. In this way, any comparison failures (such as the built-in argument comparison when running under JUnit) will also be collected rather than propagating through to the test framework.

There are also two commits which are more cosmetic improvements to `VerificationCollectorImplTest`:

* Rename `assertAtLeastOneFailure()` to `assertExactlyOneFailure()` (more accurate description of what it does).
* Change `Assert.fail()` to AssertJ's `assertBecauseExceptionWasNotThrown()` (produces better diagnostics in the case of a failure).