### PR TITLE
Update shipkit plugin (v2.1.6)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.6'
 
         //Using buildscript.classpath so that we can resolve shipkit from maven local, during local testing
-        classpath 'org.shipkit:shipkit:2.1.3'
+        classpath 'org.shipkit:shipkit:2.1.6'
     }
 }
 

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
 #Currently building Mockito version
-version=2.24.8
+version=2.24.9
 
 #Previous version used to generate release notes delta
 previousVersion=2.24.7


### PR DESCRIPTION
and increase the version since we already have a tag for 2.24.8.

fixes #1645 

shipkit v2.1.6 contains a fix for wrong task order (see https://github.com/mockito/shipkit/issues/781)

