### PR TITLE
Prevent NPE in findTypeFromGenericInArguments

### DIFF
--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/RetrieveGenericsForDefaultAnswers.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/RetrieveGenericsForDefaultAnswers.java
@@ -115,11 +115,11 @@ class RetrieveGenericsForDefaultAnswers {
             Type argType = parameterTypes[i];
             if (returnType.equals(argType)) {
                 Object argument = invocation.getArgument(i);
-                
+
                 if (argument == null) {
                     return null;
                 }
-                
+
                 return argument.getClass();
             }
             if (argType instanceof GenericArrayType) {

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/RetrieveGenericsForDefaultAnswers.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/RetrieveGenericsForDefaultAnswers.java
@@ -114,7 +114,13 @@ class RetrieveGenericsForDefaultAnswers {
         for (int i = 0; i < parameterTypes.length; i++) {
             Type argType = parameterTypes[i];
             if (returnType.equals(argType)) {
-                return invocation.getArgument(i).getClass();
+                Object argument = invocation.getArgument(i);
+                
+                if (argument == null) {
+                    return null;
+                }
+                
+                return argument.getClass();
             }
             if (argType instanceof GenericArrayType) {
                 argType = ((GenericArrayType) argType).getGenericComponentType();

--- a/src/test/java/org/mockitousage/stubbing/SmartNullsStubbingTest.java
+++ b/src/test/java/org/mockitousage/stubbing/SmartNullsStubbingTest.java
@@ -42,6 +42,15 @@ public class SmartNullsStubbingTest extends TestBase {
         }
     }
 
+    @Test
+    public void should_not_throw_NPE_when_verifying_with_returns_smart_nulls() {
+        Foo mock = mock(Foo.class, RETURNS_SMART_NULLS);
+
+        when(mock.returnsFromArg(null)).thenReturn("Does not fail.");
+
+        assertThat((Object) mock.returnsFromArg(null)).isEqualTo("Does not fail.");
+    }
+
     interface Bar {
         void boo();
     }
@@ -58,6 +67,8 @@ public class SmartNullsStubbingTest extends TestBase {
         Bar getBarWithParams(int x, String y) {
             return null;
         }
+
+        <T> T returnsFromArg(T arg) { return arg; }
 
         void boo() {}
     }


### PR DESCRIPTION
There was only a single test failing on this. I think the issue was RETURNS_SMART_NULLS in combination with an ArgumentCaptor, but
couldn't figure that part out. At least this fixes prevented the NPE.