### PR TITLE
Use JUnit 4 ComparisonFailure if present

### DIFF
--- a/src/main/java/org/mockito/exceptions/verification/ArgumentsAreDifferent.java
+++ b/src/main/java/org/mockito/exceptions/verification/ArgumentsAreDifferent.java
@@ -21,7 +21,7 @@ public class ArgumentsAreDifferent extends MockitoAssertionError {
      * Three-arg constructor for compatibility with ExceptionFactory's three-arg
      * create method. This implementation simply ignores the second and third
      * arguments.
-     * 
+     *
      * @param message
      * @param wanted ignored
      * @param actual ignored

--- a/src/main/java/org/mockito/exceptions/verification/ArgumentsAreDifferent.java
+++ b/src/main/java/org/mockito/exceptions/verification/ArgumentsAreDifferent.java
@@ -17,6 +17,19 @@ public class ArgumentsAreDifferent extends MockitoAssertionError {
         super(message);
     }
 
+    /**
+     * Three-arg constructor for compatibility with ExceptionFactory's three-arg
+     * create method. This implementation simply ignores the second and third
+     * arguments.
+     * 
+     * @param message
+     * @param wanted ignored
+     * @param actual ignored
+     */
+    public ArgumentsAreDifferent(String message, String wanted, String actual) {
+        this(message);
+    }
+
     @Override
     public String toString() {
         return removeFirstLine(super.toString());

--- a/src/main/java/org/mockito/exceptions/verification/junit/package-info.java
+++ b/src/main/java/org/mockito/exceptions/verification/junit/package-info.java
@@ -4,6 +4,8 @@
  */
 
 /**
- * JUnit integration to provide better support for junit runners in IDEs.
+ * JUnit 3 integration to provide better support for junit 3 runners in IDEs.
+ *
+ * @see org.mockito.execeptions.verification.junit4
  */
 package org.mockito.exceptions.verification.junit;

--- a/src/main/java/org/mockito/exceptions/verification/junit4/ArgumentsAreDifferent.java
+++ b/src/main/java/org/mockito/exceptions/verification/junit4/ArgumentsAreDifferent.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2019 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito.exceptions.verification.junit4;
+
+import static org.mockito.internal.util.StringUtil.removeFirstLine;
+
+import org.junit.ComparisonFailure;
+import org.mockito.internal.exceptions.stacktrace.ConditionalStackTraceFilter;
+
+
+public class ArgumentsAreDifferent extends ComparisonFailure {
+
+    private static final long serialVersionUID = 1L;
+    private final String message;
+    private final StackTraceElement[] unfilteredStackTrace;
+
+    public ArgumentsAreDifferent(String message, String wanted, String actual) {
+        super(message, wanted, actual);
+        this.message = message;
+
+        unfilteredStackTrace = getStackTrace();
+        ConditionalStackTraceFilter filter = new ConditionalStackTraceFilter();
+        filter.filter(this);
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    public StackTraceElement[] getUnfilteredStackTrace() {
+        return unfilteredStackTrace;
+    }
+
+    @Override
+    public String toString() {
+        return removeFirstLine(super.toString());
+    }
+}

--- a/src/main/java/org/mockito/exceptions/verification/junit4/package-info.java
+++ b/src/main/java/org/mockito/exceptions/verification/junit4/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+/**
+ * JUnit 4 integration to provide better support for junit 4 runners in IDEs.
+ *
+ * @see org.mocktio.exceptions.verification.junit
+ */
+package org.mockito.exceptions.verification.junit4;

--- a/src/main/java/org/mockito/internal/junit/ExceptionFactory.java
+++ b/src/main/java/org/mockito/internal/junit/ExceptionFactory.java
@@ -4,49 +4,47 @@
  */
 package org.mockito.internal.junit;
 
-import junit.framework.ComparisonFailure;
 import org.mockito.exceptions.verification.ArgumentsAreDifferent;
 
 public class ExceptionFactory {
 
-    private final static boolean hasJUnit = canLoadJunitClass();
-
     private ExceptionFactory() {
     }
 
+    private static interface ExceptionFactoryImpl {
+        AssertionError create(String message, String wanted, String actual);
+    }
+    
+    private final static ExceptionFactoryImpl factory;
+    
+    static {
+        ExceptionFactoryImpl theFactory = null;
+        
+        try {
+            // The following is neater but requires -source >= 1.8
+            // theFactory = org.mockito.exceptions.verification.junit.ArgumentsAreDifferent::new;
+            theFactory = new ExceptionFactoryImpl() {
+                @Override
+                public AssertionError create(String message, String wanted, String actual) {
+                    return new org.mockito.exceptions.verification.junit.ArgumentsAreDifferent(message, wanted, actual);
+                }
+            };
+        } catch (Throwable onlyIfJUnit3IsNotAvailable) {
+        }
+        // The following is much neater but requires -source >= 1.8
+        // factory = (theFactory == null) ? ArgumentsAreDifferent::new : theFactory;
+        factory = (theFactory == null) ? new ExceptionFactoryImpl() {
+            @Override
+            public AssertionError create(String message, String wanted, String actual) {
+                return new ArgumentsAreDifferent(message, wanted, actual);
+            }
+        } : theFactory;
+    }
+    
     /**
      * If JUnit is used, an AssertionError is returned that extends from JUnit {@link ComparisonFailure} and hence provide a better IDE support as the comparison result is comparable
      */
     public static AssertionError createArgumentsAreDifferentException(String message, String wanted, String actual) {
-        if (hasJUnit) {
-            return createJUnitArgumentsAreDifferent(message, wanted, actual);
-        }
-        return new ArgumentsAreDifferent(message);
-    }
-
-    private static AssertionError createJUnitArgumentsAreDifferent(String message, String wanted, String actual) {
-        return JUnitArgsAreDifferent.create(message, wanted, actual);
-    }
-
-    private static boolean canLoadJunitClass() {
-        try {
-            JUnitArgsAreDifferent.create("message", "wanted", "actual");
-        } catch (Throwable onlyIfJUnitIsNotAvailable) {
-            return false;
-        }
-        return true;
-    }
-
-    /**
-     * Don't inline this class! It allows create the JUnit-ArgumentsAreDifferent exception without the need to use reflection.
-     * <p>
-     * If JUnit is not available a call to {@link #create(String, String, String)} will throw a {@link NoClassDefFoundError}.
-     * The {@link NoClassDefFoundError} will be thrown by the class loader cause the JUnit class {@link ComparisonFailure}
-     * can't be loaded which is a upper class of ArgumentsAreDifferent.
-     */
-    private static class JUnitArgsAreDifferent {
-        static AssertionError create(String message, String wanted, String actual) {
-            return new org.mockito.exceptions.verification.junit.ArgumentsAreDifferent(message, wanted, actual);
-        }
+        return factory.create(message, wanted, actual);
     }
 }

--- a/src/main/java/org/mockito/internal/junit/ExceptionFactory.java
+++ b/src/main/java/org/mockito/internal/junit/ExceptionFactory.java
@@ -14,24 +14,35 @@ public class ExceptionFactory {
     private static interface ExceptionFactoryImpl {
         AssertionError create(String message, String wanted, String actual);
     }
-    
+
     private final static ExceptionFactoryImpl factory;
-    
+
     static {
         ExceptionFactoryImpl theFactory = null;
-        
+
         try {
-            // The following is neater but requires -source >= 1.8
-            // theFactory = org.mockito.exceptions.verification.junit.ArgumentsAreDifferent::new;
+            // The following is neater but requires -source and -target >= 1.8
+            // theFactory = org.mockito.exceptions.verification.junit4.ArgumentsAreDifferent::new;
             theFactory = new ExceptionFactoryImpl() {
                 @Override
                 public AssertionError create(String message, String wanted, String actual) {
-                    return new org.mockito.exceptions.verification.junit.ArgumentsAreDifferent(message, wanted, actual);
+                    return new org.mockito.exceptions.verification.junit4.ArgumentsAreDifferent(message, wanted, actual);
                 }
             };
-        } catch (Throwable onlyIfJUnit3IsNotAvailable) {
+        } catch (Throwable onlyIfJUnit4IsNotAvailable) {
+            try {
+                // The following is neater but requires -source and -target >= 1.8
+                // theFactory = org.mockito.exceptions.verification.junit.ArgumentsAreDifferent::new;
+                theFactory = new ExceptionFactoryImpl() {
+                    @Override
+                    public AssertionError create(String message, String wanted, String actual) {
+                        return new org.mockito.exceptions.verification.junit.ArgumentsAreDifferent(message, wanted, actual);
+                    }
+                };
+            } catch (Throwable onlyIfJUnit3IsNotAvailable) {
+            }
         }
-        // The following is much neater but requires -source >= 1.8
+        // The following is neater but requires -source and -target >= 1.8
         // factory = (theFactory == null) ? ArgumentsAreDifferent::new : theFactory;
         factory = (theFactory == null) ? new ExceptionFactoryImpl() {
             @Override
@@ -40,9 +51,13 @@ public class ExceptionFactory {
             }
         } : theFactory;
     }
-    
+
     /**
-     * If JUnit is used, an AssertionError is returned that extends from JUnit {@link ComparisonFailure} and hence provide a better IDE support as the comparison result is comparable
+     * Returns an AssertionError that describes the fact that the arguments of an invocation are different.
+     * If JUnit 4+ is on the class path, it returns a class that extends from JUnit's {@link org.junit.ComparisonFailure},
+     * or else if JUnit 3 is on the class path it returns a class that extends from JUnit 3's
+     * {@link junit.framework.ComparisonFailure}. This provides a better IDE support as the comparison result
+     * can be opened in a visual diff.
      */
     public static AssertionError createArgumentsAreDifferentException(String message, String wanted, String actual) {
         return factory.create(message, wanted, actual);

--- a/src/test/java/org/mockito/StaticMockingExperimentTest.java
+++ b/src/test/java/org/mockito/StaticMockingExperimentTest.java
@@ -8,7 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockito.exceptions.verification.WantedButNotInvoked;
-import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
+import org.mockito.exceptions.verification.junit4.ArgumentsAreDifferent;
 import org.mockito.invocation.Invocation;
 import org.mockito.invocation.InvocationFactory;
 import org.mockito.invocation.MockHandler;

--- a/src/test/java/org/mockito/internal/junit/ExceptionFactoryTest.java
+++ b/src/test/java/org/mockito/internal/junit/ExceptionFactoryTest.java
@@ -8,32 +8,32 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockitoutil.ClassLoaders.excludingClassLoader;
 
 import java.lang.reflect.Method;
+
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.exceptions.verification.ArgumentsAreDifferent;
 
 public class ExceptionFactoryTest {
 
-    private static ClassLoader classLoaderWithoutJUnit = excludingClassLoader().withCodeSourceUrlOf(ExceptionFactory.class).without("org.junit", "junit").build();
-
-    /** loaded by the current current class loader */
+    private static ClassLoader classLoaderWithoutJUnit  = excludingClassLoader().withCodeSourceUrlOf(ExceptionFactory.class).without("org.junit", "junit").build();
+    
+    /** loaded by the current classloader */
+    private static Class<?> comparisonFailure;
     private static Class<?> junitArgumentsAreDifferent;
 
-    /** loaded by the custom classloader {@value #classLoaderWithoutJUnit}, which excludes junit-classes */
+    /** loaded by the custom classloader {@value #classLoaderWithoutJUnit}, which excludes JUnit classes */
     private static Class<?> nonJunitArgumentsAreDifferent;
 
     @BeforeClass
     public static void init() throws ClassNotFoundException {
         nonJunitArgumentsAreDifferent = classLoaderWithoutJUnit.loadClass(ArgumentsAreDifferent.class.getName());
+        comparisonFailure = junit.framework.ComparisonFailure.class;
         junitArgumentsAreDifferent = org.mockito.exceptions.verification.junit.ArgumentsAreDifferent.class;
     }
 
     @Test
     public void createArgumentsAreDifferentException_withoutJUnit() throws Exception {
-        Class<?> exceptionFactory = classLoaderWithoutJUnit.loadClass(ExceptionFactory.class.getName());
-
-        Method m = exceptionFactory.getDeclaredMethod("createArgumentsAreDifferentException", String.class, String.class, String.class);
-        Object e = m.invoke(null, "message", "wanted", "actual");
+        AssertionError e = invokeFactoryThroughLoader(classLoaderWithoutJUnit);
 
         assertThat(e).isExactlyInstanceOf(nonJunitArgumentsAreDifferent);
     }
@@ -42,17 +42,24 @@ public class ExceptionFactoryTest {
     public void createArgumentsAreDifferentException_withJUnit() throws Exception {
         AssertionError e = ExceptionFactory.createArgumentsAreDifferentException("message", "wanted", "actual");
 
-        assertThat(e).isExactlyInstanceOf(junitArgumentsAreDifferent);
+        assertThat(e).isExactlyInstanceOf(junitArgumentsAreDifferent).isInstanceOf(comparisonFailure);
     }
 
     @Test
-    public void createArgumentsAreDifferentException_withJUnit2x() throws Exception {
+    public void createArgumentsAreDifferentException_withJUnit_2x() throws Exception {
         AssertionError e;
-
+        
         e = ExceptionFactory.createArgumentsAreDifferentException("message", "wanted", "actual");
         assertThat(e).isExactlyInstanceOf(junitArgumentsAreDifferent);
 
         e = ExceptionFactory.createArgumentsAreDifferentException("message", "wanted", "actual");
         assertThat(e).isExactlyInstanceOf(junitArgumentsAreDifferent);
+    }
+
+    private static AssertionError invokeFactoryThroughLoader(ClassLoader loader) throws Exception {
+        Class<?> exceptionFactory = loader.loadClass(ExceptionFactory.class.getName());
+
+        Method m = exceptionFactory.getDeclaredMethod("createArgumentsAreDifferentException", String.class, String.class, String.class);
+        return (AssertionError) m.invoke(null, "message", "wanted", "actual");
     }
 }

--- a/src/test/java/org/mockito/internal/verification/VerificationOverTimeImplTest.java
+++ b/src/test/java/org/mockito/internal/verification/VerificationOverTimeImplTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.exceptions.base.MockitoAssertionError;
-import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
+import org.mockito.exceptions.verification.junit4.ArgumentsAreDifferent;
 import org.mockito.verification.VerificationMode;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/org/mockito/internal/verification/checkers/MissingInvocationCheckerTest.java
+++ b/src/test/java/org/mockito/internal/verification/checkers/MissingInvocationCheckerTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.exceptions.verification.WantedButNotInvoked;
-import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
+import org.mockito.exceptions.verification.junit4.ArgumentsAreDifferent;
 import org.mockito.internal.invocation.InvocationBuilder;
 import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockito.invocation.Invocation;

--- a/src/test/java/org/mockito/internal/verification/checkers/MissingInvocationInOrderCheckerTest.java
+++ b/src/test/java/org/mockito/internal/verification/checkers/MissingInvocationInOrderCheckerTest.java
@@ -12,7 +12,7 @@ import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.exceptions.verification.VerificationInOrderFailure;
 import org.mockito.exceptions.verification.WantedButNotInvoked;
-import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
+import org.mockito.exceptions.verification.junit4.ArgumentsAreDifferent;
 import org.mockito.internal.invocation.InvocationBuilder;
 import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockito.internal.verification.InOrderContextImpl;

--- a/src/test/java/org/mockitousage/basicapi/UsingVarargsTest.java
+++ b/src/test/java/org/mockitousage/basicapi/UsingVarargsTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
-import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
+import org.mockito.exceptions.verification.junit4.ArgumentsAreDifferent;
 import org.mockitoutil.TestBase;
 
 import java.util.ArrayList;

--- a/src/test/java/org/mockitousage/matchers/CustomMatcherDoesYieldCCETest.java
+++ b/src/test/java/org/mockitousage/matchers/CustomMatcherDoesYieldCCETest.java
@@ -7,7 +7,7 @@ package org.mockitousage.matchers;
 import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
-import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
+import org.mockito.exceptions.verification.junit4.ArgumentsAreDifferent;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 

--- a/src/test/java/org/mockitousage/matchers/HamcrestMatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/HamcrestMatchersTest.java
@@ -11,7 +11,7 @@ import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
+import org.mockito.exceptions.verification.junit4.ArgumentsAreDifferent;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 

--- a/src/test/java/org/mockitousage/matchers/MatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/MatchersTest.java
@@ -14,7 +14,7 @@ import java.util.regex.Pattern;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.exceptions.verification.WantedButNotInvoked;
-import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
+import org.mockito.exceptions.verification.junit4.ArgumentsAreDifferent;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 

--- a/src/test/java/org/mockitousage/matchers/MoreMatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/MoreMatchersTest.java
@@ -9,7 +9,7 @@ import org.assertj.core.api.ThrowableAssert;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
+import org.mockito.exceptions.verification.junit4.ArgumentsAreDifferent;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 

--- a/src/test/java/org/mockitousage/matchers/ReflectionMatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/ReflectionMatchersTest.java
@@ -7,7 +7,7 @@ package org.mockitousage.matchers;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
+import org.mockito.exceptions.verification.junit4.ArgumentsAreDifferent;
 import org.mockitoutil.TestBase;
 
 import static org.mockito.Matchers.refEq;

--- a/src/test/java/org/mockitousage/matchers/VarargsTest.java
+++ b/src/test/java/org/mockitousage/matchers/VarargsTest.java
@@ -23,7 +23,7 @@ import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
+import org.mockito.exceptions.verification.junit4.ArgumentsAreDifferent;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.mockitousage.IMethods;

--- a/src/test/java/org/mockitousage/stacktrace/ClickableStackTracesTest.java
+++ b/src/test/java/org/mockitousage/stacktrace/ClickableStackTracesTest.java
@@ -7,7 +7,7 @@ package org.mockitousage.stacktrace;
 
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
+import org.mockito.exceptions.verification.junit4.ArgumentsAreDifferent;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 

--- a/src/test/java/org/mockitousage/verification/BasicVerificationInOrderTest.java
+++ b/src/test/java/org/mockitousage/verification/BasicVerificationInOrderTest.java
@@ -12,7 +12,7 @@ import org.mockito.exceptions.base.MockitoException;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockito.exceptions.verification.VerificationInOrderFailure;
 import org.mockito.exceptions.verification.WantedButNotInvoked;
-import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
+import org.mockito.exceptions.verification.junit4.ArgumentsAreDifferent;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 

--- a/src/test/java/org/mockitousage/verification/BasicVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/BasicVerificationTest.java
@@ -11,7 +11,7 @@ import org.mockito.Mock;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockito.exceptions.verification.TooManyActualInvocations;
 import org.mockito.exceptions.verification.WantedButNotInvoked;
-import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
+import org.mockito.exceptions.verification.junit4.ArgumentsAreDifferent;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 

--- a/src/test/java/org/mockitousage/verification/DescriptiveMessagesOnVerificationInOrderErrorsTest.java
+++ b/src/test/java/org/mockitousage/verification/DescriptiveMessagesOnVerificationInOrderErrorsTest.java
@@ -96,7 +96,7 @@ public class DescriptiveMessagesOnVerificationInOrderErrorsTest extends TestBase
         try {
             inOrder.verify(one).simpleMethod(999);
             fail();
-        } catch (org.mockito.exceptions.verification.junit.ArgumentsAreDifferent e) {
+        } catch (org.mockito.exceptions.verification.junit4.ArgumentsAreDifferent e) {
             assertThat(e).hasMessageContaining("has different arguments");
         }
     }

--- a/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
+++ b/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
@@ -13,7 +13,7 @@ import org.mockito.Mockito;
 import org.mockito.exceptions.verification.NeverWantedButInvoked;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockito.exceptions.verification.WantedButNotInvoked;
-import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
+import org.mockito.exceptions.verification.junit4.ArgumentsAreDifferent;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 

--- a/src/test/java/org/mockitousage/verification/PrintingVerboseTypesWithArgumentsTest.java
+++ b/src/test/java/org/mockitousage/verification/PrintingVerboseTypesWithArgumentsTest.java
@@ -7,7 +7,7 @@ package org.mockitousage.verification;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
-import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
+import org.mockito.exceptions.verification.junit4.ArgumentsAreDifferent;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 

--- a/src/test/java/org/mockitousage/verification/VerificationUsingMatchersTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationUsingMatchersTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.mockito.exceptions.verification.WantedButNotInvoked;
-import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent;
+import org.mockito.exceptions.verification.junit4.ArgumentsAreDifferent;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 


### PR DESCRIPTION
Fixes #1649.

I do have a minor concern about the way this has been implemented, which I discovered when I ran the full test suite - if there is any code out there running on JUnit 4+ that is relying on catching `org.mockito.exceptions.verification.junit.ArgumentsAreDifferent`, that code will now fail until it has been updated.

Possible alternative implementations:

1. Make `org.mockito.exceptions.verification.junit.ArgumentsAreDifferent` the JUnit 4 version and `org.mockito.exceptions.verification.junit3.ArgumentsAreDifferent` the JUnit 3 version. Disadvantage: By changing the class hierarchy of the existing class name, it may break implementations that rely on this class deriving from `junit.framework.ComparisonFailure` will be affected.
2. Abandon the old name entirely and use two new ones in packages `junit3` & `junit4`. This will force the compiler to fail on these usages - at least code writers will be aware and can update their code (the backward-compatible options above may leave some hidden bugs waiting to manifest at an inopportune time).
3. Drop the whole idea of upgrading to the latest `ComparisonFailure`.

Comments/thoughts welcome. I don't have a feel for how common it is to people to try and catch these exceptions directly and whether or not this will be an issue in practice vs theory only.