### PR TITLE
New public API: invocation.getArgumentsAsMatchers()

### DIFF
--- a/src/main/java/org/mockito/internal/invocation/InterceptedInvocation.java
+++ b/src/main/java/org/mockito/internal/invocation/InterceptedInvocation.java
@@ -4,6 +4,7 @@
  */
 package org.mockito.internal.invocation;
 
+import org.mockito.ArgumentMatcher;
 import org.mockito.internal.invocation.mockref.MockReference;
 import org.mockito.internal.exceptions.VerificationAwareInvocation;
 import org.mockito.internal.reporting.PrintSettings;
@@ -13,8 +14,10 @@ import org.mockito.invocation.StubInfo;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.List;
 
 import static org.mockito.internal.exceptions.Reporter.cannotCallAbstractRealMethod;
+import static org.mockito.internal.invocation.ArgumentsProcessor.argumentsToMatchers;
 
 public class InterceptedInvocation implements Invocation, VerificationAwareInvocation {
 
@@ -119,6 +122,23 @@ public class InterceptedInvocation implements Invocation, VerificationAwareInvoc
         return (T) arguments[index];
     }
 
+    public MockReference<Object> getMockRef() {
+        return mockRef;
+    }
+
+    public MockitoMethod getMockitoMethod() {
+        return mockitoMethod;
+    }
+
+    public RealMethod getRealMethod() {
+        return realMethod;
+    }
+
+    @Override
+    public List<ArgumentMatcher> getArgumentsAsMatchers() {
+        return argumentsToMatchers(getArguments());
+    }
+
     @Override
     public <T> T getArgument(int index, Class<T> clazz) {
         return clazz.cast(arguments[index]);
@@ -154,7 +174,7 @@ public class InterceptedInvocation implements Invocation, VerificationAwareInvoc
     }
 
     public String toString() {
-        return new PrintSettings().print(ArgumentsProcessor.argumentsToMatchers(getArguments()), this);
+        return new PrintSettings().print(getArgumentsAsMatchers(), this);
     }
 
     public final static RealMethod NO_OP = new RealMethod() {

--- a/src/main/java/org/mockito/internal/invocation/InvocationMatcher.java
+++ b/src/main/java/org/mockito/internal/invocation/InvocationMatcher.java
@@ -5,7 +5,6 @@
 
 package org.mockito.internal.invocation;
 
-import static org.mockito.internal.invocation.ArgumentsProcessor.argumentsToMatchers;
 import static org.mockito.internal.invocation.MatcherApplicationStrategy.getMatcherApplicationStrategyFor;
 import static org.mockito.internal.invocation.TypeSafeMatching.matchesTypeSafe;
 
@@ -36,7 +35,7 @@ public class InvocationMatcher implements MatchableInvocation, DescribedInvocati
     public InvocationMatcher(Invocation invocation, List<ArgumentMatcher> matchers) {
         this.invocation = invocation;
         if (matchers.isEmpty()) {
-            this.matchers = (List) argumentsToMatchers(invocation.getArguments());
+            this.matchers = (List) invocation.getArgumentsAsMatchers();
         } else {
             this.matchers = (List) matchers;
         }

--- a/src/main/java/org/mockito/internal/reporting/PrintSettings.java
+++ b/src/main/java/org/mockito/internal/reporting/PrintSettings.java
@@ -5,7 +5,6 @@
 package org.mockito.internal.reporting;
 
 import org.mockito.ArgumentMatcher;
-import org.mockito.internal.invocation.ArgumentsProcessor;
 import org.mockito.internal.matchers.text.MatchersPrinter;
 import org.mockito.internal.util.MockUtil;
 import org.mockito.invocation.Invocation;
@@ -55,7 +54,7 @@ public class PrintSettings {
     }
 
     public String print(Invocation invocation) {
-        return print(ArgumentsProcessor.argumentsToMatchers(invocation.getArguments()), invocation);
+        return print(invocation.getArgumentsAsMatchers(), invocation);
     }
 
     public String print(MatchableInvocation invocation) {

--- a/src/main/java/org/mockito/invocation/Invocation.java
+++ b/src/main/java/org/mockito/invocation/Invocation.java
@@ -51,9 +51,11 @@ public interface Invocation extends InvocationOnMock, DescribedInvocation {
     Object[] getRawArguments();
 
     /**
-     * Returns arguments wrapped into ArgumentMatchers
+     * Wraps each argument using ArgumentMatchers.eq() or AdditionalMatchers.arryEq()
+     * Used internally for the purposes of human-readable invocation printing.
      *
      * @return a list of ArgumentMatcher wrapping each of this invocation arguments
+     * @since 2.25.6
      */
     List<ArgumentMatcher> getArgumentsAsMatchers();
 

--- a/src/main/java/org/mockito/invocation/Invocation.java
+++ b/src/main/java/org/mockito/invocation/Invocation.java
@@ -51,10 +51,11 @@ public interface Invocation extends InvocationOnMock, DescribedInvocation {
     Object[] getRawArguments();
 
     /**
-     * Wraps each argument using ArgumentMatchers.eq() or AdditionalMatchers.arryEq()
+     * Wraps each argument using {@link org.mockito.ArgumentMatchers#eq(Object)} or
+     * {@link org.mockito.AdditionalMatchers#aryEq(Object[])}
      * Used internally for the purposes of human-readable invocation printing.
      *
-     * @return a list of ArgumentMatcher wrapping each of this invocation arguments
+     * @return a list of {@link ArgumentMatcher} wrapping each of this invocation arguments
      * @since 2.25.6
      */
     List<ArgumentMatcher> getArgumentsAsMatchers();

--- a/src/main/java/org/mockito/invocation/Invocation.java
+++ b/src/main/java/org/mockito/invocation/Invocation.java
@@ -4,7 +4,10 @@
  */
 package org.mockito.invocation;
 
+import org.mockito.ArgumentMatcher;
 import org.mockito.NotExtensible;
+
+import java.util.List;
 
 /**
  * A method call on a mock object. Contains all information and state needed for the Mockito framework to operate.
@@ -46,6 +49,13 @@ public interface Invocation extends InvocationOnMock, DescribedInvocation {
      * @return unprocessed arguments, exactly as provided to this invocation.
      */
     Object[] getRawArguments();
+
+    /**
+     * Returns arguments wrapped into ArgumentMatchers
+     *
+     * @return a list of ArgumentMatcher wrapping each of this invocation arguments
+     */
+    List<ArgumentMatcher> getArgumentsAsMatchers();
 
     /**
      * Returns unprocessed arguments whereas {@link #getArguments()} returns

--- a/src/test/java/org/mockito/internal/invocation/InvocationBuilder.java
+++ b/src/test/java/org/mockito/internal/invocation/InvocationBuilder.java
@@ -6,6 +6,7 @@
 package org.mockito.internal.invocation;
 
 import org.mockito.Mockito;
+import org.mockito.internal.invocation.mockref.MockReference;
 import org.mockito.internal.invocation.mockref.MockStrongReference;
 import org.mockito.internal.debugging.LocationImpl;
 import org.mockito.invocation.Invocation;
@@ -61,7 +62,7 @@ public class InvocationBuilder {
             }
         }
 
-        Invocation i = new InterceptedInvocation(new MockStrongReference<Object>(mock, false),
+        Invocation i = createInvocation(new MockStrongReference<Object>(mock, false),
             new SerializableMethod(method),
             args,
             NO_OP,
@@ -71,6 +72,11 @@ public class InvocationBuilder {
             i.markVerified();
         }
         return i;
+    }
+
+    protected Invocation createInvocation(MockReference<Object> mockRef, MockitoMethod mockitoMethod, Object[] arguments,
+                                          RealMethod realMethod, Location location, int sequenceNumber) {
+        return new InterceptedInvocation(mockRef, mockitoMethod, arguments, realMethod, location, sequenceNumber);
     }
 
     public InvocationBuilder method(String methodName) {

--- a/src/test/java/org/mockito/internal/verification/checkers/MissingInvocationCheckerTest.java
+++ b/src/test/java/org/mockito/internal/verification/checkers/MissingInvocationCheckerTest.java
@@ -5,78 +5,125 @@
 
 package org.mockito.internal.verification.checkers;
 
-import static java.util.Arrays.asList;
-
-import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
-import org.mockito.exceptions.verification.WantedButNotInvoked;
 import org.mockito.exceptions.verification.opentest4j.ArgumentsAreDifferent;
-import org.mockito.internal.invocation.InvocationBuilder;
-import org.mockito.internal.invocation.InvocationMatcher;
+import org.mockito.exceptions.verification.WantedButNotInvoked;
+import org.mockito.internal.invocation.*;
+import org.mockito.internal.invocation.mockref.MockReference;
 import org.mockito.invocation.Invocation;
+import org.mockito.invocation.Location;
 import org.mockitousage.IMethods;
 import org.mockitoutil.TestBase;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+
 public class MissingInvocationCheckerTest extends TestBase {
 
-	private InvocationMatcher wanted;
-	private List<Invocation> invocations;
+    private InvocationMatcher wanted;
+    private List<Invocation> invocations;
 
-	@Mock
-	private IMethods mock;
+    @Mock
+    private IMethods mock;
 
-	@Rule
-	public ExpectedException exception = ExpectedException.none();
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
 
-	@Test
-	public void shouldPassBecauseActualInvocationFound() {
-		wanted = buildSimpleMethod().toInvocationMatcher();
-		invocations = asList(buildSimpleMethod().toInvocation());
+    @Test
+    public void shouldPassBecauseActualInvocationFound() {
+        wanted = buildSimpleMethod().toInvocationMatcher();
+        invocations = asList(buildSimpleMethod().toInvocation());
 
-		MissingInvocationChecker.checkMissingInvocation(invocations, wanted);
-	}
+        MissingInvocationChecker.checkMissingInvocation(invocations, wanted);
+    }
 
-	@Test
-	public void shouldReportWantedButNotInvoked() {
-		wanted = buildSimpleMethod().toInvocationMatcher();
-		invocations = asList(buildDifferentMethod().toInvocation());
+    @Test
+    public void shouldReportWantedButNotInvoked() {
+        wanted = buildSimpleMethod().toInvocationMatcher();
+        invocations = asList(buildDifferentMethod().toInvocation());
 
-		exception.expect(WantedButNotInvoked.class);
-		exception.expectMessage("Wanted but not invoked:");
-		exception.expectMessage("mock.simpleMethod()");
-		exception.expectMessage("However, there was exactly 1 interaction with this mock:");
-		exception.expectMessage("mock.differentMethod();");
+        exception.expect(WantedButNotInvoked.class);
+        exception.expectMessage("Wanted but not invoked:");
+        exception.expectMessage("mock.simpleMethod()");
+        exception.expectMessage("However, there was exactly 1 interaction with this mock:");
+        exception.expectMessage("mock.differentMethod();");
 
-		MissingInvocationChecker.checkMissingInvocation(invocations, wanted);
-	}
+        MissingInvocationChecker.checkMissingInvocation(invocations, wanted);
+    }
 
-	@Test
-	public void shouldReportWantedInvocationDiffersFromActual() {
-		wanted = buildIntArgMethod().arg(2222).toInvocationMatcher();
-		invocations = asList(buildIntArgMethod().arg(1111).toInvocation());
+    @Test
+    public void shouldReportWantedInvocationDiffersFromActual() {
+        wanted = buildIntArgMethod(new InvocationBuilder()).arg(2222).toInvocationMatcher();
+        invocations = asList(buildIntArgMethod(new InvocationBuilder()).arg(1111).toInvocation());
 
-		exception.expect(ArgumentsAreDifferent.class);
+        exception.expect(ArgumentsAreDifferent.class);
 
-		exception.expectMessage("Argument(s) are different! Wanted:");
-		exception.expectMessage("mock.intArgumentMethod(2222);");
-		exception.expectMessage("Actual invocation has different arguments:");
-		exception.expectMessage("mock.intArgumentMethod(1111);");
+        exception.expectMessage("Argument(s) are different! Wanted:");
+        exception.expectMessage("mock.intArgumentMethod(2222);");
+        exception.expectMessage("Actual invocation has different arguments:");
+        exception.expectMessage("mock.intArgumentMethod(1111);");
 
-		MissingInvocationChecker.checkMissingInvocation(invocations, wanted);
-	}
+        MissingInvocationChecker.checkMissingInvocation(invocations, wanted);
+    }
 
-	private InvocationBuilder buildIntArgMethod() {
-		return new InvocationBuilder().mock(mock).method("intArgumentMethod").argTypes(int.class);
-	}
+    @Test
+    public void shouldReportUsingInvocationDescription() {
+        wanted = buildIntArgMethod(new CustomInvocationBuilder()).arg(2222).toInvocationMatcher();
+        invocations = singletonList(buildIntArgMethod(new CustomInvocationBuilder()).arg(1111).toInvocation());
 
-	private InvocationBuilder buildSimpleMethod() {
-		return new InvocationBuilder().mock(mock).simpleMethod();
-	}
+        exception.expect(ArgumentsAreDifferent.class);
 
-	private InvocationBuilder buildDifferentMethod() {
-		return new InvocationBuilder().mock(mock).differentMethod();
-	}
+        exception.expectMessage("Argument(s) are different! Wanted:");
+        exception.expectMessage("mock.intArgumentMethod(MyCoolPrint(2222));");
+        exception.expectMessage("Actual invocation has different arguments:");
+        exception.expectMessage("mock.intArgumentMethod(MyCoolPrint(1111));");
+
+        MissingInvocationChecker.checkMissingInvocation(invocations, wanted);
+    }
+
+    private InvocationBuilder buildIntArgMethod(InvocationBuilder invocationBuilder) {
+        return invocationBuilder.mock(mock).method("intArgumentMethod").argTypes(int.class);
+    }
+
+    private InvocationBuilder buildSimpleMethod() {
+        return new InvocationBuilder().mock(mock).simpleMethod();
+    }
+
+    private InvocationBuilder buildDifferentMethod() {
+        return new InvocationBuilder().mock(mock).differentMethod();
+    }
+
+    static class CustomInvocationBuilder extends InvocationBuilder {
+        @Override
+        protected Invocation createInvocation(MockReference<Object> mockRef, MockitoMethod mockitoMethod, final Object[] arguments,
+                                              RealMethod realMethod, Location location, int sequenceNumber) {
+            return new InterceptedInvocation(mockRef, mockitoMethod, arguments, realMethod, location, sequenceNumber) {
+                @Override
+                public List<ArgumentMatcher> getArgumentsAsMatchers() {
+                    List<ArgumentMatcher> matchers = new ArrayList<ArgumentMatcher>();
+                    for (final Object argument : getRawArguments()) {
+                        matchers.add(new ArgumentMatcher() {
+                            @Override
+                            public boolean matches(Object a) {
+                                return a == argument;
+                            }
+
+                            @Override
+                            public String toString() {
+                                return "MyCoolPrint(" + argument + ")";
+                            }
+                        });
+                    }
+                    return matchers;
+                }
+            };
+        }
+    }
 }


### PR DESCRIPTION
- New public API: invocation.getArgumentsAsMatchers(), useful for advanced integrations, such as mockito-scala
- Some internal refactorings that provide temporary help with mockito-scala integration

Fixes #1664