### PR TITLE
Add ErrorProne subproject

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ versions.bytebuddy = '1.9.7'
 versions.junitJupiter = '5.1.1'
 versions.errorprone = '2.3.2'
 
-libraries.junit4 = 'junit:junit:4.13-beta-1'
+libraries.junit4 = 'junit:junit:4.12'
 libraries.junitJupiterApi = "org.junit.jupiter:junit-jupiter-api:${versions.junitJupiter}"
 libraries.junitPlatformLauncher = 'org.junit.platform:junit-platform-launcher:1.1.0'
 libraries.junitJupiterEngine = "org.junit.jupiter:junit-jupiter-engine:${versions.junitJupiter}"

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -6,8 +6,9 @@ def versions = [:]
 
 versions.bytebuddy = '1.9.7'
 versions.junitJupiter = '5.1.1'
+versions.errorprone = '2.3.2'
 
-libraries.junit4 = 'junit:junit:4.12'
+libraries.junit4 = 'junit:junit:4.13-beta-1'
 libraries.junitJupiterApi = "org.junit.jupiter:junit-jupiter-api:${versions.junitJupiter}"
 libraries.junitPlatformLauncher = 'org.junit.platform:junit-platform-launcher:1.1.0'
 libraries.junitJupiterEngine = "org.junit.jupiter:junit-jupiter-engine:${versions.junitJupiter}"
@@ -18,7 +19,8 @@ libraries.bytebuddy = "net.bytebuddy:byte-buddy:${versions.bytebuddy}"
 libraries.bytebuddyagent = "net.bytebuddy:byte-buddy-agent:${versions.bytebuddy}"
 libraries.bytebuddyandroid = "net.bytebuddy:byte-buddy-android:${versions.bytebuddy}"
 
-libraries.errorprone = 'com.google.errorprone:error_prone_core:2.3.2'
+libraries.errorprone = "com.google.errorprone:error_prone_core:${versions.errorprone}"
+libraries.errorproneTestApi = "com.google.errorprone:error_prone_test_helpers:${versions.errorprone}"
 
 // objenesis 3.x with full Java 11 support requires Java 8, bump version when Java 7 support is dropped
 libraries.objenesis = 'org.objenesis:objenesis:2.6'

--- a/gradle/root/java-compatibility-check.gradle
+++ b/gradle/root/java-compatibility-check.gradle
@@ -2,10 +2,11 @@
 //if we're skipping release, let's also skip checking compatibility (faster builds)
 if (project.hasProperty('checkJavaCompatibility') && !System.getenv("SKIP_RELEASE")) {
     allprojects { p ->
+        def isJava8 = p.name != 'junit-jupiter' && p.name != 'errorprone'
         plugins.withId('java') {
             p.apply plugin: 'ru.vyarus.animalsniffer'
             p.dependencies {
-                signature "org.codehaus.mojo.signature:java1${p.name != 'junit-jupiter' ? '6' : '8'}:1.0@signature"
+                signature "org.codehaus.mojo.signature:java1${isJava8 ? '6' : '8'}:1.0@signature"
             }
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,6 +7,7 @@ include 'android'
 include 'junit-jupiter'
 include 'junitJupiterExtensionTest'
 include 'module-test'
+include 'errorprone'
 
 rootProject.name = 'mockito'
 

--- a/subprojects/errorprone/errorprone.gradle
+++ b/subprojects/errorprone/errorprone.gradle
@@ -1,0 +1,15 @@
+description = "ErrorProne plugins for Mockito"
+
+apply from: "$rootDir/gradle/java-library.gradle"
+apply from: "$rootDir/gradle/dependencies.gradle"
+
+dependencies {
+    compile project.rootProject
+    compile libraries.errorprone
+
+    testCompile libraries.junit4
+    testCompile libraries.errorproneTestApi
+}
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8

--- a/subprojects/errorprone/errorprone.gradle
+++ b/subprojects/errorprone/errorprone.gradle
@@ -13,3 +13,8 @@ dependencies {
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
+
+test {
+    inputs.files(configurations.errorproneJavac).withNormalizer(ClasspathNormalizer)
+    jvmArgs += "-Xbootclasspath/p:${configurations.errorproneJavac.asPath}"
+}

--- a/subprojects/errorprone/errorprone.gradle
+++ b/subprojects/errorprone/errorprone.gradle
@@ -7,7 +7,7 @@ dependencies {
     compile project.rootProject
     compile libraries.errorprone
 
-    testCompile libraries.junit4
+    testCompile 'junit:junit:4.13-beta-1'
     testCompile libraries.errorproneTestApi
 }
 

--- a/subprojects/errorprone/errorprone.gradle
+++ b/subprojects/errorprone/errorprone.gradle
@@ -17,4 +17,7 @@ targetCompatibility = 1.8
 test {
     inputs.files(configurations.errorproneJavac).withNormalizer(ClasspathNormalizer)
     jvmArgs += "-Xbootclasspath/p:${configurations.errorproneJavac.asPath}"
+
+    // ErrorProne can only run on JDK 8
+    it.enabled = !JavaVersion.current().isJava9Compatible()
 }

--- a/subprojects/errorprone/src/main/java/org/mockito/errorprone/bugpatterns/MockitoNotExtensible.java
+++ b/subprojects/errorprone/src/main/java/org/mockito/errorprone/bugpatterns/MockitoNotExtensible.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.errorprone.bugpatterns;
+
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ClassTree;
+
+/** Finds subclasses of @NotExtensible interfaces. */
+@BugPattern(
+    name = "MockitoNotExtensible",
+    summary = "Some types that are a part of Mockito public API are not intended to be extended.",
+    explanation =
+        "Some types that are a part of Mockito public API are not intended to be extended."
+            + " It's because Mockito team needs to be able to add new methods to some types"
+            + " without breaking compatibility contract. Any type that is not intended"
+            + " to be extended is annotated with @NotExtensible.",
+    severity = SeverityLevel.ERROR)
+public class MockitoNotExtensible extends BugChecker implements ClassTreeMatcher {
+
+    @Override
+    public Description matchClass(ClassTree tree, VisitorState state) {
+        if (tree.getImplementsClause().stream()
+            .anyMatch(
+                implementing ->
+                    ASTHelpers.hasAnnotation(
+                        ASTHelpers.getSymbol(implementing), "org.mockito.NotExtensible", state))) {
+            return describeMatch(tree);
+        }
+
+        return NO_MATCH;
+    }
+}

--- a/subprojects/errorprone/src/test/java/org/mockito/errorprone/bugpatterns/MockitoNotExtensibleTest.java
+++ b/subprojects/errorprone/src/test/java/org/mockito/errorprone/bugpatterns/MockitoNotExtensibleTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.errorprone.bugpatterns;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Verifies that there are no subclasses of {@link org.mockito.NotExtensible} Mockito types. */
+@RunWith(JUnit4.class)
+public class MockitoNotExtensibleTest {
+
+    private CompilationTestHelper compilationTestHelper;
+
+    @Before
+    public void setup() {
+        compilationTestHelper =
+            CompilationTestHelper.newInstance(MockitoNotExtensible.class, getClass());
+    }
+
+    @Test
+    public void notExtensibleSubclass_shouldWarn() {
+        compilationTestHelper
+            .addSourceLines(
+                "input.java",
+                "import org.mockito.invocation.InvocationOnMock;",
+                "// BUG: Diagnostic contains:",
+                "abstract class Invocation implements InvocationOnMock { }")
+            .doTest();
+    }
+
+    @Test
+    public void anonymousClassImplementingNotExtensible_shouldWarn() {
+        compilationTestHelper
+            .addSourceLines(
+                "input.java",
+                "import org.mockito.NotExtensible;",
+                "class Test {",
+                "  public void test() {",
+                "    // BUG: Diagnostic contains:",
+                "    new Anonymous() { };",
+                "  }",
+                "  @NotExtensible",
+                "  interface Anonymous {}",
+                "}")
+            .doTest();
+    }
+
+    @Test
+    public void anonymousClassImplementingOtherAnnotation_shouldNotWarn() {
+        compilationTestHelper
+            .addSourceLines(
+                "input.java",
+                "import org.mockito.NotExtensible;",
+                "class Test {",
+                "  public void test() {",
+                "    new Anonymous() { };",
+                "  }",
+                "  @OtherAnnotation",
+                "  interface Anonymous {}",
+                "  @interface OtherAnnotation {}",
+                "}")
+            .doTest();
+    }
+}


### PR DESCRIPTION
These checkers allow us to enforce API contracts that the Java compiler
otherwise would not enforce. As a first example, the added checker
enforces that users can not subclass interfaces that are annotated by
`@NotExtensible`.

Fixes #1668