### PR TITLE
Add support for Answer6 and VoidAnswer6

### DIFF
--- a/src/main/java/org/mockito/AdditionalAnswers.java
+++ b/src/main/java/org/mockito/AdditionalAnswers.java
@@ -16,11 +16,13 @@ import org.mockito.stubbing.Answer2;
 import org.mockito.stubbing.Answer3;
 import org.mockito.stubbing.Answer4;
 import org.mockito.stubbing.Answer5;
+import org.mockito.stubbing.Answer6;
 import org.mockito.stubbing.VoidAnswer1;
 import org.mockito.stubbing.VoidAnswer2;
 import org.mockito.stubbing.VoidAnswer3;
 import org.mockito.stubbing.VoidAnswer4;
 import org.mockito.stubbing.VoidAnswer5;
+import org.mockito.stubbing.VoidAnswer6;
 
 import static org.mockito.internal.stubbing.answers.AnswerFunctionalInterfaces.toAnswer;
 
@@ -486,6 +488,45 @@ public class AdditionalAnswers {
      */
     @Incubating
     public static <A, B, C, D, E> Answer<Void> answerVoid(VoidAnswer5<A, B, C, D, E> answer) {
+        return toAnswer(answer);
+    }
+
+    /**
+     * Creates an answer from a functional interface - allows for a strongly typed answer to be created
+     * idiomatically in Java 8
+     *
+     * @param answer interface to the answer - which is expected to return something
+     * @param <T> return type
+     * @param <A> input parameter type 1
+     * @param <B> input parameter type 2
+     * @param <C> input parameter type 3
+     * @param <D> input parameter type 4
+     * @param <E> input parameter type 5
+     * @param <F> input parameter type 6
+     * @return the answer object to use
+     * @since 2.26.0
+     */
+    @Incubating
+    public static <T, A, B, C, D, E, F> Answer<T> answer(Answer6<T, A, B, C, D, E, F> answer) {
+        return toAnswer(answer);
+    }
+
+    /**
+     * Creates an answer from a functional interface - allows for a strongly typed answer to be created
+     * idiomatically in Java 8
+     *
+     * @param answer interface to the answer - a void method
+     * @param <A> input parameter type 1
+     * @param <B> input parameter type 2
+     * @param <C> input parameter type 3
+     * @param <D> input parameter type 4
+     * @param <E> input parameter type 5
+     * @param <F> input parameter type 6
+     * @return the answer object to use
+     * @since 2.26.0
+     */
+    @Incubating
+    public static <A, B, C, D, E, F> Answer<Void> answerVoid(VoidAnswer6<A, B, C, D, E, F> answer) {
         return toAnswer(answer);
     }
 }

--- a/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java
@@ -11,11 +11,13 @@ import org.mockito.stubbing.Answer2;
 import org.mockito.stubbing.Answer3;
 import org.mockito.stubbing.Answer4;
 import org.mockito.stubbing.Answer5;
+import org.mockito.stubbing.Answer6;
 import org.mockito.stubbing.VoidAnswer1;
 import org.mockito.stubbing.VoidAnswer2;
 import org.mockito.stubbing.VoidAnswer3;
 import org.mockito.stubbing.VoidAnswer4;
 import org.mockito.stubbing.VoidAnswer5;
+import org.mockito.stubbing.VoidAnswer6;
 
 /**
  * Functional interfaces to make it easy to implement answers in Java 8
@@ -232,6 +234,62 @@ public class AnswerFunctionalInterfaces {
                         (C)invocation.getArgument(2),
                         (D)invocation.getArgument(3),
                         (E)invocation.getArgument(4));
+                return null;
+            }
+        };
+    }
+
+    /**
+     * Construct an answer from a six parameter answer interface
+     *
+     * @param answer answer interface
+     * @param <T> return type
+     * @param <A> input parameter 1 type
+     * @param <B> input parameter 2 type
+     * @param <C> input parameter 3 type
+     * @param <D> input parameter 4 type
+     * @param <E> input parameter 5 type
+     * @param <F> input parameter 6 type
+     * @return a new answer object
+     */
+    public static <T, A, B, C, D, E, F> Answer<T> toAnswer(final Answer6<T, A, B, C, D, E, F> answer) {
+        return new Answer<T>() {
+            @SuppressWarnings("unchecked")
+            public T answer(InvocationOnMock invocation) throws Throwable {
+                return answer.answer(
+                        (A)invocation.getArgument(0),
+                        (B)invocation.getArgument(1),
+                        (C)invocation.getArgument(2),
+                        (D)invocation.getArgument(3),
+                        (E)invocation.getArgument(4),
+                        (F)invocation.getArgument(5));
+            }
+        };
+    }
+
+    /**
+     * Construct an answer from a five parameter answer interface
+
+     * @param answer answer interface
+     * @param <A> input parameter 1 type
+     * @param <B> input parameter 2 type
+     * @param <C> input parameter 3 type
+     * @param <D> input parameter 4 type
+     * @param <E> input parameter 5 type
+     * @param <F> input parameter 6 type
+     * @return a new answer object
+     */
+    public static <A, B, C, D, E, F> Answer<Void> toAnswer(final VoidAnswer6<A, B, C, D, E, F> answer) {
+        return new Answer<Void>() {
+            @SuppressWarnings("unchecked")
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                answer.answer(
+                        (A)invocation.getArgument(0),
+                        (B)invocation.getArgument(1),
+                        (C)invocation.getArgument(2),
+                        (D)invocation.getArgument(3),
+                        (E)invocation.getArgument(4),
+                        (F)invocation.getArgument(5));
                 return null;
             }
         };

--- a/src/main/java/org/mockito/stubbing/Answer6.java
+++ b/src/main/java/org/mockito/stubbing/Answer6.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.stubbing;
+
+import org.mockito.Incubating;
+
+/**
+ * Generic interface to be used for configuring mock's answer for a six argument invocation.
+ *
+ * Answer specifies an action that is executed and a return value that is returned when you interact with the mock.
+ * <p>
+ * Example of stubbing a mock with this custom answer:
+ *
+ * <pre class="code"><code class="java">
+ * import static org.mockito.AdditionalAnswers.answer;
+ *
+ * when(mock.someMethod(anyInt(), anyString(), anyChar(), any(), any(), anyBoolean())).then(answer(
+ *     new Answer6&lt;StringBuilder, Integer, String, Character, Object, Object, Boolean&gt;() {
+ *         public StringBuilder answer(Integer i, String s, Character c, Object o1, Object o2, Boolean isIt) {
+ *             return new StringBuilder().append(i).append(s).append(c).append(o1.hashCode()).append(o2.hashCode()).append(isIt);
+ *         }
+ * }));
+ *
+ * //Following will print a string like "3xyz131635550true"
+ * System.out.println(mock.someMethod(3, "xy", 'z', new Object(), new Object(), true));
+ * </code></pre>
+ *
+ * @param <T> return type
+ * @param <A0> type of the first argument
+ * @param <A1> type of the second argument
+ * @param <A2> type of the third argument
+ * @param <A3> type of the fourth argument
+ * @param <A4> type of the fifth argument
+ * @param <A5> type of the sixth argument
+ * @see Answer
+ */
+@Incubating
+public interface Answer6<T, A0, A1, A2, A3, A4, A5> {
+    /**
+     * @param argument0 the first argument.
+     * @param argument1 the second argument.
+     * @param argument2 the third argument.
+     * @param argument3 the fourth argument.
+     * @param argument4 the fifth argument.
+     * @param argument5 the sixth argument.
+     *
+     * @return the value to be returned.
+     *
+     * @throws Throwable the throwable to be thrown
+     */
+    T answer( A0 argument0, A1 argument1, A2 argument2, A3 argument3, A4 argument4, A5 argument5 ) throws Throwable;
+}

--- a/src/main/java/org/mockito/stubbing/VoidAnswer6.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer6.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.stubbing;
+
+import org.mockito.Incubating;
+
+/**
+ * Generic interface to be used for configuring mock's answer for a six argument invocation that returns nothing.
+ *
+ * Answer specifies an action that is executed when you interact with the mock.
+ * <p>
+ * Example of stubbing a mock with this custom answer:
+ *
+ * <pre class="code"><code class="java">
+ * import static org.mockito.AdditionalAnswers.answerVoid;
+ *
+ * doAnswer(answerVoid(
+ *     new VoidAnswer5&lt;String, Integer, String, Character, Object, String&gt;() {
+ *         public void answer(String msg, Integer count, String another, Character c, Object o, String subject) throws Exception {
+ *             throw new Exception(String.format(msg, another, c, o, count, subject));
+ *         }
+ * })).when(mock).someMethod(anyString(), anyInt(), anyString(), anyChar(), any(), anyString());
+ *
+ * // The following will raise an exception with the message "ka-boom <3 mockito"
+ * mock.someMethod("%s-boom %c%d %s", 3, "ka", '&lt;', new Object(), "mockito");
+ * </code></pre>
+ *
+ * @param <A0> type of the first argument
+ * @param <A1> type of the second argument
+ * @param <A2> type of the third argument
+ * @param <A3> type of the fourth argument
+ * @param <A4> type of the fifth argument
+ * @param <A5> type of the sixth argument
+ * @see Answer
+ */
+@Incubating
+public interface VoidAnswer6<A0, A1, A2, A3, A4, A5> {
+    /**
+     * @param argument0 the first argument.
+     * @param argument1 the second argument.
+     * @param argument2 the third argument.
+     * @param argument3 the fourth argument.
+     * @param argument4 the fifth argument.
+     * @param argument5 the sixth argument.
+     *
+     * @throws Throwable the throwable to be thrown
+     */
+    void answer(A0 argument0, A1 argument1, A2 argument2, A3 argument3, A4 argument4, A5 argument5) throws Throwable;
+}

--- a/src/test/java/org/mockitousage/IMethods.java
+++ b/src/test/java/org/mockitousage/IMethods.java
@@ -124,6 +124,8 @@ public interface IMethods {
 
     String simpleMethod(String one, Integer two, Integer three, Integer four, Integer five);
 
+    String simpleMethod(String one, Integer two, Integer three, Integer four, Integer five, Integer six);
+
     String simpleMethod(String one, String[] two);
 
     Object threeArgumentMethod(int valueOne, Object valueTwo, String valueThree);

--- a/src/test/java/org/mockitousage/MethodsImpl.java
+++ b/src/test/java/org/mockitousage/MethodsImpl.java
@@ -237,6 +237,10 @@ public class MethodsImpl implements IMethods {
         return null;
     }
 
+    public String simpleMethod(String one, Integer two, Integer three, Integer four, Integer five, Integer six) {
+        return null;
+    }
+
     public String simpleMethod(String one, String[] two) {
         return null;
     }

--- a/src/test/java/org/mockitousage/stubbing/StubbingWithAdditionalAnswersTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingWithAdditionalAnswersTest.java
@@ -30,11 +30,13 @@ import org.mockito.stubbing.Answer2;
 import org.mockito.stubbing.Answer3;
 import org.mockito.stubbing.Answer4;
 import org.mockito.stubbing.Answer5;
+import org.mockito.stubbing.Answer6;
 import org.mockito.stubbing.VoidAnswer1;
 import org.mockito.stubbing.VoidAnswer2;
 import org.mockito.stubbing.VoidAnswer3;
 import org.mockito.stubbing.VoidAnswer4;
 import org.mockito.stubbing.VoidAnswer5;
+import org.mockito.stubbing.VoidAnswer6;
 import org.mockitousage.IMethods;
 
 import java.util.Date;
@@ -246,4 +248,36 @@ public class StubbingWithAdditionalAnswersTest {
         verify(target, times(1)).simpleMethod("hello", 1, 2, 3, 4);
     }
 
+    @Test
+    public void can_return_based_on_strongly_typed_six_parameter_function() throws Exception {
+        final IMethods target = mock(IMethods.class);
+        given(iMethods.simpleMethod(anyString(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt()))
+                .will(answer(new Answer6<String, String, Integer, Integer, Integer, Integer, Integer>() {
+                    public String answer(String s1, Integer i1, Integer i2, Integer i3, Integer i4, Integer i5) {
+                        target.simpleMethod(s1, i1, i2, i3, i4, i5);
+                        return "answered";
+                    }
+                }));
+
+        assertThat(iMethods.simpleMethod("hello", 1, 2, 3, 4, 5)).isEqualTo("answered");
+        verify(target, times(1)).simpleMethod("hello", 1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void will_execute_a_void_returning_strongly_typed_six_parameter_function() throws Exception {
+        final IMethods target = mock(IMethods.class);
+
+        given(iMethods.simpleMethod(anyString(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt()))
+                .will(answerVoid(new VoidAnswer6<String, Integer, Integer, Integer, Integer, Integer>() {
+                    public void answer(String s1, Integer i1, Integer i2, Integer i3, Integer i4, Integer i5) {
+                        target.simpleMethod(s1, i1, i2, i3, i4, i5);
+                    }
+                }));
+
+        // invoke on iMethods
+        iMethods.simpleMethod("hello", 1, 2, 3, 4, 5);
+
+        // expect the answer to write correctly to "target"
+        verify(target, times(1)).simpleMethod("hello", 1, 2, 3, 4, 5);
+    }
 }


### PR DESCRIPTION
Regretfully, I ran into a case where I needed to mock a six-argument method. One can of course claim that such methods _ought not to exist_, but sadly, this is not always the reality and I think that some pragmatism is useful in tools like Mockito, so here is my attempt at adding support for it.

Of course, it's possible to use the plain `Answer` interface in this case, but adding a dedicated `Answer6` interface makes it more convenient on the user; `Answer` is a quite raw interface.

(I'm not sure if this should target the 2.x release or `master` also, but feel free to cherry-pick as needed after review/merge.)