### PR TITLE
Report initialization failures per test method

### DIFF
--- a/src/main/java/org/mockito/internal/runners/DefaultInternalRunner.java
+++ b/src/main/java/org/mockito/internal/runners/DefaultInternalRunner.java
@@ -30,34 +30,29 @@ public class DefaultInternalRunner implements InternalRunner {
             public Object target;
             private MockitoTestListener mockitoTestListener;
 
-            protected Statement withBefores(FrameworkMethod method, Object target, Statement statement) {
+            protected Statement withBefores(FrameworkMethod method, final Object target, Statement statement) {
                 this.target = target;
-                // get new test listener and add it to the framework
-                mockitoTestListener = listenerSupplier.get();
-                Mockito.framework().addListener(mockitoTestListener);
-                // init annotated mocks before tests
-                MockitoAnnotations.initMocks(target);
-                return super.withBefores(method, target, statement);
+                final Statement base = super.withBefores(method, target, statement);
+                return new Statement() {
+                    @Override
+                    public void evaluate() throws Throwable {
+                        // get new test listener and add it to the framework
+                        mockitoTestListener = listenerSupplier.get();
+                        Mockito.framework().addListener(mockitoTestListener);
+                        // init annotated mocks before tests
+                        MockitoAnnotations.initMocks(target);
+                        base.evaluate();
+                    }
+                };
             }
 
             public void run(final RunNotifier notifier) {
                 RunListener listener = new RunListener() {
-                    private boolean started;
                     Throwable failure;
-
-                    @Override
-                    public void testStarted(Description description) throws Exception {
-                        started = true;
-                    }
 
                     @Override
                     public void testFailure(Failure failure) throws Exception {
                         this.failure = failure.getException();
-                        // If the test fails during the setup, `testFinished` is never invoked
-                        // Therefore, if we have not started, cleanup the testlistener
-                        if (!started && mockitoTestListener != null) {
-                            Mockito.framework().removeListener(mockitoTestListener);
-                        }
                     }
 
                     @Override

--- a/src/test/java/org/mockito/internal/runners/DefaultInternalRunnerTest.java
+++ b/src/test/java/org/mockito/internal/runners/DefaultInternalRunnerTest.java
@@ -45,10 +45,10 @@ public class DefaultInternalRunnerTest {
             .run(newNotifier(runListener));
 
         verify(runListener, times(1)).testFailure(any(Failure.class));
-        verify(runListener, never()).testFinished(any(Description.class));
-        verify(mockitoTestListener, never()).testFinished(any(TestFinishedEvent.class));
+        verify(runListener, times(1)).testFinished(any(Description.class));
+        verify(mockitoTestListener, only()).testFinished(any(TestFinishedEvent.class));
 
-        reset(runListener);
+        reset(runListener, mockitoTestListener);
 
         new DefaultInternalRunner(SuccessTest.class, supplier)
             .run(newNotifier(runListener));


### PR DESCRIPTION
Prior to this commit, `DefaultInternalRunner` threw an exception when
`MockitoAnnotations.initMocks()` failed from the overridden
`withBefores` method. Instead, it now returns a `Statement` that is
responsible for initializing. Potential exceptions are then handled by
JUnit, regardless whether version 4.12 or 4.13-beta-2 is used. Instead
of reporting a class-level error, JUnit will now report a failure for
each test method in such test classes.

Related issue: junit-team/junit4#1599

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/2.x/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [ ] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

