### PR TITLE
Mockito ships Javadocs to GitHub pages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.6'
 
         //Using buildscript.classpath so that we can resolve shipkit from maven local, during local testing
-        classpath 'org.shipkit:shipkit:2.1.6'
+        classpath 'org.shipkit:shipkit:2.2.2'
     }
 }
 
@@ -26,6 +26,7 @@ apply plugin: 'base'
 archivesBaseName = "mockito-core"
 
 apply plugin: "org.shipkit.java"
+apply plugin: "org.shipkit.javadoc"
 allprojects {
     plugins.withId("java") {
         //Only upload specific modules we select

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ apply plugin: 'base'
 archivesBaseName = "mockito-core"
 
 apply plugin: "org.shipkit.java"
-apply plugin: "org.shipkit.javadoc"
 allprojects {
     plugins.withId("java") {
         //Only upload specific modules we select
@@ -71,6 +70,8 @@ allprojects { proj ->
        configFile = rootProject.file('config/checkstyle/checkstyle.xml')
     }
 }
+
+apply plugin: "org.shipkit.javadoc"
 
 configurations {
     testUtil //TODO move to separate project

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -22,6 +22,8 @@ shipkit {
     git.commitMessagePostfix = buildNo? "by CI build $buildNo\n\n[ci skip-release]" : "by local build\n\n[ci skip-release]"
 
     team.developers = ['mockitoguy:Szczepan Faber', 'bric3:Brice Dutheil', 'raphw:Rafael Winterhalter', 'TimvdLippe:Tim van der Lippe']
+
+    javadoc.repository = "mockito/javadoc"
 }
 
 /**


### PR DESCRIPTION
As discussed in https://github.com/mockito/mockito/issues/1651 the Javadoc will be shipped to https://github.com/mockito/javadoc/

This way, we can tackle some limitations of http://javadoc.io (which is a good system!)