### PR TITLE
Pinned ByteBuddy to 1.9.10

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -4,7 +4,7 @@ ext {
 
 def versions = [:]
 
-versions.bytebuddy = '1.9.11'
+versions.bytebuddy = '1.9.10'
 versions.junitJupiter = '5.1.1'
 versions.errorprone = '2.3.2'
 


### PR DESCRIPTION
It seems that new version of BB breaks the build for Java 9+. I'm still investigating. Opening the PR for visibility - we can see if the build is happy now.