### PR TITLE
Fix handling of generic Void type for doNothing()

### DIFF
--- a/src/main/java/org/mockito/internal/stubbing/answers/InvocationInfo.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/InvocationInfo.java
@@ -7,15 +7,20 @@ package org.mockito.internal.stubbing.answers;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import org.mockito.internal.invocation.AbstractAwareMethod;
+import org.mockito.internal.util.MockUtil;
 import org.mockito.internal.util.Primitives;
+import org.mockito.internal.util.reflection.GenericMetadataSupport;
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.mock.MockCreationSettings;
 
 public class InvocationInfo implements AbstractAwareMethod {
 
     private final Method method;
+    private final InvocationOnMock invocation;
 
     public InvocationInfo(InvocationOnMock theInvocation) {
         this.method = theInvocation.getMethod();
+        this.invocation = theInvocation;
     }
 
     public boolean isValidException(Throwable throwable) {
@@ -43,8 +48,12 @@ public class InvocationInfo implements AbstractAwareMethod {
      * E.g:  {@code void foo()} or {@code Void bar()}
      */
     public boolean isVoid() {
-        Class<?> returnType = this.method.getReturnType();
-        return returnType == Void.TYPE|| returnType == Void.class;
+        final MockCreationSettings mockSettings = MockUtil.getMockHandler(invocation.getMock())
+            .getMockSettings();
+        Class<?> returnType = GenericMetadataSupport.inferFrom(mockSettings.getTypeToMock())
+            .resolveGenericReturnType(this.method)
+            .rawType();
+        return returnType == Void.TYPE || returnType == Void.class;
     }
 
     public String printMethodReturnType() {

--- a/src/test/java/org/mockito/internal/stubbing/answers/DoesNothingTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/answers/DoesNothingTest.java
@@ -5,6 +5,7 @@
 package org.mockito.internal.stubbing.answers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.internal.stubbing.answers.DoesNothing.doesNothing;
 import static org.mockitoutil.TestBase.getLastInvocation;
@@ -58,5 +59,16 @@ public class DoesNothingTest   {
         doesNothing().validateFor(invocation_Void);
     }
 
+    @Test
+    public void answer_returns_null_for_generic_parameter() {
+        SubclassWithGenericParameter mock = mock(SubclassWithGenericParameter.class);
+        doNothing().when(mock).methodReturningT();
+    }
 
+    static class SuperClassWithGenericParameter<T> {
+        T methodReturningT() {
+            return null;
+        }
+    }
+    static class SubclassWithGenericParameter extends SuperClassWithGenericParameter<Void> {}
 }


### PR DESCRIPTION
When the return type bound to a generic type resolved to Void,
`doNothing()` would still throw an exception. Update the `isVoid`
implementation to also handle generic return types.