### PR TITLE
[DO NOT MERGE] Add test about wrong annotations for Guice injectors

### DIFF
--- a/gradle/java-library.gradle
+++ b/gradle/java-library.gradle
@@ -15,8 +15,8 @@ generatePomFileForJavaLibraryPublication.doLast {
 
 bintrayUpload.enabled = true
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 test {
     include "**/*Test.class"

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,6 +8,7 @@ include 'junit-jupiter'
 include 'junitJupiterExtensionTest'
 include 'module-test'
 include 'memory-test'
+include 'guice-test'
 include 'errorprone'
 
 rootProject.name = 'mockito'

--- a/subprojects/guice-test/guice-test.gradle
+++ b/subprojects/guice-test/guice-test.gradle
@@ -1,0 +1,16 @@
+plugins {
+    id 'java'
+}
+description = "Test suite for Guice integration"
+
+apply from: "$rootDir/gradle/dependencies.gradle"
+
+dependencies {
+    compile project.rootProject
+    testCompile libraries.junit4
+    testCompile libraries.assertj
+    testCompile 'com.google.inject:guice:4.2.2'
+}
+
+tasks.javadoc.enabled = false
+

--- a/subprojects/guice-test/src/test/java/org/mockito/guicetest/ShouldInjectCorrectParameterIntoMethod.java
+++ b/subprojects/guice-test/src/test/java/org/mockito/guicetest/ShouldInjectCorrectParameterIntoMethod.java
@@ -1,0 +1,99 @@
+package org.mockito.guicetest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.CreationException;
+import com.google.inject.Guice;
+import com.google.inject.Key;
+import java.util.List;
+import javax.inject.Inject;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class ShouldInjectCorrectParameterIntoMethod {
+
+    /** A base class providing some cool functionality for many subclasses. */
+    static class Injectable<T> {
+        private List<String> strings;
+
+        /**
+         * Inject-annotated method used to avoid having to pass some superclass implementation details
+         * through all subclasses.
+         */
+        @Inject
+        void setStrings(List<String> strings) {
+            this.strings = strings;
+        }
+    }
+
+    /**
+     * A list of strings bound in the injectors to demonstrate that Guice calls
+     * Injectable.setStrings().
+     */
+    private static final ImmutableList<String> PRIMARY_COLORS = ImmutableList
+        .of("Red", "Yellow", "Green", "Blue");
+
+    /** A Guice key for a fully-parameterized subtype of Injectable. */
+    private static final Key<Injectable<Void>> VOID_INJECTABLE = new Key<>() {
+    };
+
+    @Mock
+    private Injectable<Void> mockInjectable;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testWithRealInstance() {
+        Injectable<Void> injectable =
+            Guice.createInjector(
+                binder -> {
+                    binder.bind(new Key<List<String>>() {}).toInstance(PRIMARY_COLORS);
+                    // This tells Guice to bind this parameterized type. It allows the injector to
+                    // create an instance as long as it can find all the injected dependencies from
+                    // constructor, field, and method injection.
+                    binder.bind(VOID_INJECTABLE);
+                })
+                .getInstance(VOID_INJECTABLE);
+        // In our case, Guice creates the instance by calling the default constructor (since there is
+        // not a constructor tagged with @Inject) and then calling each method tagged with @Inject with
+        // arguments pulled from the injector. Since we bound List<String>, it is able to inject that
+        // method argument.
+        assertThat(injectable.strings).contains("Green");
+    }
+
+    @Test
+    public void testWithMockInstance() {
+        // This should also create an object, but fails looking for a raw instance of List.
+        Injectable<Void> injectable =
+            Guice.createInjector(
+                binder -> {
+                    binder.bind(new Key<List<String>>() {}).toInstance(PRIMARY_COLORS);
+                    // This tells Guice to use this instance.
+                    binder.bind(VOID_INJECTABLE).toInstance(mockInjectable);
+                })
+                .getInstance(VOID_INJECTABLE);
+        // Throws:
+        // com.google.inject.CreationException: Unable to create injector, see the following errors:
+        //
+        // 1) No implementation for java.util.List was bound.
+        //   Did you mean?
+        //     java.util.List<java.lang.String> bound  at
+        // bug.GuiceRepro.lambda$testWithMockInstance$1(GuiceRepro.java:78)
+        //
+        //   while locating java.util.List
+        //     for the 1st parameter of
+        // bug.GuiceRepro$Injectable$MockitoMock$1394068293.setStrings(Unknown Source)
+        //   at bug.GuiceRepro$Injectable$MockitoMock$1394068293.setStrings(Unknown Source)
+        //   at bug.GuiceRepro.lambda$testWithMockInstance$1(GuiceRepro.java:79)
+
+        // If instead the object were created without issue we'd expect this to pass again:
+        assertThat(injectable.strings).contains("Green");
+    }
+}


### PR DESCRIPTION
This is intended to show the problem we observed with our Guice integration. We should be able to construct a test case without Guice once we are able to determine what the issue is.

This is a problem with the ByteBuddy mockmaker, as it is passing with the CGLibMockmaker. We are not sure what the issue is, but it is related to annotations being persisted and generic types being removed from method parameters. @raphw do you maybe know what might be going on here?

CC @erichrison