### PR TITLE
Make `MockitoNotExtensible` service-loadable

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,6 +23,8 @@ libraries.bytebuddyandroid = "net.bytebuddy:byte-buddy-android:${versions.bytebu
 libraries.errorprone = "com.google.errorprone:error_prone_core:${versions.errorprone}"
 libraries.errorproneTestApi = "com.google.errorprone:error_prone_test_helpers:${versions.errorprone}"
 
+libraries.autoservice = "com.google.auto.service:auto-service:1.0-rc5"
+
 // objenesis 3.x with full Java 11 support requires Java 8, bump version when Java 7 support is dropped
 libraries.objenesis = 'org.objenesis:objenesis:2.6'
 

--- a/subprojects/errorprone/errorprone.gradle
+++ b/subprojects/errorprone/errorprone.gradle
@@ -4,6 +4,9 @@ apply from: "$rootDir/gradle/java-library.gradle"
 apply from: "$rootDir/gradle/dependencies.gradle"
 
 dependencies {
+    compileOnly libraries.autoservice
+    annotationProcessor libraries.autoservice
+
     compile project.rootProject
     compile libraries.errorprone
 

--- a/subprojects/errorprone/src/main/java/org/mockito/errorprone/bugpatterns/MockitoNotExtensible.java
+++ b/subprojects/errorprone/src/main/java/org/mockito/errorprone/bugpatterns/MockitoNotExtensible.java
@@ -6,6 +6,7 @@ package org.mockito.errorprone.bugpatterns;
 
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
+import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
@@ -16,6 +17,7 @@ import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
 
 /** Finds subclasses of @NotExtensible interfaces. */
+@AutoService(BugChecker.class)
 @BugPattern(
     name = "MockitoNotExtensible",
     summary = "Some types that are a part of Mockito public API are not intended to be extended.",


### PR DESCRIPTION
This way Error Prone can find the plugin when `mockito-errorprone` is added to the annotation processor classpath.

Fixes #1692.