### PR TITLE
Fix javadoc typo and use HTML list

### DIFF
--- a/src/main/java/org/mockito/invocation/InvocationOnMock.java
+++ b/src/main/java/org/mockito/invocation/InvocationOnMock.java
@@ -63,14 +63,16 @@ public interface InvocationOnMock extends Serializable {
      * In general, {@link #getArgument(int)} is the appropriate function to use. This particular
      * function is only necessary if you are doing one of the following things:
      *
-     * 1. You want to directly invoke a method on the result of {@link #getArgument(int)}.
-     * 2. You want to directly pas the result of the invocation into a function that accepts a generic parameter.
+     * <ol>
+     *  <li>You want to directly invoke a method on the result of {@link #getArgument(int)}.</li>
+     *  <li>You want to directly pass the result of the invocation into a function that accepts a generic parameter.</li>
+     * </ol>
      *
      * If you prefer to use {@link #getArgument(int)} instead, you can circumvent the compilation
      * issues by storing the intermediate result into a local variable with the correct type.
      *
      * @param index argument index
-     * @param clazz clazz to cast the argument to
+     * @param clazz class to cast the argument to
      * @return casted argument at the given index
      */
     <T> T getArgument(int index, Class<T> clazz);


### PR DESCRIPTION
The javadoc for `InvocationOnMock.getArgument(int index, Class<T> clazz);` had two typos:
- "to directly **pas** the result"
- "**clazz** to cast the argument to"

Additionally I changed the list to be a proper HTML list, the current version just collapsed it into one text block: https://static.javadoc.io/org.mockito/mockito-core/2.27.0/org/mockito/invocation/InvocationOnMock.html#getArgument-int-java.lang.Class-

It might also be worth it adding the actual HTML paragraphs into the javadoc (for the other methods as well).