### PR TITLE
Fix ClonesArguments for null and arrays

### DIFF
--- a/src/test/java/org/mockitousage/stubbing/CloningParameterTest.java
+++ b/src/test/java/org/mockitousage/stubbing/CloningParameterTest.java
@@ -12,6 +12,7 @@ import org.mockitoutil.TestBase;
 import java.util.List;
 
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 public class CloningParameterTest extends TestBase {
@@ -26,12 +27,12 @@ public class CloningParameterTest extends TestBase {
         businessLogic(emailSender);
 
         // then
-        verify(emailSender).sendEmail(1, new Person("Wes"));
+        verify(emailSender).sendEmail(eq(1), eq(new Person("Wes")), (Person)any(), (Person[])any());
     }
 
     private void businessLogic(EmailSender emailSender) {
         Person person = new Person("Wes");
-        emailSender.sendEmail(1, person);
+        emailSender.sendEmail(1, person, null, new Person[0]);
         person.emailSent();
     }
 
@@ -101,7 +102,7 @@ public class CloningParameterTest extends TestBase {
 
     public interface EmailSender {
 
-        void sendEmail(int i, Person person);
+        void sendEmail(int i, Person person, Person from, Person[] ccList);
 
         List<?> getAllEmails(Person person);
 

--- a/src/test/java/org/mockitousage/stubbing/CloningParameterTest.java
+++ b/src/test/java/org/mockitousage/stubbing/CloningParameterTest.java
@@ -27,12 +27,12 @@ public class CloningParameterTest extends TestBase {
         businessLogic(emailSender);
 
         // then
-        verify(emailSender).sendEmail(eq(1), eq(new Person("Wes")), (Person)any(), (Person[])any());
+        verify(emailSender).sendEmail(1, new Person("Wes"));
     }
 
     private void businessLogic(EmailSender emailSender) {
         Person person = new Person("Wes");
-        emailSender.sendEmail(1, person, null, new Person[0]);
+        emailSender.sendEmail(1, person);
         person.emailSent();
     }
 
@@ -48,6 +48,34 @@ public class CloningParameterTest extends TestBase {
 
         // then
         assertNotNull(emails);
+    }
+
+    @Test
+    public void shouldCloneArrays() throws Exception {
+
+        EmailSender emailSender = mock(EmailSender.class, new ClonesArguments());
+
+        // 1. Pass an array into a mock that "ClonesArguments"
+        Person[] ccList = new Person[] { new Person("Wes") };
+        emailSender.sendGroupEmail(1, ccList);
+
+        // 2. Mutate the array
+        ccList[0] = new Person("Joe");
+
+        // 3. Verify that the mock made a copy of the array
+        verify(emailSender).sendGroupEmail(1, new Person[] { new Person("Wes") });
+    }
+
+    @Test
+    public void shouldNotThrowNPEWhenCloningNulls() throws Exception {
+
+        EmailSender emailSender = mock(EmailSender.class, new ClonesArguments());
+
+        // 1. Pass a null into a mock that "ClonesArguments"
+        emailSender.sendEmail(1, (Person)null);
+
+        // 2. Verify that the null argument was captured
+        verify(emailSender).sendEmail(eq(1), (Person)isNull());
     }
 
     public class Person {
@@ -102,7 +130,9 @@ public class CloningParameterTest extends TestBase {
 
     public interface EmailSender {
 
-        void sendEmail(int i, Person person, Person from, Person[] ccList);
+        void sendEmail(int i, Person person);
+
+        void sendGroupEmail(int i, Person[] persons);
 
         List<?> getAllEmails(Person person);
 


### PR DESCRIPTION
The ClonesArguments class works for many cases, but fails when trying to clone an argument that is an array, or is null. This PR fixes those edge cases. This does not directly resolve any open issue, but it is related to #1153, #1469

check list

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/2.x/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_
