### PR TITLE
Fix JaCoCo code coverage report

### DIFF
--- a/gradle/root/coverage.gradle
+++ b/gradle/root/coverage.gradle
@@ -22,15 +22,12 @@ task mockitoCoverage(type: JacocoReport) {
                 if (currentProject != rootProject) {   //already automatically enhanced in mockito main project as "java" plugin was applied before
                     applyTo test
                 }
+                test.jacoco.destinationFile = file("${currentProject.buildDir}/jacoco/test.exec")
             }
 
-            currentProject.tasks.withType(Test) { testTask ->
-                mockitoCoverage.dependsOn testTask
-            }
+            mockitoCoverage.executionData(files(test.jacoco.destinationFile).builtBy(test))
         }
     }
-
-    executionData(file("$buildDir/jacoco/test.exec"))
 
     reports {
         xml.enabled true
@@ -38,13 +35,14 @@ task mockitoCoverage(type: JacocoReport) {
         html.destination file("${buildDir}/jacocoHtml")
     }
 
-    afterEvaluate {
-      classDirectories = files(classDirectories.files.collect {
-        fileTree(
-          dir: it,
-          exclude: ['**/org/mockito/internal/util/concurrent/**']
-        )
-      })
+    doFirst {
+        classDirectories.from = classDirectories.files.collect {
+            fileTree(
+                dir: it,
+                exclude: ['**/org/mockito/internal/util/concurrent/**']
+            )
+        }
+        executionData.from = executionData.files.findAll { it.exists() }
     }
 
     doLast {


### PR DESCRIPTION
Instead of collecting execution data of all test tasks of all
subprojects in a single file, each subproject's test task writes its own
execution data file. The `mockitoCoverage` task is configured to include
all execution data files into account that exists when it starts. This
is done to avoid exceptions for missing files for skipped test tasks for
the `android` and `errorprone` subprojects.

Fixes #1689.

---

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/2.x/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

