### PR TITLE
Use require instead of assert in settings.gradle.kts

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,8 +16,12 @@ rootProject.children.forEach { project ->
     val projectDirName = "subprojects/${project.name}"
     project.projectDir = File(settingsDir, projectDirName)
     project.buildFileName = "${project.name}.gradle"
-    assert(project.projectDir.isDirectory)
-    assert(project.buildFile.isFile)
+    require(project.projectDir.isDirectory) {
+        "Project directory ${project.projectDir} for project ${project.name} does not exist."
+    }
+    require(project.buildFile.isFile) {
+        "Build file ${project.buildFile} for project ${project.name} does not exist."
+    }
 }
 
 enableFeaturePreview("STABLE_PUBLISHING")


### PR DESCRIPTION
While migrating a very first subproject to kotlin I realized that the current implementation does not fail if e.g. the expected build file is not available.
I will provide another pr with the actual migration of the first subproject once this pr is merged.