### PR TITLE
Remove no longer relevant code from settings.gradle.kts

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,8 +24,6 @@ rootProject.children.forEach { project ->
     }
 }
 
-enableFeaturePreview("STABLE_PUBLISHING")
-
 buildCache {
     local {
         isEnabled = !System.getenv().containsKey("CI")


### PR DESCRIPTION
No need to enable feature preview for "STABLE_PUBLISHING" any longer since it is default starting from gradle 5.0.