### PR TITLE
Fixes #1623 : Rename TooLittleActualInvocations

### DIFF
--- a/src/main/java/org/mockito/exceptions/verification/TooFewActualInvocations.java
+++ b/src/main/java/org/mockito/exceptions/verification/TooFewActualInvocations.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2019 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.exceptions.verification;
+
+/**
+ * @since 2.27.5
+ */
+public class TooFewActualInvocations extends TooLittleActualInvocations {
+
+    private static final long serialVersionUID = 1L;
+
+    public TooFewActualInvocations(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/mockito/exceptions/verification/TooLittleActualInvocations.java
+++ b/src/main/java/org/mockito/exceptions/verification/TooLittleActualInvocations.java
@@ -7,6 +7,11 @@ package org.mockito.exceptions.verification;
 
 import org.mockito.exceptions.base.MockitoAssertionError;
 
+/**
+ * @deprecated as of 2.27.5. Please use {@link TooFewActualInvocations} instead.
+ * @see TooFewActualInvocations
+ */
+@Deprecated
 public class TooLittleActualInvocations extends MockitoAssertionError {
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/org/mockito/internal/exceptions/Reporter.java
+++ b/src/main/java/org/mockito/internal/exceptions/Reporter.java
@@ -12,7 +12,7 @@ import org.mockito.exceptions.verification.MoreThanAllowedActualInvocations;
 import org.mockito.exceptions.verification.NeverWantedButInvoked;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockito.exceptions.verification.SmartNullPointerException;
-import org.mockito.exceptions.verification.TooLittleActualInvocations;
+import org.mockito.exceptions.verification.TooFewActualInvocations;
 import org.mockito.exceptions.verification.TooManyActualInvocations;
 import org.mockito.exceptions.verification.VerificationInOrderFailure;
 import org.mockito.exceptions.verification.WantedButNotInvoked;
@@ -419,9 +419,9 @@ public class Reporter {
         return sb.toString();
     }
 
-    private static String createTooLittleInvocationsMessage(org.mockito.internal.reporting.Discrepancy discrepancy,
-                                                            DescribedInvocation wanted,
-                                                            List<Location> locations) {
+    private static String createTooFewInvocationsMessage(org.mockito.internal.reporting.Discrepancy discrepancy,
+                                                         DescribedInvocation wanted,
+                                                         List<Location> locations) {
         return join(
                 wanted.toString(),
                 "Wanted " + discrepancy.getPluralizedWantedCount() + (discrepancy.getWantedCount() == 0 ? "." : ":"),
@@ -431,14 +431,14 @@ public class Reporter {
         );
     }
 
-    public static MockitoAssertionError tooLittleActualInvocations(org.mockito.internal.reporting.Discrepancy discrepancy, DescribedInvocation wanted, List<Location> allLocations) {
-        String message = createTooLittleInvocationsMessage(discrepancy, wanted, allLocations);
+    public static MockitoAssertionError tooFewActualInvocations(org.mockito.internal.reporting.Discrepancy discrepancy, DescribedInvocation wanted, List<Location> allLocations) {
+        String message = createTooFewInvocationsMessage(discrepancy, wanted, allLocations);
 
-        return new TooLittleActualInvocations(message);
+        return new TooFewActualInvocations(message);
     }
 
-    public static MockitoAssertionError tooLittleActualInvocationsInOrder(org.mockito.internal.reporting.Discrepancy discrepancy, DescribedInvocation wanted, List<Location> locations) {
-        String message = createTooLittleInvocationsMessage(discrepancy, wanted, locations);
+    public static MockitoAssertionError tooFewActualInvocationsInOrder(org.mockito.internal.reporting.Discrepancy discrepancy, DescribedInvocation wanted, List<Location> locations) {
+        String message = createTooFewInvocationsMessage(discrepancy, wanted, locations);
 
         return new VerificationInOrderFailure(join(
                 "Verification in order failure:" + message

--- a/src/main/java/org/mockito/internal/verification/checkers/AtLeastXNumberOfInvocationsChecker.java
+++ b/src/main/java/org/mockito/internal/verification/checkers/AtLeastXNumberOfInvocationsChecker.java
@@ -11,8 +11,8 @@ import org.mockito.invocation.Invocation;
 import org.mockito.invocation.Location;
 import org.mockito.invocation.MatchableInvocation;
 
-import static org.mockito.internal.exceptions.Reporter.tooLittleActualInvocations;
-import static org.mockito.internal.exceptions.Reporter.tooLittleActualInvocationsInOrder;
+import static org.mockito.internal.exceptions.Reporter.tooFewActualInvocations;
+import static org.mockito.internal.exceptions.Reporter.tooFewActualInvocationsInOrder;
 import static org.mockito.internal.invocation.InvocationMarker.markVerified;
 import static org.mockito.internal.invocation.InvocationMarker.markVerifiedInOrder;
 import static org.mockito.internal.invocation.InvocationsFinder.findAllMatchingUnverifiedChunks;
@@ -27,7 +27,7 @@ public class AtLeastXNumberOfInvocationsChecker {
         int actualCount = actualInvocations.size();
         if (wantedCount > actualCount) {
             List<Location> allLocations = getAllLocations(actualInvocations);
-            throw tooLittleActualInvocations(new AtLeastDiscrepancy(wantedCount, actualCount), wanted, allLocations);
+            throw tooFewActualInvocations(new AtLeastDiscrepancy(wantedCount, actualCount), wanted, allLocations);
         }
 
         markVerified(actualInvocations, wanted);
@@ -40,7 +40,7 @@ public class AtLeastXNumberOfInvocationsChecker {
 
         if (wantedCount > actualCount) {
             List<Location> allLocations = getAllLocations(chunk);
-            throw tooLittleActualInvocationsInOrder(new AtLeastDiscrepancy(wantedCount, actualCount), wanted, allLocations);
+            throw tooFewActualInvocationsInOrder(new AtLeastDiscrepancy(wantedCount, actualCount), wanted, allLocations);
         }
 
         markVerifiedInOrder(chunk, wanted, orderingContext);

--- a/src/main/java/org/mockito/internal/verification/checkers/NumberOfInvocationsChecker.java
+++ b/src/main/java/org/mockito/internal/verification/checkers/NumberOfInvocationsChecker.java
@@ -14,8 +14,8 @@ import org.mockito.invocation.Location;
 import org.mockito.invocation.MatchableInvocation;
 
 import static org.mockito.internal.exceptions.Reporter.neverWantedButInvoked;
-import static org.mockito.internal.exceptions.Reporter.tooLittleActualInvocations;
-import static org.mockito.internal.exceptions.Reporter.tooLittleActualInvocationsInOrder;
+import static org.mockito.internal.exceptions.Reporter.tooFewActualInvocations;
+import static org.mockito.internal.exceptions.Reporter.tooFewActualInvocationsInOrder;
 import static org.mockito.internal.exceptions.Reporter.tooManyActualInvocations;
 import static org.mockito.internal.exceptions.Reporter.tooManyActualInvocationsInOrder;
 import static org.mockito.internal.invocation.InvocationMarker.markVerified;
@@ -36,7 +36,7 @@ public class NumberOfInvocationsChecker {
         int actualCount = actualInvocations.size();
         if (wantedCount > actualCount) {
             List<Location> allLocations = getAllLocations(actualInvocations);
-            throw tooLittleActualInvocations(new Discrepancy(wantedCount, actualCount), wanted, allLocations);
+            throw tooFewActualInvocations(new Discrepancy(wantedCount, actualCount), wanted, allLocations);
         }
         if (wantedCount == 0 && actualCount > 0) {
             throw neverWantedButInvoked(wanted, getAllLocations(actualInvocations));
@@ -55,7 +55,7 @@ public class NumberOfInvocationsChecker {
 
         if (wantedCount > actualCount) {
             List<Location> allLocations = getAllLocations(chunk);
-            throw tooLittleActualInvocationsInOrder(new Discrepancy(wantedCount, actualCount), wanted, allLocations);
+            throw tooFewActualInvocationsInOrder(new Discrepancy(wantedCount, actualCount), wanted, allLocations);
         }
         if (wantedCount < actualCount) {
             throw tooManyActualInvocationsInOrder(wantedCount, actualCount, wanted, getAllLocations(chunk));
@@ -70,7 +70,7 @@ public class NumberOfInvocationsChecker {
         while( actualCount < wantedCount ){
             Invocation next = findFirstMatchingUnverifiedInvocation(invocations, wanted, context );
             if( next == null ){
-                throw tooLittleActualInvocationsInOrder(new Discrepancy(wantedCount, actualCount), wanted, Arrays.asList(lastLocation));
+                throw tooFewActualInvocationsInOrder(new Discrepancy(wantedCount, actualCount), wanted, Arrays.asList(lastLocation));
             }
             markVerified( next, wanted );
             context.markVerified( next );

--- a/src/test/java/org/mockito/internal/exceptions/ReporterTest.java
+++ b/src/test/java/org/mockito/internal/exceptions/ReporterTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
-import org.mockito.exceptions.verification.TooLittleActualInvocations;
+import org.mockito.exceptions.verification.TooFewActualInvocations;
 import org.mockito.exceptions.verification.VerificationInOrderFailure;
 import org.mockito.internal.invocation.InvocationBuilder;
 import org.mockito.internal.stubbing.answers.Returns;
@@ -24,9 +24,9 @@ import static org.mockito.Mockito.mock;
 
 public class ReporterTest extends TestBase {
 
-    @Test(expected = TooLittleActualInvocations.class)
+    @Test(expected = TooFewActualInvocations.class)
     public void should_let_passing_null_last_actual_stack_trace() throws Exception {
-        throw Reporter.tooLittleActualInvocations(new org.mockito.internal.reporting.Discrepancy(1, 2), new InvocationBuilder().toInvocation(), null);
+        throw Reporter.tooFewActualInvocations(new org.mockito.internal.reporting.Discrepancy(1, 2), new InvocationBuilder().toInvocation(), null);
     }
 
     @Test(expected = MockitoException.class)

--- a/src/test/java/org/mockito/internal/verification/checkers/AtLeastXNumberOfInvocationsCheckerTest.java
+++ b/src/test/java/org/mockito/internal/verification/checkers/AtLeastXNumberOfInvocationsCheckerTest.java
@@ -7,7 +7,7 @@ package org.mockito.internal.verification.checkers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.mockito.exceptions.verification.TooLittleActualInvocations;
+import org.mockito.exceptions.verification.TooFewActualInvocations;
 import org.mockito.exceptions.verification.VerificationInOrderFailure;
 import org.mockito.internal.invocation.InvocationBuilder;
 import org.mockito.internal.invocation.InvocationMatcher;
@@ -39,7 +39,7 @@ public class AtLeastXNumberOfInvocationsCheckerTest   {
     }
 
     @Test
-    public void shouldReportTooLittleInvocationsInOrder() {
+    public void shouldReportTooFewInvocationsInOrder() {
         InOrderContext context = new InOrderContextImpl();
         //given
         Invocation invocation = new InvocationBuilder().simpleMethod().toInvocation();
@@ -70,12 +70,12 @@ public class AtLeastXNumberOfInvocationsCheckerTest   {
     }
 
     @Test
-    public void shouldReportTooLittleInvocations() {
+    public void shouldReportTooFewInvocations() {
         //given
         Invocation invocation = new InvocationBuilder().simpleMethod().toInvocation();
         Invocation invocationTwo = new InvocationBuilder().differentMethod().toInvocation();
 
-        exception.expect(TooLittleActualInvocations.class);
+        exception.expect(TooFewActualInvocations.class);
         exception.expectMessage("iMethods.simpleMethod()");
         exception.expectMessage("Wanted *at least* 2 times");
         exception.expectMessage("But was 1 time");

--- a/src/test/java/org/mockito/internal/verification/checkers/NumberOfInvocationsCheckerTest.java
+++ b/src/test/java/org/mockito/internal/verification/checkers/NumberOfInvocationsCheckerTest.java
@@ -16,7 +16,7 @@ import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.exceptions.verification.NeverWantedButInvoked;
-import org.mockito.exceptions.verification.TooLittleActualInvocations;
+import org.mockito.exceptions.verification.TooFewActualInvocations;
 import org.mockito.exceptions.verification.TooManyActualInvocations;
 import org.mockito.internal.invocation.InvocationBuilder;
 import org.mockito.internal.invocation.InvocationMatcher;
@@ -45,11 +45,11 @@ public class NumberOfInvocationsCheckerTest {
     public TestName testName = new TestName();
 
     @Test
-    public void shouldReportTooLittleActual() throws Exception {
+    public void shouldReportTooFewActual() throws Exception {
         wanted = buildSimpleMethod().toInvocationMatcher();
         invocations = asList(buildSimpleMethod().toInvocation(), buildSimpleMethod().toInvocation());
 
-        exception.expect(TooLittleActualInvocations.class);
+        exception.expect(TooFewActualInvocations.class);
         exception.expectMessage("mock.simpleMethod()");
         exception.expectMessage("Wanted 100 times");
         exception.expectMessage("But was 2 times");
@@ -62,7 +62,7 @@ public class NumberOfInvocationsCheckerTest {
         wanted = buildSimpleMethod().toInvocationMatcher();
         invocations = asList(buildSimpleMethod().toInvocation(), buildSimpleMethod().toInvocation());
 
-        exception.expect(TooLittleActualInvocations.class);
+        exception.expect(TooFewActualInvocations.class);
         exception.expectMessage("mock.simpleMethod()");
         exception.expectMessage("Wanted 100 times");
         exception.expectMessage("But was 2 times");
@@ -76,7 +76,7 @@ public class NumberOfInvocationsCheckerTest {
         invocations = emptyList();
         wanted = buildSimpleMethod().toInvocationMatcher();
 
-        exception.expect(TooLittleActualInvocations.class);
+        exception.expect(TooFewActualInvocations.class);
         exception.expectMessage("mock.simpleMethod()");
         exception.expectMessage("Wanted 100 times");
         exception.expectMessage("But was 0 times");

--- a/src/test/java/org/mockito/internal/verification/checkers/NumberOfInvocationsInOrderCheckerTest.java
+++ b/src/test/java/org/mockito/internal/verification/checkers/NumberOfInvocationsInOrderCheckerTest.java
@@ -61,7 +61,7 @@ public class NumberOfInvocationsInOrderCheckerTest {
     }
 
     @Test
-    public void shouldReportTooLittleInvocations() throws Exception {
+    public void shouldReportTooFewInvocations() throws Exception {
         Invocation first = buildSimpleMethod().toInvocation();
         Invocation second = buildSimpleMethod().toInvocation();
 
@@ -89,7 +89,7 @@ public class NumberOfInvocationsInOrderCheckerTest {
     }
 
     @Test
-    public void shouldReportTooLittleActual() throws Exception {
+    public void shouldReportTooFewActual() throws Exception {
         wanted = buildSimpleMethod().toInvocationMatcher();
         invocations = asList(buildSimpleMethod().toInvocation(), buildSimpleMethod().toInvocation());
 

--- a/src/test/java/org/mockitousage/junitrunner/SilentRunnerTest.java
+++ b/src/test/java/org/mockitousage/junitrunner/SilentRunnerTest.java
@@ -11,7 +11,7 @@ import org.junit.runner.Result;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.exceptions.misusing.UnfinishedStubbingException;
-import org.mockito.exceptions.verification.TooLittleActualInvocations;
+import org.mockito.exceptions.verification.TooFewActualInvocations;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockitousage.IMethods;
 import org.mockitoutil.JUnitResultAssert;
@@ -42,7 +42,7 @@ public class SilentRunnerTest extends TestBase {
                 SomeFailingFeature.class
         );
         //then
-        JUnitResultAssert.assertThat(result).fails(1, TooLittleActualInvocations.class);
+        JUnitResultAssert.assertThat(result).fails(1, TooFewActualInvocations.class);
     }
 
     @Test public void failing_test_in_constructor() {

--- a/src/test/java/org/mockitousage/spies/SpyingOnRealObjectsTest.java
+++ b/src/test/java/org/mockitousage/spies/SpyingOnRealObjectsTest.java
@@ -10,7 +10,7 @@ import org.mockito.InOrder;
 import org.mockito.Mockito;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
-import org.mockito.exceptions.verification.TooLittleActualInvocations;
+import org.mockito.exceptions.verification.TooFewActualInvocations;
 import org.mockito.exceptions.verification.VerificationInOrderFailure;
 import org.mockitoutil.TestBase;
 
@@ -141,7 +141,7 @@ public class SpyingOnRealObjectsTest extends TestBase {
         try {
             verify(spy, times(3)).add("one");
             fail();
-        } catch (TooLittleActualInvocations e) {}
+        } catch (TooFewActualInvocations e) {}
     }
 
     @Test

--- a/src/test/java/org/mockitousage/stacktrace/ModellingDescriptiveMessagesTest.java
+++ b/src/test/java/org/mockitousage/stacktrace/ModellingDescriptiveMessagesTest.java
@@ -59,7 +59,7 @@ public class ModellingDescriptiveMessagesTest extends TestBase {
     }
 
     @Test
-    public void shouldSayTooLittleInvocations() {
+    public void shouldSayTooFewInvocations() {
         mock.simpleMethod();
         verify(mock, times(2)).simpleMethod();
     }
@@ -81,7 +81,7 @@ public class ModellingDescriptiveMessagesTest extends TestBase {
     }
 
     @Test
-    public void shouldSayTooLittleInvocationsInOrder() {
+    public void shouldSayTooFewInvocationsInOrder() {
         mock.simpleMethod();
         mock.otherMethod();
         mock.otherMethod();
@@ -108,7 +108,7 @@ public class ModellingDescriptiveMessagesTest extends TestBase {
     }
 
     @Test
-    public void shouldSayTooLittleInvocationsInAtLeastModeInOrder() {
+    public void shouldSayTooFewInvocationsInAtLeastModeInOrder() {
         mock.simpleMethod();
 
         InOrder inOrder = inOrder(mock);
@@ -116,7 +116,7 @@ public class ModellingDescriptiveMessagesTest extends TestBase {
     }
 
     @Test
-    public void shouldSayTooLittleInvocationsInAtLeastMode() {
+    public void shouldSayTooFewInvocationsInAtLeastMode() {
         mock.simpleMethod();
 
         verify(mock, atLeast(2)).simpleMethod();

--- a/src/test/java/org/mockitousage/stacktrace/PointingStackTraceToActualInvocationChunkInOrderTest.java
+++ b/src/test/java/org/mockitousage/stacktrace/PointingStackTraceToActualInvocationChunkInOrderTest.java
@@ -79,7 +79,7 @@ public class PointingStackTraceToActualInvocationChunkInOrderTest extends TestBa
     }
 
     @Test
-    public void shouldPointToThirdChunkWhenTooLittleActualInvocations() {
+    public void shouldPointToThirdChunkWhenTooFewActualInvocations() {
         inOrder.verify(mock, times(2)).simpleMethod(anyInt());
         inOrder.verify(mockTwo, times(2)).simpleMethod(anyInt());
         inOrder.verify(mock, atLeastOnce()).simpleMethod(anyInt());

--- a/src/test/java/org/mockitousage/stacktrace/PointingStackTraceToActualInvocationInOrderTest.java
+++ b/src/test/java/org/mockitousage/stacktrace/PointingStackTraceToActualInvocationInOrderTest.java
@@ -111,7 +111,7 @@ public class PointingStackTraceToActualInvocationInOrderTest extends TestBase {
     }
 
     @Test
-    public void shouldPointToFourthMethodBecauseOfTooLittleActualInvocations() {
+    public void shouldPointToFourthMethodBecauseOfTooFewActualInvocations() {
         inOrder.verify(mock).simpleMethod(anyInt());
         inOrder.verify(mockTwo).simpleMethod(anyInt());
         inOrder.verify(mock).simpleMethod(anyInt());

--- a/src/test/java/org/mockitousage/verification/DescriptiveMessagesOnVerificationInOrderErrorsTest.java
+++ b/src/test/java/org/mockitousage/verification/DescriptiveMessagesOnVerificationInOrderErrorsTest.java
@@ -163,7 +163,7 @@ public class DescriptiveMessagesOnVerificationInOrderErrorsTest extends TestBase
     }
 
     @Test
-    public void shouldPrintTooLittleInvocations() {
+    public void shouldPrintTooFewInvocations() {
         two.simpleMethod(2);
 
         inOrder.verify(one, atLeastOnce()).simpleMethod(anyInt());

--- a/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenTimesXVerificationFailsTest.java
+++ b/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenTimesXVerificationFailsTest.java
@@ -8,7 +8,7 @@ package org.mockitousage.verification;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.exceptions.verification.TooLittleActualInvocations;
+import org.mockito.exceptions.verification.TooFewActualInvocations;
 import org.mockito.exceptions.verification.TooManyActualInvocations;
 import org.mockitoutil.TestBase;
 
@@ -33,7 +33,7 @@ public class DescriptiveMessagesWhenTimesXVerificationFailsTest extends TestBase
         try {
             Mockito.verify(mock, times(100)).clear();
             fail();
-        } catch (TooLittleActualInvocations e) {
+        } catch (TooFewActualInvocations e) {
             assertThat(e)
                 .hasMessageContaining("mock.clear();")
                 .hasMessageContaining("Wanted 100 times")

--- a/src/test/java/org/mockitousage/verification/ExactNumberOfTimesVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/ExactNumberOfTimesVerificationTest.java
@@ -28,7 +28,7 @@ public class ExactNumberOfTimesVerificationTest extends TestBase {
     }
 
     @Test
-    public void shouldDetectTooLittleActualInvocations() throws Exception {
+    public void shouldDetectTooFewActualInvocations() throws Exception {
         mock.clear();
         mock.clear();
 
@@ -36,7 +36,7 @@ public class ExactNumberOfTimesVerificationTest extends TestBase {
         try {
             verify(mock, times(100)).clear();
             fail();
-        } catch (TooLittleActualInvocations e) {
+        } catch (TooFewActualInvocations e) {
             assertThat(e)
                 .hasMessageContaining("Wanted 100 times")
                 .hasMessageContaining("was 2");

--- a/src/test/java/org/mockitousage/verification/SelectedMocksInOrderVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/SelectedMocksInOrderVerificationTest.java
@@ -138,7 +138,7 @@ public class SelectedMocksInOrderVerificationTest extends TestBase {
     }
 
     @Test
-    public void shouldThrowTooLittleInvocationsForMockTwo() {
+    public void shouldThrowTooFewInvocationsForMockTwo() {
         InOrder inOrder = inOrder(mockTwo);
 
         try {

--- a/src/test/java/org/mockitousage/verification/VerificationWithTimeoutTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationWithTimeoutTest.java
@@ -13,7 +13,7 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.exceptions.verification.TooLittleActualInvocations;
+import org.mockito.exceptions.verification.TooFewActualInvocations;
 import org.mockito.junit.MockitoRule;
 import org.mockitousage.IMethods;
 import org.mockitoutil.Stopwatch;
@@ -116,7 +116,7 @@ public class VerificationWithTimeoutTest {
             public void call() {
                 verify(mock, timeout(100).times(2)).oneArg('c');
             }
-        }).isInstanceOf(TooLittleActualInvocations.class);
+        }).isInstanceOf(TooFewActualInvocations.class);
     }
 
     @Test
@@ -150,7 +150,7 @@ public class VerificationWithTimeoutTest {
             public void call() {
                 verify(mock, timeout(100).atLeast(3)).oneArg('c');
             }
-        }).isInstanceOf(TooLittleActualInvocations.class);
+        }).isInstanceOf(TooFewActualInvocations.class);
     }
 
     @Test


### PR DESCRIPTION
Rename the exception TooLittleActualInvocations to
TooFewActualInvocations as this is more correct English. As this
exception is public API, we rename by subclassing and deprecating the
original. Rename all tests and internal methods that were referencing
the old name by aligning with the new name.

check list

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/2.x/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [ ] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

