### PR TITLE
Fixes #298: replaces Objenesis references from stubbing classes with plugin equivalents.

### DIFF
--- a/src/main/java/org/mockito/internal/stubbing/BaseStubbing.java
+++ b/src/main/java/org/mockito/internal/stubbing/BaseStubbing.java
@@ -4,6 +4,8 @@
  */
 package org.mockito.internal.stubbing;
 
+import org.mockito.creation.instance.Instantiator;
+import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.internal.stubbing.answers.CallsRealMethods;
 import org.mockito.internal.stubbing.answers.Returns;
 import org.mockito.internal.stubbing.answers.ThrowsException;
@@ -12,7 +14,6 @@ import org.mockito.stubbing.OngoingStubbing;
 
 import static org.mockito.internal.exceptions.Reporter.notAnException;
 import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
-import static org.objenesis.ObjenesisHelper.newInstance;
 
 public abstract class BaseStubbing<T> implements OngoingStubbing<T> {
 
@@ -74,7 +75,8 @@ public abstract class BaseStubbing<T> implements OngoingStubbing<T> {
             mockingProgress().reset();
             throw notAnException();
         }
-        return thenThrow(newInstance(throwableType));
+        Instantiator instantiator = Plugins.getInstantiatorProvider().getInstantiator(null);
+        return thenThrow(instantiator.newInstance(throwableType));
     }
 
     @Override

--- a/src/main/java/org/mockito/internal/stubbing/StubberImpl.java
+++ b/src/main/java/org/mockito/internal/stubbing/StubberImpl.java
@@ -15,13 +15,13 @@ import org.mockito.stubbing.Stubber;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.mockito.internal.configuration.plugins.Plugins;
 import static org.mockito.internal.exceptions.Reporter.notAMockPassedToWhenMethod;
 import static org.mockito.internal.exceptions.Reporter.notAnException;
 import static org.mockito.internal.exceptions.Reporter.nullPassedToWhenMethod;
 import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
 import static org.mockito.internal.stubbing.answers.DoesNothing.doesNothing;
 import static org.mockito.internal.util.MockUtil.isMock;
-import static org.objenesis.ObjenesisHelper.newInstance;
 
 public class StubberImpl implements Stubber {
 
@@ -89,7 +89,7 @@ public class StubberImpl implements Stubber {
         }
         Throwable e = null;
         try {
-            e = newInstance(toBeThrown);
+            e = Plugins.getInstantiatorProvider().getInstantiator(null).newInstance(toBeThrown);
         } finally {
             if (e == null) {
                 //this means that an exception or error was thrown when trying to create new instance

--- a/src/test/java/org/mockitointegration/NoByteCodeDependenciesTest.java
+++ b/src/test/java/org/mockitointegration/NoByteCodeDependenciesTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitointegration;
+
+import org.hamcrest.Matcher;
+import org.junit.*;
+import org.mockito.Mockito;
+import org.mockitoutil.ClassLoaders;
+
+import java.util.Set;
+
+import static org.mockitoutil.ClassLoaders.coverageTool;
+
+public class NoByteCodeDependenciesTest {
+
+    private ClassLoader contextClassLoader;
+
+    @Test
+    public void pure_mockito_should_not_depend_bytecode_libraries() throws Exception {
+
+        ClassLoader classLoader_without_bytecode_libraries = ClassLoaders.excludingClassLoader()
+            .withCodeSourceUrlOf(
+                Mockito.class,
+                Matcher.class
+            )
+            .withCodeSourceUrlOf(coverageTool())
+            .without("net.bytebuddy", "org.objenesis")
+            .build();
+
+        Set<String> pureMockitoAPIClasses = ClassLoaders.in(classLoader_without_bytecode_libraries).omit(
+            "bytebuddy", "runners", "junit", "JUnit", "opentest4j").listOwnedClasses();
+        pureMockitoAPIClasses.remove("org.mockito.internal.creation.instance.DefaultInstantiatorProvider");
+        pureMockitoAPIClasses.remove("org.mockito.internal.creation.instance.ObjenesisInstantiator");
+
+        // Remove classes that trigger plugin-loading, since bytebuddy plugins are the default.
+        pureMockitoAPIClasses.remove("org.mockito.internal.debugging.LocationImpl");
+        pureMockitoAPIClasses.remove("org.mockito.internal.exceptions.stacktrace.StackTraceFilter");
+        pureMockitoAPIClasses.remove("org.mockito.internal.util.MockUtil");
+
+        for (String pureMockitoAPIClass : pureMockitoAPIClasses) {
+            checkDependency(classLoader_without_bytecode_libraries, pureMockitoAPIClass);
+        }
+    }
+
+    private void checkDependency(ClassLoader classLoader, String pureMockitoAPIClass) throws ClassNotFoundException {
+        try {
+            Class.forName(pureMockitoAPIClass, true, classLoader);
+        } catch (Throwable e) {
+            e.printStackTrace();
+            throw new AssertionError(String.format("'%s' has some dependency to Byte Buddy or Objenesis", pureMockitoAPIClass));
+        }
+    }
+}


### PR DESCRIPTION
This enables the iOS Mockito plugin
(https://github.com/google/j2objc/tree/master/testing/mockito) to upgrade to v2.