### PR TITLE
Fixes #1717 : configure the MethodVisitor for Java 11 compatibility

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
@@ -20,7 +20,6 @@ import net.bytebuddy.dynamic.scaffold.TypeValidation;
 import net.bytebuddy.implementation.Implementation;
 import net.bytebuddy.jar.asm.ClassVisitor;
 import net.bytebuddy.jar.asm.MethodVisitor;
-import net.bytebuddy.jar.asm.Opcodes;
 import net.bytebuddy.matcher.ElementMatchers;
 import net.bytebuddy.pool.TypePool;
 import net.bytebuddy.utility.OpenedClassReader;
@@ -311,7 +310,7 @@ public class InlineBytecodeGenerator implements BytecodeGenerator, ClassFileTran
         private static class MethodParameterStrippingMethodVisitor extends MethodVisitor {
 
             public MethodParameterStrippingMethodVisitor(MethodVisitor mv) {
-                super(Opcodes.ASM5, mv);
+                super(OpenedClassReader.ASM_API, mv);
             }
 
             @Override


### PR DESCRIPTION
I'm looking into adding a unit test, if I can find how to use Byte Buddy to generate a class with a Conditional Dynamic instruction when running with Java 11.