### PR TITLE
Change implementation of ExceptionFactory to explicitly test for dependent classes

### DIFF
--- a/src/main/java/org/mockito/internal/junit/ExceptionFactory.java
+++ b/src/main/java/org/mockito/internal/junit/ExceptionFactory.java
@@ -21,29 +21,16 @@ public class ExceptionFactory {
         ExceptionFactoryImpl theFactory = null;
 
         try {
-            theFactory = new ExceptionFactoryImpl() {
-                @Override
-                public AssertionError create(String message, String wanted, String actual) {
-                    return new org.mockito.exceptions.verification.opentest4j.ArgumentsAreDifferent(message, wanted, actual);
-                }
-            };
-        } catch (Throwable onlyIfOpenTestIsNotAvailable) {
+            Class.forName("org.opentest4j.AssertionFailedError");
+            theFactory = org.mockito.exceptions.verification.opentest4j.ArgumentsAreDifferent::new;
+        } catch (ClassNotFoundException onlyIfOpenTestIsNotAvailable) {
             try {
-                theFactory = new ExceptionFactoryImpl() {
-                    @Override
-                    public AssertionError create(String message, String wanted, String actual) {
-                        return new org.mockito.exceptions.verification.junit.ArgumentsAreDifferent(message, wanted, actual);
-                    }
-                };
-            } catch (Throwable onlyIfJUnitIsNotAvailable) {
+                Class.forName("junit.framework.ComparisonFailure");
+                theFactory = org.mockito.exceptions.verification.junit.ArgumentsAreDifferent::new;
+            } catch (ClassNotFoundException onlyIfJUnitIsNotAvailable) {
             }
         }
-        factory = (theFactory == null) ? new ExceptionFactoryImpl() {
-            @Override
-            public AssertionError create(String message, String wanted, String actual) {
-                return new ArgumentsAreDifferent(message, wanted, actual);
-            }
-        } : theFactory;
+        factory = (theFactory == null) ? ArgumentsAreDifferent::new : theFactory;
     }
 
     /**


### PR DESCRIPTION
The original implementation of conditional OpenTest4J support (#1667) relied on some implicit behaviour of the Java classloader to generate and catch the exception at the right time. It seems that this behaviour is not always exactly replicated in all environments - for example, in #1716, where Mockito was being used in an instrumentation test that was being run on an Android emulator.

The new implementation is a bit more direct in how it tests for the dependent classes. The existing test cases still pass, and @matejdro confirmed that this fixed his problem.

Fixes #1716.