### PR TITLE
[2.x] Fix missing README logo and other broken links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,7 +14,7 @@
 
 Which branch : 
 * On mockito 2.x, make your pull request target `release/2.x`
-* On next mockito version make your pull request target `master`
+* On next mockito version make your pull request target `release/3.x`
 
 ## Pull request criteria
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -20,6 +20,6 @@ check that
  - [ ] Provide versions (mockito / jdk / os / any other relevant information)
  - [ ] Provide a [Short, Self Contained, Correct (Compilable), Example](http://sscce.org) of the issue
        (same as any question on stackoverflow.com)
- - [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/master/.github/CONTRIBUTING.md)
+ - [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/2.x/.github/CONTRIBUTING.md)
 
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <a href="http://site.mockito.org">
-<img src="https://raw.githubusercontent.com/mockito/mockito/master/src/javadoc/org/mockito/logo.png"
-     srcset="https://raw.githubusercontent.com/mockito/mockito/master/src/javadoc/org/mockito/logo@2x.png 2x"
+<img src="https://raw.githubusercontent.com/mockito/mockito/release/2.x/src/javadoc/org/mockito/logo.png"
+     srcset="https://raw.githubusercontent.com/mockito/mockito/mockito/release/2.x/src/javadoc/org/mockito/logo@2x.png 2x"
      alt="Mockito" />
 </a>
 
 Most popular mocking framework for Java
 
-[![Build Status](https://travis-ci.org/mockito/mockito.svg?branch=release/2.x)](https://travis-ci.org/mockito/mockito) [![Coverage Status](https://img.shields.io/codecov/c/github/mockito/mockito.svg)](https://codecov.io/github/mockito/mockito) [![MIT License](http://img.shields.io/badge/license-MIT-green.svg) ](https://github.com/mockito/mockito/blob/master/LICENSE)
+[![Build Status](https://travis-ci.org/mockito/mockito.svg?branch=release/2.x)](https://travis-ci.org/mockito/mockito) [![Coverage Status](https://img.shields.io/codecov/c/github/mockito/mockito.svg)](https://codecov.io/github/mockito/mockito) [![MIT License](http://img.shields.io/badge/license-MIT-green.svg) ](https://github.com/mockito/mockito/blob/release/2.x/LICENSE)
 
 [![latest release](https://img.shields.io/badge/release%20notes-2.x-yellow.svg)](https://github.com/mockito/mockito/blob/release/2.x/doc/release-notes/official.md)
 [![Bintray](https://api.bintray.com/packages/mockito/maven/mockito-development/images/download.svg)](https://bintray.com/mockito/maven)


### PR DESCRIPTION
Noticed the logo in the README was a broken link. Found a few more broken links and master branch comments that needed updating:
<img width="1061" alt="Screen Shot 2019-06-10 at 6 24 27 PM" src="https://user-images.githubusercontent.com/16943514/59235112-15089d80-8bad-11e9-986e-e0ddb375d128.png">
