### PR TITLE
Consistent punctuation in hints list for UnfinishedStubbingException

### DIFF
--- a/src/main/java/org/mockito/internal/exceptions/Reporter.java
+++ b/src/main/java/org/mockito/internal/exceptions/Reporter.java
@@ -83,7 +83,7 @@ public class Reporter {
                 "Hints:",
                 " 1. missing thenReturn()",
                 " 2. you are trying to stub a final method, which is not supported",
-                " 3: you are stubbing the behaviour of another mock inside before 'thenReturn' instruction is completed",
+                " 3. you are stubbing the behaviour of another mock inside before 'thenReturn' instruction is completed",
                 ""
         ));
     }


### PR DESCRIPTION
Previously the numbered list had two periods and a colon after the three numbers.

After, it consistently uses dots like other suggestions, i.e. missingMethodInvocation