### PR TITLE
Run Travis on Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ sudo: true
 
 language: java
 
-dist: trusty
-
 matrix:
   include:
   - jdk: openjdk8


### PR DESCRIPTION
Per https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment this is now the default. We previously set Trusty explicitly to fix our build failures. However, since then we switched to `openjdk` which should not have any issues on Xenial.