### PR TITLE
Fixes #1758: Method GenericTypeExtractor#findGenericInterface always …

### DIFF
--- a/src/main/java/org/mockito/internal/util/reflection/GenericTypeExtractor.java
+++ b/src/main/java/org/mockito/internal/util/reflection/GenericTypeExtractor.java
@@ -61,7 +61,7 @@ public class GenericTypeExtractor {
         for (int i = 0; i < sourceClass.getInterfaces().length; i++) {
             Class<?> inter = sourceClass.getInterfaces()[i];
             if (inter == targetBaseInterface) {
-                return sourceClass.getGenericInterfaces()[0];
+                return sourceClass.getGenericInterfaces()[i];
             } else {
                 Type deeper = findGenericInterface(inter, targetBaseInterface);
                 if (deeper != null) {

--- a/src/test/java/org/mockito/internal/util/reflection/GenericTypeExtractorTest.java
+++ b/src/test/java/org/mockito/internal/util/reflection/GenericTypeExtractorTest.java
@@ -38,6 +38,7 @@ public class GenericTypeExtractorTest extends TestBase {
 
     interface Crazy extends Serializable, IDeeper, Cloneable {}
     class Crazier extends EvenDeeper implements Crazy {}
+    class SecondGeneric implements Serializable, IBase<Integer> {}
 
     @Test public void finds_generic_type() {
         assertEquals(Integer.class, genericTypeOf(IntImpl.class, Base.class, IBase.class));
@@ -64,5 +65,7 @@ public class GenericTypeExtractorTest extends TestBase {
         assertEquals(Integer.class, genericTypeOf(IDeeper.class, Base.class, IBase.class));
         assertEquals(Integer.class, genericTypeOf(Crazy.class, Base.class, IBase.class));
         assertEquals(Integer.class, genericTypeOf(Crazier.class, Base.class, IBase.class));
+
+        assertEquals(Integer.class, genericTypeOf(SecondGeneric.class, Base.class, IBase.class));
     }
 }


### PR DESCRIPTION
…returns first interface