### PR TITLE
Update assertj (v3.13.2)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,7 +12,7 @@ libraries.junit4 = 'junit:junit:4.12'
 libraries.junitJupiterApi = "org.junit.jupiter:junit-jupiter-api:${versions.junitJupiter}"
 libraries.junitPlatformLauncher = 'org.junit.platform:junit-platform-launcher:1.1.0'
 libraries.junitJupiterEngine = "org.junit.jupiter:junit-jupiter-engine:${versions.junitJupiter}"
-libraries.assertj = 'org.assertj:assertj-core:2.9.0'
+libraries.assertj = 'org.assertj:assertj-core:3.13.2'
 libraries.hamcrest = 'org.hamcrest:hamcrest-core:1.3'
 libraries.opentest4j = 'org.opentest4j:opentest4j:1.1.1'
 


### PR DESCRIPTION
Since mockito 3.x now has java8 as minimum requirement we could go for assertj 3.x (which also has java8 as minimum requirement).
