### PR TITLE
Fixes #1771: Upgrade byte-buddy to 1.10.1 (from 1.9.10)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -4,7 +4,7 @@ ext {
 
 def versions = [:]
 
-versions.bytebuddy = '1.9.10'
+versions.bytebuddy = '1.10.1'
 versions.junitJupiter = '5.1.1'
 versions.errorprone = '2.3.2'
 


### PR DESCRIPTION
Release notes:
https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.10.1
https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.10.0
https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.9.16
https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.9.15
https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.9.14
https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.9.13
https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.9.12
https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.9.11

Relevant commits:
https://github.com/raphw/byte-buddy/compare/byte-buddy-1.9.10...byte-buddy-1.10.1

