### PR TITLE
Convenience factory method for creating stub objects

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -1881,6 +1881,24 @@ public class Mockito extends ArgumentMatchers {
     }
 
     /**
+     * Creates stub object of given class or interface. A stub is distinct from a mock in that it does not verify interactions.
+     * <p>
+     * This factory method is a convenience for creating a mock with setting {@link MockSettings#stubOnly()}.
+     *
+     * <pre><code>
+     *     Foo stub = mock(Foo.class, withSettings().stubOnly());
+     * </code></pre>
+     *
+     * @param classToStub class or interface to mock
+     * @return stub object
+     * @since 3.0.8
+     */
+    @CheckReturnValue
+    public static <T> T stub(Class<T> classToStub) {
+        return mock(classToStub, withSettings().stubOnly());
+    }
+
+    /**
      * Creates a mock with some non-standard settings.
      * <p>
      * The number of configuration points for a mock grows

--- a/src/test/java/org/mockito/MockitoTest.java
+++ b/src/test/java/org/mockito/MockitoTest.java
@@ -11,6 +11,7 @@ import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingPro
 
 import java.util.List;
 import org.junit.Test;
+import org.mockito.exceptions.misusing.CannotVerifyStubOnlyMock;
 import org.mockito.exceptions.misusing.NotAMockException;
 import org.mockito.exceptions.misusing.NullInsteadOfMockException;
 import org.mockito.internal.creation.MockSettingsImpl;
@@ -71,6 +72,12 @@ public class MockitoTest {
 
         //then
         assertThat(Mockito.RETURNS_DEFAULTS).isEqualTo(settings.getDefaultAnswer());
+    }
+
+    @Test(expected = CannotVerifyStubOnlyMock.class)
+    public void shouldThrowWhenVerifyingStubBehavior() {
+        final List stub = Mockito.stub(List.class);
+        Mockito.verifyNoInteractions(stub);
     }
 
 }


### PR DESCRIPTION
Fixes #1778

This improves test clarity when creating stubs by helping test authors succinctly communicate their intentions.

Adds a `stub(Class)` convenience method to `Mockito` which is an alias for `mock(stubClass, withSettings().stubOnly())`.

