### PR TITLE
Fixes #1780: Close file handle to avoid a file-handle-leak

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
@@ -135,7 +135,9 @@ public class InlineByteBuddyMockMaker implements ClassCreatingMockMaker, InlineM
                 } finally {
                     outputStream.close();
                 }
-                instrumentation.appendToBootstrapClassLoaderSearch(new JarFile(boot));
+                try (JarFile jarfile = new JarFile(boot)) {
+                    instrumentation.appendToBootstrapClassLoaderSearch(jarfile);
+                }
                 try {
                     Class.forName("org.mockito.internal.creation.bytebuddy.inject.MockMethodDispatcher", false, null);
                 } catch (ClassNotFoundException cnfe) {


### PR DESCRIPTION
Fix a small file-handle-leak which pops up when running tests with [file-leak-detector](https://file-leak-detector.kohsuke.org/) 

Fixes #1780