### PR TITLE
Fixed JUnit Jupiter parallel issue

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,8 @@ include("deprecatedPluginsTest",
     "junitJupiterExtensionTest",
     "module-test",
     "memory-test",
-    "errorprone")
+    "errorprone",
+    "junitJupiterParallelTest")
 
 rootProject.name = "mockito"
 

--- a/subprojects/junit-jupiter/src/main/java/org/mockito/junit/jupiter/MockitoExtension.java
+++ b/subprojects/junit-jupiter/src/main/java/org/mockito/junit/jupiter/MockitoExtension.java
@@ -5,6 +5,13 @@
 package org.mockito.junit.jupiter;
 
 
+import static org.junit.jupiter.api.extension.ExtensionContext.Namespace.create;
+import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
+
+import java.lang.reflect.Parameter;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -21,14 +28,6 @@ import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.internal.session.MockitoSessionLoggerAdapter;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.quality.Strictness;
-
-import java.lang.reflect.Parameter;
-import java.util.LinkedHashSet;
-import java.util.Optional;
-import java.util.Set;
-
-import static org.junit.jupiter.api.extension.ExtensionContext.Namespace.create;
-import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
 
 /**
  * Extension that initializes mocks and handles strict stubbings. This extension is the JUnit Jupiter equivalent
@@ -194,27 +193,30 @@ public class MockitoExtension implements TestInstancePostProcessor, BeforeEachCa
     }
 
     private void collectParentTestInstances(ExtensionContext context, Set<Object> testInstances) {
-        Optional<ExtensionContext> parent = context.getParent();
+        Optional<ExtensionContext> initialParent = context.getParent();
 
-        boolean firstParent = true;
-        while (parent.isPresent() && parent.get() != context.getRoot()) {
-            ExtensionContext parentContext = parent.get();
-            parent = parentContext.getParent();
+        // Ignoring first parent avoids parallel execution issues
+        // We can ignore the first parent because it has the test instance that is already in 'testInstances'
+        // See how 'testInstances' is populated
+        initialParent.ifPresent(parent -> collectParentTestInstance(parent.getParent(), context, testInstances));
+    }
 
-            if (firstParent) {
-                // Ignoring first parent avoids parallel execution issues
-                // We can ignore the first parent because it has the test instance that is already in 'testInstances'
-                // See how 'testInstances' is populated
-                firstParent = false;
-                continue;
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    private void collectParentTestInstance(
+        Optional<ExtensionContext> parent, ExtensionContext context,
+        Set<Object> testInstances) {
+
+        parent.ifPresent(currentParent -> {
+            if (currentParent != context.getRoot()) {
+                Object testInstance = currentParent.getStore(MOCKITO).remove(TEST_INSTANCE);
+
+                if (testInstance != null) {
+                    testInstances.add(testInstance);
+                }
+
+                collectParentTestInstance(currentParent.getParent(), context, testInstances);
             }
-
-            Object testInstance = parentContext.getStore(MOCKITO).remove(TEST_INSTANCE);
-
-            if (testInstance != null) {
-                testInstances.add(testInstance);
-            }
-        }
+        });
     }
 
     /**

--- a/subprojects/junitJupiterParallelTest/junitJupiterParallelTest.gradle
+++ b/subprojects/junitJupiterParallelTest/junitJupiterParallelTest.gradle
@@ -1,0 +1,15 @@
+description = "Tests that require fine tuned parallel settings for JUnit Jupiter (bug #1630)"
+
+apply from: "$rootDir/gradle/dependencies.gradle"
+
+apply plugin: "java"
+
+dependencies {
+    testImplementation libraries.junitJupiterApi
+    testImplementation project(":junit-jupiter")
+    testRuntime libraries.junitJupiterEngine
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/subprojects/junitJupiterParallelTest/src/test/java/org/mockito/ParallelBugTest.java
+++ b/subprojects/junitJupiterParallelTest/src/test/java/org/mockito/ParallelBugTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2019 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * See bug #1630
+ */
+@ExtendWith(MockitoExtension.class)
+class ParallelBugTest {
+
+    @Mock
+    private SomeService someService;
+
+    @InjectMocks
+    private AnotherService anotherService;
+
+    @Test
+    void test() {
+        perform();
+    }
+
+    private void perform() {
+        // when
+        anotherService.callSomeService();
+
+        // then
+        Mockito.verify(someService).doSomething();
+    }
+
+    @Test
+    void test2() {
+        perform();
+    }
+
+    @Test
+    void test3() {
+        perform();
+    }
+
+    @Test
+    void test4() {
+        perform();
+    }
+
+    @Test
+    void test5() {
+        perform();
+    }
+
+    @Test
+    void test6() {
+        perform();
+    }
+
+    @Test
+    void test7() {
+        perform();
+    }
+
+    public static class AnotherService {
+        private final SomeService someService;
+
+        public AnotherService(final SomeService someService) {
+            this.someService = someService;
+        }
+
+        void callSomeService() {
+            someService.doSomething();
+        }
+    }
+
+    static class SomeService {
+
+        void doSomething() {
+        }
+    }
+}

--- a/subprojects/junitJupiterParallelTest/src/test/resources/junit-platform.properties
+++ b/subprojects/junitJupiterParallelTest/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.config.strategy=dynamic
+junit.jupiter.execution.parallel.mode.default=concurrent


### PR DESCRIPTION
Fixes #1630

This fix improves Mockito JUnit Jupiter extension. However, it does not completely resolve all kinds of parallel issues when nested test classes are used. I'll open a separate ticket for it.