### PR TITLE
Enable spotless to automatically format our source code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ script:
   # We are using && below on purpose
   # ciPerformRelease must run only when the entire build has completed
   # This guarantees that no release steps are executed when the build or tests fail
-  - ./gradlew build idea -s && ./gradlew ciPerformRelease
+  - ./gradlew spotlessCheck && ./gradlew build idea -s && ./gradlew ciPerformRelease
 
 after_success:
   #Generates coverage report:

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ buildscript {
 
 plugins {
     id 'com.gradle.build-scan' version '2.2.1'
+    id "com.diffplug.gradle.spotless" version "3.24.3"
     id 'eclipse'
 }
 
@@ -100,6 +101,17 @@ buildScan {
     termsOfServiceUrl = 'https://gradle.com/terms-of-service'
     termsOfServiceAgree = 'yes'
 }
+
+spotless {
+    java {
+        licenseHeaderFile rootProject.file('config/spotless/spotless.header')
+
+        removeUnusedImports()
+        trimTrailingWhitespace()
+        endWithNewline()
+    }
+}
+
 
 //workaround for #1444, delete when Shipkit bug is fixed
 subprojects {

--- a/config/spotless/spotless.header
+++ b/config/spotless/spotless.header
@@ -1,0 +1,4 @@
+/*
+ * Copyright (c) $YEAR Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */

--- a/src/main/java/org/mockito/AdditionalMatchers.java
+++ b/src/main/java/org/mockito/AdditionalMatchers.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito;
 
 import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;

--- a/src/main/java/org/mockito/InOrder.java
+++ b/src/main/java/org/mockito/InOrder.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito;
 
 import org.mockito.verification.VerificationMode;

--- a/src/main/java/org/mockito/Incubating.java
+++ b/src/main/java/org/mockito/Incubating.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito;
 
 import java.lang.annotation.Documented;

--- a/src/main/java/org/mockito/MockitoAnnotations.java
+++ b/src/main/java/org/mockito/MockitoAnnotations.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito;
 
 import org.mockito.exceptions.base.MockitoException;

--- a/src/main/java/org/mockito/exceptions/base/MockitoAssertionError.java
+++ b/src/main/java/org/mockito/exceptions/base/MockitoAssertionError.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.exceptions.base;
 
 import org.mockito.internal.exceptions.stacktrace.ConditionalStackTraceFilter;

--- a/src/main/java/org/mockito/exceptions/base/MockitoException.java
+++ b/src/main/java/org/mockito/exceptions/base/MockitoException.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.exceptions.base;
 
 import org.mockito.internal.exceptions.stacktrace.ConditionalStackTraceFilter;

--- a/src/main/java/org/mockito/exceptions/base/MockitoInitializationException.java
+++ b/src/main/java/org/mockito/exceptions/base/MockitoInitializationException.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.exceptions.base;
 
 public class MockitoInitializationException extends RuntimeException {

--- a/src/main/java/org/mockito/exceptions/base/MockitoSerializationIssue.java
+++ b/src/main/java/org/mockito/exceptions/base/MockitoSerializationIssue.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.exceptions.base;
 
 import org.mockito.internal.exceptions.stacktrace.ConditionalStackTraceFilter;

--- a/src/main/java/org/mockito/exceptions/misusing/CannotVerifyStubOnlyMock.java
+++ b/src/main/java/org/mockito/exceptions/misusing/CannotVerifyStubOnlyMock.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.exceptions.misusing;
 
 import org.mockito.exceptions.base.MockitoException;

--- a/src/main/java/org/mockito/exceptions/misusing/FriendlyReminderException.java
+++ b/src/main/java/org/mockito/exceptions/misusing/FriendlyReminderException.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.exceptions.misusing;
 
 import org.mockito.exceptions.base.MockitoException;

--- a/src/main/java/org/mockito/exceptions/misusing/InvalidUseOfMatchersException.java
+++ b/src/main/java/org/mockito/exceptions/misusing/InvalidUseOfMatchersException.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.exceptions.misusing;
 
 import org.mockito.exceptions.base.MockitoException;

--- a/src/main/java/org/mockito/exceptions/misusing/MissingMethodInvocationException.java
+++ b/src/main/java/org/mockito/exceptions/misusing/MissingMethodInvocationException.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.exceptions.misusing;
 
 import org.mockito.exceptions.base.MockitoException;

--- a/src/main/java/org/mockito/exceptions/misusing/NotAMockException.java
+++ b/src/main/java/org/mockito/exceptions/misusing/NotAMockException.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.exceptions.misusing;
 
 import org.mockito.exceptions.base.MockitoException;

--- a/src/main/java/org/mockito/exceptions/misusing/NullInsteadOfMockException.java
+++ b/src/main/java/org/mockito/exceptions/misusing/NullInsteadOfMockException.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.exceptions.misusing;
 
 import org.mockito.exceptions.base.MockitoException;

--- a/src/main/java/org/mockito/exceptions/misusing/UnfinishedStubbingException.java
+++ b/src/main/java/org/mockito/exceptions/misusing/UnfinishedStubbingException.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.exceptions.misusing;
 
 import org.mockito.exceptions.base.MockitoException;

--- a/src/main/java/org/mockito/exceptions/misusing/UnfinishedVerificationException.java
+++ b/src/main/java/org/mockito/exceptions/misusing/UnfinishedVerificationException.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.exceptions.misusing;
 
 import org.mockito.exceptions.base.MockitoException;

--- a/src/main/java/org/mockito/exceptions/verification/ArgumentsAreDifferent.java
+++ b/src/main/java/org/mockito/exceptions/verification/ArgumentsAreDifferent.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.exceptions.verification;
 
 import static org.mockito.internal.util.StringUtil.removeFirstLine;

--- a/src/main/java/org/mockito/exceptions/verification/MoreThanAllowedActualInvocations.java
+++ b/src/main/java/org/mockito/exceptions/verification/MoreThanAllowedActualInvocations.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.exceptions.verification;
 
 import org.mockito.exceptions.base.MockitoAssertionError;

--- a/src/main/java/org/mockito/exceptions/verification/NeverWantedButInvoked.java
+++ b/src/main/java/org/mockito/exceptions/verification/NeverWantedButInvoked.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.exceptions.verification;
 
 import org.mockito.exceptions.base.MockitoAssertionError;

--- a/src/main/java/org/mockito/exceptions/verification/NoInteractionsWanted.java
+++ b/src/main/java/org/mockito/exceptions/verification/NoInteractionsWanted.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.exceptions.verification;
 
 import org.mockito.exceptions.base.MockitoAssertionError;

--- a/src/main/java/org/mockito/exceptions/verification/TooLittleActualInvocations.java
+++ b/src/main/java/org/mockito/exceptions/verification/TooLittleActualInvocations.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.exceptions.verification;
 
 import org.mockito.exceptions.base.MockitoAssertionError;

--- a/src/main/java/org/mockito/exceptions/verification/TooManyActualInvocations.java
+++ b/src/main/java/org/mockito/exceptions/verification/TooManyActualInvocations.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.exceptions.verification;
 
 import org.mockito.exceptions.base.MockitoAssertionError;

--- a/src/main/java/org/mockito/exceptions/verification/VerificationInOrderFailure.java
+++ b/src/main/java/org/mockito/exceptions/verification/VerificationInOrderFailure.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.exceptions.verification;
 
 import org.mockito.exceptions.base.MockitoAssertionError;

--- a/src/main/java/org/mockito/exceptions/verification/WantedButNotInvoked.java
+++ b/src/main/java/org/mockito/exceptions/verification/WantedButNotInvoked.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.exceptions.verification;
 
 import static org.mockito.internal.util.StringUtil.removeFirstLine;

--- a/src/main/java/org/mockito/exceptions/verification/junit/ArgumentsAreDifferent.java
+++ b/src/main/java/org/mockito/exceptions/verification/junit/ArgumentsAreDifferent.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.exceptions.verification.junit;
 
 import static org.mockito.internal.util.StringUtil.removeFirstLine;

--- a/src/main/java/org/mockito/exceptions/verification/opentest4j/ArgumentsAreDifferent.java
+++ b/src/main/java/org/mockito/exceptions/verification/opentest4j/ArgumentsAreDifferent.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2019 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.exceptions.verification.opentest4j;
 
 import static org.mockito.internal.util.StringUtil.removeFirstLine;

--- a/src/main/java/org/mockito/internal/InOrderImpl.java
+++ b/src/main/java/org/mockito/internal/InOrderImpl.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal;
 
 import org.mockito.InOrder;

--- a/src/main/java/org/mockito/internal/configuration/injection/ConstructorInjection.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/ConstructorInjection.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.configuration.injection;
 
 import org.mockito.exceptions.base.MockitoException;

--- a/src/main/java/org/mockito/internal/configuration/injection/MockInjection.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/MockInjection.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.configuration.injection;
 
 import java.lang.reflect.Field;

--- a/src/main/java/org/mockito/internal/configuration/injection/MockInjectionStrategy.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/MockInjectionStrategy.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.configuration.injection;
 
 import java.lang.reflect.Field;

--- a/src/main/java/org/mockito/internal/configuration/injection/PropertyAndSetterInjection.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/PropertyAndSetterInjection.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.configuration.injection;
 
 import static org.mockito.internal.exceptions.Reporter.cannotInitializeForInjectMocksAnnotation;

--- a/src/main/java/org/mockito/internal/configuration/injection/SpyOnInjectedFieldsHandler.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/SpyOnInjectedFieldsHandler.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.configuration.injection;
 
 import org.mockito.Mockito;

--- a/src/main/java/org/mockito/internal/creation/MockSettingsImpl.java
+++ b/src/main/java/org/mockito/internal/creation/MockSettingsImpl.java
@@ -264,4 +264,3 @@ public class MockSettingsImpl<T> extends CreationSettings<T> implements MockSett
     }
 
 }
-

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyCrossClassLoaderSerializationSupport.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyCrossClassLoaderSerializationSupport.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.creation.bytebuddy;
 
 import org.mockito.Incubating;

--- a/src/main/java/org/mockito/internal/debugging/VerboseMockInvocationLogger.java
+++ b/src/main/java/org/mockito/internal/debugging/VerboseMockInvocationLogger.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.debugging;
 
 import java.io.PrintStream;

--- a/src/main/java/org/mockito/internal/exceptions/Reporter.java
+++ b/src/main/java/org/mockito/internal/exceptions/Reporter.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.exceptions;
 
 import org.mockito.exceptions.base.MockitoAssertionError;

--- a/src/main/java/org/mockito/internal/exceptions/VerificationAwareInvocation.java
+++ b/src/main/java/org/mockito/internal/exceptions/VerificationAwareInvocation.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.exceptions;
 
 import org.mockito.invocation.DescribedInvocation;

--- a/src/main/java/org/mockito/internal/exceptions/stacktrace/ConditionalStackTraceFilter.java
+++ b/src/main/java/org/mockito/internal/exceptions/stacktrace/ConditionalStackTraceFilter.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.exceptions.stacktrace;
 
 import org.mockito.configuration.IMockitoConfiguration;

--- a/src/main/java/org/mockito/internal/exceptions/stacktrace/StackTraceFilter.java
+++ b/src/main/java/org/mockito/internal/exceptions/stacktrace/StackTraceFilter.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.exceptions.stacktrace;
 
 import java.lang.reflect.Method;

--- a/src/main/java/org/mockito/internal/invocation/AbstractAwareMethod.java
+++ b/src/main/java/org/mockito/internal/invocation/AbstractAwareMethod.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.invocation;
 
 public interface AbstractAwareMethod {

--- a/src/main/java/org/mockito/internal/invocation/InvocationMatcher.java
+++ b/src/main/java/org/mockito/internal/invocation/InvocationMatcher.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.invocation;
 
 import static org.mockito.internal.invocation.MatcherApplicationStrategy.getMatcherApplicationStrategyFor;

--- a/src/main/java/org/mockito/internal/invocation/InvocationsFinder.java
+++ b/src/main/java/org/mockito/internal/invocation/InvocationsFinder.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.invocation;
 
 import java.util.LinkedList;

--- a/src/main/java/org/mockito/internal/invocation/MatchersBinder.java
+++ b/src/main/java/org/mockito/internal/invocation/MatchersBinder.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.invocation;
 
 

--- a/src/main/java/org/mockito/internal/invocation/UnusedStubsFinder.java
+++ b/src/main/java/org/mockito/internal/invocation/UnusedStubsFinder.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.invocation;
 
 import org.mockito.internal.util.MockUtil;

--- a/src/main/java/org/mockito/internal/invocation/finder/AllInvocationsFinder.java
+++ b/src/main/java/org/mockito/internal/invocation/finder/AllInvocationsFinder.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.invocation.finder;
 
 import org.mockito.internal.invocation.InvocationComparator;

--- a/src/main/java/org/mockito/internal/invocation/finder/VerifiableInvocationsFinder.java
+++ b/src/main/java/org/mockito/internal/invocation/finder/VerifiableInvocationsFinder.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.invocation.finder;
 
 import org.mockito.internal.util.collections.ListUtil;

--- a/src/main/java/org/mockito/internal/invocation/mockref/MockReference.java
+++ b/src/main/java/org/mockito/internal/invocation/mockref/MockReference.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2018 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.invocation.mockref;
 
 import java.io.Serializable;

--- a/src/main/java/org/mockito/internal/invocation/mockref/MockStrongReference.java
+++ b/src/main/java/org/mockito/internal/invocation/mockref/MockStrongReference.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2018 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.invocation.mockref;
 
 import java.io.ObjectStreamException;

--- a/src/main/java/org/mockito/internal/invocation/mockref/MockWeakReference.java
+++ b/src/main/java/org/mockito/internal/invocation/mockref/MockWeakReference.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2018 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.invocation.mockref;
 
 import java.io.ObjectStreamException;

--- a/src/main/java/org/mockito/internal/matchers/And.java
+++ b/src/main/java/org/mockito/internal/matchers/And.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.matchers;
 
 import java.io.Serializable;

--- a/src/main/java/org/mockito/internal/matchers/Any.java
+++ b/src/main/java/org/mockito/internal/matchers/Any.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.matchers;
 
 import java.io.Serializable;

--- a/src/main/java/org/mockito/internal/matchers/ArrayEquals.java
+++ b/src/main/java/org/mockito/internal/matchers/ArrayEquals.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.matchers;
 
 import java.lang.reflect.Array;

--- a/src/main/java/org/mockito/internal/matchers/CompareEqual.java
+++ b/src/main/java/org/mockito/internal/matchers/CompareEqual.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.matchers;
 
 import java.io.Serializable;

--- a/src/main/java/org/mockito/internal/matchers/CompareTo.java
+++ b/src/main/java/org/mockito/internal/matchers/CompareTo.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.matchers;
 
 import org.mockito.ArgumentMatcher;

--- a/src/main/java/org/mockito/internal/matchers/Contains.java
+++ b/src/main/java/org/mockito/internal/matchers/Contains.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.matchers;
 
 import org.mockito.ArgumentMatcher;

--- a/src/main/java/org/mockito/internal/matchers/EndsWith.java
+++ b/src/main/java/org/mockito/internal/matchers/EndsWith.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.matchers;
 
 import java.io.Serializable;

--- a/src/main/java/org/mockito/internal/matchers/Equals.java
+++ b/src/main/java/org/mockito/internal/matchers/Equals.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.matchers;
 
 import org.mockito.ArgumentMatcher;

--- a/src/main/java/org/mockito/internal/matchers/EqualsWithDelta.java
+++ b/src/main/java/org/mockito/internal/matchers/EqualsWithDelta.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.matchers;
 
 import org.mockito.ArgumentMatcher;

--- a/src/main/java/org/mockito/internal/matchers/Find.java
+++ b/src/main/java/org/mockito/internal/matchers/Find.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.matchers;
 
 import java.io.Serializable;

--- a/src/main/java/org/mockito/internal/matchers/GreaterOrEqual.java
+++ b/src/main/java/org/mockito/internal/matchers/GreaterOrEqual.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.matchers;
 
 import java.io.Serializable;

--- a/src/main/java/org/mockito/internal/matchers/GreaterThan.java
+++ b/src/main/java/org/mockito/internal/matchers/GreaterThan.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.matchers;
 
 import java.io.Serializable;

--- a/src/main/java/org/mockito/internal/matchers/InstanceOf.java
+++ b/src/main/java/org/mockito/internal/matchers/InstanceOf.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.matchers;
 
 import org.mockito.ArgumentMatcher;

--- a/src/main/java/org/mockito/internal/matchers/LessOrEqual.java
+++ b/src/main/java/org/mockito/internal/matchers/LessOrEqual.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.matchers;
 
 import java.io.Serializable;

--- a/src/main/java/org/mockito/internal/matchers/LessThan.java
+++ b/src/main/java/org/mockito/internal/matchers/LessThan.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.matchers;
 
 import java.io.Serializable;

--- a/src/main/java/org/mockito/internal/matchers/Matches.java
+++ b/src/main/java/org/mockito/internal/matchers/Matches.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.matchers;
 
 import java.io.Serializable;

--- a/src/main/java/org/mockito/internal/matchers/Not.java
+++ b/src/main/java/org/mockito/internal/matchers/Not.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.matchers;
 
 import org.mockito.ArgumentMatcher;

--- a/src/main/java/org/mockito/internal/matchers/NotNull.java
+++ b/src/main/java/org/mockito/internal/matchers/NotNull.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.matchers;
 
 import org.mockito.ArgumentMatcher;

--- a/src/main/java/org/mockito/internal/matchers/Null.java
+++ b/src/main/java/org/mockito/internal/matchers/Null.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.matchers;
 
 import org.mockito.ArgumentMatcher;

--- a/src/main/java/org/mockito/internal/matchers/Or.java
+++ b/src/main/java/org/mockito/internal/matchers/Or.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.matchers;
 
 import java.io.Serializable;

--- a/src/main/java/org/mockito/internal/matchers/Same.java
+++ b/src/main/java/org/mockito/internal/matchers/Same.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.matchers;
 
 import org.mockito.ArgumentMatcher;

--- a/src/main/java/org/mockito/internal/matchers/StartsWith.java
+++ b/src/main/java/org/mockito/internal/matchers/StartsWith.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.matchers;
 
 import org.mockito.ArgumentMatcher;

--- a/src/main/java/org/mockito/internal/matchers/apachecommons/EqualsBuilder.java
+++ b/src/main/java/org/mockito/internal/matchers/apachecommons/EqualsBuilder.java
@@ -2,9 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
-//NON-STANDARD LICENCE HEADER HERE - THAT'S OK
-//Class comes from Apache Commons Lang, added some tiny changes
 package org.mockito.internal.matchers.apachecommons;
 
 import java.lang.reflect.AccessibleObject;
@@ -14,6 +11,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+// Class comes from Apache Commons Lang, added some tiny changes
 /**
  * <p>Assists in implementing {@link Object#equals(Object)} methods.</p>
  *

--- a/src/main/java/org/mockito/internal/matchers/apachecommons/ReflectionEquals.java
+++ b/src/main/java/org/mockito/internal/matchers/apachecommons/ReflectionEquals.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.matchers.apachecommons;
 
 import org.mockito.ArgumentMatcher;

--- a/src/main/java/org/mockito/internal/progress/ArgumentMatcherStorageImpl.java
+++ b/src/main/java/org/mockito/internal/progress/ArgumentMatcherStorageImpl.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.progress;
 
 import org.mockito.ArgumentMatcher;

--- a/src/main/java/org/mockito/internal/progress/MockingProgress.java
+++ b/src/main/java/org/mockito/internal/progress/MockingProgress.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.progress;
 
 import java.util.Set;

--- a/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
+++ b/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.progress;
 
 import org.mockito.internal.configuration.GlobalConfiguration;

--- a/src/main/java/org/mockito/internal/stubbing/BaseStubbing.java
+++ b/src/main/java/org/mockito/internal/stubbing/BaseStubbing.java
@@ -102,5 +102,3 @@ public abstract class BaseStubbing<T> implements OngoingStubbing<T> {
         return (M) this.strongMockRef;
     }
 }
-
-

--- a/src/main/java/org/mockito/internal/stubbing/OngoingStubbingImpl.java
+++ b/src/main/java/org/mockito/internal/stubbing/OngoingStubbingImpl.java
@@ -42,5 +42,3 @@ public class OngoingStubbingImpl<T> extends BaseStubbing<T> {
         this.strictness = strictness;
     }
 }
-
-

--- a/src/main/java/org/mockito/internal/stubbing/StubberImpl.java
+++ b/src/main/java/org/mockito/internal/stubbing/StubberImpl.java
@@ -137,5 +137,3 @@ public class StubberImpl implements Stubber {
         return this;
     }
 }
-
-

--- a/src/main/java/org/mockito/internal/stubbing/answers/AnswersWithDelay.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/AnswersWithDelay.java
@@ -44,4 +44,3 @@ public class AnswersWithDelay implements Answer<Object>, ValidableAnswer, Serial
         }
     }
 }
-

--- a/src/main/java/org/mockito/internal/stubbing/answers/DefaultAnswerValidator.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/DefaultAnswerValidator.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.stubbing.answers;
 
 import org.mockito.invocation.InvocationOnMock;

--- a/src/main/java/org/mockito/internal/stubbing/answers/ReturnsArgumentAt.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/ReturnsArgumentAt.java
@@ -150,4 +150,3 @@ public class ReturnsArgumentAt implements Answer<Object>, ValidableAnswer, Seria
 
     }
 }
-

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsMoreEmptyValues.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsMoreEmptyValues.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.stubbing.defaultanswers;
 
 import java.io.Serializable;

--- a/src/main/java/org/mockito/internal/util/Checks.java
+++ b/src/main/java/org/mockito/internal/util/Checks.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.util;
 
 /**

--- a/src/main/java/org/mockito/internal/util/DefaultMockingDetails.java
+++ b/src/main/java/org/mockito/internal/util/DefaultMockingDetails.java
@@ -86,4 +86,3 @@ public class DefaultMockingDetails implements MockingDetails {
         }
     }
 }
-

--- a/src/main/java/org/mockito/internal/util/collections/ListUtil.java
+++ b/src/main/java/org/mockito/internal/util/collections/ListUtil.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.util.collections;
 
 import java.util.Collection;

--- a/src/main/java/org/mockito/internal/util/reflection/FieldInitializationReport.java
+++ b/src/main/java/org/mockito/internal/util/reflection/FieldInitializationReport.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.util.reflection;
 
 /**
@@ -55,4 +54,3 @@ public class FieldInitializationReport {
         return fieldInstance != null ? fieldInstance.getClass() : null;
     }
 }
-

--- a/src/main/java/org/mockito/internal/util/reflection/GenericMetadataSupport.java
+++ b/src/main/java/org/mockito/internal/util/reflection/GenericMetadataSupport.java
@@ -692,5 +692,3 @@ public abstract class GenericMetadataSupport {
     }
 
 }
-
-

--- a/src/main/java/org/mockito/internal/util/reflection/SuperTypesLastSorter.java
+++ b/src/main/java/org/mockito/internal/util/reflection/SuperTypesLastSorter.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2015 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.util.reflection;
 
 import java.lang.reflect.Field;

--- a/src/main/java/org/mockito/internal/verification/AtLeast.java
+++ b/src/main/java/org/mockito/internal/verification/AtLeast.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.verification;
 
 import static org.mockito.internal.verification.checkers.AtLeastXNumberOfInvocationsChecker.checkAtLeastNumberOfInvocations;

--- a/src/main/java/org/mockito/internal/verification/AtMost.java
+++ b/src/main/java/org/mockito/internal/verification/AtMost.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.verification;
 
 import static org.mockito.internal.exceptions.Reporter.wantedAtMostX;

--- a/src/main/java/org/mockito/internal/verification/Calls.java
+++ b/src/main/java/org/mockito/internal/verification/Calls.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.verification;
 
 import static org.mockito.internal.verification.checkers.MissingInvocationChecker.checkMissingInvocation;

--- a/src/main/java/org/mockito/internal/verification/DefaultRegisteredInvocations.java
+++ b/src/main/java/org/mockito/internal/verification/DefaultRegisteredInvocations.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.verification;
 
 import org.mockito.internal.util.collections.ListUtil;

--- a/src/main/java/org/mockito/internal/verification/NoInteractions.java
+++ b/src/main/java/org/mockito/internal/verification/NoInteractions.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2017 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.verification;
 
 import org.mockito.internal.verification.api.VerificationData;

--- a/src/main/java/org/mockito/internal/verification/NoMoreInteractions.java
+++ b/src/main/java/org/mockito/internal/verification/NoMoreInteractions.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.verification;
 
 import static org.mockito.internal.exceptions.Reporter.noMoreInteractionsWanted;

--- a/src/main/java/org/mockito/internal/verification/RegisteredInvocations.java
+++ b/src/main/java/org/mockito/internal/verification/RegisteredInvocations.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.verification;
 
 import org.mockito.invocation.Invocation;

--- a/src/main/java/org/mockito/internal/verification/SingleRegisteredInvocation.java
+++ b/src/main/java/org/mockito/internal/verification/SingleRegisteredInvocation.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.verification;
 
 import org.mockito.invocation.Invocation;

--- a/src/main/java/org/mockito/internal/verification/Times.java
+++ b/src/main/java/org/mockito/internal/verification/Times.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.verification;
 
 import static org.mockito.internal.verification.checkers.MissingInvocationChecker.checkMissingInvocation;

--- a/src/main/java/org/mockito/internal/verification/VerificationModeFactory.java
+++ b/src/main/java/org/mockito/internal/verification/VerificationModeFactory.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.verification;
 
 import org.mockito.verification.VerificationMode;

--- a/src/main/java/org/mockito/internal/verification/checkers/AtLeastXNumberOfInvocationsChecker.java
+++ b/src/main/java/org/mockito/internal/verification/checkers/AtLeastXNumberOfInvocationsChecker.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.verification.checkers;
 
 import java.util.List;

--- a/src/main/java/org/mockito/internal/verification/checkers/MissingInvocationChecker.java
+++ b/src/main/java/org/mockito/internal/verification/checkers/MissingInvocationChecker.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.verification.checkers;
 
 import static org.mockito.internal.exceptions.Reporter.argumentsAreDifferent;

--- a/src/main/java/org/mockito/internal/verification/checkers/NumberOfInvocationsChecker.java
+++ b/src/main/java/org/mockito/internal/verification/checkers/NumberOfInvocationsChecker.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.verification.checkers;
 
 import java.util.Arrays;

--- a/src/main/java/org/mockito/invocation/InvocationOnMock.java
+++ b/src/main/java/org/mockito/invocation/InvocationOnMock.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.invocation;
 
 import java.io.Serializable;

--- a/src/main/java/org/mockito/mock/MockCreationSettings.java
+++ b/src/main/java/org/mockito/mock/MockCreationSettings.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.mock;
 
 import org.mockito.Incubating;

--- a/src/main/java/org/mockito/plugins/InlineMockMaker.java
+++ b/src/main/java/org/mockito/plugins/InlineMockMaker.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2019 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.plugins;
 
 import org.mockito.Incubating;

--- a/src/main/java/org/mockito/stubbing/ValidableAnswer.java
+++ b/src/main/java/org/mockito/stubbing/ValidableAnswer.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.stubbing;
 
 import org.mockito.Incubating;

--- a/src/main/java/org/mockito/verification/VerificationAfterDelay.java
+++ b/src/main/java/org/mockito/verification/VerificationAfterDelay.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.verification;
 
 import org.mockito.Mockito;

--- a/src/main/java/org/mockito/verification/VerificationMode.java
+++ b/src/main/java/org/mockito/verification/VerificationMode.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.verification;
 
 import org.mockito.Mockito;

--- a/src/main/java/org/mockito/verification/VerificationWithTimeout.java
+++ b/src/main/java/org/mockito/verification/VerificationWithTimeout.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.verification;
 
 import org.mockito.Mockito;

--- a/src/test/java/org/concurrentmockito/ThreadVerifiesContinuouslyInteractingMockTest.java
+++ b/src/test/java/org/concurrentmockito/ThreadVerifiesContinuouslyInteractingMockTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.concurrentmockito;
 
 import org.junit.Test;

--- a/src/test/java/org/concurrentmockito/ThreadsShareAMockTest.java
+++ b/src/test/java/org/concurrentmockito/ThreadsShareAMockTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.concurrentmockito;
 
 import org.junit.Test;

--- a/src/test/java/org/concurrentmockito/ThreadsShareGenerouslyStubbedMockTest.java
+++ b/src/test/java/org/concurrentmockito/ThreadsShareGenerouslyStubbedMockTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.concurrentmockito;
 
 import org.junit.Test;

--- a/src/test/java/org/concurrentmockito/VerificationInOrderFromMultipleThreadsTest.java
+++ b/src/test/java/org/concurrentmockito/VerificationInOrderFromMultipleThreadsTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.concurrentmockito;
 
 import org.junit.Test;

--- a/src/test/java/org/mockito/InvocationFactoryTest.java
+++ b/src/test/java/org/mockito/InvocationFactoryTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2018 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito;
 
 import org.junit.Test;

--- a/src/test/java/org/mockito/MockitoTest.java
+++ b/src/test/java/org/mockito/MockitoTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/org/mockito/StateMaster.java
+++ b/src/test/java/org/mockito/StateMaster.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito;
 
 import org.mockito.listeners.MockitoListener;

--- a/src/test/java/org/mockito/exceptions/base/MockitoAssertionErrorTest.java
+++ b/src/test/java/org/mockito/exceptions/base/MockitoAssertionErrorTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.exceptions.base;
 
 import org.junit.Test;

--- a/src/test/java/org/mockito/exceptions/base/MockitoExceptionTest.java
+++ b/src/test/java/org/mockito/exceptions/base/MockitoExceptionTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.exceptions.base;
 
 import org.junit.Test;

--- a/src/test/java/org/mockito/exceptions/base/MockitoSerializationIssueTest.java
+++ b/src/test/java/org/mockito/exceptions/base/MockitoSerializationIssueTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.exceptions.base;
 
 import org.junit.Test;

--- a/src/test/java/org/mockito/exceptions/base/StackTraceBuilder.java
+++ b/src/test/java/org/mockito/exceptions/base/StackTraceBuilder.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.exceptions.base;
 
 import java.util.Arrays;

--- a/src/test/java/org/mockito/exceptions/base/TraceBuilder.java
+++ b/src/test/java/org/mockito/exceptions/base/TraceBuilder.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.exceptions.base;
 
 import java.util.Collections;

--- a/src/test/java/org/mockito/internal/AllInvocationsFinderTest.java
+++ b/src/test/java/org/mockito/internal/AllInvocationsFinderTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal;
 
 import org.junit.Before;

--- a/src/test/java/org/mockito/internal/InvalidStateDetectionTest.java
+++ b/src/test/java/org/mockito/internal/InvalidStateDetectionTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal;
 
 import org.junit.After;

--- a/src/test/java/org/mockito/internal/configuration/MockInjectionTest.java
+++ b/src/test/java/org/mockito/internal/configuration/MockInjectionTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.configuration;
 
 import org.junit.After;

--- a/src/test/java/org/mockito/internal/configuration/injection/ConstructorInjectionTest.java
+++ b/src/test/java/org/mockito/internal/configuration/injection/ConstructorInjectionTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.configuration.injection;
 
 import org.junit.Before;

--- a/src/test/java/org/mockito/internal/configuration/injection/SimpleArgumentResolverTest.java
+++ b/src/test/java/org/mockito/internal/configuration/injection/SimpleArgumentResolverTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.configuration.injection;
 
 import org.junit.Test;

--- a/src/test/java/org/mockito/internal/exceptions/ReporterTest.java
+++ b/src/test/java/org/mockito/internal/exceptions/ReporterTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.exceptions;
 
 import org.junit.Test;

--- a/src/test/java/org/mockito/internal/exceptions/stacktrace/StackTraceFilterTest.java
+++ b/src/test/java/org/mockito/internal/exceptions/stacktrace/StackTraceFilterTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.exceptions.stacktrace;
 
 import org.assertj.core.api.Assertions;

--- a/src/test/java/org/mockito/internal/handler/MockHandlerImplTest.java
+++ b/src/test/java/org/mockito/internal/handler/MockHandlerImplTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.handler;
 
 import org.junit.Test;

--- a/src/test/java/org/mockito/internal/invocation/InvocationBuilder.java
+++ b/src/test/java/org/mockito/internal/invocation/InvocationBuilder.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.invocation;
 
 import org.mockito.Mockito;

--- a/src/test/java/org/mockito/internal/invocation/InvocationMatcherTest.java
+++ b/src/test/java/org/mockito/internal/invocation/InvocationMatcherTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.invocation;
 
 import static java.util.Arrays.asList;

--- a/src/test/java/org/mockito/internal/invocation/InvocationsFinderTest.java
+++ b/src/test/java/org/mockito/internal/invocation/InvocationsFinderTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.invocation;
 
 import org.assertj.core.api.Assertions;

--- a/src/test/java/org/mockito/internal/invocation/mockref/MockWeakReferenceTest.java
+++ b/src/test/java/org/mockito/internal/invocation/mockref/MockWeakReferenceTest.java
@@ -6,7 +6,6 @@ package org.mockito.internal.invocation.mockref;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
-import org.mockito.internal.invocation.mockref.MockWeakReference;
 import org.mockitoutil.TestBase;
 
 import static org.junit.Assert.fail;

--- a/src/test/java/org/mockito/internal/matchers/ComparableMatchersTest.java
+++ b/src/test/java/org/mockito/internal/matchers/ComparableMatchersTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.matchers;
 
 import org.junit.Test;

--- a/src/test/java/org/mockito/internal/matchers/EqualsTest.java
+++ b/src/test/java/org/mockito/internal/matchers/EqualsTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.matchers;
 
 import org.junit.Test;

--- a/src/test/java/org/mockito/internal/matchers/MatchersToStringTest.java
+++ b/src/test/java/org/mockito/internal/matchers/MatchersToStringTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.matchers;
 
 import java.util.regex.Pattern;

--- a/src/test/java/org/mockito/internal/matchers/apachecommons/EqualsBuilderTest.java
+++ b/src/test/java/org/mockito/internal/matchers/apachecommons/EqualsBuilderTest.java
@@ -2,8 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
-//Class comes from Apache Commons Lang, added some tiny changes
 package org.mockito.internal.matchers.apachecommons;
 
 import org.junit.Test;
@@ -14,6 +12,7 @@ import java.util.Arrays;
 
 import static org.junit.Assert.*;
 
+// Class comes from Apache Commons Lang, added some tiny changes
 /**
  * @author <a href="mailto:sdowney@panix.com">Steve Downey</a>
  * @author <a href="mailto:scolebourne@joda.org">Stephen Colebourne</a>

--- a/src/test/java/org/mockito/internal/progress/MockingProgressImplTest.java
+++ b/src/test/java/org/mockito/internal/progress/MockingProgressImplTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.progress;
 
 import org.assertj.core.api.Assertions;

--- a/src/test/java/org/mockito/internal/progress/TimesTest.java
+++ b/src/test/java/org/mockito/internal/progress/TimesTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.progress;
 
 import org.junit.Rule;

--- a/src/test/java/org/mockito/internal/progress/VerificationModeBuilder.java
+++ b/src/test/java/org/mockito/internal/progress/VerificationModeBuilder.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.progress;
 
 

--- a/src/test/java/org/mockito/internal/stubbing/InvocationContainerImplStubbingTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/InvocationContainerImplStubbingTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.stubbing;
 
 import org.junit.Before;

--- a/src/test/java/org/mockito/internal/stubbing/answers/AnswersWithDelayTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/answers/AnswersWithDelayTest.java
@@ -43,4 +43,3 @@ public class AnswersWithDelayTest {
         assertThat(timePassed).isCloseTo(sleepyTime, within(15L));
     }
 }
-

--- a/src/test/java/org/mockito/internal/stubbing/answers/CallsRealMethodsTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/answers/CallsRealMethodsTest.java
@@ -1,9 +1,4 @@
 /*
- * Copyright (c) 2017 Mockito contributors
- * This program is made available under the terms of the MIT License.
- */
-
-/*
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */

--- a/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValuesTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValuesTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.stubbing.defaultanswers;
 
 import org.junit.Assume;

--- a/src/test/java/org/mockito/internal/util/ChecksTest.java
+++ b/src/test/java/org/mockito/internal/util/ChecksTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2017 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.util;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mockito/internal/util/MockUtilTest.java
+++ b/src/test/java/org/mockito/internal/util/MockUtilTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.util;
 
 import org.assertj.core.api.Assertions;

--- a/src/test/java/org/mockito/internal/util/StringUtilTest.java
+++ b/src/test/java/org/mockito/internal/util/StringUtilTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.util;
 
 import org.junit.Test;

--- a/src/test/java/org/mockito/internal/util/collections/ListUtilTest.java
+++ b/src/test/java/org/mockito/internal/util/collections/ListUtilTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.util.collections;
 
 import org.assertj.core.api.Assertions;

--- a/src/test/java/org/mockito/internal/util/reflection/AccessibilityChangerTest.java
+++ b/src/test/java/org/mockito/internal/util/reflection/AccessibilityChangerTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.util.reflection;
 
 import org.junit.Test;

--- a/src/test/java/org/mockito/internal/util/reflection/ParameterizedConstructorInstantiatorTest.java
+++ b/src/test/java/org/mockito/internal/util/reflection/ParameterizedConstructorInstantiatorTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.util.reflection;
 
 

--- a/src/test/java/org/mockito/internal/verification/DefaultRegisteredInvocationsTest.java
+++ b/src/test/java/org/mockito/internal/verification/DefaultRegisteredInvocationsTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.verification;
 
 import org.junit.Before;

--- a/src/test/java/org/mockito/internal/verification/checkers/MissingInvocationCheckerTest.java
+++ b/src/test/java/org/mockito/internal/verification/checkers/MissingInvocationCheckerTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.verification.checkers;
 
 import org.junit.Rule;

--- a/src/test/java/org/mockito/internal/verification/checkers/MissingInvocationInOrderCheckerTest.java
+++ b/src/test/java/org/mockito/internal/verification/checkers/MissingInvocationInOrderCheckerTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.verification.checkers;
 
 import org.junit.Before;

--- a/src/test/java/org/mockito/internal/verification/checkers/NumberOfInvocationsCheckerTest.java
+++ b/src/test/java/org/mockito/internal/verification/checkers/NumberOfInvocationsCheckerTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.verification.checkers;
 
 import java.util.List;

--- a/src/test/java/org/mockito/internal/verification/checkers/NumberOfInvocationsInOrderCheckerTest.java
+++ b/src/test/java/org/mockito/internal/verification/checkers/NumberOfInvocationsInOrderCheckerTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockito.internal.verification.checkers;
 
 import java.util.List;

--- a/src/test/java/org/mockitousage/PlaygroundTest.java
+++ b/src/test/java/org/mockitousage/PlaygroundTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/PlaygroundWithDemoOfUnclonedParametersProblemTest.java
+++ b/src/test/java/org/mockitousage/PlaygroundWithDemoOfUnclonedParametersProblemTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage;
 
 import org.junit.Before;

--- a/src/test/java/org/mockitousage/annotation/AnnotationsTest.java
+++ b/src/test/java/org/mockitousage/annotation/AnnotationsTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.annotation;
 
 import org.junit.Before;

--- a/src/test/java/org/mockitousage/annotation/CaptorAnnotationBasicTest.java
+++ b/src/test/java/org/mockitousage/annotation/CaptorAnnotationBasicTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.annotation;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/annotation/CaptorAnnotationTest.java
+++ b/src/test/java/org/mockitousage/annotation/CaptorAnnotationTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.annotation;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/annotation/CaptorAnnotationUnhappyPathTest.java
+++ b/src/test/java/org/mockitousage/annotation/CaptorAnnotationUnhappyPathTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.annotation;
 
 import org.junit.Before;

--- a/src/test/java/org/mockitousage/annotation/DeprecatedAnnotationEngineApiTest.java
+++ b/src/test/java/org/mockitousage/annotation/DeprecatedAnnotationEngineApiTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.annotation;
 
 import org.junit.After;

--- a/src/test/java/org/mockitousage/annotation/MockInjectionUsingConstructorIssue421Test.java
+++ b/src/test/java/org/mockitousage/annotation/MockInjectionUsingConstructorIssue421Test.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.annotation;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/annotation/MockInjectionUsingConstructorTest.java
+++ b/src/test/java/org/mockitousage/annotation/MockInjectionUsingConstructorTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.annotation;
 
 import org.junit.Before;

--- a/src/test/java/org/mockitousage/basicapi/MockingMultipleInterfacesTest.java
+++ b/src/test/java/org/mockitousage/basicapi/MockingMultipleInterfacesTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.basicapi;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/basicapi/MocksCreationTest.java
+++ b/src/test/java/org/mockitousage/basicapi/MocksCreationTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.basicapi;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/basicapi/MocksSerializationForAnnotationTest.java
+++ b/src/test/java/org/mockitousage/basicapi/MocksSerializationForAnnotationTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.basicapi;
 
 import org.assertj.core.api.Assertions;

--- a/src/test/java/org/mockitousage/basicapi/MocksSerializationTest.java
+++ b/src/test/java/org/mockitousage/basicapi/MocksSerializationTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.basicapi;
 
 import net.bytebuddy.ClassFileVersion;

--- a/src/test/java/org/mockitousage/basicapi/ObjectsSerializationTest.java
+++ b/src/test/java/org/mockitousage/basicapi/ObjectsSerializationTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.basicapi;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/basicapi/ReplacingObjectMethodsTest.java
+++ b/src/test/java/org/mockitousage/basicapi/ReplacingObjectMethodsTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.basicapi;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/org/mockitousage/basicapi/UsingVarargsTest.java
+++ b/src/test/java/org/mockitousage/basicapi/UsingVarargsTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.basicapi;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/bugs/AIOOBExceptionWithAtLeastTest.java
+++ b/src/test/java/org/mockitousage/bugs/AIOOBExceptionWithAtLeastTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.bugs;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/bugs/ActualInvocationHasNullArgumentNPEBugTest.java
+++ b/src/test/java/org/mockitousage/bugs/ActualInvocationHasNullArgumentNPEBugTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.bugs;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/bugs/BridgeMethodsHitAgainTest.java
+++ b/src/test/java/org/mockitousage/bugs/BridgeMethodsHitAgainTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.bugs;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/bugs/CaptorAnnotationAutoboxingTest.java
+++ b/src/test/java/org/mockitousage/bugs/CaptorAnnotationAutoboxingTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.bugs;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/bugs/CovariantOverrideTest.java
+++ b/src/test/java/org/mockitousage/bugs/CovariantOverrideTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.bugs;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/bugs/InheritedGenericsPolimorphicCallTest.java
+++ b/src/test/java/org/mockitousage/bugs/InheritedGenericsPolimorphicCallTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.bugs;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/bugs/MockitoRunnerBreaksWhenNoTestMethodsTest.java
+++ b/src/test/java/org/mockitousage/bugs/MockitoRunnerBreaksWhenNoTestMethodsTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.bugs;
 
 import java.io.OutputStream;

--- a/src/test/java/org/mockitousage/bugs/NPEOnAnyClassMatcherAutounboxTest.java
+++ b/src/test/java/org/mockitousage/bugs/NPEOnAnyClassMatcherAutounboxTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.bugs;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/bugs/NPEWhenMockingThrowablesTest.java
+++ b/src/test/java/org/mockitousage/bugs/NPEWhenMockingThrowablesTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.bugs;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/bugs/ShouldMocksCompareToBeConsistentWithEqualsTest.java
+++ b/src/test/java/org/mockitousage/bugs/ShouldMocksCompareToBeConsistentWithEqualsTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.bugs;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/bugs/ShouldNotDeadlockAnswerExecutionTest.java
+++ b/src/test/java/org/mockitousage/bugs/ShouldNotDeadlockAnswerExecutionTest.java
@@ -115,4 +115,3 @@ public class ShouldNotDeadlockAnswerExecutionTest {
     }
 
 }
-

--- a/src/test/java/org/mockitousage/bugs/ShouldOnlyModeAllowCapturingArgumentsTest.java
+++ b/src/test/java/org/mockitousage/bugs/ShouldOnlyModeAllowCapturingArgumentsTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.bugs;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/bugs/SpyShouldHaveNiceNameTest.java
+++ b/src/test/java/org/mockitousage/bugs/SpyShouldHaveNiceNameTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.bugs;
 
 import org.assertj.core.api.Assertions;

--- a/src/test/java/org/mockitousage/bugs/StubbingMocksThatAreConfiguredToReturnMocksTest.java
+++ b/src/test/java/org/mockitousage/bugs/StubbingMocksThatAreConfiguredToReturnMocksTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.bugs;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/bugs/VerifyingWithAnExtraCallToADifferentMockTest.java
+++ b/src/test/java/org/mockitousage/bugs/VerifyingWithAnExtraCallToADifferentMockTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.bugs;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/bugs/creation/ShouldAllowInlineMockCreationTest.java
+++ b/src/test/java/org/mockitousage/bugs/creation/ShouldAllowInlineMockCreationTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.bugs.creation;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/bugs/injection/ShouldNotTryToInjectInFinalOrStaticFieldsTest.java
+++ b/src/test/java/org/mockitousage/bugs/injection/ShouldNotTryToInjectInFinalOrStaticFieldsTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.bugs.injection;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/bugs/varargs/VarargsAndAnyObjectPicksUpExtraInvocationsTest.java
+++ b/src/test/java/org/mockitousage/bugs/varargs/VarargsAndAnyObjectPicksUpExtraInvocationsTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.bugs.varargs;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/bugs/varargs/VarargsErrorWhenCallingRealMethodTest.java
+++ b/src/test/java/org/mockitousage/bugs/varargs/VarargsErrorWhenCallingRealMethodTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.bugs.varargs;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/bugs/varargs/VarargsNotPlayingWithAnyObjectTest.java
+++ b/src/test/java/org/mockitousage/bugs/varargs/VarargsNotPlayingWithAnyObjectTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.bugs.varargs;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/examples/use/Article.java
+++ b/src/test/java/org/mockitousage/examples/use/Article.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.examples.use;
 
 public class Article {

--- a/src/test/java/org/mockitousage/examples/use/ArticleCalculator.java
+++ b/src/test/java/org/mockitousage/examples/use/ArticleCalculator.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.examples.use;
 
 public interface ArticleCalculator {

--- a/src/test/java/org/mockitousage/examples/use/ArticleDatabase.java
+++ b/src/test/java/org/mockitousage/examples/use/ArticleDatabase.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.examples.use;
 
 import java.util.List;

--- a/src/test/java/org/mockitousage/examples/use/ArticleManager.java
+++ b/src/test/java/org/mockitousage/examples/use/ArticleManager.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.examples.use;
 
 import java.util.List;

--- a/src/test/java/org/mockitousage/examples/use/ExampleTest.java
+++ b/src/test/java/org/mockitousage/examples/use/ExampleTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.examples.use;
 
 import org.junit.Rule;

--- a/src/test/java/org/mockitousage/matchers/CapturingArgumentsTest.java
+++ b/src/test/java/org/mockitousage/matchers/CapturingArgumentsTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.matchers;
 
 import org.assertj.core.api.Assertions;

--- a/src/test/java/org/mockitousage/matchers/CustomMatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/CustomMatchersTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.matchers;
 
 import org.junit.Before;

--- a/src/test/java/org/mockitousage/matchers/GenericMatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/GenericMatchersTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.matchers;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/matchers/HamcrestMatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/HamcrestMatchersTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.matchers;
 
 import org.hamcrest.BaseMatcher;

--- a/src/test/java/org/mockitousage/matchers/InvalidUseOfMatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/InvalidUseOfMatchersTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.matchers;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/matchers/MatchersMixedWithRawArgumentsTest.java
+++ b/src/test/java/org/mockitousage/matchers/MatchersMixedWithRawArgumentsTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.matchers;
 
 import org.junit.Ignore;

--- a/src/test/java/org/mockitousage/matchers/MatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/MatchersTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.matchers;
 
 import java.math.BigDecimal;

--- a/src/test/java/org/mockitousage/matchers/MoreMatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/MoreMatchersTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.matchers;
 
 import org.assertj.core.api.ThrowableAssert;

--- a/src/test/java/org/mockitousage/matchers/ReflectionMatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/ReflectionMatchersTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.matchers;
 
 import org.junit.Before;

--- a/src/test/java/org/mockitousage/matchers/VerificationAndStubbingUsingMatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/VerificationAndStubbingUsingMatchersTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.matchers;
 
 import org.junit.Before;

--- a/src/test/java/org/mockitousage/misuse/DescriptiveMessagesOnMisuseTest.java
+++ b/src/test/java/org/mockitousage/misuse/DescriptiveMessagesOnMisuseTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.misuse;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/misuse/ExplicitFrameworkValidationTest.java
+++ b/src/test/java/org/mockitousage/misuse/ExplicitFrameworkValidationTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.misuse;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/misuse/InvalidUsageTest.java
+++ b/src/test/java/org/mockitousage/misuse/InvalidUsageTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.misuse;
 
 import org.junit.After;

--- a/src/test/java/org/mockitousage/misuse/RestrictedObjectMethodsTest.java
+++ b/src/test/java/org/mockitousage/misuse/RestrictedObjectMethodsTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.misuse;
 
 import org.junit.After;

--- a/src/test/java/org/mockitousage/packageprotected/MockingPackageProtectedTest.java
+++ b/src/test/java/org/mockitousage/packageprotected/MockingPackageProtectedTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.packageprotected;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/performance/LoadsOfMocksTest.java
+++ b/src/test/java/org/mockitousage/performance/LoadsOfMocksTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.performance;
 
 import org.junit.Ignore;

--- a/src/test/java/org/mockitousage/puzzlers/BridgeMethodPuzzleTest.java
+++ b/src/test/java/org/mockitousage/puzzlers/BridgeMethodPuzzleTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.puzzlers;
 
 import org.assertj.core.api.Assertions;

--- a/src/test/java/org/mockitousage/serialization/ParallelSerializationTest.java
+++ b/src/test/java/org/mockitousage/serialization/ParallelSerializationTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.serialization;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/spies/PartialMockingWithSpiesTest.java
+++ b/src/test/java/org/mockitousage/spies/PartialMockingWithSpiesTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.spies;
 
 import org.assertj.core.api.Assertions;

--- a/src/test/java/org/mockitousage/spies/SpyingOnInterfacesTest.java
+++ b/src/test/java/org/mockitousage/spies/SpyingOnInterfacesTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.spies;
 
 import net.bytebuddy.ByteBuddy;

--- a/src/test/java/org/mockitousage/spies/SpyingOnRealObjectsTest.java
+++ b/src/test/java/org/mockitousage/spies/SpyingOnRealObjectsTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.spies;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/stacktrace/ClickableStackTracesTest.java
+++ b/src/test/java/org/mockitousage/stacktrace/ClickableStackTracesTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.stacktrace;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/stacktrace/ClickableStackTracesWhenFrameworkMisusedTest.java
+++ b/src/test/java/org/mockitousage/stacktrace/ClickableStackTracesWhenFrameworkMisusedTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.stacktrace;
 
 import org.junit.After;

--- a/src/test/java/org/mockitousage/stacktrace/ModellingDescriptiveMessagesTest.java
+++ b/src/test/java/org/mockitousage/stacktrace/ModellingDescriptiveMessagesTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.stacktrace;
 
 import org.junit.Before;

--- a/src/test/java/org/mockitousage/stacktrace/PointingStackTraceToActualInvocationChunkInOrderTest.java
+++ b/src/test/java/org/mockitousage/stacktrace/PointingStackTraceToActualInvocationChunkInOrderTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.stacktrace;
 
 import org.junit.Before;

--- a/src/test/java/org/mockitousage/stacktrace/PointingStackTraceToActualInvocationInOrderTest.java
+++ b/src/test/java/org/mockitousage/stacktrace/PointingStackTraceToActualInvocationInOrderTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.stacktrace;
 
 import org.junit.Before;

--- a/src/test/java/org/mockitousage/stacktrace/PointingStackTraceToActualInvocationTest.java
+++ b/src/test/java/org/mockitousage/stacktrace/PointingStackTraceToActualInvocationTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.stacktrace;
 
 import org.junit.Before;

--- a/src/test/java/org/mockitousage/stacktrace/StackTraceFilteringTest.java
+++ b/src/test/java/org/mockitousage/stacktrace/StackTraceFilteringTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.stacktrace;
 
 import org.assertj.core.api.Assertions;

--- a/src/test/java/org/mockitousage/strictness/LenientMockAnnotationTest.java
+++ b/src/test/java/org/mockitousage/strictness/LenientMockAnnotationTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.strictness;
 
 import org.assertj.core.api.Assertions;

--- a/src/test/java/org/mockitousage/strictness/PotentialStubbingSensitivityTest.java
+++ b/src/test/java/org/mockitousage/strictness/PotentialStubbingSensitivityTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.strictness;
 
 import org.assertj.core.api.Assertions;

--- a/src/test/java/org/mockitousage/strictness/ProductionCode.java
+++ b/src/test/java/org/mockitousage/strictness/ProductionCode.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.strictness;
 
 import org.mockitousage.IMethods;

--- a/src/test/java/org/mockitousage/strictness/StrictnessPerMockTest.java
+++ b/src/test/java/org/mockitousage/strictness/StrictnessPerMockTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.strictness;
 
 import org.assertj.core.api.Assertions;

--- a/src/test/java/org/mockitousage/strictness/StrictnessPerStubbingTest.java
+++ b/src/test/java/org/mockitousage/strictness/StrictnessPerStubbingTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.strictness;
 
 import org.assertj.core.api.ThrowableAssert;

--- a/src/test/java/org/mockitousage/strictness/StrictnessPerStubbingWithRunnerTest.java
+++ b/src/test/java/org/mockitousage/strictness/StrictnessPerStubbingWithRunnerTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.strictness;
 
 import org.assertj.core.api.ThrowableAssert;

--- a/src/test/java/org/mockitousage/strictness/StrictnessWhenRuleStrictnessIsUpdatedTest.java
+++ b/src/test/java/org/mockitousage/strictness/StrictnessWhenRuleStrictnessIsUpdatedTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.strictness;
 
 import org.assertj.core.api.ThrowableAssert;

--- a/src/test/java/org/mockitousage/strictness/StrictnessWithRulesTest.java
+++ b/src/test/java/org/mockitousage/strictness/StrictnessWithRulesTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.strictness;
 
 import org.assertj.core.api.ThrowableAssert;

--- a/src/test/java/org/mockitousage/stubbing/BasicStubbingTest.java
+++ b/src/test/java/org/mockitousage/stubbing/BasicStubbingTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.stubbing;
 
 import org.junit.Before;

--- a/src/test/java/org/mockitousage/stubbing/CloningParameterTest.java
+++ b/src/test/java/org/mockitousage/stubbing/CloningParameterTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.stubbing;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/stubbing/ReturningDefaultValuesTest.java
+++ b/src/test/java/org/mockitousage/stubbing/ReturningDefaultValuesTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.stubbing;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/stubbing/SmartNullsStubbingTest.java
+++ b/src/test/java/org/mockitousage/stubbing/SmartNullsStubbingTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.stubbing;
 
 import org.junit.Before;

--- a/src/test/java/org/mockitousage/stubbing/StubbingConsecutiveAnswersTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingConsecutiveAnswersTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.stubbing;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/stubbing/StubbingUsingDoReturnTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingUsingDoReturnTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.stubbing;
 
 import org.assertj.core.api.Assertions;

--- a/src/test/java/org/mockitousage/stubbing/StubbingWithExtraAnswersTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingWithExtraAnswersTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.stubbing;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/stubbing/StubbingWithThrowablesTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingWithThrowablesTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.stubbing;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mockitousage/verification/AtLeastXVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/AtLeastXVerificationTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.verification;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/verification/AtMostXVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/AtMostXVerificationTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.verification;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/verification/BasicVerificationInOrderTest.java
+++ b/src/test/java/org/mockitousage/verification/BasicVerificationInOrderTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.verification;
 
 import org.junit.Before;

--- a/src/test/java/org/mockitousage/verification/BasicVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/BasicVerificationTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.verification;
 
 import org.assertj.core.api.ThrowableAssert;

--- a/src/test/java/org/mockitousage/verification/DescriptiveMessagesOnVerificationInOrderErrorsTest.java
+++ b/src/test/java/org/mockitousage/verification/DescriptiveMessagesOnVerificationInOrderErrorsTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.verification;
 
 import org.junit.Before;

--- a/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenTimesXVerificationFailsTest.java
+++ b/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenTimesXVerificationFailsTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.verification;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
+++ b/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.verification;
 
 import org.junit.Before;

--- a/src/test/java/org/mockitousage/verification/ExactNumberOfTimesVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/ExactNumberOfTimesVerificationTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.verification;
 
 import org.junit.Before;

--- a/src/test/java/org/mockitousage/verification/FindingRedundantInvocationsInOrderTest.java
+++ b/src/test/java/org/mockitousage/verification/FindingRedundantInvocationsInOrderTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.verification;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/verification/NoMoreInteractionsVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/NoMoreInteractionsVerificationTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.verification;
 
 import org.junit.Before;

--- a/src/test/java/org/mockitousage/verification/OnlyVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/OnlyVerificationTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.verification;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/verification/OrdinaryVerificationPrintsAllInteractionsTest.java
+++ b/src/test/java/org/mockitousage/verification/OrdinaryVerificationPrintsAllInteractionsTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.verification;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/verification/PrintingVerboseTypesWithArgumentsTest.java
+++ b/src/test/java/org/mockitousage/verification/PrintingVerboseTypesWithArgumentsTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.verification;
 
 import org.assertj.core.api.Assertions;

--- a/src/test/java/org/mockitousage/verification/RelaxedVerificationInOrderTest.java
+++ b/src/test/java/org/mockitousage/verification/RelaxedVerificationInOrderTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.verification;
 
 import org.junit.Before;

--- a/src/test/java/org/mockitousage/verification/SelectedMocksInOrderVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/SelectedMocksInOrderVerificationTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.verification;
 
 import org.junit.Before;

--- a/src/test/java/org/mockitousage/verification/VerificationExcludingStubsTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationExcludingStubsTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.verification;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/verification/VerificationInOrderMixedWithOrdiraryVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationInOrderMixedWithOrdiraryVerificationTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.verification;
 
 import org.junit.Before;

--- a/src/test/java/org/mockitousage/verification/VerificationInOrderTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationInOrderTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.verification;
 
 import org.junit.Before;

--- a/src/test/java/org/mockitousage/verification/VerificationInOrderWithTimeoutTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationInOrderWithTimeoutTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.verification;
 
 import org.assertj.core.api.Assertions;

--- a/src/test/java/org/mockitousage/verification/VerificationOnMultipleMocksUsingMatchersTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationOnMultipleMocksUsingMatchersTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.verification;
 
 import org.junit.Test;

--- a/src/test/java/org/mockitousage/verification/VerificationUsingMatchersTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationUsingMatchersTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.verification;
 
 import org.junit.Before;

--- a/src/test/java/org/mockitousage/verification/VerificationWithAfterAndCaptorTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationWithAfterAndCaptorTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.verification;
 
 import org.junit.Ignore;

--- a/src/test/java/org/mockitousage/verification/VerificationWithAfterTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationWithAfterTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.verification;
 
 import org.assertj.core.api.Assertions;

--- a/src/test/java/org/mockitousage/verification/VerificationWithTimeoutTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationWithTimeoutTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.verification;
 
 import org.assertj.core.api.Assertions;

--- a/src/test/java/org/mockitoutil/Conditions.java
+++ b/src/test/java/org/mockitoutil/Conditions.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitoutil;
 
 import org.assertj.core.api.Assertions;

--- a/src/test/java/org/mockitoutil/TestBase.java
+++ b/src/test/java/org/mockitoutil/TestBase.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitoutil;
 
 import org.assertj.core.api.Condition;

--- a/subprojects/deprecatedPluginsTest/src/test/java/org/mockitousage/plugins/DeprecatedInstantiatorProviderTest.java
+++ b/subprojects/deprecatedPluginsTest/src/test/java/org/mockitousage/plugins/DeprecatedInstantiatorProviderTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2018 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.plugins;
 
 import org.junit.Test;

--- a/subprojects/extTest/src/test/java/org/mockitousage/plugins/stacktrace/PluginStackTraceFilteringTest.java
+++ b/subprojects/extTest/src/test/java/org/mockitousage/plugins/stacktrace/PluginStackTraceFilteringTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.plugins.stacktrace;
 
 import org.junit.After;

--- a/subprojects/extTest/src/test/java/org/mockitousage/plugins/switcher/PluginSwitchTest.java
+++ b/subprojects/extTest/src/test/java/org/mockitousage/plugins/switcher/PluginSwitchTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitousage.plugins.switcher;
 
 import org.junit.Test;

--- a/subprojects/inline/src/test/java/org/mockitoinline/bugs/CyclicMockMethodArgumentMemoryLeakTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/bugs/CyclicMockMethodArgumentMemoryLeakTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2019 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitoinline.bugs;
 
 import org.junit.Test;

--- a/subprojects/inline/src/test/java/org/mockitoinline/bugs/SelfSpyReferenceMemoryLeakTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/bugs/SelfSpyReferenceMemoryLeakTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2019 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-
 package org.mockitoinline.bugs;
 
 import org.junit.Test;


### PR DESCRIPTION
Spotless [1] has been used by various popular open source projects,
including JUnit [2]. While working on Mockito inside of Google, I
discovered that our formatting is inconsistent. We can use Spotless to
automatically take care of that.

To be able to format the source code, run

./gradlew spotlessApply

This check runs on Travis to make sure code remains formatted. This
should also reduce the amount of trouble with the CheckStyle linter, as
Spotless will automatically resolve these issues.

On purpose, the spotless configuration is quite minimal. The current
configuration is mostly a reflection on the current state of affairs. We
can later discuss different configuration options and how we can
integrate them.

[1]: https://github.com/diffplug/spotless/tree/master/plugin-gradle
[2]: https://github.com/junit-team/junit5/blob/3f491f3148d2c745808fc75b0a802b60243e104e/build.gradle.kts#L124-L144