### PR TITLE
Delete dummy-commit.txt

### DIFF
--- a/dummy-commit.txt
+++ b/dummy-commit.txt
@@ -1,1 +1,0 @@
-Change this if you need a dummy commit. Push build.


### PR DESCRIPTION
The `--allow-empty` option of `git commit` allows one to create dummy commits without any code change.

Moreover, this file was last modified 3 years ago and therefore might be a good candidate for removal.