### PR TITLE
Fixes placeholder `3.x.x` version in javadoc with correct `3.0.1`

### DIFF
--- a/src/main/java/org/mockito/BDDMockito.java
+++ b/src/main/java/org/mockito/BDDMockito.java
@@ -251,7 +251,7 @@ public class BDDMockito extends Mockito {
         /**
          * @see #verifyZeroInteractions(Object...)
          * @since 2.1.0
-         * @deprecated Since 3.x.x. Please migrate your code to {@link #shouldHaveNoInteractions()}
+         * @deprecated Since 3.0.1. Please migrate your code to {@link #shouldHaveNoInteractions()}
          */
         @Deprecated
         void shouldHaveZeroInteractions();
@@ -264,7 +264,7 @@ public class BDDMockito extends Mockito {
 
         /**
          * @see #verifyNoInteractions(Object...)
-         * @since 3.x.x
+         * @since 3.0.1
          */
         void shouldHaveNoInteractions();
     }
@@ -327,7 +327,7 @@ public class BDDMockito extends Mockito {
 
         /**
          * @see #verifyNoInteractions(Object...)
-         * @since 3.x.x
+         * @since 3.0.1
          */
         public void shouldHaveNoInteractions() {
             verifyNoInteractions(mock);

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -2249,7 +2249,7 @@ public class Mockito extends ArgumentMatchers {
      * This method has the same behavior as {@link #verifyNoMoreInteractions(Object...)}.
      *
      * @param mocks to be verified
-     * @deprecated Since 3.x.x. Please migrate your code to {@link #verifyNoInteractions(Object...)}
+     * @deprecated Since 3.0.1. Please migrate your code to {@link #verifyNoInteractions(Object...)}
      */
     @Deprecated
     public static void verifyZeroInteractions(Object... mocks) {
@@ -2270,7 +2270,7 @@ public class Mockito extends ArgumentMatchers {
      * See examples in javadoc for {@link Mockito} class
      *
      * @param mocks to be verified
-     * @since 3.x.x
+     * @since 3.0.1
      */
     public static void verifyNoInteractions(Object... mocks) {
         MOCKITO_CORE.verifyNoInteractions(mocks);


### PR DESCRIPTION
This is a small javadoc fix

When I contributed with #1733, I didn't know which version of mockito will have included it, so I left a placeholder `3.x.x` in the javadoc. I then forgot to update the code once `3.0.1` was tagged.