### PR TITLE
Add default implementation for VerificationMode#description

### DIFF
--- a/src/main/java/org/mockito/internal/verification/AtLeast.java
+++ b/src/main/java/org/mockito/internal/verification/AtLeast.java
@@ -45,8 +45,4 @@ public class AtLeast implements VerificationInOrderMode, VerificationMode {
         return "Wanted invocations count: at least " + wantedCount;
     }
 
-    @Override
-    public VerificationMode description(String description) {
-        return VerificationModeFactory.description(this, description);
-    }
 }

--- a/src/main/java/org/mockito/internal/verification/AtMost.java
+++ b/src/main/java/org/mockito/internal/verification/AtMost.java
@@ -41,11 +41,6 @@ public class AtMost implements VerificationMode {
         markVerified(found, wanted);
     }
 
-    @Override
-    public VerificationMode description(String description) {
-        return VerificationModeFactory.description(this, description);
-    }
-
     private void removeAlreadyVerified(List<Invocation> invocations) {
         for (Iterator<Invocation> iterator = invocations.iterator(); iterator.hasNext(); ) {
             Invocation i = iterator.next();

--- a/src/main/java/org/mockito/internal/verification/Calls.java
+++ b/src/main/java/org/mockito/internal/verification/Calls.java
@@ -46,8 +46,4 @@ public class Calls implements VerificationMode, VerificationInOrderMode {
         return "Wanted invocations count (non-greedy): " + wantedCount;
     }
 
-    @Override
-    public VerificationMode description(String description) {
-        return VerificationModeFactory.description(this, description);
-    }
 }

--- a/src/main/java/org/mockito/internal/verification/Description.java
+++ b/src/main/java/org/mockito/internal/verification/Description.java
@@ -43,9 +43,4 @@ public class Description implements VerificationMode {
             throw new MockitoAssertionError(e, description);
         }
     }
-
-    @Override
-    public VerificationMode description(String description) {
-        return VerificationModeFactory.description(this, description);
-    }
 }

--- a/src/main/java/org/mockito/internal/verification/InOrderWrapper.java
+++ b/src/main/java/org/mockito/internal/verification/InOrderWrapper.java
@@ -29,9 +29,4 @@ public class InOrderWrapper implements VerificationMode {
         VerificationDataInOrderImpl dataInOrder = new VerificationDataInOrderImpl(inOrder, invocations, data.getTarget());
         mode.verifyInOrder(dataInOrder);
     }
-
-    @Override
-    public VerificationMode description(String description) {
-        return VerificationModeFactory.description(this, description);
-    }
 }

--- a/src/main/java/org/mockito/internal/verification/MockAwareVerificationMode.java
+++ b/src/main/java/org/mockito/internal/verification/MockAwareVerificationMode.java
@@ -46,7 +46,4 @@ public class MockAwareVerificationMode implements VerificationMode {
         return mock;
     }
 
-    public VerificationMode description(String description) {
-        return VerificationModeFactory.description(this, description);
-    }
 }

--- a/src/main/java/org/mockito/internal/verification/NoInteractions.java
+++ b/src/main/java/org/mockito/internal/verification/NoInteractions.java
@@ -22,9 +22,4 @@ public class NoInteractions implements VerificationMode {
         }
     }
 
-    @Override
-    public VerificationMode description(String description) {
-        return VerificationModeFactory.description(this, description);
-    }
-
 }

--- a/src/main/java/org/mockito/internal/verification/NoMoreInteractions.java
+++ b/src/main/java/org/mockito/internal/verification/NoMoreInteractions.java
@@ -35,9 +35,4 @@ public class NoMoreInteractions implements VerificationMode, VerificationInOrder
             throw noMoreInteractionsWantedInOrder(unverified);
         }
     }
-
-    @Override
-    public VerificationMode description(String description) {
-        return VerificationModeFactory.description(this, description);
-    }
 }

--- a/src/main/java/org/mockito/internal/verification/Only.java
+++ b/src/main/java/org/mockito/internal/verification/Only.java
@@ -33,8 +33,4 @@ public class Only implements VerificationMode {
         }
         markVerified(chunk.get(0), target);
     }
-
-    public VerificationMode description(String description) {
-        return VerificationModeFactory.description(this, description);
-    }
 }

--- a/src/main/java/org/mockito/internal/verification/VerificationOverTimeImpl.java
+++ b/src/main/java/org/mockito/internal/verification/VerificationOverTimeImpl.java
@@ -120,11 +120,6 @@ public class VerificationOverTimeImpl implements VerificationMode {
         }
     }
 
-    @Override
-    public VerificationMode description(String description) {
-        return VerificationModeFactory.description(this, description);
-    }
-
     public boolean isReturnOnSuccess() {
         return returnOnSuccess;
     }

--- a/src/main/java/org/mockito/internal/verification/VerificationWrapperInOrderWrapper.java
+++ b/src/main/java/org/mockito/internal/verification/VerificationWrapperInOrderWrapper.java
@@ -26,11 +26,6 @@ public class VerificationWrapperInOrderWrapper implements VerificationMode {
         delegate.verify(data);
     }
 
-    @Override
-    public VerificationMode description(String description) {
-        return VerificationModeFactory.description(this, description);
-    }
-
     private VerificationMode wrapInOrder(VerificationWrapper<?> verificationWrapper, VerificationMode verificationMode, InOrderImpl inOrder) {
         if (verificationMode instanceof VerificationInOrderMode) {
             final VerificationInOrderMode verificationInOrderMode = (VerificationInOrderMode)verificationMode;

--- a/src/main/java/org/mockito/verification/After.java
+++ b/src/main/java/org/mockito/verification/After.java
@@ -4,7 +4,6 @@
  */
 package org.mockito.verification;
 
-import org.mockito.internal.verification.VerificationModeFactory;
 import org.mockito.internal.verification.VerificationOverTimeImpl;
 import org.mockito.internal.verification.VerificationWrapper;
 
@@ -37,10 +36,5 @@ public class After extends VerificationWrapper<VerificationOverTimeImpl> impleme
     @Override
     protected VerificationMode copySelfWithNewVerificationMode(VerificationMode verificationMode) {
         return new After(wrappedVerification.copyWithVerificationMode(verificationMode));
-    }
-
-    @Override
-    public VerificationMode description(String description) {
-        return VerificationModeFactory.description(this, description);
     }
 }

--- a/src/main/java/org/mockito/verification/Timeout.java
+++ b/src/main/java/org/mockito/verification/Timeout.java
@@ -7,7 +7,6 @@ package org.mockito.verification;
 import static org.mockito.internal.exceptions.Reporter.atMostAndNeverShouldNotBeUsedWithTimeout;
 
 import org.mockito.internal.util.Timer;
-import org.mockito.internal.verification.VerificationModeFactory;
 import org.mockito.internal.verification.VerificationOverTimeImpl;
 import org.mockito.internal.verification.VerificationWrapper;
 
@@ -58,11 +57,6 @@ public class Timeout extends VerificationWrapper<VerificationOverTimeImpl> imple
 
     public VerificationMode never() {
         throw atMostAndNeverShouldNotBeUsedWithTimeout();
-    }
-
-    @Override
-    public VerificationMode description(String description) {
-        return VerificationModeFactory.description(this, description);
     }
 
 }

--- a/src/main/java/org/mockito/verification/VerificationMode.java
+++ b/src/main/java/org/mockito/verification/VerificationMode.java
@@ -5,6 +5,7 @@
 package org.mockito.verification;
 
 import org.mockito.Mockito;
+import org.mockito.internal.verification.VerificationModeFactory;
 import org.mockito.internal.verification.api.VerificationData;
 
 /**
@@ -41,5 +42,7 @@ public interface VerificationMode {
      * @return VerificationMode
      * @since 2.1.0
      */
-    VerificationMode description(String description);
+    default VerificationMode description(String description) {
+        return VerificationModeFactory.description(this, description);
+    }
 }


### PR DESCRIPTION
This method was added in Mockito 2 ([1]) and was implemented in all
relevant subclasses. However, most subclasses do not implement a custom
description.

Since we are now building on Java 8, we can ship this as a default
method and remove all duplicate subclass implementations. As a
side-effect, it allows users of Mockito 1 to migrate to Mockito 3
without additional breakages. (They could implement it, but
VerificationModeFactory is internal and would require additional
boilerplate)

[1]: https://github.com/mockito/mockito/pull/68