### PR TITLE
Revert "Fixes #1587 : Remove unnecessary loop from InjectingAnnotationEngine"

### DIFF
--- a/src/main/java/org/mockito/internal/configuration/InjectingAnnotationEngine.java
+++ b/src/main/java/org/mockito/internal/configuration/InjectingAnnotationEngine.java
@@ -39,7 +39,15 @@ public class InjectingAnnotationEngine implements AnnotationEngine, org.mockito.
      */
     public void process(Class<?> clazz, Object testInstance) {
         processIndependentAnnotations(testInstance.getClass(), testInstance);
-        injectMocks(testInstance);
+        processInjectMocks(testInstance.getClass(), testInstance);
+    }
+
+    private void processInjectMocks(final Class<?> clazz, final Object testInstance) {
+        Class<?> classContext = clazz;
+        while (classContext != Object.class) {
+            injectMocks(testInstance);
+            classContext = classContext.getSuperclass();
+        }
     }
 
     private void processIndependentAnnotations(final Class<?> clazz, final Object testInstance) {

--- a/src/test/java/org/mockito/internal/configuration/InjectingAnnotationEngineTest.java
+++ b/src/test/java/org/mockito/internal/configuration/InjectingAnnotationEngineTest.java
@@ -1,0 +1,51 @@
+package org.mockito.internal.configuration;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+class I { }
+
+@RunWith(MockitoJUnitRunner.class)
+public class InjectingAnnotationEngineTest extends I {
+    @InjectMocks
+    Target target;
+    @Mock
+    Foo foo;
+    @Spy
+    Bar bar = new Bar();
+
+    /*
+     If the test case has super classes, the @InjectMocks field has a field that not listed in the constructor argument
+     will fill by setter/property injection .
+
+     https://github.com/mockito/mockito/issues/1631
+    */
+    @Test
+    public void injectMocks() {
+        Assert.assertNotNull(target.bar);
+    }
+
+    public static class Target {
+        private final Foo foo;
+        private Bar bar;
+
+        public Target(Foo foo) {
+            this.foo = foo;
+        }
+
+        public Bar getBar() {
+            return bar;
+        }
+    }
+
+    public static class Foo {
+    }
+
+    public static class Bar {
+    }
+}

--- a/src/test/java/org/mockito/internal/configuration/InjectingAnnotationEngineTest.java
+++ b/src/test/java/org/mockito/internal/configuration/InjectingAnnotationEngineTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2019 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito.internal.configuration;
 
 import org.junit.Assert;
@@ -27,7 +31,8 @@ public class InjectingAnnotationEngineTest extends I {
     */
     @Test
     public void injectMocks() {
-        Assert.assertNotNull(target.bar);
+        Assert.assertEquals(foo, target.getFoo());
+        Assert.assertNotNull(target.getBar());
     }
 
     public static class Target {
@@ -36,6 +41,10 @@ public class InjectingAnnotationEngineTest extends I {
 
         public Target(Foo foo) {
             this.foo = foo;
+        }
+
+        public Foo getFoo() {
+            return foo;
         }
 
         public Bar getBar() {


### PR DESCRIPTION
Reverts mockito/mockito#1588
Related to #1631 

Here's a pseudo code to describe the issues around this issue.

# Before 2.23.15:	

```
while (clazz != Object.clazz) {
	val mocks = aggregateSpyOrMockFields(clazz.getMockFields());
  val fields = aggregateInjectMocksFields(clazz);
	val ret = tryConstructorInjection(clazz, fields, mock);
  if (! ret.fieldWasInitializedUsingConstructorInjection()) {
    trySetterOrPropertyInjection(clazz, fields, mock);
  }
	clazz = clazz.getSuperclass();
}
```
# After 2.23.15:
```
	val mocks = aggregateSpyOrMockFields(clazz.getMockFields());
  val fields = aggregateInjectMocksFields(clazz);
	val ret = tryConstructorInjection(clazz, fields, mock);
  if (! ret.fieldWasInitializedUsingConstructorInjection()) {
    trySetterOrPropertyInjection(clazz, fields, mock);
  }
```

# Details

Before 2.23.15, if the `@InjectMocks` field has a field that not listed in the constructor argument will fill by setter/property injection at the 2nd loop 😃
It may not the expected behaviors by Mockito authors, but some users' code depends on this behavior.

My suggestion is to revert the [Fixes #1587 : Remove unnecessary loop from InjectingAnnotationEngine by LihMeh · Pull Request #1588 · mockito/mockito · GitHub](https://github.com/mockito/mockito/pull/1588) at this time.
