### PR TITLE
Demonstrate problem with ArgumentMatchers and Kotlin (#1808)

### DIFF
--- a/subprojects/kotlinTest/src/test/kotlin/org/mockito/kotlin/ArgumentMatchersTest.kt
+++ b/subprojects/kotlinTest/src/test/kotlin/org/mockito/kotlin/ArgumentMatchersTest.kt
@@ -1,0 +1,30 @@
+package org.mockito.kotlin
+
+import org.hamcrest.core.IsEqual
+import org.junit.Assert.assertThat
+import org.junit.Test
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+
+class ArgumentMatchersTest {
+
+    @Test
+    fun `test argument matchers`() {
+        val mockDependency = mock(Dependency::class.java)
+        `when`(mockDependency.foo(ArgumentMatchers.any(InputArgument::class.java))).thenReturn("mocked response")
+
+        val target = Target(mockDependency)
+        assertThat(target.doSomething(), IsEqual("mocked response"))
+    }
+}
+
+class Target(val dependency: Dependency) {
+    fun doSomething() = dependency.foo(InputArgument("blah"))
+}
+
+class Dependency {
+    fun foo(input: InputArgument) = "do something with ${input.value}"
+}
+
+class InputArgument(val value: String)


### PR DESCRIPTION
An attempt to demonstrate a problem with ArgumentMatchers in Kotlin described in #1808 

As mentioned in the issue, I get a
```
java.lang.IllegalStateException: ArgumentMatchers.any(InputArgument::class.java) must not be null
```
And then an explanation that I'm using argument matching outside of stubbing/verification.

If I replace the argument type with a string and use ```anyString()``` instead of ```any(Class<T>)```, it works fine.

I might as well be missing something, any help would be greatly appreciated.