### PR TITLE
Fixes #1771: Upgrade byte-buddy to 1.10.2 (from 1.9.10)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -4,7 +4,7 @@ ext {
 
 def versions = [:]
 
-versions.bytebuddy = '1.9.10'
+versions.bytebuddy = '1.10.2'
 versions.junitJupiter = '5.4.2'
 versions.errorprone = '2.3.2'
 

--- a/src/test/java/org/mockitoutil/ClassLoaders.java
+++ b/src/test/java/org/mockitoutil/ClassLoaders.java
@@ -474,6 +474,11 @@ public abstract class ClassLoaders {
                     addFromFileBasedClassLoader(classes, uri);
                 } else if (uri.getScheme().equalsIgnoreCase(InMemoryClassLoader.SCHEME)) {
                     addFromInMemoryBasedClassLoader(classes, uri);
+                } else if (uri.getScheme().equalsIgnoreCase("jar")) {
+                    // Java 9+ returns "jar:file:" style urls for modules.
+                    // It's not a classes owned by mockito itself.
+                    // Just ignore it.
+                    continue;
                 } else {
                     throw new IllegalArgumentException(format("Given ClassLoader '%s' don't have reachable by File or vi ClassLoaders.inMemory", classLoader));
                 }


### PR DESCRIPTION
Release notes:
https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.10.2
https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.10.1
https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.10.0
https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.9.16
https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.9.15
https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.9.14
https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.9.13
https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.9.12
https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.9.11

Relevant commits:
raphw/byte-buddy@byte-buddy-1.9.10...byte-buddy-1.10.2