### PR TITLE
Indent with spaces using spotless

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,7 @@ spotless {
         removeUnusedImports()
         trimTrailingWhitespace()
         endWithNewline()
+        indentWithSpaces(4)
 
         importOrder 'static java', 'static javax', 'static ', 'java', 'javax', ''
     }

--- a/src/main/java/org/mockito/internal/configuration/injection/SpyOnInjectedFieldsHandler.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/SpyOnInjectedFieldsHandler.java
@@ -40,10 +40,10 @@ public class SpyOnInjectedFieldsHandler extends MockInjectionStrategy {
                     Mockito.reset(instance);
                 } else {
                     Object mock = Mockito.mock(instance.getClass(), withSettings()
-					    .spiedInstance(instance)
-					    .defaultAnswer(Mockito.CALLS_REAL_METHODS)
-					    .name(field.getName()));
-					setField(fieldOwner, field, mock);
+                        .spiedInstance(instance)
+                        .defaultAnswer(Mockito.CALLS_REAL_METHODS)
+                        .name(field.getName()));
+                    setField(fieldOwner, field, mock);
                 }
             } catch (Exception e) {
                 throw new MockitoException("Problems initiating spied field " + field.getName(), e);

--- a/src/main/java/org/mockito/internal/junit/JUnitRule.java
+++ b/src/main/java/org/mockito/internal/junit/JUnitRule.java
@@ -31,8 +31,8 @@ public class JUnitRule implements MockitoRule {
         this.strictness = strictness;
     }
 
-	@Override
-	public Statement apply(final Statement base, final FrameworkMethod method, final Object target) {
+    @Override
+    public Statement apply(final Statement base, final FrameworkMethod method, final Object target) {
         return new Statement() {
             public void evaluate() throws Throwable {
                 if (session == null) {

--- a/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java
@@ -25,7 +25,7 @@ import org.mockito.stubbing.VoidAnswer6;
  * @since 2.1.0
  */
 public class AnswerFunctionalInterfaces {
-	/**
+    /**
      * Hide constructor to avoid instantiation of class with only static methods
      */
     private AnswerFunctionalInterfaces() {

--- a/src/main/java/org/mockito/internal/util/MockUtil.java
+++ b/src/main/java/org/mockito/internal/util/MockUtil.java
@@ -89,7 +89,7 @@ public class MockUtil {
         MockName mockName = getMockName(mock);
         //TODO SF hacky...
         MockCreationSettings mockSettings = getMockHandler(mock).getMockSettings();
-		if (mockName.isDefault() && mockSettings instanceof CreationSettings) {
+        if (mockName.isDefault() && mockSettings instanceof CreationSettings) {
             ((CreationSettings) mockSettings).setMockName(new MockNameImpl(newName));
         }
     }

--- a/src/test/java/org/mockito/ArgumentCaptorTest.java
+++ b/src/test/java/org/mockito/ArgumentCaptorTest.java
@@ -13,24 +13,24 @@ import org.mockito.exceptions.misusing.InvalidUseOfMatchersException;
 
 public class ArgumentCaptorTest {
 
-	/**
-	 * Clean up the internal Mockito-Stubbing state
-	 */
-	@After
-	public void tearDown() {
-		try {
-			validateMockitoUsage();
-		} catch (InvalidUseOfMatchersException ignore) {
-		}
+    /**
+     * Clean up the internal Mockito-Stubbing state
+     */
+    @After
+    public void tearDown() {
+        try {
+            validateMockitoUsage();
+        } catch (InvalidUseOfMatchersException ignore) {
+        }
 
-	}
+    }
 
-	@Test
-	public void tell_handy_return_values_to_return_value_for() throws Exception {
+    @Test
+    public void tell_handy_return_values_to_return_value_for() throws Exception {
 
-		ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
-		assertThat(captor.capture()).isNull();
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        assertThat(captor.capture()).isNull();
 
-	}
+    }
 
 }

--- a/src/test/java/org/mockito/internal/InvalidStateDetectionTest.java
+++ b/src/test/java/org/mockito/internal/InvalidStateDetectionTest.java
@@ -152,7 +152,7 @@ public class InvalidStateDetectionTest extends TestBase {
         doThrow(new RuntimeException()).when(mock);
 
         try {
-        	doThrow(new RuntimeException()).when(mock).oneArg(true);
+            doThrow(new RuntimeException()).when(mock).oneArg(true);
             fail();
         } catch (UnfinishedStubbingException e) {}
 

--- a/src/test/java/org/mockito/internal/handler/MockHandlerFactoryTest.java
+++ b/src/test/java/org/mockito/internal/handler/MockHandlerFactoryTest.java
@@ -30,7 +30,7 @@ public class MockHandlerFactoryTest extends TestBase {
     public void handle_result_must_not_be_null_for_primitives() throws Throwable {
         //given:
         MockCreationSettings<?> settings = (MockCreationSettings<?>) new MockSettingsImpl().defaultAnswer(new Returns(null));
-		MockHandler<?> handler = createMockHandler(settings);
+        MockHandler<?> handler = createMockHandler(settings);
 
         mock.intReturningMethod();
         Invocation invocation = super.getLastInvocation();

--- a/src/test/java/org/mockito/internal/matchers/StringMatchersTest.java
+++ b/src/test/java/org/mockito/internal/matchers/StringMatchersTest.java
@@ -13,65 +13,65 @@ import org.junit.Test;
  * Tests for the Matchers that operate over strings
  */
 public class StringMatchersTest {
-	@Test
-	public void startsWithString() {
-		assertTrue(new StartsWith("mockito").matches("mockito is here"));
-	}
+    @Test
+    public void startsWithString() {
+        assertTrue(new StartsWith("mockito").matches("mockito is here"));
+    }
 
-	@Test
-	public void doesNotStartWithString() {
-		assertFalse(new StartsWith("junit").matches("mockito is here"));
-	}
+    @Test
+    public void doesNotStartWithString() {
+        assertFalse(new StartsWith("junit").matches("mockito is here"));
+    }
 
-	@Test
-	public void nullStartsWith() {
-		assertFalse(new StartsWith("java").matches(null));
-	}
+    @Test
+    public void nullStartsWith() {
+        assertFalse(new StartsWith("java").matches(null));
+    }
 
-	@Test
-	public void endsWithString() {
-		assertTrue(new EndsWith("mockito").matches("here is mockito"));
-	}
+    @Test
+    public void endsWithString() {
+        assertTrue(new EndsWith("mockito").matches("here is mockito"));
+    }
 
-	@Test
-	public void doesNotEndWithString() {
-		assertFalse(new EndsWith("junit").matches("here is mockito"));
-	}
+    @Test
+    public void doesNotEndWithString() {
+        assertFalse(new EndsWith("junit").matches("here is mockito"));
+    }
 
-	@Test
-	public void nullEndsWith() {
-		assertFalse(new EndsWith("java").matches(null));
-	}
+    @Test
+    public void nullEndsWith() {
+        assertFalse(new EndsWith("java").matches(null));
+    }
 
-	@Test
-	public void containsString() {
-		assertTrue(new Contains("mockito").matches("****mockito****"));
-	}
+    @Test
+    public void containsString() {
+        assertTrue(new Contains("mockito").matches("****mockito****"));
+    }
 
-	@Test
-	public void stringDoesNotContain() {
-		assertFalse(new Contains("junit").matches("****mockito****"));
-	}
+    @Test
+    public void stringDoesNotContain() {
+        assertFalse(new Contains("junit").matches("****mockito****"));
+    }
 
-	@Test
-	public void nullContainsNothing() {
-		assertFalse(new Contains("mockito").matches(null));
-	}
+    @Test
+    public void nullContainsNothing() {
+        assertFalse(new Contains("mockito").matches(null));
+    }
 
-	@Test
-	public void matchesRegex() {
-		assertTrue(new Find("eleph.nt").matches("the elephant in the room"));
-		assertTrue(new Find("eleph.nt").matches("the elephInt in the room"));
-	}
+    @Test
+    public void matchesRegex() {
+        assertTrue(new Find("eleph.nt").matches("the elephant in the room"));
+        assertTrue(new Find("eleph.nt").matches("the elephInt in the room"));
+    }
 
-	@Test
-	public void doesNotMatchRegex() {
-		assertFalse(new Find("eleph.nt").matches("the otter in the room"));
-	}
+    @Test
+    public void doesNotMatchRegex() {
+        assertFalse(new Find("eleph.nt").matches("the otter in the room"));
+    }
 
-	@Test
-	public void nullDoesNotMatchRegex() {
-		assertFalse(new Find("eleph.nt").matches(null));
-	}
+    @Test
+    public void nullDoesNotMatchRegex() {
+        assertFalse(new Find("eleph.nt").matches(null));
+    }
 
 }

--- a/src/test/java/org/mockito/internal/progress/TimesTest.java
+++ b/src/test/java/org/mockito/internal/progress/TimesTest.java
@@ -12,15 +12,15 @@ import org.mockito.internal.verification.VerificationModeFactory;
 
 
 public class TimesTest  {
-	@Rule
-	public ExpectedException exception = ExpectedException.none();
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
 
     @Test
     public void shouldNotAllowNegativeNumberOfInvocations() throws Exception {
 
-    	exception.expect(MockitoException.class);
-    	exception.expectMessage("Negative value is not allowed here");
+        exception.expect(MockitoException.class);
+        exception.expectMessage("Negative value is not allowed here");
 
-    	VerificationModeFactory.times(-50);
+        VerificationModeFactory.times(-50);
     }
 }

--- a/src/test/java/org/mockito/internal/verification/checkers/MissingInvocationInOrderCheckerTest.java
+++ b/src/test/java/org/mockito/internal/verification/checkers/MissingInvocationInOrderCheckerTest.java
@@ -29,17 +29,17 @@ import org.mockitousage.IMethods;
 
 public class MissingInvocationInOrderCheckerTest  {
 
-	private InvocationMatcher wanted;
-	private List<Invocation> invocations;
+    private InvocationMatcher wanted;
+    private List<Invocation> invocations;
 
-	@Mock
-	private IMethods mock;
+    @Mock
+    private IMethods mock;
 
-	@Rule
-	public ExpectedException exception = ExpectedException.none();
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
 
-	@Rule
-	public MockitoRule mockitoRule = MockitoJUnit.rule();
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     private InOrderContext context = new InOrderContextImpl();
 
@@ -50,7 +50,7 @@ public class MissingInvocationInOrderCheckerTest  {
     @Test
     public void shouldPassWhenMatchingInteractionFound() throws Exception {
 
-    	invocations = asList(buildSimpleMethod().toInvocation());
+        invocations = asList(buildSimpleMethod().toInvocation());
         wanted = buildSimpleMethod().toInvocationMatcher();
 
         checkMissingInvocation(invocations, wanted, context);
@@ -58,64 +58,64 @@ public class MissingInvocationInOrderCheckerTest  {
 
     @Test
     public void shouldReportWantedButNotInvoked() throws Exception {
-    	invocations = asList(buildDifferentMethod().toInvocation());
+        invocations = asList(buildDifferentMethod().toInvocation());
         wanted = buildSimpleMethod().toInvocationMatcher();
 
         exception.expect(WantedButNotInvoked.class);
-		exception.expectMessage("Wanted but not invoked:");
-		exception.expectMessage("mock.simpleMethod()");
+        exception.expectMessage("Wanted but not invoked:");
+        exception.expectMessage("mock.simpleMethod()");
 
         checkMissingInvocation(invocations, wanted, context);
     }
 
     @Test
     public void shouldReportArgumentsAreDifferent() throws Exception {
-    	invocations = asList(buildIntArgMethod().arg(1111).toInvocation());
+        invocations = asList(buildIntArgMethod().arg(1111).toInvocation());
         wanted = buildIntArgMethod().arg(2222).toInvocationMatcher();
 
         exception.expect(ArgumentsAreDifferent.class);
 
-		exception.expectMessage("Argument(s) are different! Wanted:");
-		exception.expectMessage("mock.intArgumentMethod(2222);");
-		exception.expectMessage("Actual invocations have different arguments:");
-		exception.expectMessage("mock.intArgumentMethod(1111);");
+        exception.expectMessage("Argument(s) are different! Wanted:");
+        exception.expectMessage("mock.intArgumentMethod(2222);");
+        exception.expectMessage("Actual invocations have different arguments:");
+        exception.expectMessage("mock.intArgumentMethod(1111);");
 
-    	checkMissingInvocation(invocations, wanted, context);
+        checkMissingInvocation(invocations, wanted, context);
 
      }
 
     @Test
     public void shouldReportWantedDiffersFromActual() throws Exception {
 
-    	Invocation invocation1 = buildIntArgMethod().arg(1111).toInvocation();
-    	Invocation invocation2 = buildIntArgMethod().arg(2222).toInvocation();
+        Invocation invocation1 = buildIntArgMethod().arg(1111).toInvocation();
+        Invocation invocation2 = buildIntArgMethod().arg(2222).toInvocation();
 
-    	context.markVerified(invocation2);
-		invocations = asList(invocation1,invocation2);
+        context.markVerified(invocation2);
+        invocations = asList(invocation1,invocation2);
         wanted = buildIntArgMethod().arg(2222).toInvocationMatcher();
 
         exception.expect(VerificationInOrderFailure.class);
 
-		exception.expectMessage("Verification in order failure");
-		exception.expectMessage("Wanted but not invoked:");
-		exception.expectMessage("mock.intArgumentMethod(2222);");
-		exception.expectMessage("Wanted anywhere AFTER following interaction:");
-		exception.expectMessage("mock.intArgumentMethod(2222);");
+        exception.expectMessage("Verification in order failure");
+        exception.expectMessage("Wanted but not invoked:");
+        exception.expectMessage("mock.intArgumentMethod(2222);");
+        exception.expectMessage("Wanted anywhere AFTER following interaction:");
+        exception.expectMessage("mock.intArgumentMethod(2222);");
 
         checkMissingInvocation(invocations, wanted, context);
     }
 
     private InvocationBuilder buildIntArgMethod() {
-		return new InvocationBuilder().mock(mock).method("intArgumentMethod").argTypes(int.class);
-	}
+        return new InvocationBuilder().mock(mock).method("intArgumentMethod").argTypes(int.class);
+    }
 
-	private InvocationBuilder buildSimpleMethod() {
-		return new InvocationBuilder().mock(mock).simpleMethod();
-	}
+    private InvocationBuilder buildSimpleMethod() {
+        return new InvocationBuilder().mock(mock).simpleMethod();
+    }
 
-	private InvocationBuilder buildDifferentMethod() {
-		return new InvocationBuilder().mock(mock).differentMethod();
-	}
+    private InvocationBuilder buildDifferentMethod() {
+        return new InvocationBuilder().mock(mock).differentMethod();
+    }
 
 
 }

--- a/src/test/java/org/mockito/internal/verification/checkers/NumberOfInvocationsCheckerTest.java
+++ b/src/test/java/org/mockito/internal/verification/checkers/NumberOfInvocationsCheckerTest.java
@@ -131,16 +131,16 @@ public class NumberOfInvocationsCheckerTest {
         NumberOfInvocationsChecker.checkNumberOfInvocations(invocations, wanted, 0);
     }
 
-	@Test
-	public void shouldMarkInvocationsAsVerified() throws Exception {
-		Invocation invocation = buildSimpleMethod().toInvocation();
-		assertThat(invocation.isVerified()).isFalse();
+    @Test
+    public void shouldMarkInvocationsAsVerified() throws Exception {
+        Invocation invocation = buildSimpleMethod().toInvocation();
+        assertThat(invocation.isVerified()).isFalse();
 
-		invocations = asList(invocation);
-		wanted = buildSimpleMethod().toInvocationMatcher();
-		NumberOfInvocationsChecker.checkNumberOfInvocations(invocations, wanted, 1);
-		assertThat(invocation.isVerified()).isTrue();
-	}
+        invocations = asList(invocation);
+        wanted = buildSimpleMethod().toInvocationMatcher();
+        NumberOfInvocationsChecker.checkNumberOfInvocations(invocations, wanted, 1);
+        assertThat(invocation.isVerified()).isTrue();
+    }
 
     private InvocationBuilder buildSimpleMethod() {
         return new InvocationBuilder().mock(mock).simpleMethod();

--- a/src/test/java/org/mockitousage/junitrule/RuleTestWithParameterConstructorTest.java
+++ b/src/test/java/org/mockitousage/junitrule/RuleTestWithParameterConstructorTest.java
@@ -16,8 +16,8 @@ import org.mockito.junit.MockitoRule;
 
 public class RuleTestWithParameterConstructorTest {
 
-	 @Rule
-	 public MockitoRule mockitoJUnitRule = MockitoJUnit.rule();
+     @Rule
+     public MockitoRule mockitoJUnitRule = MockitoJUnit.rule();
 
     @Mock
     private Injected injected;


### PR DESCRIPTION
Discovered in #1818 that (if new contributors are unaware of our indentation with 4 spaces), spotless did not fix the formatting. `indentWithSpaces(4)` does just that and it actually found other formatting issues.