### PR TITLE
Guard against multiple evaluations of before statement

### DIFF
--- a/src/main/java/org/mockito/internal/runners/DefaultInternalRunner.java
+++ b/src/main/java/org/mockito/internal/runners/DefaultInternalRunner.java
@@ -63,6 +63,7 @@ public class DefaultInternalRunner implements InternalRunner {
                             if (mockitoTestListener != null) {
                                 Mockito.framework().removeListener(mockitoTestListener);
                                 mockitoTestListener.testFinished(new DefaultTestFinishedEvent(target, description.getMethodName(), failure));
+                                mockitoTestListener = null;
                             }
                             Mockito.validateMockitoUsage();
                         } catch (Throwable t) {

--- a/src/main/java/org/mockito/internal/runners/DefaultInternalRunner.java
+++ b/src/main/java/org/mockito/internal/runners/DefaultInternalRunner.java
@@ -36,11 +36,13 @@ public class DefaultInternalRunner implements InternalRunner {
                 return new Statement() {
                     @Override
                     public void evaluate() throws Throwable {
-                        // get new test listener and add it to the framework
-                        mockitoTestListener = listenerSupplier.get();
-                        Mockito.framework().addListener(mockitoTestListener);
-                        // init annotated mocks before tests
-                        MockitoAnnotations.initMocks(target);
+                        if (mockitoTestListener == null) {
+                            // get new test listener and add it to the framework
+                            mockitoTestListener = listenerSupplier.get();
+                            Mockito.framework().addListener(mockitoTestListener);
+                            // init annotated mocks before tests
+                            MockitoAnnotations.initMocks(target);
+                        }
                         base.evaluate();
                     }
                 };


### PR DESCRIPTION
Some rules evaluate the base statement multiple times, e.g. to execute
tests repeatedly. The changes made in #1672 led to an exception in such
cases because the `MockitoListener` was registered multiple times. Now,
we only add the listener the first time the statement is evaluated in
order to restore the old behavior.

Fixes #1767.