### PR TITLE
Performance optimization by using Method.getParameterCount() where possible

### DIFF
--- a/src/main/java/org/mockito/internal/creation/instance/ConstructorInstantiator.java
+++ b/src/main/java/org/mockito/internal/creation/instance/ConstructorInstantiator.java
@@ -40,8 +40,7 @@ public class ConstructorInstantiator implements Instantiator {
         List<Constructor<?>> matchingConstructors = new LinkedList<Constructor<?>>();
         try {
             for (Constructor<?> constructor : cls.getDeclaredConstructors()) {
-                Class<?>[] types = constructor.getParameterTypes();
-                if (paramsMatch(types, params)) {
+                if (constructorParamsMatch(constructor, params)) {
                     evaluateConstructor(matchingConstructors, constructor);
                 }
             }
@@ -116,10 +115,11 @@ public class ConstructorInstantiator implements Instantiator {
             ), null);
     }
 
-    private static boolean paramsMatch(Class<?>[] types, Object[] params) {
-        if (params.length != types.length) {
+    private static boolean constructorParamsMatch(Constructor<?> constructor, Object[] params) {
+        if (params.length != constructor.getParameterCount()) {
             return false;
         }
+        Class<?>[] types = constructor.getParameterTypes();
         for (int i = 0; i < params.length; i++) {
             if (params[i] == null) {
                 if (types[i].isPrimitive()) {

--- a/src/main/java/org/mockito/internal/exceptions/Reporter.java
+++ b/src/main/java/org/mockito/internal/exceptions/Reporter.java
@@ -783,16 +783,17 @@ public class Reporter {
     }
 
     private static StringBuilder possibleArgumentTypesOf(InvocationOnMock invocation) {
-        Class<?>[] parameterTypes = invocation.getMethod().getParameterTypes();
-        if (parameterTypes.length == 0) {
+        Method method = invocation.getMethod();
+        if (method.getParameterCount() == 0) {
             return new StringBuilder("the method has no arguments.\n");
         }
 
+        Class<?>[] parameterTypes = method.getParameterTypes();
         StringBuilder stringBuilder = new StringBuilder("the possible argument indexes for this method are :\n");
         for (int i = 0, parameterTypesLength = parameterTypes.length; i < parameterTypesLength; i++) {
             stringBuilder.append("    [").append(i);
 
-            if (invocation.getMethod().isVarArgs() && i == parameterTypesLength - 1) {
+            if (method.isVarArgs() && i == parameterTypesLength - 1) {
                 stringBuilder.append("+] ").append(parameterTypes[i].getComponentType().getSimpleName()).append("  <- Vararg").append("\n");
             } else {
                 stringBuilder.append("] ").append(parameterTypes[i].getSimpleName()).append("\n");

--- a/src/main/java/org/mockito/internal/invocation/InvocationMatcher.java
+++ b/src/main/java/org/mockito/internal/invocation/InvocationMatcher.java
@@ -111,7 +111,7 @@ public class InvocationMatcher implements MatchableInvocation, DescribedInvocati
         Method m1 = invocation.getMethod();
         Method m2 = candidate.getMethod();
 
-        if (m1.getName() != null && m1.getName().equals(m2.getName())) {
+        if (m1.getName() != null && m1.getName().equals(m2.getName()) && m1.getParameterCount() == m2.getParameterCount()) {
             /* Avoid unnecessary cloning */
             Class<?>[] params1 = m1.getParameterTypes();
             Class<?>[] params2 = m2.getParameterTypes();

--- a/src/main/java/org/mockito/internal/invocation/TypeSafeMatching.java
+++ b/src/main/java/org/mockito/internal/invocation/TypeSafeMatching.java
@@ -59,7 +59,7 @@ public class TypeSafeMatching implements ArgumentMatcherAction {
      * {@link ArgumentMatcher#matches(Object)}
      */
     private static boolean isMatchesMethod(Method method) {
-        if (method.getParameterTypes().length != 1) {
+        if (method.getParameterCount() != 1) {
             return false;
         }
         if (method.isBridge()) {

--- a/src/main/java/org/mockito/internal/stubbing/answers/ReturnsArgumentAt.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/ReturnsArgumentAt.java
@@ -101,10 +101,9 @@ public class ReturnsArgumentAt implements Answer<Object>, ValidableAnswer, Seria
     }
 
     private boolean wantedArgIndexIsVarargAndSameTypeAsReturnType(Method method, int argumentPosition) {
-        Class<?>[] parameterTypes = method.getParameterTypes();
         return method.isVarArgs() &&
-              argumentPosition == /* vararg index */ parameterTypes.length - 1 &&
-              method.getReturnType().isAssignableFrom(parameterTypes[argumentPosition]);
+              argumentPosition == /* vararg index */ method.getParameterCount() - 1 &&
+              method.getReturnType().isAssignableFrom(method.getParameterTypes()[argumentPosition]);
     }
 
     private boolean wantedArgumentPositionIsValidForInvocation(InvocationOnMock invocation, int argumentPosition) {

--- a/src/main/java/org/mockito/internal/util/ObjectMethodsGuru.java
+++ b/src/main/java/org/mockito/internal/util/ObjectMethodsGuru.java
@@ -24,7 +24,7 @@ public class ObjectMethodsGuru{
     public static boolean isCompareToMethod(Method method) {
         return Comparable.class.isAssignableFrom(method.getDeclaringClass())
                 && "compareTo".equals(method.getName())
-                && method.getParameterTypes().length == 1
+                && method.getParameterCount() == 1
                 && method.getParameterTypes()[0] == method.getDeclaringClass();
     }
 }

--- a/src/main/java/org/mockito/internal/util/reflection/FieldInitializer.java
+++ b/src/main/java/org/mockito/internal/util/reflection/FieldInitializer.java
@@ -229,7 +229,7 @@ public class FieldInitializer {
         private final ConstructorArgumentResolver argResolver;
         private final Comparator<Constructor<?>> byParameterNumber = new Comparator<Constructor<?>>() {
             public int compare(Constructor<?> constructorA, Constructor<?> constructorB) {
-                int argLengths = constructorB.getParameterTypes().length - constructorA.getParameterTypes().length;
+                int argLengths = constructorB.getParameterCount() - constructorA.getParameterCount();
                 if (argLengths == 0) {
                     int constructorAMockableParamsSize = countMockableParams(constructorA);
                     int constructorBMockableParamsSize = countMockableParams(constructorB);
@@ -287,7 +287,7 @@ public class FieldInitializer {
         }
 
         private void checkParameterized(Constructor<?> constructor, Field field) {
-            if(constructor.getParameterTypes().length == 0) {
+            if (constructor.getParameterCount() == 0) {
                 throw new MockitoException("the field " + field.getName() + " of type " + field.getType() + " has no parameterized constructor");
             }
         }


### PR DESCRIPTION
Hi,

as described in #1848 we could make use of `Method.getParameterCount()` in order to save some overhead from unnecessary cloning caused by `Method.getParameterTypes()`.

As this is my first contribution to Mockito, let me know if I can do something to help.

Let me know what you think.
Cheers,
Christoph