### PR TITLE
Fixes  #522 : Basic test suite for OSGi framework

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -30,6 +30,10 @@ libraries.objenesis = 'org.objenesis:objenesis:2.6'
 
 libraries.asm = 'org.ow2.asm:asm:7.0'
 
+libraries.osgi = 'org.osgi:osgi.core:7.0.0'
+libraries.equinox = 'org.eclipse.platform:org.eclipse.osgi:3.15.0'
+libraries.bndGradle =  'biz.aQute.bnd:biz.aQute.bnd.gradle:4.3.1'
+
 def kotlinVersion = '1.2.10'
 def kotlinVersion_1_3 = '1.3.0-rc-57'
 libraries.kotlin = [

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,7 +9,8 @@ include("deprecatedPluginsTest",
     "module-test",
     "memory-test",
     "errorprone",
-    "junitJupiterParallelTest")
+    "junitJupiterParallelTest",
+    "osgi-test")
 
 rootProject.name = "mockito"
 

--- a/subprojects/osgi-test/osgi-test-bundles.gradle
+++ b/subprojects/osgi-test/osgi-test-bundles.gradle
@@ -7,6 +7,8 @@ buildscript {
     }
 }
 
+apply from: "$rootDir/gradle/dependencies.gradle"
+
 description = "Test bundles for OSGi tests"
 
 sourceSets {
@@ -16,6 +18,7 @@ sourceSets {
 
 dependencies {
     testBundleCompile project.rootProject
+    testBundleCompile libraries.junit4
     testBundleCompile sourceSets.otherBundle.output
 }
 

--- a/subprojects/osgi-test/osgi-test-bundles.gradle
+++ b/subprojects/osgi-test/osgi-test-bundles.gradle
@@ -1,0 +1,38 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath libraries.bndGradle
+    }
+}
+
+description = "Test bundles for OSGi tests"
+
+sourceSets {
+    testBundle
+    otherBundle
+}
+
+dependencies {
+    testBundleCompile project.rootProject
+    testBundleCompile sourceSets.otherBundle.output
+}
+
+import aQute.bnd.gradle.Bundle
+
+task testBundle(type: Bundle) {
+    from sourceSets.testBundle.output
+}
+
+task otherBundle(type: Bundle) {
+    from sourceSets.otherBundle.output
+}
+
+tasks.withType(Bundle) {
+    archiveAppendix = name
+    bnd = """
+Bundle-SymbolicName: $name
+-exportcontents: *
+"""
+}

--- a/subprojects/osgi-test/osgi-test.gradle
+++ b/subprojects/osgi-test/osgi-test.gradle
@@ -1,0 +1,38 @@
+plugins {
+    id 'java'
+}
+
+apply from: "$rootDir/gradle/dependencies.gradle"
+apply from: "osgi-test-bundles.gradle"
+
+description = "Test suite for OSGi framework with Mockito"
+
+dependencies {
+    testCompile libraries.junit4
+    testCompile libraries.osgi
+
+    testRuntime libraries.equinox
+}
+
+tasks.javadoc.enabled = false
+
+configurations {
+    testRuntimeBundles
+}
+
+dependencies {
+    testRuntimeBundles project.rootProject
+    testRuntimeBundles libraries.bytebuddy
+    testRuntimeBundles libraries.objenesis
+    testRuntimeBundles tasks.testBundle.outputs.files
+    testRuntimeBundles tasks.otherBundle.outputs.files
+}
+
+test {
+    dependsOn configurations.testRuntimeBundles
+    inputs.files(sourceSets.testBundle.allSource)
+    inputs.files(sourceSets.otherBundle.allSource)
+    systemProperty 'testRuntimeBundles', configurations.testRuntimeBundles.asPath
+    useJUnit()
+}
+

--- a/subprojects/osgi-test/src/otherBundle/java/org/mockito/osgitest/otherbundle/Methods.java
+++ b/subprojects/osgi-test/src/otherBundle/java/org/mockito/osgitest/otherbundle/Methods.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2019 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.osgitest.otherbundle;
+
+public class Methods {
+
+    public int intReturningMethod() {
+        return 0;
+    }
+}

--- a/subprojects/osgi-test/src/test/java/org/mockito/osgitest/OsgiTest.java
+++ b/subprojects/osgi-test/src/test/java/org/mockito/osgitest/OsgiTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2019 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.osgitest;
+
+import org.junit.*;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.Constants;
+import org.osgi.framework.launch.Framework;
+import org.osgi.framework.launch.FrameworkFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.fail;
+
+public class OsgiTest {
+
+    private static final FrameworkFactory frameworkFactory = ServiceLoader.load(FrameworkFactory.class).iterator().next();
+    private static final String STORAGE_TEMPDIR_NAME = "osgi-test-storage";
+    private static final List<String> EXTRA_SYSTEMPACKAGES = Arrays.asList("sun.misc", "sun.reflect");
+
+    private static final List<Path> TEST_RUNTIME_BUNDLES = splitPaths(System.getProperty("testRuntimeBundles"));
+    private static final String TEST_BUNDLE_SYMBOLIC_NAME = "testBundle";
+
+    private static final long STOP_TIMEOUT_MS = 10000;
+
+    private static Path frameworkStorage;
+    private static Framework framework;
+    private static Bundle testBundle;
+
+    @BeforeClass
+    public static void setUp() throws IOException, BundleException {
+        frameworkStorage = Files.createTempDirectory(STORAGE_TEMPDIR_NAME);
+        Map<String, String> configuration = new HashMap<>();
+        configuration.put(Constants.FRAMEWORK_STORAGE, frameworkStorage.toString());
+        configuration.put(Constants.FRAMEWORK_SYSTEMPACKAGES_EXTRA, String.join(",", EXTRA_SYSTEMPACKAGES));
+        framework = frameworkFactory.newFramework(configuration);
+        framework.init();
+        BundleContext bundleContext = framework.getBundleContext();
+        for (Path dependencyPath : TEST_RUNTIME_BUNDLES) {
+            Bundle installedBundle;
+            try {
+                installedBundle = bundleContext.installBundle(dependencyPath.toUri().toString());
+            } catch (BundleException e) {
+                throw new IllegalStateException("Failed to install bundle: " + dependencyPath.getFileName(), e);
+            }
+            if (TEST_BUNDLE_SYMBOLIC_NAME.equals(installedBundle.getSymbolicName())) {
+                testBundle = installedBundle;
+            }
+        }
+        if (testBundle == null) {
+            fail("Test bundle not found.");
+        }
+        framework.start();
+    }
+
+    @AfterClass
+    public static void tearDown() throws IOException, BundleException, InterruptedException {
+        try {
+            if (framework != null) {
+                framework.stop();
+                framework.waitForStop(STOP_TIMEOUT_MS);
+            }
+        } finally {
+            if (frameworkStorage != null) {
+                deleteRecursively(frameworkStorage);
+            }
+        }
+    }
+
+    @Test
+    public void testSimpleMock() throws BundleException, InterruptedException, ClassNotFoundException, IllegalAccessException, InstantiationException, IOException {
+        createTestRunnable("SimpleMockTest").run();
+    }
+
+    @Test
+    public void testMockNonPublicClassFails() throws BundleException, InterruptedException, ClassNotFoundException, IllegalAccessException, InstantiationException, IOException {
+        createTestRunnable("MockNonPublicClassFailsTest").run();
+    }
+
+    @Test
+    public void testMockClassInOtherBundle() throws BundleException, InterruptedException, ClassNotFoundException, IllegalAccessException, InstantiationException, IOException {
+        createTestRunnable("MockClassInOtherBundleTest").run();
+    }
+
+    private Runnable createTestRunnable(String className) throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        return (Runnable) testBundle.loadClass("org.mockito.osgitest.testbundle." + className).newInstance();
+    }
+
+    private static List<Path> splitPaths(String paths) {
+        return Stream.of(paths.split(Pattern.quote(File.pathSeparator)))
+            .map(p -> Paths.get(p))
+            .collect(Collectors.toList());
+    }
+
+    private static void deleteRecursively(Path pathToDelete) throws IOException {
+        Files.walkFileTree(pathToDelete,
+            new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    Files.delete(dir);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.delete(file);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+    }
+}

--- a/subprojects/osgi-test/src/testBundle/java/org/mockito/osgitest/testbundle/MockClassInOtherBundleTest.java
+++ b/subprojects/osgi-test/src/testBundle/java/org/mockito/osgitest/testbundle/MockClassInOtherBundleTest.java
@@ -4,19 +4,19 @@
  */
 package org.mockito.osgitest.testbundle;
 
+import org.junit.Test;
 import org.mockito.osgitest.otherbundle.Methods;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class MockClassInOtherBundleTest implements Runnable {
+public class MockClassInOtherBundleTest {
 
-    @Override
-    public void run() {
+    @Test
+    public void test() {
         Methods methods = mock(Methods.class);
         when(methods.intReturningMethod()).thenReturn(42);
-        if (methods.intReturningMethod() != 42) {
-            throw new AssertionError();
-        }
+        assertEquals(42, methods.intReturningMethod());
     }
 }

--- a/subprojects/osgi-test/src/testBundle/java/org/mockito/osgitest/testbundle/MockClassInOtherBundleTest.java
+++ b/subprojects/osgi-test/src/testBundle/java/org/mockito/osgitest/testbundle/MockClassInOtherBundleTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2019 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.osgitest.testbundle;
+
+import org.mockito.osgitest.otherbundle.Methods;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MockClassInOtherBundleTest implements Runnable {
+
+    @Override
+    public void run() {
+        Methods methods = mock(Methods.class);
+        when(methods.intReturningMethod()).thenReturn(42);
+        if (methods.intReturningMethod() != 42) {
+            throw new AssertionError();
+        }
+    }
+}

--- a/subprojects/osgi-test/src/testBundle/java/org/mockito/osgitest/testbundle/MockNonPublicClassFailsTest.java
+++ b/subprojects/osgi-test/src/testBundle/java/org/mockito/osgitest/testbundle/MockNonPublicClassFailsTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2019 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.osgitest.testbundle;
+
+import org.mockito.exceptions.base.MockitoException;
+
+import static org.mockito.Mockito.mock;
+
+public class MockNonPublicClassFailsTest implements Runnable {
+
+    static class NonPublicClass {}
+
+    @Override
+    public void run() {
+        try {
+            NonPublicClass nonPublicClass = mock(NonPublicClass.class);
+            throw new AssertionError();
+        } catch(MockitoException e) {
+            // Expected: The type is not public and its mock class is loaded by a different class loader.
+        }
+    }
+}

--- a/subprojects/osgi-test/src/testBundle/java/org/mockito/osgitest/testbundle/MockNonPublicClassFailsTest.java
+++ b/subprojects/osgi-test/src/testBundle/java/org/mockito/osgitest/testbundle/MockNonPublicClassFailsTest.java
@@ -4,21 +4,18 @@
  */
 package org.mockito.osgitest.testbundle;
 
+import org.junit.Test;
 import org.mockito.exceptions.base.MockitoException;
 
 import static org.mockito.Mockito.mock;
 
-public class MockNonPublicClassFailsTest implements Runnable {
+public class MockNonPublicClassFailsTest {
 
     static class NonPublicClass {}
 
-    @Override
-    public void run() {
-        try {
-            NonPublicClass nonPublicClass = mock(NonPublicClass.class);
-            throw new AssertionError();
-        } catch(MockitoException e) {
+    @Test(expected = MockitoException.class)
+    public void test() {
             // Expected: The type is not public and its mock class is loaded by a different class loader.
-        }
+            NonPublicClass nonPublicClass = mock(NonPublicClass.class);
     }
 }

--- a/subprojects/osgi-test/src/testBundle/java/org/mockito/osgitest/testbundle/SimpleMockTest.java
+++ b/subprojects/osgi-test/src/testBundle/java/org/mockito/osgitest/testbundle/SimpleMockTest.java
@@ -4,19 +4,20 @@
  */
 package org.mockito.osgitest.testbundle;
 
+import org.junit.Test;
+
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class SimpleMockTest implements Runnable {
+public class SimpleMockTest {
 
-    @Override
-    public void run() {
+    @Test
+    public void test() {
         List list = mock(List.class);
         when(list.get(0)).thenReturn("a");
-        if (!list.get(0).equals("a")) {
-            throw new AssertionError();
-        }
+        assertEquals("a", list.get(0));
     }
 }

--- a/subprojects/osgi-test/src/testBundle/java/org/mockito/osgitest/testbundle/SimpleMockTest.java
+++ b/subprojects/osgi-test/src/testBundle/java/org/mockito/osgitest/testbundle/SimpleMockTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2019 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.osgitest.testbundle;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SimpleMockTest implements Runnable {
+
+    @Override
+    public void run() {
+        List list = mock(List.class);
+        when(list.get(0)).thenReturn("a");
+        if (!list.get(0).equals("a")) {
+            throw new AssertionError();
+        }
+    }
+}


### PR DESCRIPTION
This is a proposal for a basic test project to ensure that the Mockito artifacts can be consumed from an OSGi environment. For example, reverting the fix for #678 is caught with the following exception:

```
java.lang.IllegalStateException: Failed to install bundle: mockito-core-3.2.3.jar
	at org.mockito.osgitest.OsgiTest.setUp(OsgiTest.java:55)
	... (snipped)
Caused by: org.osgi.framework.BundleException: Error occurred installing a bundle.
	at org.eclipse.osgi.storage.Storage.install(Storage.java:739)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.installBundle(BundleContextImpl.java:187)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.installBundle(BundleContextImpl.java:179)
	at org.mockito.osgitest.OsgiTest.setUp(OsgiTest.java:53)
	... 40 more
Caused by: java.lang.IllegalArgumentException: invalid range "[1.6.0": invalid format
	at org.osgi.framework.VersionRange.<init>(VersionRange.java:173)
	at org.eclipse.osgi.container.builders.OSGiManifestBuilderFactory.addPackageImports(OSGiManifestBuilderFactory.java:373)
	at org.eclipse.osgi.container.builders.OSGiManifestBuilderFactory.getPackageImports(OSGiManifestBuilderFactory.java:352)
	at org.eclipse.osgi.container.builders.OSGiManifestBuilderFactory.createBuilder(OSGiManifestBuilderFactory.java:111)
	at org.eclipse.osgi.container.builders.OSGiManifestBuilderFactory.createBuilder(OSGiManifestBuilderFactory.java:78)
	at org.eclipse.osgi.storage.Storage.getBuilder(Storage.java:784)
	at org.eclipse.osgi.storage.Storage.getBuilder(Storage.java:766)
	at org.eclipse.osgi.storage.Storage.install(Storage.java:706)
	... 43 more
Caused by: java.util.NoSuchElementException
	at java.util.StringTokenizer.nextToken(StringTokenizer.java:349)
	at org.osgi.framework.VersionRange.<init>(VersionRange.java:157)
	... 50 more
```

The OSGi test project consists of three source sets:

1. A regular JUnit4 `test` source set with a single class OsgiTest. Starts an OSGi framework, installs mockito-core, byte-buddy and objenesis bundles as well as two test bundles, and executes some simple Mockito test cases inside the OSGi framework.
2. A source set `testBundle` that's built to an OSGi bundle using the `Bundle` task from the Bnd Gradle Plugin. Contains the test classes that run the Mockito test cases and thus depends on the Mockito bundle.
3. A source set `otherBundle` that's also built to an OSGi bundle but with no other dependencies. Used for testing mocking of classes from other bundles.

Some further technical details:

- The `test` source set only has compile dependencies on the OSGi APIs and JUnit4, i.e. not on Mockito. The OSGi framework is created using the standard Framework API. At runtime Equinox is added as a dependency to supply an actual framework implementation, but the intention is that any framework implementation could be used.
- The test cases are run by loading classes from the test bundle that all implement `Runnable`. This is to provide a simple bridge using a common JDK class. The reason for setting up such a bridge is that I want to drive the tests using a test runner that Gradle supports, for example to get good test reports, but the test bundles don't know anything about JUnit4 inside the OSGi framework. I didn't want to explore adding an OSGified version of JUnit into the mix at this point since that would also entail solving test discovery inside an OSGi framework.
- The OSGi bundles are built using the [Bnd Gradle Plugin](https://github.com/bndtools/bnd/blob/master/biz.aQute.bnd.gradle/README.md#gradle-plugin-for-workspace-builds) instead of the deprecated `osgi` plugin in Gradle. The reason is both future proofing, to not impede a migration to Gradle 6.0 in this new sub project, and that I believe it better mirrors how other projects would consume the Mockito artifacts. Further it paves the way for replacing the usage of the deprecated plugin for the creating the OSGi manifests in the root project.

Since this is my first contribution I'll be happy to fix anything that goes against the grains.