### PR TITLE
Add TestRule to MockitoJUnit

### DIFF
--- a/src/main/java/org/mockito/internal/junit/AbstractJUnitRule.java
+++ b/src/main/java/org/mockito/internal/junit/AbstractJUnitRule.java
@@ -12,7 +12,7 @@ import org.mockito.internal.session.MockitoSessionLoggerAdapter;
 import org.mockito.plugins.MockitoLogger;
 import org.mockito.quality.Strictness;
 
-public class AbstractJUnitRule {
+abstract class AbstractJUnitRule {
 
   private final MockitoLogger logger;
   private MockitoSession session;

--- a/src/main/java/org/mockito/internal/junit/AbstractJUnitRule.java
+++ b/src/main/java/org/mockito/internal/junit/AbstractJUnitRule.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2020 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.junit;
+
+import org.junit.runners.model.Statement;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.MockitoSession;
+import org.mockito.internal.session.MockitoSessionLoggerAdapter;
+import org.mockito.plugins.MockitoLogger;
+import org.mockito.quality.Strictness;
+
+public class AbstractJUnitRule {
+
+  private final MockitoLogger logger;
+  private MockitoSession session;
+  protected Strictness strictness;
+
+  AbstractJUnitRule(MockitoLogger logger, Strictness strictness) {
+    this.logger = logger;
+    this.strictness = strictness;
+  }
+
+  Statement createStatement(final Statement base, final String methodName, final Object target) {
+    return new Statement() {
+      public void evaluate() throws Throwable {
+        if (session == null) {
+          session =
+              Mockito.mockitoSession()
+                  .name(methodName)
+                  .strictness(strictness)
+                  .logger(new MockitoSessionLoggerAdapter(logger))
+                  .initMocks(target)
+                  .startMocking();
+        } else {
+          MockitoAnnotations.initMocks(target);
+        }
+        Throwable testFailure = evaluateSafely(base);
+        session.finishMocking(testFailure);
+        if (testFailure != null) {
+          throw testFailure;
+        }
+      }
+
+      private Throwable evaluateSafely(Statement base) {
+        try {
+          base.evaluate();
+          return null;
+        } catch (Throwable throwable) {
+          return throwable;
+        }
+      }
+    };
+  }
+
+  void setStrictness(Strictness strictness) {
+    this.strictness = strictness;
+    // session is null when this method is called during initialization of
+    // the @Rule field of the test class
+    if (session != null) {
+      session.setStrictness(strictness);
+    }
+  }
+
+}

--- a/src/main/java/org/mockito/internal/junit/JUnitRule.java
+++ b/src/main/java/org/mockito/internal/junit/JUnitRule.java
@@ -11,7 +11,7 @@ import org.mockito.plugins.MockitoLogger;
 import org.mockito.quality.Strictness;
 
 /** Internal implementation. */
-public class JUnitRule extends AbstractJUnitRule implements MockitoRule {
+public final class JUnitRule extends AbstractJUnitRule implements MockitoRule {
 
     /** @param strictness how strict mocking / stubbing is concerned */
     public JUnitRule(MockitoLogger logger, Strictness strictness) {

--- a/src/main/java/org/mockito/internal/junit/JUnitRule.java
+++ b/src/main/java/org/mockito/internal/junit/JUnitRule.java
@@ -14,18 +14,14 @@ import org.mockito.junit.MockitoRule;
 import org.mockito.plugins.MockitoLogger;
 import org.mockito.quality.Strictness;
 
-/**
- * Internal implementation.
- */
+/** Internal implementation. */
 public class JUnitRule implements MockitoRule {
 
     private final MockitoLogger logger;
     private Strictness strictness;
     private MockitoSession session;
 
-    /**
-     * @param strictness how strict mocking / stubbing is concerned
-     */
+    /** @param strictness how strict mocking / stubbing is concerned */
     public JUnitRule(MockitoLogger logger, Strictness strictness) {
         this.logger = logger;
         this.strictness = strictness;
@@ -33,15 +29,20 @@ public class JUnitRule implements MockitoRule {
 
     @Override
     public Statement apply(final Statement base, final FrameworkMethod method, final Object target) {
+        return createStatement(base, target.getClass().getSimpleName() + "." + method.getName(), target);
+    }
+
+    protected Statement createStatement(final Statement base, final String methodName, final Object target) {
         return new Statement() {
             public void evaluate() throws Throwable {
                 if (session == null) {
-                    session = Mockito.mockitoSession()
-                                     .name(target.getClass().getSimpleName() + "." + method.getName())
-                                     .strictness(strictness)
-                                     .logger(new MockitoSessionLoggerAdapter(logger))
-                                     .initMocks(target)
-                                     .startMocking();
+                    session =
+                        Mockito.mockitoSession()
+                            .name(methodName)
+                            .strictness(strictness)
+                            .logger(new MockitoSessionLoggerAdapter(logger))
+                            .initMocks(target)
+                            .startMocking();
                 } else {
                     MockitoAnnotations.initMocks(target);
                 }

--- a/src/main/java/org/mockito/internal/junit/JUnitRule.java
+++ b/src/main/java/org/mockito/internal/junit/JUnitRule.java
@@ -6,25 +6,16 @@ package org.mockito.internal.junit;
 
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-import org.mockito.MockitoSession;
-import org.mockito.internal.session.MockitoSessionLoggerAdapter;
 import org.mockito.junit.MockitoRule;
 import org.mockito.plugins.MockitoLogger;
 import org.mockito.quality.Strictness;
 
 /** Internal implementation. */
-public class JUnitRule implements MockitoRule {
-
-    private final MockitoLogger logger;
-    private Strictness strictness;
-    private MockitoSession session;
+public class JUnitRule extends AbstractJUnitRule implements MockitoRule {
 
     /** @param strictness how strict mocking / stubbing is concerned */
     public JUnitRule(MockitoLogger logger, Strictness strictness) {
-        this.logger = logger;
-        this.strictness = strictness;
+        super(logger, strictness);
     }
 
     @Override
@@ -32,49 +23,12 @@ public class JUnitRule implements MockitoRule {
         return createStatement(base, target.getClass().getSimpleName() + "." + method.getName(), target);
     }
 
-    protected Statement createStatement(final Statement base, final String methodName, final Object target) {
-        return new Statement() {
-            public void evaluate() throws Throwable {
-                if (session == null) {
-                    session =
-                        Mockito.mockitoSession()
-                            .name(methodName)
-                            .strictness(strictness)
-                            .logger(new MockitoSessionLoggerAdapter(logger))
-                            .initMocks(target)
-                            .startMocking();
-                } else {
-                    MockitoAnnotations.initMocks(target);
-                }
-                Throwable testFailure = evaluateSafely(base);
-                session.finishMocking(testFailure);
-                if (testFailure != null) {
-                    throw testFailure;
-                }
-            }
-
-            private Throwable evaluateSafely(Statement base) {
-                try {
-                    base.evaluate();
-                    return null;
-                } catch (Throwable throwable) {
-                    return throwable;
-                }
-            }
-        };
-    }
-
     public MockitoRule silent() {
         return strictness(Strictness.LENIENT);
     }
 
     public MockitoRule strictness(Strictness strictness) {
-        this.strictness = strictness;
-        // session is null when this method is called during initialization of
-        // the @Rule field of the test class
-        if (session != null) {
-            session.setStrictness(strictness);
-        }
+        super.setStrictness(strictness);
         return this;
     }
 }

--- a/src/main/java/org/mockito/internal/junit/JUnitRule.java
+++ b/src/main/java/org/mockito/internal/junit/JUnitRule.java
@@ -11,16 +11,18 @@ import org.mockito.plugins.MockitoLogger;
 import org.mockito.quality.Strictness;
 
 /** Internal implementation. */
-public final class JUnitRule extends AbstractJUnitRule implements MockitoRule {
+public final class JUnitRule implements MockitoRule {
+
+    private final JUnitSessionStore sessionStore;
 
     /** @param strictness how strict mocking / stubbing is concerned */
     public JUnitRule(MockitoLogger logger, Strictness strictness) {
-        super(logger, strictness);
+        this.sessionStore = new JUnitSessionStore(logger, strictness);
     }
 
     @Override
     public Statement apply(final Statement base, final FrameworkMethod method, final Object target) {
-        return createStatement(base, target.getClass().getSimpleName() + "." + method.getName(), target);
+        return sessionStore.createStatement(base, target.getClass().getSimpleName() + "." + method.getName(), target);
     }
 
     public MockitoRule silent() {
@@ -28,7 +30,7 @@ public final class JUnitRule extends AbstractJUnitRule implements MockitoRule {
     }
 
     public MockitoRule strictness(Strictness strictness) {
-        super.setStrictness(strictness);
+        sessionStore.setStrictness(strictness);
         return this;
     }
 }

--- a/src/main/java/org/mockito/internal/junit/JUnitSessionStore.java
+++ b/src/main/java/org/mockito/internal/junit/JUnitSessionStore.java
@@ -12,13 +12,13 @@ import org.mockito.internal.session.MockitoSessionLoggerAdapter;
 import org.mockito.plugins.MockitoLogger;
 import org.mockito.quality.Strictness;
 
-abstract class AbstractJUnitRule {
+class JUnitSessionStore {
 
   private final MockitoLogger logger;
   private MockitoSession session;
   protected Strictness strictness;
 
-  AbstractJUnitRule(MockitoLogger logger, Strictness strictness) {
+  JUnitSessionStore(MockitoLogger logger, Strictness strictness) {
     this.logger = logger;
     this.strictness = strictness;
   }

--- a/src/main/java/org/mockito/internal/junit/JUnitTestRule.java
+++ b/src/main/java/org/mockito/internal/junit/JUnitTestRule.java
@@ -6,26 +6,23 @@ package org.mockito.internal.junit;
 
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
-import org.mockito.exceptions.base.MockitoException;
 import org.mockito.junit.MockitoTestRule;
 import org.mockito.plugins.MockitoLogger;
 import org.mockito.quality.Strictness;
 
-public final class JUnitTestRule extends AbstractJUnitRule implements MockitoTestRule {
+public final class JUnitTestRule implements MockitoTestRule {
 
     private final Object testInstance;
+    private final JUnitSessionStore sessionStore;
 
     public JUnitTestRule(MockitoLogger logger, Strictness strictness, Object testInstance) {
-        super(logger, strictness);
+        this.sessionStore = new JUnitSessionStore(logger, strictness);
         this.testInstance = testInstance;
     }
 
     @Override
     public Statement apply(Statement base, Description description) {
-        if (description.isSuite()) {
-            throw new MockitoException("JUnitTestRule can not be used as a @ClassRule.");
-        }
-        return createStatement(base, description.getDisplayName(), this.testInstance);
+        return sessionStore.createStatement(base, description.getDisplayName(), this.testInstance);
     }
 
     public MockitoTestRule silent() {
@@ -33,7 +30,7 @@ public final class JUnitTestRule extends AbstractJUnitRule implements MockitoTes
     }
 
     public MockitoTestRule strictness(Strictness strictness) {
-        super.setStrictness(strictness);
+        sessionStore.setStrictness(strictness);
         return this;
     }
 }

--- a/src/main/java/org/mockito/internal/junit/JUnitTestRule.java
+++ b/src/main/java/org/mockito/internal/junit/JUnitTestRule.java
@@ -11,7 +11,7 @@ import org.mockito.junit.MockitoTestRule;
 import org.mockito.plugins.MockitoLogger;
 import org.mockito.quality.Strictness;
 
-public class JUnitTestRule extends JUnitRule implements MockitoTestRule {
+public class JUnitTestRule extends AbstractJUnitRule implements MockitoTestRule {
 
     private final Object testInstance;
 
@@ -26,5 +26,14 @@ public class JUnitTestRule extends JUnitRule implements MockitoTestRule {
             throw new MockitoException("JUnitTestRule can not be used as a @ClassRule.");
         }
         return createStatement(base, description.getDisplayName(), this.testInstance);
+    }
+
+    public MockitoTestRule silent() {
+        return strictness(Strictness.LENIENT);
+    }
+
+    public MockitoTestRule strictness(Strictness strictness) {
+        super.setStrictness(strictness);
+        return this;
     }
 }

--- a/src/main/java/org/mockito/internal/junit/JUnitTestRule.java
+++ b/src/main/java/org/mockito/internal/junit/JUnitTestRule.java
@@ -11,7 +11,7 @@ import org.mockito.junit.MockitoTestRule;
 import org.mockito.plugins.MockitoLogger;
 import org.mockito.quality.Strictness;
 
-public class JUnitTestRule extends AbstractJUnitRule implements MockitoTestRule {
+public final class JUnitTestRule extends AbstractJUnitRule implements MockitoTestRule {
 
     private final Object testInstance;
 

--- a/src/main/java/org/mockito/internal/junit/JUnitTestRule.java
+++ b/src/main/java/org/mockito/internal/junit/JUnitTestRule.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.junit;
+
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.mockito.exceptions.base.MockitoException;
+import org.mockito.junit.MockitoTestRule;
+import org.mockito.plugins.MockitoLogger;
+import org.mockito.quality.Strictness;
+
+public class JUnitTestRule extends JUnitRule implements MockitoTestRule {
+
+    private final Object testInstance;
+
+    public JUnitTestRule(MockitoLogger logger, Strictness strictness, Object testInstance) {
+        super(logger, strictness);
+        this.testInstance = testInstance;
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        if (description.isSuite()) {
+            throw new MockitoException("JUnitTestRule can not be used as a @ClassRule.");
+        }
+        return createStatement(base, description.getDisplayName(), this.testInstance);
+    }
+}

--- a/src/main/java/org/mockito/junit/MockitoJUnit.java
+++ b/src/main/java/org/mockito/junit/MockitoJUnit.java
@@ -37,14 +37,15 @@ public class MockitoJUnit {
 
     /**
      * Creates a rule instance that initiates &#064;Mocks and is a {@link TestRule}. Use this method
-     * if you need to explicitly need a {@link TestRule}, for example if you need to compose
-     * multiple rules using a {@link org.junit.rules.RuleChain}.
+     * only when you need to explicitly need a {@link TestRule}, for example if you need to compose
+     * multiple rules using a {@link org.junit.rules.RuleChain}. Otherwise, always prefer {@link #rule()}
      * See {@link MockitoRule}.
      *
      * @param testInstance The instance to initiate mocks for
      * @return the rule instance
+     * @since 3.3.0
      */
-    public static MockitoTestRule rule(Object testInstance) {
+    public static MockitoTestRule testRule(Object testInstance) {
         return new JUnitTestRule(Plugins.getMockitoLogger(), Strictness.WARN, testInstance);
     }
 

--- a/src/main/java/org/mockito/junit/MockitoJUnit.java
+++ b/src/main/java/org/mockito/junit/MockitoJUnit.java
@@ -4,9 +4,11 @@
  */
 package org.mockito.junit;
 
+import org.junit.rules.TestRule;
 import org.mockito.Incubating;
 import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.internal.junit.JUnitRule;
+import org.mockito.internal.junit.JUnitTestRule;
 import org.mockito.internal.junit.VerificationCollectorImpl;
 import org.mockito.quality.Strictness;
 
@@ -31,6 +33,19 @@ public class MockitoJUnit {
      */
     public static MockitoRule rule() {
         return new JUnitRule(Plugins.getMockitoLogger(), Strictness.WARN);
+    }
+
+    /**
+     * Creates a rule instance that initiates &#064;Mocks and is a {@link TestRule}. Use this method
+     * if you need to explicitly need a {@link TestRule}, for example if you need to compose
+     * multiple rules using a {@link org.junit.rules.RuleChain}.
+     * See {@link MockitoRule}.
+     *
+     * @param testInstance The instance to initiate mocks for
+     * @return the rule instance
+     */
+    public static MockitoTestRule rule(Object testInstance) {
+        return new JUnitTestRule(Plugins.getMockitoLogger(), Strictness.WARN, testInstance);
     }
 
     /**

--- a/src/main/java/org/mockito/junit/MockitoTestRule.java
+++ b/src/main/java/org/mockito/junit/MockitoTestRule.java
@@ -6,87 +6,27 @@ package org.mockito.junit;
 
 import org.junit.rules.TestRule;
 import org.mockito.Incubating;
-import org.mockito.MockSettings;
-import org.mockito.Mockito;
-import org.mockito.exceptions.misusing.PotentialStubbingProblem;
-import org.mockito.quality.MockitoHint;
 import org.mockito.quality.Strictness;
 
 /**
- * Equivalent to {@link MockitoRule}, but also inherits from {@link TestRule}. For more information,
- * please see the documentation on {@link MockitoRule}.
+ * Equivalent to {@link MockitoRule}, but inherits a different JUnit4 base interface {@link TestRule}.
+ * For more information, please see the documentation on {@link MockitoRule}.
+ *
+ * @since 3.3.0
  */
 public interface MockitoTestRule extends TestRule {
 
     /**
-     * Rule will not report stubbing warnings during test execution. By default, stubbing warnings are
-     * printed to Standard output to help debugging. Equivalent of configuring {@link
-     * #strictness(Strictness)} with {@link Strictness#LENIENT}.
+     * Equivalent to {@link MockitoRule#silent()}.
      *
-     * <p><strong>Please</strong> give us feedback about the stubbing warnings of JUnit rules by
-     * commenting on GitHub <a href="https://github.com/mockito/mockito/issues/769">issue 769</a>.
-     * It's a new feature of Mockito 2.1.0. It aims to help debugging tests. We want to make sure the
-     * feature is useful. We would really like to know why do you wish to silence the warnings! See
-     * also {@link MockitoHint}.
-     *
-     * <p>Example:
-     *
-     * <pre class="code"><code class="java">
-     * public class ExampleTest {
-     *
-     *     &#064;Rule
-     *     public MockitoRule rule = MockitoJUnit.rule().silent();
-     *
-     * }
-     * </code></pre>
-     *
-     * @since 2.1.0
+     * @since 3.3.0
      */
     MockitoTestRule silent();
 
     /**
-     * The strictness, especially "strict stubs" ({@link Strictness#STRICT_STUBS}) helps debugging and
-     * keeping tests clean. It's a new feature introduced in Mockito 2.3. Other levels of strictness -
-     * "warn" - ({@link Strictness#WARN}) and "lenient" ({@link MockitoRule#silent()}) strictness were
-     * already present in Mockito 2.1.0. Version 2.3.0 introduces "strict stubs" ({@link
-     * Strictness#STRICT_STUBS}).
+     * Equivalent to {@link MockitoRule#strictness(Strictness)}.
      *
-     * <pre class="code"><code class="java">
-     * public class ExampleTest {
-     *     &#064;Rule
-     *     public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
-     * }
-     * </code></pre>
-     *
-     * See Javadoc for {@link Strictness} to learn how strictness influences the behavior of the JUnit
-     * rule. See {@link Strictness#STRICT_STUBS} to learn why is it recommended to use "strict
-     * stubbing".
-     *
-     * <p>It is possible to tweak the strictness per test method. Why would you need it? See the use
-     * cases in Javadoc for {@link PotentialStubbingProblem} class. In order to tweak strictness per
-     * stubbing see {@link Mockito#lenient()}, per mock see {@link MockSettings#lenient()}.
-     *
-     * <pre class="code"><code class="java">
-     * public class ExampleTest {
-     *     &#064;Rule
-     *     public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
-     *
-     *     &#064;Test public void exampleTest() {
-     *         //Change the strictness level only for this test method
-     *         //Useful for edge cases (see Javadoc for PotentialStubbingProblem class)
-     *         mockito.strictness(Strictness.LENIENT);
-     *
-     *         //remaining test code
-     *     }
-     * }
-     * </code></pre>
-     *
-     * "Strict stubs" are planned to be the default for Mockito v3 We are very eager to hear feedback
-     * about "strict stubbing" feature, let us know by commenting on GitHub <a
-     * href="https://github.com/mockito/mockito/issues/769">issue 769</a>. Strict stubbing is an
-     * attempt to improve testability and productivity with Mockito. Tell us what you think!
-     *
-     * @since 2.3.0
+     * @since 3.3.0
      */
     @Incubating
     MockitoTestRule strictness(Strictness strictness);

--- a/src/main/java/org/mockito/junit/MockitoTestRule.java
+++ b/src/main/java/org/mockito/junit/MockitoTestRule.java
@@ -5,11 +5,90 @@
 package org.mockito.junit;
 
 import org.junit.rules.TestRule;
+import org.mockito.Incubating;
+import org.mockito.MockSettings;
+import org.mockito.Mockito;
+import org.mockito.exceptions.misusing.PotentialStubbingProblem;
+import org.mockito.quality.MockitoHint;
+import org.mockito.quality.Strictness;
 
 /**
  * Equivalent to {@link MockitoRule}, but also inherits from {@link TestRule}. For more information,
  * please see the documentation on {@link MockitoRule}.
  */
-public interface MockitoTestRule extends MockitoRule, TestRule {
+public interface MockitoTestRule extends TestRule {
+
+    /**
+     * Rule will not report stubbing warnings during test execution. By default, stubbing warnings are
+     * printed to Standard output to help debugging. Equivalent of configuring {@link
+     * #strictness(Strictness)} with {@link Strictness#LENIENT}.
+     *
+     * <p><strong>Please</strong> give us feedback about the stubbing warnings of JUnit rules by
+     * commenting on GitHub <a href="https://github.com/mockito/mockito/issues/769">issue 769</a>.
+     * It's a new feature of Mockito 2.1.0. It aims to help debugging tests. We want to make sure the
+     * feature is useful. We would really like to know why do you wish to silence the warnings! See
+     * also {@link MockitoHint}.
+     *
+     * <p>Example:
+     *
+     * <pre class="code"><code class="java">
+     * public class ExampleTest {
+     *
+     *     &#064;Rule
+     *     public MockitoRule rule = MockitoJUnit.rule().silent();
+     *
+     * }
+     * </code></pre>
+     *
+     * @since 2.1.0
+     */
+    MockitoTestRule silent();
+
+    /**
+     * The strictness, especially "strict stubs" ({@link Strictness#STRICT_STUBS}) helps debugging and
+     * keeping tests clean. It's a new feature introduced in Mockito 2.3. Other levels of strictness -
+     * "warn" - ({@link Strictness#WARN}) and "lenient" ({@link MockitoRule#silent()}) strictness were
+     * already present in Mockito 2.1.0. Version 2.3.0 introduces "strict stubs" ({@link
+     * Strictness#STRICT_STUBS}).
+     *
+     * <pre class="code"><code class="java">
+     * public class ExampleTest {
+     *     &#064;Rule
+     *     public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+     * }
+     * </code></pre>
+     *
+     * See Javadoc for {@link Strictness} to learn how strictness influences the behavior of the JUnit
+     * rule. See {@link Strictness#STRICT_STUBS} to learn why is it recommended to use "strict
+     * stubbing".
+     *
+     * <p>It is possible to tweak the strictness per test method. Why would you need it? See the use
+     * cases in Javadoc for {@link PotentialStubbingProblem} class. In order to tweak strictness per
+     * stubbing see {@link Mockito#lenient()}, per mock see {@link MockSettings#lenient()}.
+     *
+     * <pre class="code"><code class="java">
+     * public class ExampleTest {
+     *     &#064;Rule
+     *     public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+     *
+     *     &#064;Test public void exampleTest() {
+     *         //Change the strictness level only for this test method
+     *         //Useful for edge cases (see Javadoc for PotentialStubbingProblem class)
+     *         mockito.strictness(Strictness.LENIENT);
+     *
+     *         //remaining test code
+     *     }
+     * }
+     * </code></pre>
+     *
+     * "Strict stubs" are planned to be the default for Mockito v3 We are very eager to hear feedback
+     * about "strict stubbing" feature, let us know by commenting on GitHub <a
+     * href="https://github.com/mockito/mockito/issues/769">issue 769</a>. Strict stubbing is an
+     * attempt to improve testability and productivity with Mockito. Tell us what you think!
+     *
+     * @since 2.3.0
+     */
+    @Incubating
+    MockitoTestRule strictness(Strictness strictness);
 
 }

--- a/src/main/java/org/mockito/junit/MockitoTestRule.java
+++ b/src/main/java/org/mockito/junit/MockitoTestRule.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2020 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.junit;
+
+import org.junit.rules.TestRule;
+
+/**
+ * Equivalent to {@link MockitoRule}, but also inherits from {@link TestRule}. For more information,
+ * please see the documentation on {@link MockitoRule}.
+ */
+public interface MockitoTestRule extends MockitoRule, TestRule {
+
+}

--- a/src/test/java/org/mockitousage/junitrule/JUnitTestRuleIntegratesWithRuleChainTest.java
+++ b/src/test/java/org/mockitousage/junitrule/JUnitTestRuleIntegratesWithRuleChainTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage.junitrule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.runners.model.Statement;
+import org.mockito.Mock;
+import org.mockito.internal.util.MockUtil;
+import org.mockito.junit.MockitoJUnit;
+
+public class JUnitTestRuleIntegratesWithRuleChainTest {
+
+    @Rule
+    public final RuleChain chain = RuleChain.outerRule(MockitoJUnit.rule(this)).around((base, description) -> new Statement() {
+        @Override
+        public void evaluate() throws Throwable {
+            assertThat(MockUtil.isMock(mock)).isTrue();
+            called.set(true);
+            base.evaluate();
+        }
+    });
+
+    @Mock
+    public Object mock;
+
+    private AtomicBoolean called = new AtomicBoolean(false);
+
+    @Test
+    public void creates_mocks_in_correct_rulechain_ordering() {
+        assertThat(MockUtil.isMock(mock)).isTrue();
+        assertThat(called.get()).isTrue();
+    }
+}

--- a/src/test/java/org/mockitousage/junitrule/JUnitTestRuleIntegratesWithRuleChainTest.java
+++ b/src/test/java/org/mockitousage/junitrule/JUnitTestRuleIntegratesWithRuleChainTest.java
@@ -20,7 +20,6 @@ import org.mockito.internal.util.MockUtil;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.quality.Strictness;
 import org.mockitousage.IMethods;
-import org.mockitousage.junitrule.MutableStrictJUnitTestRuleTest.StrictByDefault;
 import org.mockitoutil.JUnitResultAssert;
 
 public class JUnitTestRuleIntegratesWithRuleChainTest {
@@ -28,16 +27,6 @@ public class JUnitTestRuleIntegratesWithRuleChainTest {
     JUnitCore runner = new JUnitCore();
 
     @Test public void rule_can_be_changed_to_strict() {
-        //when
-        Result result = runner.run(MutableStrictJUnitTestRuleTest.LenientByDefault.class);
-
-        //then
-        JUnitResultAssert.assertThat(result)
-            .succeeds(1)
-            .fails(1, RuntimeException.class);
-    }
-
-    @Test public void rule_can_be_changed_to_lenient() {
         //when
         Result result = runner.run(StrictByDefault.class);
 
@@ -47,10 +36,19 @@ public class JUnitTestRuleIntegratesWithRuleChainTest {
             .fails(1, RuntimeException.class);
     }
 
+    @Test public void rule_can_be_changed_to_lenient() {
+        //when
+        Result result = runner.run(LenientByDefault.class);
+
+        //then
+        JUnitResultAssert.assertThat(result)
+            .isSuccessful();
+    }
+
     public static class LenientByDefault {
         @Rule
         public final RuleChain chain = RuleChain.outerRule(
-            MockitoJUnit.rule(this)
+            MockitoJUnit.testRule(this)
         ).around((base, description) -> new Statement() {
             @Override
             public void evaluate() throws Throwable {
@@ -75,7 +73,7 @@ public class JUnitTestRuleIntegratesWithRuleChainTest {
     public static class StrictByDefault {
         @Rule
         public final RuleChain chain = RuleChain.outerRule(
-            MockitoJUnit.rule(this).strictness(Strictness.STRICT_STUBS)
+            MockitoJUnit.testRule(this).strictness(Strictness.STRICT_STUBS)
         ).around((base, description) -> new Statement() {
             @Override
             public void evaluate() throws Throwable {
@@ -98,6 +96,7 @@ public class JUnitTestRuleIntegratesWithRuleChainTest {
 
         @Test public void unused_stub() throws Throwable {
             when(mock.simpleMethod()).thenReturn("1");
+            assertThat(called.get()).isTrue();
         }
     }
 }

--- a/src/test/java/org/mockitousage/junitrule/JUnitTestRuleIntegratesWithRuleChainTest.java
+++ b/src/test/java/org/mockitousage/junitrule/JUnitTestRuleIntegratesWithRuleChainTest.java
@@ -5,37 +5,99 @@
 package org.mockitousage.junitrule;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
 import org.junit.runners.model.Statement;
 import org.mockito.Mock;
 import org.mockito.internal.util.MockUtil;
 import org.mockito.junit.MockitoJUnit;
+import org.mockito.quality.Strictness;
+import org.mockitousage.IMethods;
+import org.mockitousage.junitrule.MutableStrictJUnitTestRuleTest.StrictByDefault;
+import org.mockitoutil.JUnitResultAssert;
 
 public class JUnitTestRuleIntegratesWithRuleChainTest {
 
-    @Rule
-    public final RuleChain chain = RuleChain.outerRule(MockitoJUnit.rule(this)).around((base, description) -> new Statement() {
-        @Override
-        public void evaluate() throws Throwable {
+    JUnitCore runner = new JUnitCore();
+
+    @Test public void rule_can_be_changed_to_strict() {
+        //when
+        Result result = runner.run(MutableStrictJUnitTestRuleTest.LenientByDefault.class);
+
+        //then
+        JUnitResultAssert.assertThat(result)
+            .succeeds(1)
+            .fails(1, RuntimeException.class);
+    }
+
+    @Test public void rule_can_be_changed_to_lenient() {
+        //when
+        Result result = runner.run(StrictByDefault.class);
+
+        //then
+        JUnitResultAssert.assertThat(result)
+            .succeeds(1)
+            .fails(1, RuntimeException.class);
+    }
+
+    public static class LenientByDefault {
+        @Rule
+        public final RuleChain chain = RuleChain.outerRule(
+            MockitoJUnit.rule(this)
+        ).around((base, description) -> new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                assertThat(MockUtil.isMock(mock)).isTrue();
+                called.set(true);
+                base.evaluate();
+            }
+        });
+
+        @Mock
+        public IMethods mock;
+
+        private AtomicBoolean called = new AtomicBoolean(false);
+
+        @Test
+        public void creates_mocks_in_correct_rulechain_ordering() {
             assertThat(MockUtil.isMock(mock)).isTrue();
-            called.set(true);
-            base.evaluate();
+            assertThat(called.get()).isTrue();
         }
-    });
+    }
 
-    @Mock
-    public Object mock;
+    public static class StrictByDefault {
+        @Rule
+        public final RuleChain chain = RuleChain.outerRule(
+            MockitoJUnit.rule(this).strictness(Strictness.STRICT_STUBS)
+        ).around((base, description) -> new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                assertThat(MockUtil.isMock(mock)).isTrue();
+                called.set(true);
+                base.evaluate();
+            }
+        });
 
-    private AtomicBoolean called = new AtomicBoolean(false);
+        @Mock
+        public IMethods mock;
 
-    @Test
-    public void creates_mocks_in_correct_rulechain_ordering() {
-        assertThat(MockUtil.isMock(mock)).isTrue();
-        assertThat(called.get()).isTrue();
+        private AtomicBoolean called = new AtomicBoolean(false);
+
+        @Test
+        public void creates_mocks_in_correct_rulechain_ordering() {
+            assertThat(MockUtil.isMock(mock)).isTrue();
+            assertThat(called.get()).isTrue();
+        }
+
+        @Test public void unused_stub() throws Throwable {
+            when(mock.simpleMethod()).thenReturn("1");
+        }
     }
 }

--- a/src/test/java/org/mockitousage/junitrule/MockitoJUnitTestRuleTest.java
+++ b/src/test/java/org/mockitousage/junitrule/MockitoJUnitTestRuleTest.java
@@ -12,16 +12,16 @@ import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.MockitoTestRule;
 
 public class MockitoJUnitTestRuleTest {
 
     @Rule
-    public MockitoRule mockitoRule = MockitoJUnit.rule(this);
+    public MockitoTestRule mockitoRule = MockitoJUnit.rule(this);
 
     // Fixes #1578: Protect against multiple execution.
     @Rule
-    public MockitoRule mockitoRule2 = mockitoRule;
+    public MockitoTestRule mockitoRule2 = mockitoRule;
 
     @Mock
     private Injected injected;

--- a/src/test/java/org/mockitousage/junitrule/MockitoJUnitTestRuleTest.java
+++ b/src/test/java/org/mockitousage/junitrule/MockitoJUnitTestRuleTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage.junitrule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class MockitoJUnitTestRuleTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule(this);
+
+    // Fixes #1578: Protect against multiple execution.
+    @Rule
+    public MockitoRule mockitoRule2 = mockitoRule;
+
+    @Mock
+    private Injected injected;
+
+    @InjectMocks
+    private InjectInto injectInto;
+
+    @Test
+    public void testInjectMocks() throws Exception {
+        assertNotNull("Mock created", injected);
+        assertNotNull("Object created", injectInto);
+        assertEquals("A injected into B", injected, injectInto.getInjected());
+    }
+
+    public static class Injected { }
+
+    public static class InjectInto {
+        private Injected injected;
+
+        public Injected getInjected() {
+            return injected;
+        }
+    }
+}

--- a/src/test/java/org/mockitousage/junitrule/MockitoJUnitTestRuleTest.java
+++ b/src/test/java/org/mockitousage/junitrule/MockitoJUnitTestRuleTest.java
@@ -17,7 +17,7 @@ import org.mockito.junit.MockitoTestRule;
 public class MockitoJUnitTestRuleTest {
 
     @Rule
-    public MockitoTestRule mockitoRule = MockitoJUnit.rule(this);
+    public MockitoTestRule mockitoRule = MockitoJUnit.testRule(this);
 
     // Fixes #1578: Protect against multiple execution.
     @Rule

--- a/src/test/java/org/mockitousage/junitrule/MutableStrictJUnitTestRuleTest.java
+++ b/src/test/java/org/mockitousage/junitrule/MutableStrictJUnitTestRuleTest.java
@@ -42,7 +42,7 @@ public class MutableStrictJUnitTestRuleTest {
     }
 
     public static class LenientByDefault {
-        @Rule public MockitoTestRule mockito = MockitoJUnit.rule(this).strictness(Strictness.LENIENT);
+        @Rule public MockitoTestRule mockito = MockitoJUnit.testRule(this).strictness(Strictness.LENIENT);
         @Mock IMethods mock;
 
         @Test public void unused_stub() throws Throwable {
@@ -58,7 +58,7 @@ public class MutableStrictJUnitTestRuleTest {
     }
 
     public static class StrictByDefault {
-        @Rule public MockitoTestRule mockito = MockitoJUnit.rule(this).strictness(Strictness.STRICT_STUBS);
+        @Rule public MockitoTestRule mockito = MockitoJUnit.testRule(this).strictness(Strictness.STRICT_STUBS);
         @Mock IMethods mock;
 
         @Test public void unused_stub() throws Throwable {

--- a/src/test/java/org/mockitousage/junitrule/MutableStrictJUnitTestRuleTest.java
+++ b/src/test/java/org/mockitousage/junitrule/MutableStrictJUnitTestRuleTest.java
@@ -12,7 +12,7 @@ import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.MockitoTestRule;
 import org.mockito.quality.Strictness;
 import org.mockitousage.IMethods;
 import org.mockitoutil.JUnitResultAssert;
@@ -42,7 +42,7 @@ public class MutableStrictJUnitTestRuleTest {
     }
 
     public static class LenientByDefault {
-        @Rule public MockitoRule mockito = MockitoJUnit.rule(this).strictness(Strictness.LENIENT);
+        @Rule public MockitoTestRule mockito = MockitoJUnit.rule(this).strictness(Strictness.LENIENT);
         @Mock IMethods mock;
 
         @Test public void unused_stub() throws Throwable {
@@ -58,7 +58,7 @@ public class MutableStrictJUnitTestRuleTest {
     }
 
     public static class StrictByDefault {
-        @Rule public MockitoRule mockito = MockitoJUnit.rule(this).strictness(Strictness.STRICT_STUBS);
+        @Rule public MockitoTestRule mockito = MockitoJUnit.rule(this).strictness(Strictness.STRICT_STUBS);
         @Mock IMethods mock;
 
         @Test public void unused_stub() throws Throwable {

--- a/src/test/java/org/mockitousage/junitrule/MutableStrictJUnitTestRuleTest.java
+++ b/src/test/java/org/mockitousage/junitrule/MutableStrictJUnitTestRuleTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage.junitrule;
+
+import static org.mockito.Mockito.when;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
+import org.mockitousage.IMethods;
+import org.mockitoutil.JUnitResultAssert;
+
+public class MutableStrictJUnitTestRuleTest {
+
+    JUnitCore runner = new JUnitCore();
+
+    @Test public void rule_can_be_changed_to_strict() throws Throwable {
+        //when
+        Result result = runner.run(LenientByDefault.class);
+
+        //then
+        JUnitResultAssert.assertThat(result)
+                .succeeds(1)
+                .fails(1, RuntimeException.class);
+    }
+
+    @Test public void rule_can_be_changed_to_lenient() throws Throwable {
+        //when
+        Result result = runner.run(StrictByDefault.class);
+
+        //then
+        JUnitResultAssert.assertThat(result)
+                .succeeds(1)
+                .fails(1, RuntimeException.class);
+    }
+
+    public static class LenientByDefault {
+        @Rule public MockitoRule mockito = MockitoJUnit.rule(this).strictness(Strictness.LENIENT);
+        @Mock IMethods mock;
+
+        @Test public void unused_stub() throws Throwable {
+            when(mock.simpleMethod()).thenReturn("1");
+        }
+
+        @Test public void unused_stub_with_strictness() throws Throwable {
+            //making Mockito strict only for this test method
+            mockito.strictness(Strictness.STRICT_STUBS);
+
+            when(mock.simpleMethod()).thenReturn("1");
+        }
+    }
+
+    public static class StrictByDefault {
+        @Rule public MockitoRule mockito = MockitoJUnit.rule(this).strictness(Strictness.STRICT_STUBS);
+        @Mock IMethods mock;
+
+        @Test public void unused_stub() throws Throwable {
+            when(mock.simpleMethod()).thenReturn("1");
+        }
+
+        @Test public void unused_stub_with_lenient() throws Throwable {
+            //making Mockito lenient only for this test method
+            mockito.strictness(Strictness.LENIENT);
+
+            when(mock.simpleMethod()).thenReturn("1");
+        }
+    }
+}


### PR DESCRIPTION
JUnit has two types of test rules: MethodRule and TestRule. The existing
MockitoJUnit rule returns a MockitoRule which extends MethodRule.
However, since this is not a TestRule, some features of JUnit do not
nicely integrate with Mockito. For example, the RuleChain feature of
JUnit only works on TestRules.

Therefore, add a separate entrypoint to MockitoJUnit which returns a
TestRule that can be integrated with RuleChain. It introduces a separate
interface to make this distinction clear. If we would change the
existing MockitoRule to also extend TestRule, the JUnit logic would no
longer run the MethodRule [1] and would thus break existing users.

[1]: https://github.com/junit-team/junit4/blob/2df7e0882128d551565f87f688bbe745d85aacba/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java#L402