### PR TITLE
Make JARs build reproducibly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ out
 classes
 .gradletasknamecache
 *.log
+
+# Used to check reproducibility of Mockito jars
+checksums/

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ script:
   # We are using && below on purpose
   # ciPerformRelease must run only when the entire build has completed
   # This guarantees that no release steps are executed when the build or tests fail
-  - ./gradlew spotlessCheck && ./gradlew build idea -s && ./gradlew ciPerformRelease
+  - ./gradlew spotlessCheck && ./gradlew build idea -s && ./gradlew checkReproducibility && ./gradlew ciPerformRelease
 
 after_success:
   #Generates coverage report:

--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,12 @@ allprojects { proj ->
         options.addStringOption('charSet', 'UTF-8')
         options.setSource('8')
     }
+
+    tasks.withType(AbstractArchiveTask) {
+        preserveFileTimestamps = false
+        reproducibleFileOrder = true
+    }
+
     apply plugin: 'checkstyle'
     checkstyle {
        configFile = rootProject.file('config/checkstyle/checkstyle.xml')

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ apply from: 'gradle/root/coverage.gradle'
 apply from: 'gradle/mockito-core/inline-mock.gradle'
 apply from: 'gradle/mockito-core/osgi.gradle'
 apply from: 'gradle/mockito-core/javadoc.gradle'
+apply from: 'gradle/mockito-core/reproducible-build.gradle'
 apply from: 'gradle/mockito-core/testing.gradle'
 
 apply from: 'gradle/dependencies.gradle'

--- a/gradle/mockito-core/osgi.gradle
+++ b/gradle/mockito-core/osgi.gradle
@@ -1,3 +1,12 @@
+import java.nio.file.attribute.FileTime
+import java.util.jar.Attributes
+import java.util.jar.JarEntry
+import java.util.jar.JarFile
+import java.util.jar.JarOutputStream
+import java.util.jar.Manifest
+
+import static java.util.Calendar.FEBRUARY
+
 apply plugin: 'osgi'
 
 afterEvaluate {
@@ -31,5 +40,88 @@ afterEvaluate {
 
             attributes 'Automatic-Module-Name': 'org.mockito'
         }
+
+        jar.doLast {
+            JarFile originalJar = new JarFile(jar.archivePath)
+
+            new RemoveOsgiLastModifiedHeader(originalJar)
+                .transform()
+                .renameTo jar.archivePath
+        }
+
     }
+}
+
+
+/*
+ * The OSGi plugin in Gradle 5.3 has a known issue (https://github.com/gradle/gradle/issues/6187) where it embeds
+ * a Manifest entry "Bnd-LastModified" (set to the last modified time of the build directory) even if you ask it not to
+ * using `-noextraheaders` or `-removeheaders`.
+ *
+ * It cannot be pinned or removed, and is a source of non-determinism in the build.
+ *
+ * This class addresses the problem by rewriting the JAR and removing that entry from the Manifest. A side-effect of this
+ * is having to set `lastModifiedTime` for each entry to a fixed value, else this would also introduce non-determinism.
+ *
+ * The fixed value is the same as the default value for Gradle's fixed timestamps, and the rationale behind it is detailed
+ * in https://github.com/gradle/gradle/blob/58538513a3bff3b7015718976fe1304e23f40694/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipCopyAction.java#L42-L57
+ */
+
+class RemoveOsgiLastModifiedHeader {
+    private final long CONSTANT_TIME_FOR_ZIP_ENTRIES = new GregorianCalendar(1980, FEBRUARY, 1, 0, 0, 0).timeInMillis
+
+    private final JarFile artifact
+
+    RemoveOsgiLastModifiedHeader(JarFile artifact) {
+        this.artifact = artifact
+    }
+
+    File transform() {
+        File temp = File.createTempFile("temp",".jar")
+
+        temp.withOutputStream { os ->
+            JarOutputStream stream = new JarOutputStream(os)
+
+            this.artifact
+                .entries()
+                .sort { it.name }
+                .each { JarEntry entry ->
+
+                    stream.putNextEntry(newJarEntry(entry))
+
+                    if (entry.name == "META-INF/MANIFEST.MF") {
+                        newManifest(entry).write(stream)
+                    } else {
+                        stream << this.artifact.getInputStream(entry)
+                    }
+
+                    stream.closeEntry()
+                }
+
+            stream.finish()
+        }
+
+        temp
+    }
+
+    Manifest newManifest(JarEntry entry) {
+        Manifest manifest = new Manifest()
+
+        manifest.read(this.artifact.getInputStream(entry))
+
+        manifest
+            .getMainAttributes()
+            .remove(new Attributes.Name("Bnd-LastModified"))
+
+        manifest
+    }
+
+    JarEntry newJarEntry(JarEntry original) {
+        JarEntry newEntry = new JarEntry(original.name)
+
+        newEntry.setLastModifiedTime(FileTime.fromMillis(CONSTANT_TIME_FOR_ZIP_ENTRIES))
+
+        newEntry
+    }
+
 }

--- a/gradle/mockito-core/reproducible-build.gradle
+++ b/gradle/mockito-core/reproducible-build.gradle
@@ -1,0 +1,67 @@
+import java.security.DigestInputStream
+import java.security.MessageDigest
+
+/*
+ * The `checkReproducibility` task compares two sets of checksums, generated
+ * in two independent builds, from non-javadoc output archives.
+ *
+ * This task ensures that a change has not regressed the reproducibility of
+ * the Mockito project and its subprojects.
+ */
+
+task checkReproducibility {
+    doLast {
+        def first = new File("checksums-1.txt").text.split('\n')
+        def second = new File("checksums-2.txt").text.split('\n')
+
+        assert first.sort() == second.sort()
+    }
+}
+
+task getChecksums1(type: GradleBuild) {
+    tasks = ['clean', 'assemble']
+    startParameter.projectProperties = ['build-id': "1"]
+}
+
+task getChecksums2(type: GradleBuild) {
+    tasks = ['clean', 'assemble']
+    startParameter.projectProperties = ['build-id': "2"]
+}
+
+getChecksums2.dependsOn(getChecksums1)
+checkReproducibility.dependsOn(getChecksums2)
+
+if (project.hasProperty('build-id')) {
+
+    String id = project.getProperty('build-id')
+
+    File checksums = new File("checksums-${id}.txt")
+    checksums.delete()
+
+    afterEvaluate {
+
+        ([project] + subprojects).each { p ->
+
+            p.tasks.withType(AbstractArchiveTask) { task ->
+
+                if (!task.name.contains('javadoc')) {
+                    task.doLast {
+                        File output = task.archiveFile.get().getAsFile()
+
+                        checksums << "${output.name},${calculateHash(output)}\n"
+                    }
+                }
+            }
+        }
+
+    }
+}
+
+static def calculateHash(File file) {
+    file.withInputStream {
+        new DigestInputStream(it, MessageDigest.getInstance("SHA-256")).withStream {
+            it.eachByte {}
+            it.messageDigest.digest().encodeHex() as String
+        }
+    }
+}

--- a/gradle/mockito-core/reproducible-build.gradle
+++ b/gradle/mockito-core/reproducible-build.gradle
@@ -11,8 +11,8 @@ import java.security.MessageDigest
 
 task checkReproducibility {
     doLast {
-        def first = new File("checksums-1.txt").text.split('\n')
-        def second = new File("checksums-2.txt").text.split('\n')
+        def first = new File("checksums", "checksums-1.txt").text.split('\n')
+        def second = new File("checksums", "checksums-2.txt").text.split('\n')
 
         assert first.sort() == second.sort()
     }
@@ -35,7 +35,9 @@ if (project.hasProperty('build-id')) {
 
     String id = project.getProperty('build-id')
 
-    File checksums = new File("checksums-${id}.txt")
+    mkdir "checksums"
+
+    File checksums = new File("checksums", "checksums-${id}.txt")
     checksums.delete()
 
     afterEvaluate {


### PR DESCRIPTION
Fixes #1891 

## Overview

This PR makes the java bytecode generated by this project [reproducible](https://reproducible-builds.org/). This means that under identical builds condition (for example Java version), repeated builds should provide the same output byte-for-byte.

It achieves this by:

* using Gradle's [reproducible archives](https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives) functionality to fix timestamps and file ordering within JARs
* re-archiving JARs that are non-deterministic because they contain timestamps in their Manifests

Motivation for this change is best explained on the previously linked Reproducible Builds page.

## Confirming the change

```shell
#!/bin/bash -e

rm -f checksums*

./gradlew clean build -x test --parallel

find . -name '*.jar' \
    | grep '/build/libs/' \
    | sort \
    | xargs sha256sum > checksums-1.txt

./gradlew clean build -x test --parallel

find . -name '*.jar' \
    | grep '/build/libs/' \
    | sort \
    | xargs sha256sum > checksums-2.txt

diff checksums-1.txt checksums-2.txt
```

The diff should be empty, that is to say, both independent runs of the build should have generated byte-for-byte identical outputs, with the exception of the JavaDocs jars

## Omitting Javadocs

Despite Gradle allegedly supporting `noTimestamp` through [StandardJavadocDocletOptions](https://docs.gradle.org/5.3/javadoc/org/gradle/external/javadoc/StandardJavadocDocletOptions.html), I was unable to actually get this to work and remove the timestamped build comment in the javadoc. 

I'll happily fold this into the PR if I (or someone else) can get it to work.

---

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/3.x/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_