### PR TITLE
Fixes #1894 checkstyle error on windows

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -28,7 +28,7 @@
         </module>
     </module>
     <module name="RegexpHeader">
-        <property name="headerFile" value="config/checkstyle/java.header"/>
+        <property name="headerFile" value="${config_loc}/java.header"/>
         <property name="fileExtensions" value="java"/>
     </module>
 </module>

--- a/src/test/java/org/mockitousage/matchers/MatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/MatchersTest.java
@@ -608,7 +608,7 @@ public class MatchersTest extends TestBase {
     public void nullable_matcher() throws Exception {
         // imagine a Stream.of(...).map(c -> mock.oneArg(c))...
         mock.oneArg((Character) null);
-        mock.oneArg(Character.valueOf('€'));
+        mock.oneArg(Character.valueOf('\u20AC'));
 
         verify(mock, times(2)).oneArg(nullable(Character.class));
     }


### PR DESCRIPTION
windows has some issues with relative paths in checkstyle config files, additionally it failed with an Euro sign in code.

please verify if it also works on unix env