### PR TITLE
[documentation] change deprecated warnings from 3.x -> 4.x

### DIFF
--- a/src/main/java/org/mockito/ArgumentMatchers.java
+++ b/src/main/java/org/mockito/ArgumentMatchers.java
@@ -159,7 +159,8 @@ public class ArgumentMatchers {
      * @see #any(Class)
      * @see #notNull()
      * @see #notNull(Class)
-     * @deprecated This will be removed in Mockito 3.0 (which will be java 8 only)
+     * @deprecated This will be removed in Mockito 4.0 This method is only used for generic
+     * friendliness to avoid casting, this is not anymore needed in Java 8.
      */
     @Deprecated
     public static <T> T anyObject() {
@@ -519,7 +520,7 @@ public class ArgumentMatchers {
      * @see #anyList()
      * @see #isNull()
      * @see #isNull(Class)
-     * @deprecated With Java 8 this method will be removed in Mockito 3.0. This method is only used for generic
+     * @deprecated With Java 8 this method will be removed in Mockito 4.0. This method is only used for generic
      * friendliness to avoid casting, this is not anymore needed in Java 8.
      */
     @Deprecated
@@ -580,7 +581,7 @@ public class ArgumentMatchers {
      * @see #anySet()
      * @see #isNull()
      * @see #isNull(Class)
-     * @deprecated With Java 8 this method will be removed in Mockito 3.0. This method is only used for generic
+     * @deprecated With Java 8 this method will be removed in Mockito 4.0. This method is only used for generic
      * friendliness to avoid casting, this is not anymore needed in Java 8.
      */
     @Deprecated
@@ -642,7 +643,7 @@ public class ArgumentMatchers {
      * @see #anyMap()
      * @see #isNull()
      * @see #isNull(Class)
-     * @deprecated With Java 8 this method will be removed in Mockito 3.0. This method is only used for generic
+     * @deprecated With Java 8 this method will be removed in Mockito 4.0. This method is only used for generic
      * friendliness to avoid casting, this is not anymore needed in Java 8.
      */
     @Deprecated
@@ -703,7 +704,7 @@ public class ArgumentMatchers {
      * @see #anyCollection()
      * @see #isNull()
      * @see #isNull(Class)
-     * @deprecated With Java 8 this method will be removed in Mockito 3.0. This method is only used for generic
+     * @deprecated With Java 8 this method will be removed in Mockito 4.0. This method is only used for generic
      * friendliness to avoid casting, this is not anymore needed in Java 8.
      */
     @Deprecated
@@ -766,7 +767,7 @@ public class ArgumentMatchers {
      * @see #isNull()
      * @see #isNull(Class)
      * @since 2.1.0
-     * @deprecated With Java 8 this method will be removed in Mockito 3.0. This method is only used for generic
+     * @deprecated With Java 8 this method will be removed in Mockito 4.0. This method is only used for generic
      * friendliness to avoid casting, this is not anymore needed in Java 8.
      */
     @Deprecated
@@ -991,7 +992,7 @@ public class ArgumentMatchers {
      * @see #isNull()
      * @see #isNotNull()
      * @see #isNotNull(Class)
-     * @deprecated With Java 8 this method will be removed in Mockito 3.0. This method is only used for generic
+     * @deprecated With Java 8 this method will be removed in Mockito 4.0. This method is only used for generic
      * friendliness to avoid casting, this is not anymore needed in Java 8.
      */
     @Deprecated
@@ -1035,7 +1036,7 @@ public class ArgumentMatchers {
      * @see #isNotNull()
      * @see #isNull()
      * @see #isNull(Class)
-     * @deprecated With Java 8 this method will be removed in Mockito 3.0. This method is only used for generic
+     * @deprecated With Java 8 this method will be removed in Mockito 4.0. This method is only used for generic
      * friendliness to avoid casting, this is not anymore needed in Java 8.
      */
     @Deprecated
@@ -1077,7 +1078,7 @@ public class ArgumentMatchers {
      *
      * @param clazz Type to avoid casting
      * @return <code>null</code>.
-     * @deprecated With Java 8 this method will be removed in Mockito 3.0. This method is only used for generic
+     * @deprecated With Java 8 this method will be removed in Mockito 4.0. This method is only used for generic
      * friendliness to avoid casting, this is not anymore needed in Java 8.
      */
     @Deprecated

--- a/src/main/java/org/mockito/BDDMockito.java
+++ b/src/main/java/org/mockito/BDDMockito.java
@@ -354,7 +354,7 @@ public class BDDMockito extends Mockito {
         /**
          * See original {@link Stubber#doNothing()}.
          *
-         * This method will be removed in version 3.0.0
+         * This method will be removed in version 4.0.0
          *
          * @since 1.8.0
          * @deprecated as of 2.1.0 please use {@link #willDoNothing()} instead

--- a/src/main/java/org/mockito/Matchers.java
+++ b/src/main/java/org/mockito/Matchers.java
@@ -6,7 +6,7 @@ package org.mockito;
 
 /**
  * @deprecated Use {@link ArgumentMatchers}. This class is now deprecated in order to avoid a name clash with Hamcrest
- * <code>org.hamcrest.Matchers</code> class. This class will likely be removed in version 3.0.
+ * <code>org.hamcrest.Matchers</code> class. This class will likely be removed in version 4.0.
  */
 @Deprecated
 public class Matchers extends ArgumentMatchers {

--- a/src/main/java/org/mockito/configuration/AnnotationEngine.java
+++ b/src/main/java/org/mockito/configuration/AnnotationEngine.java
@@ -21,7 +21,7 @@ import org.mockito.MockitoAnnotations;
  * <code>org.mockito.configuration.MockitoConfiguration</code> will be chosen instead of the one in the file.
 
  * @deprecated Please use {@link org.mockito.plugins.AnnotationEngine} instead,
- *             this interface will probably be removed in mockito 3.
+ *             this interface will probably be removed in mockito 4.
  */
 @Deprecated
 public interface AnnotationEngine extends org.mockito.plugins.AnnotationEngine {

--- a/src/main/java/org/mockito/configuration/IMockitoConfiguration.java
+++ b/src/main/java/org/mockito/configuration/IMockitoConfiguration.java
@@ -57,7 +57,7 @@ public interface IMockitoConfiguration {
      * See javadoc for {@link IMockitoConfiguration}
      *
      * @deprecated Please use the extension mechanism {@link org.mockito.plugins.AnnotationEngine} instead,
-     *             this method will probably be removed in mockito 3.
+     *             this method will probably be removed in mockito 4.
      */
     @Deprecated
     AnnotationEngine getAnnotationEngine();

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsMoreEmptyValues.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsMoreEmptyValues.java
@@ -12,7 +12,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 /**
- * It's likely this implementation will be used by default by every Mockito 3.0.0 mock.
+ * It's likely this implementation will be used by default by every Mockito 4.0.0 mock.
  * <p>
  * Currently <b>used only</b> by {@link Mockito#RETURNS_SMART_NULLS}
  * <p>

--- a/src/main/java/org/mockito/runners/MockitoJUnitRunner.java
+++ b/src/main/java/org/mockito/runners/MockitoJUnitRunner.java
@@ -23,7 +23,7 @@ public class MockitoJUnitRunner extends org.mockito.junit.MockitoJUnitRunner {
     /**
      * Silent runner moved to a new place see {@link org.mockito.junit.MockitoJUnitRunner.Silent}
      *
-     * @deprecated Moved to {@link org.mockito.junit.MockitoJUnitRunner.Silent}, this class will be removed with Mockito 3
+     * @deprecated Moved to {@link org.mockito.junit.MockitoJUnitRunner.Silent}, this class will be removed with Mockito 4
      */
     @Deprecated
     public static class Silent extends MockitoJUnitRunner {
@@ -35,7 +35,7 @@ public class MockitoJUnitRunner extends org.mockito.junit.MockitoJUnitRunner {
     /**
      * Silent runner moved to a new place see {@link org.mockito.junit.MockitoJUnitRunner.Strict}
      *
-     * @deprecated Moved to {@link org.mockito.junit.MockitoJUnitRunner.Strict}, this class will be removed with Mockito 3
+     * @deprecated Moved to {@link org.mockito.junit.MockitoJUnitRunner.Strict}, this class will be removed with Mockito 4
      */
     @Deprecated
     public static class Strict extends MockitoJUnitRunner {


### PR DESCRIPTION
Problem

With the release of mockito 3.x as a purely java language version
change most of the comments referencing 3.x are wrong

Solution

Migrate the references to 3.x that I could find to 4.x

[ci skip-release]
 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/3.x/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_