### PR TITLE
[tests] use ArgumentMatchers over Matchers

### DIFF
--- a/src/test/java/org/mockito/internal/util/reflection/ParameterizedConstructorInstantiatorTest.java
+++ b/src/test/java/org/mockito/internal/util/reflection/ParameterizedConstructorInstantiatorTest.java
@@ -20,7 +20,7 @@ import java.util.Set;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.util.reflection.FieldInitializer.ConstructorArgumentResolver;
@@ -69,7 +69,7 @@ public class ParameterizedConstructorInstantiatorTest {
     public void should_instantiate_type_if_resolver_provide_matching_types() throws Exception {
         Observer observer = mock(Observer.class);
         Map map = mock(Map.class);
-        given(resolver.resolveTypeInstances(Matchers.<Class<?>[]>anyVararg())).willReturn(new Object[]{ observer, map });
+        given(resolver.resolveTypeInstances(ArgumentMatchers.<Class<?>[]>anyVararg())).willReturn(new Object[]{ observer, map });
 
         new ParameterizedConstructorInstantiator(this, field("withMultipleConstructor"), resolver).instantiate();
 
@@ -82,7 +82,7 @@ public class ParameterizedConstructorInstantiatorTest {
     public void should_fail_if_an_argument_instance_type_do_not_match_wanted_type() throws Exception {
         Observer observer = mock(Observer.class);
         Set<?> wrongArg = mock(Set.class);
-        given(resolver.resolveTypeInstances(Matchers.<Class<?>[]>anyVararg())).willReturn(new Object[]{ observer, wrongArg });
+        given(resolver.resolveTypeInstances(ArgumentMatchers.<Class<?>[]>any())).willReturn(new Object[]{ observer, wrongArg });
 
         try {
             new ParameterizedConstructorInstantiator(this, field("withMultipleConstructor"), resolver).instantiate();
@@ -94,7 +94,7 @@ public class ParameterizedConstructorInstantiatorTest {
 
     @Test
     public void should_report_failure_if_constructor_throws_exception() throws Exception {
-        given(resolver.resolveTypeInstances(Matchers.<Class<?>[]>anyVararg())).willReturn(new Object[]{ null });
+        given(resolver.resolveTypeInstances(ArgumentMatchers.<Class<?>[]>anyVararg())).willReturn(new Object[]{ null });
 
         try {
             new ParameterizedConstructorInstantiator(this, field("withThrowingConstructor"), resolver).instantiate();
@@ -107,7 +107,7 @@ public class ParameterizedConstructorInstantiatorTest {
     @Test
     public void should_instantiate_type_with_vararg_constructor() throws Exception {
         Observer[] vararg = new Observer[] {  };
-        given(resolver.resolveTypeInstances(Matchers.<Class<?>[]>anyVararg())).willReturn(new Object[]{ "", vararg});
+        given(resolver.resolveTypeInstances(ArgumentMatchers.<Class<?>[]>anyVararg())).willReturn(new Object[]{ "", vararg});
 
         new ParameterizedConstructorInstantiator(this, field("withVarargConstructor"), resolver).instantiate();
 


### PR DESCRIPTION
Problem
Matchers are considered deprecated but our own tests still use them.

Solution
Stop using using them. Replace with ArgumentMatchers

[ci skip-release]

check list

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/3.x/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [/] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_