### PR TITLE
Fixes #1910: update description of ArgumentMatcher javadoc

### DIFF
--- a/src/main/java/org/mockito/ArgumentMatchers.java
+++ b/src/main/java/org/mockito/ArgumentMatchers.java
@@ -121,7 +121,7 @@ public class ArgumentMatchers {
      * <p>
      * See examples in javadoc for {@link ArgumentMatchers} class
      *
-     * This is an alias of: {@link #anyObject()} and {@link #any(java.lang.Class)}
+     * This is an alias of: {@link #anyObject()}
      * </p>
      *
      * <p>
@@ -150,7 +150,7 @@ public class ArgumentMatchers {
      * Matches anything, including <code>null</code>.
      *
      * <p>
-     * This is an alias of: {@link #any()} and {@link #any(java.lang.Class)}.
+     * This is an alias of: {@link #any()}.
      * See examples in javadoc for {@link ArgumentMatchers} class.
      * </p>
      *


### PR DESCRIPTION
For any(), the doc says that
"any() is an alias of: anyObject() and any(java.lang.Class)."
But in the note, it says that
"Since mockito 2.1.0 any(Class) is not anymore an alias of this method."
This is confusing, so the alias in the doc should exclude any(java.lang.Class) to simply be
"any() is an alias of: anyObject()"
Also update the same issue of anyObject().

check list

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/3.x/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

