### PR TITLE
Fix Pattern matcher not matching to subregion

### DIFF
--- a/src/main/java/org/mockito/internal/matchers/Matches.java
+++ b/src/main/java/org/mockito/internal/matchers/Matches.java
@@ -22,7 +22,7 @@ public class Matches implements ArgumentMatcher<Object>, Serializable {
     }
 
     public boolean matches(Object actual) {
-        return (actual instanceof String) && pattern.matcher((String) actual).matches();
+        return (actual instanceof String) && pattern.matcher((String) actual).find();
     }
 
     public String toString() {

--- a/src/test/java/org/mockitousage/matchers/MatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/MatchersTest.java
@@ -512,6 +512,14 @@ public class MatchersTest extends TestBase {
     }
 
     @Test
+    public void matches_Pattern_matcher_in_subregion() {
+        when(mock.oneArg(matches(Pattern.compile("[a-z]")))).thenReturn("1");
+
+        assertEquals("1", mock.oneArg("3a45"));
+        assertEquals(null, mock.oneArg("3445"));
+    }
+
+    @Test
     public void contains_matcher() {
         when(mock.oneArg(contains("ell"))).thenReturn("1");
         when(mock.oneArg(contains("ld"))).thenReturn("2");


### PR DESCRIPTION
Issue #1905 talked about a particular pattern using Java's Pattern class that causes Mockito to not properly match the argument (provided with an invocation) to the expected answer.

It was later discovered that the Pattern matcher matches to the entire region, not some subregion, by using Java's `Matcher.match()` (see [comment](https://github.com/mockito/mockito/issues/1905#issuecomment-615295546) in #1905). This commit fixes that by using `Matcher.find()`.

Fixes #1905