### PR TITLE
[build] add ben-manes dependency upgrade finder

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -188,3 +188,7 @@ We found vertical alignment helping when reading the code, for that reason we wa
     1. For parameter `Throws list` choose : `Do not wrap`
     2. For sub-parameter `Align when multiline` tick the checkbox
 
+## Gradle Tips
+
+1. It is possible to run `./gradlew dependencyUpdates` to find out of date dependencies, including tools. Note that this
+    may show beta or alpha dependencies.

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ plugins {
     id 'com.gradle.build-scan' version '2.2.1'
     id "com.diffplug.gradle.spotless" version "3.24.3"
     id 'eclipse'
+    id 'com.github.ben-manes.versions' version '0.28.0'
 }
 
 description = 'Mockito mock objects library core API and implementation'


### PR DESCRIPTION
Problem

The mockito build system has several pieces which are out of date. This
includes dependencies

Solution

This plugin adds a new task dependencyUpdates which identifies
dependencies which may be out of date
