### PR TITLE
JUnit 5 strict stubs check should not suppress the regular test failure

### DIFF
--- a/subprojects/junit-jupiter/src/main/java/org/mockito/junit/jupiter/MockitoExtension.java
+++ b/subprojects/junit-jupiter/src/main/java/org/mockito/junit/jupiter/MockitoExtension.java
@@ -5,6 +5,13 @@
 package org.mockito.junit.jupiter;
 
 
+import static org.junit.jupiter.api.extension.ExtensionContext.Namespace.create;
+import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
+
+import java.lang.reflect.Parameter;
+import java.util.List;
+import java.util.Optional;
+
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -20,13 +27,6 @@ import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.internal.session.MockitoSessionLoggerAdapter;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.quality.Strictness;
-
-import java.lang.reflect.Parameter;
-import java.util.List;
-import java.util.Optional;
-
-import static org.junit.jupiter.api.extension.ExtensionContext.Namespace.create;
-import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
 
 /**
  * Extension that initializes mocks and handles strict stubbings. This extension is the JUnit Jupiter equivalent
@@ -178,7 +178,7 @@ public class MockitoExtension implements BeforeEachCallback, AfterEachCallback, 
     @Override
     public void afterEach(ExtensionContext context) {
         context.getStore(MOCKITO).remove(SESSION, MockitoSession.class)
-                .finishMocking();
+                .finishMocking(context.getExecutionException().orElse(null));
     }
 
     @Override
@@ -186,7 +186,6 @@ public class MockitoExtension implements BeforeEachCallback, AfterEachCallback, 
         return parameterContext.isAnnotated(Mock.class);
     }
 
-    @SuppressWarnings("ConstantConditions")
     @Override
     public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
         final Parameter parameter = parameterContext.getParameter();

--- a/subprojects/junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java
@@ -4,6 +4,12 @@
  */
 package org.mockitousage;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+import java.util.function.Function;
+
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,21 +23,15 @@ import org.junit.platform.launcher.core.LauncherFactory;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.exceptions.misusing.UnnecessaryStubbingException;
-import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-
-import java.util.function.Function;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 
 /**
  * Test that runs the inner test using a launcher {@see #invokeTestClassAndRetrieveMethodResult}.
  * We then assert on the actual test run output, to see if test actually failed as a result
  * of our extension.
  */
-@SuppressWarnings("ConstantConditions")
 class StrictnessTest {
 
     @MockitoSettings(strictness = Strictness.STRICT_STUBS)
@@ -51,6 +51,28 @@ class StrictnessTest {
 
         assertThat(result.getStatus()).isEqualTo(TestExecutionResult.Status.FAILED);
         assertThat(result.getThrowable().get()).isInstanceOf(UnnecessaryStubbingException.class);
+    }
+
+    @MockitoSettings(strictness = Strictness.STRICT_STUBS)
+    static class StrictStubsNotReportedOnTestFailure {
+        @Mock
+        private Function<Integer, String> rootMock;
+
+        @Test
+        void should_not_throw_exception_on_strict_stubs_because_of_test_failure() {
+            Mockito.when(rootMock.apply(10)).thenReturn("Foo");
+            fail("Test failed");
+        }
+    }
+
+    @Test
+    void session_does_not_check_for_strict_stubs_on_test_failure() {
+        TestExecutionResult result = invokeTestClassAndRetrieveMethodResult(StrictStubsNotReportedOnTestFailure.class);
+
+        assertThat(result.getStatus()).isEqualTo(TestExecutionResult.Status.FAILED);
+        Throwable throwable = result.getThrowable().get();
+        assertThat(throwable).isInstanceOf(AssertionError.class);
+        assertThat(throwable.getSuppressed()).isEmpty();
     }
 
     @MockitoSettings(strictness = Strictness.STRICT_STUBS)

--- a/subprojects/junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java
@@ -4,12 +4,6 @@
  */
 package org.mockitousage;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
-
-import java.util.function.Function;
-
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,6 +20,11 @@ import org.mockito.exceptions.misusing.UnnecessaryStubbingException;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 
 /**
  * Test that runs the inner test using a launcher {@see #invokeTestClassAndRetrieveMethodResult}.
@@ -53,6 +52,9 @@ class StrictnessTest {
         assertThat(result.getThrowable().get()).isInstanceOf(UnnecessaryStubbingException.class);
     }
 
+    static class MyAssertionError extends AssertionError {
+    }
+
     @MockitoSettings(strictness = Strictness.STRICT_STUBS)
     static class StrictStubsNotReportedOnTestFailure {
         @Mock
@@ -61,7 +63,7 @@ class StrictnessTest {
         @Test
         void should_not_throw_exception_on_strict_stubs_because_of_test_failure() {
             Mockito.when(rootMock.apply(10)).thenReturn("Foo");
-            fail("Test failed");
+            throw new MyAssertionError();
         }
     }
 
@@ -71,7 +73,7 @@ class StrictnessTest {
 
         assertThat(result.getStatus()).isEqualTo(TestExecutionResult.Status.FAILED);
         Throwable throwable = result.getThrowable().get();
-        assertThat(throwable).isInstanceOf(AssertionError.class);
+        assertThat(throwable).isInstanceOf(MyAssertionError.class);
         assertThat(throwable.getSuppressed()).isEmpty();
     }
 


### PR DESCRIPTION
If the test fails, MockitoExtension should not check for strict stubs at the end of the test, because the possible UnnecessaryStubbingException will end up as a suppressed exception on the test's initial failure.
