### PR TITLE
[Proposal] New InjectMocksNewInstance annotation

### DIFF
--- a/src/main/java/org/mockito/InjectMocksNewInstance.java
+++ b/src/main/java/org/mockito/InjectMocksNewInstance.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2020 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Documented
+@Target(FIELD)
+@Retention(RUNTIME)
+public @interface InjectMocksNewInstance {
+}

--- a/src/main/java/org/mockito/MockitoAnnotations.java
+++ b/src/main/java/org/mockito/MockitoAnnotations.java
@@ -54,17 +54,17 @@ import org.mockito.plugins.AnnotationEngine;
 public class MockitoAnnotations {
 
     /**
-     * Initializes objects annotated with Mockito annotations for given testClass:
+     * Initializes objects annotated with Mockito annotations for given testInstance:
      *  &#064;{@link org.mockito.Mock}, &#064;{@link Spy}, &#064;{@link Captor}, &#064;{@link InjectMocks}
      * <p>
      * See examples in javadoc for {@link MockitoAnnotations} class.
      */
-    public static void initMocks(Object testClass) {
-        if (testClass == null) {
-            throw new MockitoException("testClass cannot be null. For info how to use @Mock annotations see examples in javadoc for MockitoAnnotations class");
+    public static void initMocks(Object testInstance) {
+        if (testInstance == null) {
+            throw new MockitoException("testInstance cannot be null. For info how to use @Mock annotations see examples in javadoc for MockitoAnnotations class");
         }
 
         AnnotationEngine annotationEngine = new GlobalConfiguration().tryGetPluginAnnotationEngine();
-        annotationEngine.process(testClass.getClass(), testClass);
+        annotationEngine.process(testInstance.getClass(), testInstance);
     }
 }

--- a/src/main/java/org/mockito/internal/configuration/DefaultInjectionEngine.java
+++ b/src/main/java/org/mockito/internal/configuration/DefaultInjectionEngine.java
@@ -16,11 +16,11 @@ import org.mockito.internal.configuration.injection.MockInjection;
  */
 public class DefaultInjectionEngine {
 
-    public void injectMocksOnFields(Set<Field> needingInjection, Set<Object> mocks, Object testClassInstance) {
+    public void injectMocksOnFields(Set<Field> needingInjection, Set<Object> mocks, Object testClassInstance, boolean force) {
         MockInjection.onFields(needingInjection, testClassInstance)
                 .withMocks(mocks)
-                .tryConstructorInjection()
-                .tryPropertyOrFieldInjection()
+                .tryConstructorInjection(force)
+                .tryPropertyOrFieldInjection(force)
                 .handleSpyAnnotation()
                 .apply();
     }

--- a/src/main/java/org/mockito/internal/configuration/injection/ConstructorInjection.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/ConstructorInjection.java
@@ -37,12 +37,16 @@ import org.mockito.internal.util.reflection.FieldInitializer.ConstructorArgument
  */
 public class ConstructorInjection extends MockInjectionStrategy {
 
-    public ConstructorInjection() { }
+    private final boolean force;
+
+    public ConstructorInjection(boolean force) {
+        this.force = force;
+    }
 
     public boolean processInjection(Field field, Object fieldOwner, Set<Object> mockCandidates) {
         try {
             SimpleArgumentResolver simpleArgumentResolver = new SimpleArgumentResolver(mockCandidates);
-            FieldInitializationReport report = new FieldInitializer(fieldOwner, field, simpleArgumentResolver).initialize();
+            FieldInitializationReport report = new FieldInitializer(fieldOwner, field, simpleArgumentResolver).initialize(force);
 
             return report.fieldWasInitializedUsingContructorArgs();
         } catch (MockitoException e) {

--- a/src/main/java/org/mockito/internal/configuration/injection/MockInjection.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/MockInjection.java
@@ -72,12 +72,20 @@ public class MockInjection {
         }
 
         public OngoingMockInjection tryConstructorInjection() {
-            injectionStrategies.thenTry(new ConstructorInjection());
+            return tryConstructorInjection(false);
+        }
+
+        public OngoingMockInjection tryConstructorInjection(boolean force) {
+            injectionStrategies.thenTry(new ConstructorInjection(force));
             return this;
         }
 
         public OngoingMockInjection tryPropertyOrFieldInjection() {
-            injectionStrategies.thenTry(new PropertyAndSetterInjection());
+            return tryPropertyOrFieldInjection(false);
+        }
+
+        public OngoingMockInjection tryPropertyOrFieldInjection(boolean force) {
+            injectionStrategies.thenTry(new PropertyAndSetterInjection(force));
             return this;
         }
 

--- a/src/main/java/org/mockito/internal/configuration/injection/PropertyAndSetterInjection.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/PropertyAndSetterInjection.java
@@ -73,6 +73,11 @@ public class PropertyAndSetterInjection extends MockInjectionStrategy {
         }
     };
 
+    private final boolean force;
+
+    public PropertyAndSetterInjection(boolean force) {
+        this.force = force;
+    }
 
     public boolean processInjection(Field injectMocksField, Object injectMocksFieldOwner, Set<Object> mockCandidates) {
         FieldInitializationReport report = initializeInjectMocksField(injectMocksField, injectMocksFieldOwner);
@@ -90,7 +95,7 @@ public class PropertyAndSetterInjection extends MockInjectionStrategy {
 
     private FieldInitializationReport initializeInjectMocksField(Field field, Object fieldOwner) {
         try {
-            return new FieldInitializer(fieldOwner, field).initialize();
+            return new FieldInitializer(fieldOwner, field).initialize(force);
         } catch (MockitoException e) {
             if(e.getCause() instanceof InvocationTargetException) {
                 Throwable realCause = e.getCause().getCause();

--- a/src/main/java/org/mockito/internal/configuration/injection/scanner/InjectMocksScanner.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/scanner/InjectMocksScanner.java
@@ -20,14 +20,17 @@ import org.mockito.Mock;
  */
 public class InjectMocksScanner {
     private final Class<?> clazz;
+    private final Class<? extends Annotation> annotationClass;
 
     /**
      * Create a new InjectMocksScanner for the given clazz on the given instance
      *
      * @param clazz    Current class in the hierarchy of the test
+     * @param annotationClass
      */
-    public InjectMocksScanner(Class<?> clazz) {
+    public InjectMocksScanner(Class<?> clazz, Class<? extends Annotation> annotationClass) {
         this.clazz = clazz;
+        this.annotationClass = annotationClass;
     }
 
 
@@ -50,7 +53,7 @@ public class InjectMocksScanner {
         Set<Field> mockDependentFields = new HashSet<Field>();
         Field[] fields = clazz.getDeclaredFields();
         for (Field field : fields) {
-            if (null != field.getAnnotation(InjectMocks.class)) {
+            if (null != field.getAnnotation(annotationClass)) {
                 assertNoAnnotations(field, Mock.class, Captor.class);
                 mockDependentFields.add(field);
             }
@@ -59,10 +62,11 @@ public class InjectMocksScanner {
         return mockDependentFields;
     }
 
-    private static void assertNoAnnotations(Field field, Class<? extends Annotation>... annotations) {
+    @SafeVarargs
+    private final void assertNoAnnotations(Field field, Class<? extends Annotation>... annotations) {
         for (Class<? extends Annotation> annotation : annotations) {
             if (field.isAnnotationPresent(annotation)) {
-                throw unsupportedCombinationOfAnnotations(annotation.getSimpleName(), InjectMocks.class.getSimpleName());
+                throw unsupportedCombinationOfAnnotations(annotation.getSimpleName(), annotationClass.getSimpleName());
             }
         }
     }

--- a/src/main/java/org/mockito/internal/util/reflection/FieldInitializer.java
+++ b/src/main/java/org/mockito/internal/util/reflection/FieldInitializer.java
@@ -85,11 +85,15 @@ public class FieldInitializer {
      * @return Actual field instance.
      */
     public FieldInitializationReport initialize() {
+        return initialize(false);
+    }
+
+    public FieldInitializationReport initialize(boolean force) {
         final AccessibilityChanger changer = new AccessibilityChanger();
         changer.enableAccess(field);
 
         try {
-            return acquireFieldInstance();
+            return acquireFieldInstance(force);
         } catch(IllegalAccessException e) {
             throw new MockitoException("Problems initializing field '" + field.getName() + "' of type '" + field.getType().getSimpleName() + "'", e);
         } finally {
@@ -128,10 +132,9 @@ public class FieldInitializer {
         }
     }
 
-
-    private FieldInitializationReport acquireFieldInstance() throws IllegalAccessException {
+    private FieldInitializationReport acquireFieldInstance(boolean force) throws IllegalAccessException {
         Object fieldInstance = field.get(fieldOwner);
-        if(fieldInstance != null) {
+        if (fieldInstance != null && !force) {
             return new FieldInitializationReport(fieldInstance, false, false);
         }
 

--- a/src/test/java/org/mockito/internal/configuration/injection/ConstructorInjectionTest.java
+++ b/src/test/java/org/mockito/internal/configuration/injection/ConstructorInjectionTest.java
@@ -28,7 +28,7 @@ public class ConstructorInjectionTest {
 
     @Before
     public void initialize_dependencies() {
-        underTest = new ConstructorInjection();
+        underTest = new ConstructorInjection(false);
     }
 
     @Test

--- a/src/test/java/org/mockito/internal/util/reflection/FieldInitializerTest.java
+++ b/src/test/java/org/mockito/internal/util/reflection/FieldInitializerTest.java
@@ -4,7 +4,12 @@
  */
 package org.mockito.internal.util.reflection;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -16,8 +21,6 @@ import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.util.reflection.FieldInitializer.ConstructorArgumentResolver;
-
-
 
 public class FieldInitializerTest {
 

--- a/src/test/java/org/mockitousage/annotation/AnnotationsTest.java
+++ b/src/test/java/org/mockitousage/annotation/AnnotationsTest.java
@@ -4,7 +4,10 @@
  */
 package org.mockitousage.annotation;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.verify;
 
 import java.lang.annotation.Retention;
@@ -58,7 +61,7 @@ public class AnnotationsTest extends TestBase {
             MockitoAnnotations.initMocks(null);
             fail();
         } catch (MockitoException e) {
-            assertEquals("testClass cannot be null. For info how to use @Mock annotations see examples in javadoc for MockitoAnnotations class",
+            assertEquals("testInstance cannot be null. For info how to use @Mock annotations see examples in javadoc for MockitoAnnotations class",
                     e.getMessage());
         }
     }

--- a/src/test/java/org/mockitousage/annotation/MockInjectionUsingConstructorTest.java
+++ b/src/test/java/org/mockitousage/annotation/MockInjectionUsingConstructorTest.java
@@ -5,7 +5,10 @@
 package org.mockitousage.annotation;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -212,8 +215,4 @@ public class MockInjectionUsingConstructorTest {
 
         assertThat(testClass.f).isSameAs(original);
     }
-
-
-
-
 }

--- a/subprojects/junit-jupiter/src/test/java/org/mockitousage/InjectMocksDoubleInitTest.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockitousage/InjectMocksDoubleInitTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockitousage;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class InjectMocksDoubleInitTest {
+
+    @InjectMocks
+    Target target;
+
+    @Mock
+    Foo foo;
+
+    @Mock
+    Bar bar;
+
+    @Test
+    public void injectMocks() {
+        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.initMocks(this);
+
+        assertNotSame(foo, target.getFoo());
+        assertNotSame(bar, target.getBar());
+    }
+
+    public static class Target {
+        private final Foo foo;
+        private final Bar bar;
+
+        public Target(Foo foo, Bar bar) {
+            this.foo = foo;
+            this.bar = bar;
+        }
+
+        public Foo getFoo() {
+            return foo;
+        }
+
+        public Bar getBar() {
+            return bar;
+        }
+    }
+
+    public static class Foo {
+    }
+
+    public static class Bar {
+    }
+}

--- a/subprojects/junit-jupiter/src/test/java/org/mockitousage/InjectMocksNewInstanceDoubleInitTest.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockitousage/InjectMocksNewInstanceDoubleInitTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockitousage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocksNewInstance;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class InjectMocksNewInstanceDoubleInitTest {
+
+    @InjectMocksNewInstance
+    Target target;
+
+    @Mock
+    Foo foo;
+
+    @Mock
+    Bar bar;
+
+    @Test
+    public void injectMocks() {
+        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.initMocks(this);
+
+        assertEquals(foo, target.getFoo());
+        assertEquals(bar, target.getBar());
+    }
+
+    public static class Target {
+        private final Foo foo;
+        private final Bar bar;
+
+        public Target(Foo foo, Bar bar) {
+            this.foo = foo;
+            this.bar = bar;
+        }
+
+        public Foo getFoo() {
+            return foo;
+        }
+
+        public Bar getBar() {
+            return bar;
+        }
+    }
+
+    public static class Foo {
+    }
+
+    public static class Bar {
+    }
+}

--- a/subprojects/junit-jupiter/src/test/java/org/mockitousage/InjectMocksNewInstanceHierarchyTest.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockitousage/InjectMocksNewInstanceHierarchyTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2020 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockitousage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocksNewInstance;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+class I {}
+
+class InjectMocksNewInstanceHierarchyTest extends I {
+
+    @InjectMocksNewInstance
+    Target target;
+
+    @Mock
+    Foo foo;
+
+    @Spy
+    Bar bar = new Bar();
+
+    @BeforeEach
+    void beforeEach() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void injectMocks() {
+        assertEquals(foo, target.getFoo());
+        assertNull(target.getBar());
+    }
+
+    public static class Target {
+        private final Foo foo;
+        private Bar bar;
+
+        public Target(Foo foo) {
+            this.foo = foo;
+        }
+
+        public Foo getFoo() {
+            return foo;
+        }
+
+        public Bar getBar() {
+            return bar;
+        }
+    }
+
+    public static class Foo {
+    }
+
+    public static class Bar {
+    }
+}

--- a/subprojects/junit-jupiter/src/test/java/org/mockitousage/InjectMocksNewInstanceInjectionTest.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockitousage/InjectMocksNewInstanceInjectionTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2020 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockitousage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocksNewInstance;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+class InjectMocksNewInstanceInjectionTest {
+
+    @InjectMocksNewInstance
+    Target target;
+
+    @Mock
+    Foo foo;
+
+    @Mock
+    Bar bar;
+
+    @Spy
+    Baz baz = new Baz();
+
+    @BeforeEach
+    void beforeEach() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void injectMocks() {
+        assertEquals(foo, target.getFoo());
+        assertNull(target.getBar());
+        assertNull(target.getBaz());
+    }
+
+    public static class Target {
+        private final Foo foo;
+        private Bar bar;
+        private Baz baz;
+
+        public Target(Foo foo) {
+            this.foo = foo;
+        }
+
+        public Foo getFoo() {
+            return foo;
+        }
+
+        public Bar getBar() {
+            return bar;
+        }
+
+        public Baz getBaz() {
+            return baz;
+        }
+
+        public void setBaz(Baz baz) {
+            this.baz = baz;
+        }
+    }
+
+    public static class Foo {
+    }
+
+    public static class Bar {
+    }
+
+    public static class Baz {
+    }
+}

--- a/subprojects/junit-jupiter/src/test/java/org/mockitousage/InjectMocksNewInstanceNoArgConstructorTest.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockitousage/InjectMocksNewInstanceNoArgConstructorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2020 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockitousage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.mockito.InjectMocksNewInstance;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class InjectMocksNewInstanceNoArgConstructorTest {
+
+    @InjectMocksNewInstance
+    Target target;
+
+    @Mock
+    Foo foo;
+
+    @Mock
+    Bar bar;
+
+    @BeforeEach
+    void beforeEach() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void injectMocks1() {
+        assertEquals(foo, target.getFoo());
+        assertEquals(bar, target.getBar());
+    }
+
+    @Test
+    public void injectMocks2() {
+        assertEquals(foo, target.getFoo());
+        assertEquals(bar, target.getBar());
+    }
+
+    public static class Target {
+        private Foo foo;
+        private Bar bar;
+
+        public Foo getFoo() {
+            return foo;
+        }
+
+        public Bar getBar() {
+            return bar;
+        }
+    }
+
+    public static class Foo {
+    }
+
+    public static class Bar {
+    }
+}

--- a/subprojects/junit-jupiter/src/test/java/org/mockitousage/InjectMocksNewInstanceOverrideValueTest.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockitousage/InjectMocksNewInstanceOverrideValueTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockitousage;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocksNewInstance;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class InjectMocksNewInstanceOverrideValueTest {
+
+    @InjectMocksNewInstance
+    Target target = new Target(null, null);
+
+    @Mock
+    Foo foo;
+
+    @Mock
+    Bar bar;
+
+    @Test
+    public void injectMocks() {
+        Target initialTarget = target;
+
+        MockitoAnnotations.initMocks(this);
+
+        assertNotSame(initialTarget, target);
+    }
+
+    public static class Target {
+        private final Foo foo;
+        private final Bar bar;
+
+        public Target(Foo foo, Bar bar) {
+            this.foo = foo;
+            this.bar = bar;
+        }
+
+        public Foo getFoo() {
+            return foo;
+        }
+
+        public Bar getBar() {
+            return bar;
+        }
+    }
+
+    public static class Foo {
+    }
+
+    public static class Bar {
+    }
+}

--- a/subprojects/junit-jupiter/src/test/java/org/mockitousage/InjectMocksNewInstanceTest.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockitousage/InjectMocksNewInstanceTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2020 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockitousage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.mockito.InjectMocksNewInstance;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class InjectMocksNewInstanceTest {
+
+    @InjectMocksNewInstance
+    Target target;
+
+    @Mock
+    Foo foo;
+
+    @Mock
+    Bar bar;
+
+    @BeforeEach
+    void beforeEach() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void injectMocks1() {
+        assertEquals(foo, target.getFoo());
+        assertEquals(bar, target.getBar());
+    }
+
+    @Test
+    public void injectMocks2() {
+        assertEquals(foo, target.getFoo());
+        assertEquals(bar, target.getBar());
+    }
+
+    public static class Target {
+        private final Foo foo;
+        private final Bar bar;
+
+        public Target(Foo foo, Bar bar) {
+            this.foo = foo;
+            this.bar = bar;
+        }
+
+        public Foo getFoo() {
+            return foo;
+        }
+
+        public Bar getBar() {
+            return bar;
+        }
+    }
+
+    public static class Foo {
+    }
+
+    public static class Bar {
+    }
+}


### PR DESCRIPTION
I have discovered the `@InjectMocks` annotation yesterday and I was eager to use it. However, I have learnt very fast of its many problems.

One of them is the behavior of not overriding the value of a non-null field, no matter if it is already initialized by the test code or when calling `MockitoAnnotations.init()` more than once on a test instance.

Sometimes, calling `MockitoAnnotations.init()` more than once on the same test instance is accidental, as in #1912, or intended and unavoidable. Two examples are:
- using TestNG with `MockitoSession`. In TestNG, the same test instance is reused by all test methods. Using `MockitoSession` in a `@BeforeMethod` and `@AfterMethod` in order to enable Strict Stubs support and `MockitoAnnotations.init()` in order to initialize the mocks is common practice. However, if `@InjectMocks` is used, only the first test in the test class will use the mocks injected in the `@InjectMocks`-annotated field.
- using JUnit 5 in a test class annotated with `@TestInstance(TestInstance.Lifecycle.PER_CLASS)`, which is essentially the same scenario as TestNG example above.

I propose adding a new `@InjectMocksNewInstance` annotation, which always initializes the annotated field with an object having mocks injected by the same logic as `@InjectMocks` (either constructor injection or property and setter injection).

The new annotation does not suffer from the bug-which-became-a-feature from #1631.
It solves the two cases indicated above and also #1912, if used instead of `@InjectMocks`.

However, the new annotation suffers from the same problems as the old one when it comes to the brittle support for constructor injection, as seen in #1882.

This is just a draft of my idea. I created this draft before checking the many issues related to `@InjectMocks`, some of them unknown to me prior to this PR. I believe the intention of `@InjectMocks` is good, but its implementation is too unstable and unsafe to use. I believe that it should be replaced with a new annotation, with more clearly defined semantics, or just deprecated and removed completely, as suggested in #1518. The actual form of the `@InjectMocks` annotation works well only in very specific scenarios.

In my opinion, a big problem of `@InjectMocks` annotation is that it works with Strict Stubs over JUnit 4, it sometimes works with Strict Stubs over JUnit 5 and never works with Strict Stubs over TestNG.