### PR TITLE
Update javadoc - remove deprecated class

### DIFF
--- a/src/main/java/org/mockito/AdditionalAnswers.java
+++ b/src/main/java/org/mockito/AdditionalAnswers.java
@@ -308,7 +308,7 @@ public class AdditionalAnswers {
      *   when(mock.foo()).thenReturn(1, 2, 3);
      *
      *   //is equivalent to:
-     *   when(mock.foo()).thenAnswer(new ReturnsElementsOf(Arrays.asList(1, 2, 3)));
+     *   when(mock.foo()).thenAnswer(AdditionalAnswers.returnsElementsOf(Arrays.asList(1, 2, 3)));
      * </code></pre>
      *
      * @param elements The collection of elements to return.


### PR DESCRIPTION
The javadoc is misleading - pointing to the deprecated class ReturnsElementsOf that should later be internal or moved
