### PR TITLE
Fixes #1712 : prepend description to AssertionError thrown in verification

### DIFF
--- a/src/main/java/org/mockito/exceptions/base/MockitoAssertionError.java
+++ b/src/main/java/org/mockito/exceptions/base/MockitoAssertionError.java
@@ -46,6 +46,18 @@ public class MockitoAssertionError extends AssertionError {
         unfilteredStackTrace = error.getUnfilteredStackTrace();
     }
 
+    /**
+     * Creates a copy of the given assertion error with the custom failure message prepended.
+     * @param error The assertion error to copy
+     * @param message The custom message to prepend
+     * @since 3.3.13
+     */
+    public MockitoAssertionError(AssertionError error, String message) {
+        super(message + "\n" + error.getMessage());
+        unfilteredStackTrace = error.getStackTrace();
+        super.setStackTrace(unfilteredStackTrace);
+    }
+
     public StackTraceElement[] getUnfilteredStackTrace() {
         return unfilteredStackTrace;
     }

--- a/src/main/java/org/mockito/internal/verification/Description.java
+++ b/src/main/java/org/mockito/internal/verification/Description.java
@@ -41,6 +41,8 @@ public class Description implements VerificationMode {
 
         } catch (MockitoAssertionError e) {
             throw new MockitoAssertionError(e, description);
+        } catch (AssertionError e) {
+            throw new MockitoAssertionError(e, description);
         }
     }
 }

--- a/src/test/java/org/mockito/DescriptionTest.java
+++ b/src/test/java/org/mockito/DescriptionTest.java
@@ -1,0 +1,56 @@
+package org.mockito;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.exceptions.base.MockitoAssertionError;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for https://github.com/mockito/mockito/issues/1712
+ */
+public class DescriptionTest {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void verify_method_not_called_should_include_description_in_report() {
+        final String description = "Failed to call doSomethingElse";
+        expectedException.expect(MockitoAssertionError.class);
+        expectedException.expectMessage(description);
+
+        Dependency dependency = spy(Dependency.class);
+        SystemUnderTest systemUnderTest = new SystemUnderTest();
+        systemUnderTest.doNothing(dependency);
+        verify(dependency, description(description)).doSomethingElse(false);
+    }
+
+    @Test
+    public void verify_method_called_with_unexpected_argument_should_include_description_in_report() {
+        final String description = "Failed to call doSomethingElse with expected argument";
+        expectedException.expect(MockitoAssertionError.class);
+        expectedException.expectMessage(description);
+
+        Dependency dependency = spy(Dependency.class);
+        SystemUnderTest systemUnderTest = new SystemUnderTest();
+        systemUnderTest.doSomething(dependency);
+        verify(dependency, description(description)).doSomethingElse(false);
+    }
+
+    static class SystemUnderTest {
+        @SuppressWarnings("unused")
+        void doNothing(Dependency dependency) {
+        }
+
+        void doSomething(Dependency dependency) {
+            dependency.doSomethingElse(true);
+        }
+    }
+
+    static class Dependency {
+        @SuppressWarnings("unused")
+        void doSomethingElse(boolean value) {
+        }
+    }
+}

--- a/src/test/java/org/mockito/DescriptionTest.java
+++ b/src/test/java/org/mockito/DescriptionTest.java
@@ -1,18 +1,21 @@
+/*
+ * Copyright (c) 2020 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito;
+
+import static org.mockito.Mockito.*;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.exceptions.base.MockitoAssertionError;
 
-import static org.mockito.Mockito.*;
-
 /**
  * Tests for https://github.com/mockito/mockito/issues/1712
  */
 public class DescriptionTest {
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
+    @Rule public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void verify_method_not_called_should_include_description_in_report() {
@@ -27,7 +30,8 @@ public class DescriptionTest {
     }
 
     @Test
-    public void verify_method_called_with_unexpected_argument_should_include_description_in_report() {
+    public void
+            verify_method_called_with_unexpected_argument_should_include_description_in_report() {
         final String description = "Failed to call doSomethingElse with expected argument";
         expectedException.expect(MockitoAssertionError.class);
         expectedException.expectMessage(description);
@@ -40,8 +44,7 @@ public class DescriptionTest {
 
     static class SystemUnderTest {
         @SuppressWarnings("unused")
-        void doNothing(Dependency dependency) {
-        }
+        void doNothing(Dependency dependency) {}
 
         void doSomething(Dependency dependency) {
             dependency.doSomethingElse(true);
@@ -50,7 +53,6 @@ public class DescriptionTest {
 
     static class Dependency {
         @SuppressWarnings("unused")
-        void doSomethingElse(boolean value) {
-        }
+        void doSomethingElse(boolean value) {}
     }
 }

--- a/src/test/java/org/mockito/internal/verification/DescriptionTest.java
+++ b/src/test/java/org/mockito/internal/verification/DescriptionTest.java
@@ -51,4 +51,28 @@ public class DescriptionTest {
             assertEquals(expectedResult, e.getMessage());
         }
     }
+
+    /**
+     * Test of verify method, of class Description. This test validates that the custom message is prepended to the
+     * error message when verification fails and throws a Throwable which is not a MockitoAssertionError.
+     */
+    @Test
+    public void verification_failure_throwing_AssertionError_should_prepend_expected_message() {
+        String failureMessage = "message should be prepended to the original message";
+        String exceptionMessage = "original error message";
+        String expectedResult = failureMessage + "\n" + exceptionMessage;
+        AssertionError error = new AssertionError(exceptionMessage);
+        doThrow(error).when(mockVerificationMode).verify(mockVerificationData);
+
+        Description instance = new Description(mockVerificationMode, failureMessage);
+
+        try {
+            instance.verify(mockVerificationData);
+            verify(mockVerificationMode).verify(mockVerificationData);
+            fail("Should not have made it this far");
+
+        } catch (MockitoAssertionError e) {
+            assertEquals(expectedResult, e.getMessage());
+        }
+    }
 }


### PR DESCRIPTION

Extended MockitoAssertionError to wrap instance of AssertionError in addition to MockitoAssertionError, so that the various possible exceptions thrown for non-matching arguments have description prepended to the message.