### PR TITLE
Use errorprone 2.4.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -6,7 +6,7 @@ def versions = [:]
 
 versions.bytebuddy = '1.10.10'
 versions.junitJupiter = '5.4.2'
-versions.errorprone = '2.3.2'
+versions.errorprone = '2.4.0'
 
 libraries.junit4 = 'junit:junit:4.12'
 libraries.junitJupiterApi = "org.junit.jupiter:junit-jupiter-api:${versions.junitJupiter}"

--- a/gradle/errorprone.gradle
+++ b/gradle/errorprone.gradle
@@ -10,7 +10,3 @@ if (JavaVersion.current() == JavaVersion.VERSION_1_8) {
 dependencies {
     errorprone libraries.errorprone
 }
-
-tasks.named("compileTestJava").configure {
-    options.errorprone.errorproneArgs << "-Xep:MockitoCast:OFF"
-}

--- a/src/test/java/org/mockito/internal/matchers/EqualityTest.java
+++ b/src/test/java/org/mockito/internal/matchers/EqualityTest.java
@@ -31,6 +31,7 @@ public class EqualityTest extends TestBase {
         assertFalse(areEqual(new int[] {1}, new double[] {1.0}));
     }
 
+    @SuppressWarnings("EqualsHashCode")
     private final class BadEquals {
         @Override
         public boolean equals(Object oth) {

--- a/src/test/java/org/mockito/internal/util/collections/IdentitySetTest.java
+++ b/src/test/java/org/mockito/internal/util/collections/IdentitySetTest.java
@@ -24,6 +24,7 @@ public class IdentitySetTest {
         assertFalse(set.contains(new Object()));
     }
 
+    @SuppressWarnings("EqualsHashCode")
     class Fake {
         @Override
         public boolean equals(Object obj) {

--- a/src/test/java/org/mockito/internal/util/reflection/GenericMetadataSupportTest.java
+++ b/src/test/java/org/mockito/internal/util/reflection/GenericMetadataSupportTest.java
@@ -272,6 +272,7 @@ public class GenericMetadataSupportTest {
                   ).isEmpty();
     }
 
+    @SuppressWarnings("EqualsHashCode")
     private ParameterizedType parameterizedTypeOf(final Class<?> rawType, final Class<?> ownerType, final Type... actualTypeArguments) {
         return new ParameterizedType() {
             @Override

--- a/src/test/java/org/mockitousage/matchers/MatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/MatchersTest.java
@@ -340,6 +340,7 @@ public class MatchersTest extends TestBase {
         verify(mock).objectArgMethod(new int[]{1, 2});
     }
 
+    @SuppressWarnings("ReturnValueIgnored")
     @Test(expected = ArgumentsAreDifferent.class)
     public void array_equals_should_throw_ArgumentsAreDifferentException_for_non_matching_arguments() {
         List<Object> list = Mockito.mock(List.class);


### PR DESCRIPTION
in order to get java14 ready.
see https://github.com/google/error-prone/releases/tag/v2.4.0 for details.


