### PR TITLE
Move performRelease step into separate Travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,15 +19,13 @@ matrix:
   include:
   - jdk: openjdk8
   - jdk: openjdk8
-    env: SKIP_RELEASE=true MOCK_MAKER=mock-maker-inline
+    env: MOCK_MAKER=mock-maker-inline
   - jdk: openjdk11
-    env: SKIP_RELEASE=true
   - jdk: openjdk11
-    env: SKIP_RELEASE=true MOCK_MAKER=mock-maker-inline
+    env: MOCK_MAKER=mock-maker-inline
   - jdk: openjdk14
-    env: SKIP_RELEASE=true
   - jdk: openjdk14
-    env: SKIP_RELEASE=true MOCK_MAKER=mock-maker-inline
+    env: MOCK_MAKER=mock-maker-inline
     # Run Spotless as a separate job on JDK 11 (which is required for google-java-format)
   - jdk: openjdk11
     name: "Verify code formatting with Spotless"
@@ -37,6 +35,11 @@ matrix:
   - jdk: openjdk8
     name: "Check reproducibility of jars"
     script: ./check_reproducibility.sh
+    # Do not upload a coverage report, as we don't run the tests for this job
+    after_success: true
+  - jdk: openjdk8
+    name: "Publish a new version of Mockito"
+    script: ./gradlew ciPerformRelease
     # Do not upload a coverage report, as we don't run the tests for this job
     after_success: true
 
@@ -52,10 +55,7 @@ install:
  - true
 
 script:
-  # We are using && below on purpose
-  # ciPerformRelease must run only when the entire build has completed
-  # This guarantees that no release steps are executed when the build or tests fail
-  - ./gradlew build idea -s && ./gradlew ciPerformRelease
+  - ./gradlew build idea -s
 
 after_success:
   #Generates coverage report:


### PR DESCRIPTION
Currently, all jobs run this step. However, only one of them actually
performs the logic. This means that all jobs are spending ~1 min
doing nothing, except the one that actually performs the task at hand.

Since we only merge PRs that are passing the build, we don't actually
need to gate our release procedure on passing tests.

All in all, this should reduce our Travis CI build time by about
1 minute per job, and make it clearer that we have a separate
release task, as well as cleanup our env declarations.