### PR TITLE
Document using `@Mock` with method parameters

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -455,6 +455,9 @@ import org.mockito.verification.VerificationWithTimeout;
  *       &#064;Mock private UserProvider userProvider;
  *
  *       private ArticleManager manager;
+ *
+ *       @org.junit.jupiter.api.Test
+ *       void testSomethingInJunit5(@Mock ArticleDatabase database) {
  * </code></pre>
  *
  * <b>Important!</b> This needs to be somewhere in the base class or a test


### PR DESCRIPTION
Although we've called it out in the [JUnit extension], we should also
make sure it's clear in the core documentation to make it more visible.

We can fully-quality the `@Test` annotation to make clear that it has to
be with JUnit 5.

Closes #1960.

[JUnit extension]: https://javadoc.io/doc/org.mockito/mockito-junit-jupiter/latest/org/mockito/junit/jupiter/MockitoExtension.html