### PR TITLE
Fixes #1967: Correctly handle mocks with limited life-cycle in listeners.

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,6 +10,7 @@ include("deprecatedPluginsTest",
     "android",
     "junit-jupiter",
     "junitJupiterExtensionTest",
+    "junitJupiterInlineMockMakerExtensionTest",
     "module-test",
     "memory-test",
     "errorprone",
@@ -18,7 +19,7 @@ include("deprecatedPluginsTest",
 
 rootProject.name = "mockito"
 
-val koltinBuildScriptProject = hashSetOf("junitJupiterExtensionTest")
+val koltinBuildScriptProject = hashSetOf("junitJupiterExtensionTest", "junitJupiterInlineMockMakerExtensionTest")
 
 fun buildFileExtensionFor(projectName: String) =
     if (projectName in koltinBuildScriptProject) ".gradle.kts" else ".gradle"

--- a/src/main/java/org/mockito/MockedStatic.java
+++ b/src/main/java/org/mockito/MockedStatic.java
@@ -63,6 +63,16 @@ public interface MockedStatic<T> extends AutoCloseable {
      */
     void verifyNoInteractions();
 
+    /**
+     * Checks if this mock is closed.
+     *
+     * @return {@code true} if this mock is closed.
+     */
+    boolean isClosed();
+
+    /**
+     * Releases this static mock and throws a {@link org.mockito.exceptions.base.MockitoException} if closed already.
+     */
     @Override
     void close();
 

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -2058,6 +2058,12 @@ public class Mockito extends ArgumentMatchers {
      * The returned object's {@link MockedStatic#close()} method must be called upon completing the
      * test or the mock will remain active on the current thread.
      * <p>
+     * <b>Note</b>: We recommend against mocking static methods of classes in the standard library or
+     * classes used by custom class loaders used to executed the block with the mocked class. A mock
+     * maker might forbid mocking static methods of know classes that are known to cause problems.
+     * Also, if a static method is a JVM-intrinsic, it cannot typically be mocked even if not
+     * explicitly forbidden.
+     * <p>
      * See examples in javadoc for {@link Mockito} class
      *
      * @param classToMock class or interface of which static mocks should be mocked.
@@ -2073,6 +2079,12 @@ public class Mockito extends ArgumentMatchers {
      * Creates a thread-local mock controller for all static methods of the given class or interface.
      * The returned object's {@link MockedStatic#close()} method must be called upon completing the
      * test or the mock will remain active on the current thread.
+     * <p>
+     * <b>Note</b>: We recommend against mocking static methods of classes in the standard library or
+     * classes used by custom class loaders used to executed the block with the mocked class. A mock
+     * maker might forbid mocking static methods of know classes that are known to cause problems.
+     * Also, if a static method is a JVM-intrinsic, it cannot typically be mocked even if not
+     * explicitly forbidden.
      * <p>
      * See examples in javadoc for {@link Mockito} class
      *
@@ -2091,6 +2103,12 @@ public class Mockito extends ArgumentMatchers {
      * The returned object's {@link MockedStatic#close()} method must be called upon completing the
      * test or the mock will remain active on the current thread.
      * <p>
+     * <b>Note</b>: We recommend against mocking static methods of classes in the standard library or
+     * classes used by custom class loaders used to executed the block with the mocked class. A mock
+     * maker might forbid mocking static methods of know classes that are known to cause problems.
+     * Also, if a static method is a JVM-intrinsic, it cannot typically be mocked even if not
+     * explicitly forbidden.
+     * <p>
      * See examples in javadoc for {@link Mockito} class
      *
      * @param classToMock class or interface of which static mocks should be mocked.
@@ -2107,6 +2125,12 @@ public class Mockito extends ArgumentMatchers {
      * Creates a thread-local mock controller for all static methods of the given class or interface.
      * The returned object's {@link MockedStatic#close()} method must be called upon completing the
      * test or the mock will remain active on the current thread.
+     * <p>
+     * <b>Note</b>: We recommend against mocking static methods of classes in the standard library or
+     * classes used by custom class loaders used to executed the block with the mocked class. A mock
+     * maker might forbid mocking static methods of know classes that are known to cause problems.
+     * Also, if a static method is a JVM-intrinsic, it cannot typically be mocked even if not
+     * explicitly forbidden.
      * <p>
      * See examples in javadoc for {@link Mockito} class
      *

--- a/src/main/java/org/mockito/internal/MockedStaticImpl.java
+++ b/src/main/java/org/mockito/internal/MockedStaticImpl.java
@@ -158,6 +158,11 @@ public final class MockedStaticImpl<T> implements MockedStatic<T> {
     }
 
     @Override
+    public boolean isClosed() {
+        return closed;
+    }
+
+    @Override
     public void close() {
         assertNotClosed();
 
@@ -180,5 +185,10 @@ public final class MockedStaticImpl<T> implements MockedStatic<T> {
                             location.toString(),
                             "is already resolved and cannot longer be used"));
         }
+    }
+
+    @Override
+    public String toString() {
+        return "static mock for " + control.getType().getTypeName();
     }
 }

--- a/src/main/java/org/mockito/internal/configuration/MockAnnotationProcessor.java
+++ b/src/main/java/org/mockito/internal/configuration/MockAnnotationProcessor.java
@@ -58,21 +58,25 @@ public class MockAnnotationProcessor implements FieldAnnotationProcessor<Mock> {
         }
     }
 
-    private static Class<?> inferStaticMock(Type type, String name) {
+    static Class<?> inferStaticMock(Type type, String name) {
         if (type instanceof ParameterizedType) {
             ParameterizedType parameterizedType = (ParameterizedType) type;
-            return (Class<?>) parameterizedType.getRawType();
-        } else {
-            throw new MockitoException(
-                    join(
-                            "Mockito cannot infer a static mock from a raw type for " + name,
-                            "",
-                            "Instead of @Mock MockedStatic you need to specify a parameterized type",
-                            "For example, if you would like to mock static methods of Sample.class, specify",
-                            "",
-                            "@Mock MockedStatic<Sample>",
-                            "",
-                            "as the type parameter"));
+            Type[] arguments = parameterizedType.getActualTypeArguments();
+            if (arguments.length == 1) {
+                if (arguments[0] instanceof Class<?>) {
+                    return (Class<?>) arguments[0];
+                }
+            }
         }
+        throw new MockitoException(
+                join(
+                        "Mockito cannot infer a static mock from a raw type for " + name,
+                        "",
+                        "Instead of @Mock MockedStatic you need to specify a parameterized type",
+                        "For example, if you would like to mock static methods of Sample.class, specify",
+                        "",
+                        "@Mock MockedStatic<Sample>",
+                        "",
+                        "as the type parameter. If the type is parameterized, it should be specified as raw type."));
     }
 }

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
@@ -382,6 +382,13 @@ public class InlineByteBuddyMockMaker implements ClassCreatingMockMaker, InlineM
             throw new MockitoException(
                     "It is not possible to mock static methods of ConcurrentHashMap "
                             + "to avoid infinitive loops within Mockito's implementation of static mock handling");
+        } else if (type == Thread.class
+                || type == System.class
+                || ClassLoader.class.isAssignableFrom(type)) {
+            throw new MockitoException(
+                    "It is not possible to mock static methods of "
+                            + type.getTypeName()
+                            + "to avoid interfering with the class loading mechanism");
         }
 
         bytecodeGenerator.mockClassStatic(type);

--- a/src/main/java/org/mockito/internal/framework/DefaultMockitoSession.java
+++ b/src/main/java/org/mockito/internal/framework/DefaultMockitoSession.java
@@ -43,7 +43,11 @@ public class DefaultMockitoSession implements MockitoSession {
                 closeables.add(MockitoAnnotations.openMocks(testClassInstance));
             }
         } catch (RuntimeException e) {
-            release();
+            try {
+                release();
+            } catch (Throwable t) {
+                e.addSuppressed(t);
+            }
 
             // clean up in case 'openMocks' fails
             listener.setListenerDirty();
@@ -58,38 +62,38 @@ public class DefaultMockitoSession implements MockitoSession {
 
     @Override
     public void finishMocking() {
-        release();
-
         finishMocking(null);
     }
 
     @Override
     public void finishMocking(final Throwable failure) {
-        release();
+        try {
+            // Cleaning up the state, we no longer need the listener hooked up
+            // The listener implements MockCreationListener and at this point
+            // we no longer need to listen on mock creation events. We are wrapping up the session
+            Mockito.framework().removeListener(listener);
 
-        // Cleaning up the state, we no longer need the listener hooked up
-        // The listener implements MockCreationListener and at this point
-        // we no longer need to listen on mock creation events. We are wrapping up the session
-        Mockito.framework().removeListener(listener);
+            // Emit test finished event so that validation such as strict stubbing can take place
+            listener.testFinished(
+                    new TestFinishedEvent() {
+                        @Override
+                        public Throwable getFailure() {
+                            return failure;
+                        }
 
-        // Emit test finished event so that validation such as strict stubbing can take place
-        listener.testFinished(
-                new TestFinishedEvent() {
-                    @Override
-                    public Throwable getFailure() {
-                        return failure;
-                    }
+                        @Override
+                        public String getTestName() {
+                            return name;
+                        }
+                    });
 
-                    @Override
-                    public String getTestName() {
-                        return name;
-                    }
-                });
-
-        // Validate only when there is no test failure to avoid reporting multiple problems
-        if (failure == null) {
-            // Finally, validate user's misuse of Mockito framework.
-            Mockito.validateMockitoUsage();
+            // Validate only when there is no test failure to avoid reporting multiple problems
+            if (failure == null) {
+                // Finally, validate user's misuse of Mockito framework.
+                Mockito.validateMockitoUsage();
+            }
+        } finally {
+            release();
         }
     }
 
@@ -98,7 +102,7 @@ public class DefaultMockitoSession implements MockitoSession {
             try {
                 closeable.close();
             } catch (Exception e) {
-                throw new MockitoException("Failed to release mocks", e);
+                throw new MockitoException("Failed to release " + closeable, e);
             }
         }
     }

--- a/src/main/java/org/mockito/internal/invocation/finder/AllInvocationsFinder.java
+++ b/src/main/java/org/mockito/internal/invocation/finder/AllInvocationsFinder.java
@@ -42,6 +42,12 @@ public class AllInvocationsFinder {
     public static Set<Stubbing> findStubbings(Iterable<?> mocks) {
         Set<Stubbing> stubbings = new TreeSet<Stubbing>(new StubbingComparator());
         for (Object mock : mocks) {
+            // TODO due to the limited scope of static mocks they cannot be processed
+            //  it would rather be required to trigger this stubbing control upon releasing
+            //  the static mock.
+            if (mock instanceof Class<?>) {
+                continue;
+            }
             Collection<? extends Stubbing> fromSingleMock =
                     new DefaultMockingDetails(mock).getStubbings();
             stubbings.addAll(fromSingleMock);

--- a/src/test/java/org/mockito/internal/configuration/MockAnnotationProcessorTest.java
+++ b/src/test/java/org/mockito/internal/configuration/MockAnnotationProcessorTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.configuration;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.exceptions.base.MockitoException;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class MockAnnotationProcessorTest {
+
+    @SuppressWarnings("unused")
+    private MockedStatic<Void> nonGeneric;
+
+    @SuppressWarnings("unused")
+    private MockedStatic<List<?>> generic;
+
+    @SuppressWarnings({"raw", "unused"})
+    private MockedStatic raw;
+
+    @Test
+    public void testNonGeneric() throws Exception {
+        Class<?> type =
+                MockAnnotationProcessor.inferStaticMock(
+                        MockAnnotationProcessorTest.class
+                                .getDeclaredField("nonGeneric")
+                                .getGenericType(),
+                        "nonGeneric");
+        assertThat(type).isEqualTo(Void.class);
+    }
+
+    @Test(expected = MockitoException.class)
+    public void testGeneric() throws Exception {
+        MockAnnotationProcessor.inferStaticMock(
+                MockAnnotationProcessorTest.class.getDeclaredField("generic").getGenericType(),
+                "generic");
+    }
+
+    @Test(expected = MockitoException.class)
+    public void testRaw() throws Exception {
+        MockAnnotationProcessor.inferStaticMock(
+                MockAnnotationProcessorTest.class.getDeclaredField("raw").getGenericType(), "raw");
+    }
+}

--- a/subprojects/inline/src/test/java/org/mockitoinline/StaticMockTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/StaticMockTest.java
@@ -11,14 +11,20 @@ import static org.mockito.Mockito.times;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockito.exceptions.verification.WantedButNotInvoked;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 public final class StaticMockTest {
+
+    @Rule // Adding rule to assert properly managed life-cycle for static mocks
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Test
     public void testStaticMockSimple() {

--- a/subprojects/junitJupiterInlineMockMakerExtensionTest/junitJupiterInlineMockMakerExtensionTest.gradle.kts
+++ b/subprojects/junitJupiterInlineMockMakerExtensionTest/junitJupiterInlineMockMakerExtensionTest.gradle.kts
@@ -1,0 +1,25 @@
+apply(from = "$rootDir/gradle/dependencies.gradle")
+
+plugins {
+    java
+}
+
+description = "End-to-end tests for automatic registration of MockitoExtension with the inline mock maker."
+
+dependencies {
+    testCompile(project(":junit-jupiter"))
+    testCompile(library("assertj"))
+    testCompile(library("junitPlatformLauncher"))
+    testCompile(library("junitJupiterApi"))
+    testRuntime(library("junitJupiterEngine"))
+}
+
+tasks.named<Test>("test") {
+    useJUnitPlatform()
+}
+
+val Project.libraries
+    get() = rootProject.extra["libraries"] as Map<String, Any>
+
+fun Project.library(name: String) =
+    libraries[name]!!

--- a/subprojects/junitJupiterInlineMockMakerExtensionTest/src/test/java/org/mockitousage/NoExtendsTest.java
+++ b/subprojects/junitJupiterInlineMockMakerExtensionTest/src/test/java/org/mockitousage/NoExtendsTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2018 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+
+import static org.assertj.core.api.Assertions.*;
+
+class NoExtendsTest {
+
+    @Mock
+    private MockedStatic<UUID> mock;
+
+    @Test
+    void runs() {
+        mock.when(UUID::randomUUID).thenReturn(new UUID(123, 456));
+        assertThat(UUID.randomUUID()).isEqualTo(new UUID(123, 456));
+    }
+}

--- a/subprojects/junitJupiterInlineMockMakerExtensionTest/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/subprojects/junitJupiterInlineMockMakerExtensionTest/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+org.mockito.junit.jupiter.MockitoExtension

--- a/subprojects/junitJupiterInlineMockMakerExtensionTest/src/test/resources/junit-platform.properties
+++ b/subprojects/junitJupiterInlineMockMakerExtensionTest/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.extensions.autodetection.enabled = true

--- a/subprojects/junitJupiterInlineMockMakerExtensionTest/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/subprojects/junitJupiterInlineMockMakerExtensionTest/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Due to the limited lifetime of static mocks, they cannot be validated within a Mockito session since they might have expired when the validation is applied. This patch excludes static mocks from all validation. To support static mocks in the regular session validation, we would rather need to trigger the validation upon release of any static mock. 