### PR TITLE
Add support for creating constructors without using Objenesis (and unsafe API)

### DIFF
--- a/src/main/java/org/mockito/creation/instance/InstantiationException.java
+++ b/src/main/java/org/mockito/creation/instance/InstantiationException.java
@@ -14,6 +14,13 @@ import org.mockito.exceptions.base.MockitoException;
 public class InstantiationException extends MockitoException {
 
     /**
+     * @since 3.5.0
+     */
+    public InstantiationException(String message) {
+        super(message);
+    }
+
+    /**
      * @since 2.15.4
      */
     public InstantiationException(String message, Throwable cause) {

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/inject/MockMethodDispatcher.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/inject/MockMethodDispatcher.java
@@ -36,6 +36,11 @@ public abstract class MockMethodDispatcher {
         DISPATCHERS.putIfAbsent(identifier, dispatcher);
     }
 
+    @SuppressWarnings("unused")
+    public static boolean isConstructorMock(String identifier, Class<?> type) {
+        return DISPATCHERS.get(identifier).isConstructorMock(type);
+    }
+
     public abstract Callable<?> handle(Object instance, Method origin, Object[] arguments)
             throws Throwable;
 
@@ -49,4 +54,6 @@ public abstract class MockMethodDispatcher {
     public abstract boolean isMockedStatic(Class<?> type);
 
     public abstract boolean isOverridden(Object instance, Method origin);
+
+    public abstract boolean isConstructorMock(Class<?> type);
 }

--- a/src/test/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMakerTest.java
+++ b/src/test/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMakerTest.java
@@ -58,6 +58,16 @@ public class InlineByteBuddyMockMakerTest
     }
 
     @Test
+    public void should_create_mock_from_non_constructable_class() throws Exception {
+        MockCreationSettings<NonConstructableClass> settings =
+                settingsFor(NonConstructableClass.class);
+        NonConstructableClass proxy =
+                mockMaker.createMock(
+                        settings, new MockHandlerImpl<NonConstructableClass>(settings));
+        assertThat(proxy.foo()).isEqualTo("bar");
+    }
+
+    @Test
     public void should_create_mock_from_final_class_in_the_JDK() throws Exception {
         MockCreationSettings<Pattern> settings = settingsFor(Pattern.class);
         Pattern proxy = mockMaker.createMock(settings, new MockHandlerImpl<Pattern>(settings));
@@ -400,6 +410,17 @@ public class InlineByteBuddyMockMakerTest
     }
 
     private static final class FinalClass {
+
+        public String foo() {
+            return "foo";
+        }
+    }
+
+    private static class NonConstructableClass {
+
+        private NonConstructableClass() {
+            throw new AssertionError();
+        }
 
         public String foo() {
             return "foo";


### PR DESCRIPTION
This PR adds code to constructors to allow short-wiring a constructor without avoiding to call it, thus making the use of Objenesis obsolete. This is desired since Objenesis relies on Unsafe API which is deprecated and will be removed in a future release.

The idea is as follows: Any constructor for a class:

```java
class Foo extends Bar {
  Foo() {
    super(somethingWithSideeffect());
  }
}
```

is rewritten as follows:

```java
class Foo {
  Foo() {
    if (MockDispatcher.isMockedConstruction()) {
      super(null);
      return;
    }
    super(somethingWithSideeffect());
  }
}
```

The mock dispatcher then applies a thead-local check to see if the current construction is supposed to be short-wired and suppresses the original construction in such a case. The check is repeated along the super class hierarchy until reaching the `Object` constructor which is by definition side-effect free. As a result, a mock was created without triggering any user code and without relying on Unsafe API.