### PR TITLE
update dependency to byte buddy version 1.10.13

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -4,7 +4,7 @@ ext {
 
 def versions = [:]
 
-versions.bytebuddy = '1.10.10'
+versions.bytebuddy = '1.10.13'
 versions.junitJupiter = '5.4.2'
 versions.errorprone = '2.4.0'
 


### PR DESCRIPTION
Fixes #1972 : update byte buddy to 1.10.13 to include fixes and support JDK 16
