### PR TITLE
Update assertj to 3.16.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,7 +12,7 @@ libraries.junit4 = 'junit:junit:4.12'
 libraries.junitJupiterApi = "org.junit.jupiter:junit-jupiter-api:${versions.junitJupiter}"
 libraries.junitPlatformLauncher = 'org.junit.platform:junit-platform-launcher:1.1.0'
 libraries.junitJupiterEngine = "org.junit.jupiter:junit-jupiter-engine:${versions.junitJupiter}"
-libraries.assertj = 'org.assertj:assertj-core:3.15.0'
+libraries.assertj = 'org.assertj:assertj-core:3.16.1'
 libraries.hamcrest = 'org.hamcrest:hamcrest-core:1.3'
 libraries.opentest4j = 'org.opentest4j:opentest4j:1.1.1'
 


### PR DESCRIPTION
see
https://assertj.github.io/doc/#assertj-core-3-16-1-release-notes
and
https://assertj.github.io/doc/#assertj-core-3-16-0-release-notes
for details.