### PR TITLE
Replace usages of LinkedList with ArrayList/ArrayDeque

### DIFF
--- a/src/main/java/org/mockito/internal/InOrderImpl.java
+++ b/src/main/java/org/mockito/internal/InOrderImpl.java
@@ -6,7 +6,7 @@ package org.mockito.internal;
 
 import static org.mockito.internal.exceptions.Reporter.inOrderRequiresFamiliarMock;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.mockito.InOrder;
@@ -27,7 +27,7 @@ import org.mockito.verification.VerificationMode;
 public class InOrderImpl implements InOrder, InOrderContext {
 
     private final MockitoCore mockitoCore = new MockitoCore();
-    private final List<Object> mocksToBeVerifiedInOrder = new LinkedList<Object>();
+    private final List<Object> mocksToBeVerifiedInOrder = new ArrayList<>();
     private final InOrderContext inOrderContext = new InOrderContextImpl();
 
     public List<Object> getMocksToBeVerifiedInOrder() {

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassBytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassBytecodeGenerator.java
@@ -21,7 +21,6 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.Random;
 
 import net.bytebuddy.ByteBuddy;
@@ -215,7 +214,7 @@ class SubclassBytecodeGenerator implements BytecodeGenerator {
     }
 
     private <T> Collection<Class<? super T>> getAllTypes(Class<T> type) {
-        Collection<Class<? super T>> supertypes = new LinkedList<Class<? super T>>();
+        Collection<Class<? super T>> supertypes = new ArrayList<>();
         supertypes.add(type);
         Class<? super T> superType = type;
         while (superType != null) {

--- a/src/main/java/org/mockito/internal/creation/instance/ConstructorInstantiator.java
+++ b/src/main/java/org/mockito/internal/creation/instance/ConstructorInstantiator.java
@@ -8,8 +8,8 @@ import static org.mockito.internal.util.StringUtil.join;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 
 import org.mockito.creation.instance.InstantiationException;
@@ -39,7 +39,7 @@ public class ConstructorInstantiator implements Instantiator {
     }
 
     private <T> T withParams(Class<T> cls, Object... params) {
-        List<Constructor<?>> matchingConstructors = new LinkedList<Constructor<?>>();
+        List<Constructor<?>> matchingConstructors = new ArrayList<>();
         try {
             for (Constructor<?> constructor : cls.getDeclaredConstructors()) {
                 Class<?>[] types = constructor.getParameterTypes();

--- a/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
+++ b/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
@@ -7,7 +7,6 @@ package org.mockito.internal.creation.settings;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -40,7 +39,7 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
             new CopyOnWriteArrayList<StubbingLookupListener>();
 
     protected List<VerificationStartedListener> verificationStartedListeners =
-            new LinkedList<VerificationStartedListener>();
+            new ArrayList<VerificationStartedListener>();
     protected boolean stubOnly;
     protected boolean stripAnnotations;
     private boolean useConstructor;

--- a/src/main/java/org/mockito/internal/debugging/InvocationsPrinter.java
+++ b/src/main/java/org/mockito/internal/debugging/InvocationsPrinter.java
@@ -5,7 +5,7 @@
 package org.mockito.internal.debugging;
 
 import java.util.Collection;
-import java.util.LinkedList;
+import java.util.List;
 
 import org.mockito.Mockito;
 import org.mockito.internal.util.collections.ListUtil;
@@ -37,7 +37,7 @@ public class InvocationsPrinter {
             }
         }
 
-        LinkedList<Stubbing> unused =
+        List<Stubbing> unused =
                 ListUtil.filter(
                         stubbings,
                         new ListUtil.Filter<Stubbing>() {

--- a/src/main/java/org/mockito/internal/debugging/LoggingListener.java
+++ b/src/main/java/org/mockito/internal/debugging/LoggingListener.java
@@ -6,7 +6,7 @@ package org.mockito.internal.debugging;
 
 import static org.mockito.internal.util.StringUtil.join;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.mockito.internal.invocation.InvocationMatcher;
@@ -15,9 +15,9 @@ import org.mockito.invocation.Invocation;
 public class LoggingListener implements FindingsListener {
     private final boolean warnAboutUnstubbed;
 
-    private final List<String> argMismatchStubs = new LinkedList<String>();
-    private final List<String> unusedStubs = new LinkedList<String>();
-    private final List<String> unstubbedCalls = new LinkedList<String>();
+    private final List<String> argMismatchStubs = new ArrayList<>();
+    private final List<String> unusedStubs = new ArrayList<>();
+    private final List<String> unstubbedCalls = new ArrayList<>();
 
     public LoggingListener(boolean warnAboutUnstubbed) {
         this.warnAboutUnstubbed = warnAboutUnstubbed;
@@ -57,7 +57,7 @@ public class LoggingListener implements FindingsListener {
             return "";
         }
 
-        List<String> lines = new LinkedList<String>();
+        List<String> lines = new ArrayList<>();
         lines.add(
                 "[Mockito] Additional stubbing information (see javadoc for StubbingInfo class):");
 

--- a/src/main/java/org/mockito/internal/debugging/WarningsCollector.java
+++ b/src/main/java/org/mockito/internal/debugging/WarningsCollector.java
@@ -4,7 +4,7 @@
  */
 package org.mockito.internal.debugging;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.mockito.internal.invocation.InvocationMatcher;
@@ -18,7 +18,7 @@ public class WarningsCollector {
     private final List<Object> createdMocks;
 
     public WarningsCollector() {
-        createdMocks = new LinkedList<Object>();
+        createdMocks = new ArrayList<>();
     }
 
     public String getWarnings() {

--- a/src/main/java/org/mockito/internal/debugging/WarningsFinder.java
+++ b/src/main/java/org/mockito/internal/debugging/WarningsFinder.java
@@ -4,8 +4,8 @@
  */
 package org.mockito.internal.debugging;
 
+import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 
 import org.mockito.internal.invocation.InvocationMatcher;
@@ -21,9 +21,8 @@ public class WarningsFinder {
     }
 
     public void find(FindingsListener findingsListener) {
-        List<Invocation> unusedStubs = new LinkedList<Invocation>(this.baseUnusedStubs);
-        List<InvocationMatcher> allInvocations =
-                new LinkedList<InvocationMatcher>(this.baseAllInvocations);
+        List<Invocation> unusedStubs = new ArrayList<>(this.baseUnusedStubs);
+        List<InvocationMatcher> allInvocations = new ArrayList<>(this.baseAllInvocations);
 
         Iterator<Invocation> unusedIterator = unusedStubs.iterator();
         while (unusedIterator.hasNext()) {

--- a/src/main/java/org/mockito/internal/invocation/InvocationMatcher.java
+++ b/src/main/java/org/mockito/internal/invocation/InvocationMatcher.java
@@ -9,9 +9,9 @@ import static org.mockito.internal.invocation.TypeSafeMatching.matchesTypeSafe;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 
 import org.mockito.ArgumentMatcher;
@@ -47,7 +47,7 @@ public class InvocationMatcher implements MatchableInvocation, DescribedInvocati
     }
 
     public static List<InvocationMatcher> createFrom(List<Invocation> invocations) {
-        LinkedList<InvocationMatcher> out = new LinkedList<InvocationMatcher>();
+        ArrayList<InvocationMatcher> out = new ArrayList<>(invocations.size());
         for (Invocation i : invocations) {
             out.add(new InvocationMatcher(i));
         }

--- a/src/main/java/org/mockito/internal/invocation/InvocationsFinder.java
+++ b/src/main/java/org/mockito/internal/invocation/InvocationsFinder.java
@@ -4,7 +4,7 @@
  */
 package org.mockito.internal.invocation;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.mockito.internal.util.collections.ListUtil;
@@ -63,7 +63,7 @@ public class InvocationsFinder {
 
     private static List<Invocation> getFirstMatchingChunk(
             MatchableInvocation wanted, List<Invocation> unverified) {
-        List<Invocation> firstChunk = new LinkedList<Invocation>();
+        List<Invocation> firstChunk = new ArrayList<>();
         for (Invocation invocation : unverified) {
             if (wanted.matches(invocation)) {
                 firstChunk.add(invocation);
@@ -127,19 +127,19 @@ public class InvocationsFinder {
 
     public static Invocation findPreviousVerifiedInOrder(
             List<Invocation> invocations, InOrderContext context) {
-        LinkedList<Invocation> verifiedOnly =
+        List<Invocation> verifiedOnly =
                 ListUtil.filter(invocations, new RemoveUnverifiedInOrder(context));
 
         if (verifiedOnly.isEmpty()) {
             return null;
         } else {
-            return verifiedOnly.getLast();
+            return verifiedOnly.get(verifiedOnly.size() - 1);
         }
     }
 
     private static List<Invocation> removeVerifiedInOrder(
             List<Invocation> invocations, InOrderContext orderingContext) {
-        List<Invocation> unverified = new LinkedList<Invocation>();
+        List<Invocation> unverified = new ArrayList<>();
         for (Invocation i : invocations) {
             if (orderingContext.isVerified(i)) {
                 unverified.clear();
@@ -151,7 +151,7 @@ public class InvocationsFinder {
     }
 
     public static List<Location> getAllLocations(List<Invocation> invocations) {
-        List<Location> locations = new LinkedList<Location>();
+        List<Location> locations = new ArrayList<>(invocations.size());
         for (Invocation invocation : invocations) {
             locations.add(invocation.getLocation());
         }

--- a/src/main/java/org/mockito/internal/invocation/MatchersBinder.java
+++ b/src/main/java/org/mockito/internal/invocation/MatchersBinder.java
@@ -7,7 +7,7 @@ package org.mockito.internal.invocation;
 import static org.mockito.internal.exceptions.Reporter.invalidUseOfMatchers;
 
 import java.io.Serializable;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.mockito.ArgumentMatcher;
@@ -23,7 +23,7 @@ public class MatchersBinder implements Serializable {
         List<LocalizedMatcher> lastMatchers = argumentMatcherStorage.pullLocalizedMatchers();
         validateMatchers(invocation, lastMatchers);
 
-        List<ArgumentMatcher> matchers = new LinkedList<ArgumentMatcher>();
+        List<ArgumentMatcher> matchers = new ArrayList<>(lastMatchers.size());
         for (LocalizedMatcher m : lastMatchers) {
             matchers.add(m.getMatcher());
         }

--- a/src/main/java/org/mockito/internal/invocation/UnusedStubsFinder.java
+++ b/src/main/java/org/mockito/internal/invocation/UnusedStubsFinder.java
@@ -4,7 +4,7 @@
  */
 package org.mockito.internal.invocation;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.mockito.internal.util.MockUtil;
@@ -20,7 +20,7 @@ public class UnusedStubsFinder {
      * @param mocks full list of mocks
      */
     public List<Invocation> find(List<?> mocks) {
-        List<Invocation> unused = new LinkedList<Invocation>();
+        List<Invocation> unused = new ArrayList<>();
         for (Object mock : mocks) {
             List<Stubbing> fromSingleMock =
                     MockUtil.getInvocationContainer(mock).getStubbingsDescending();

--- a/src/main/java/org/mockito/internal/invocation/finder/AllInvocationsFinder.java
+++ b/src/main/java/org/mockito/internal/invocation/finder/AllInvocationsFinder.java
@@ -30,7 +30,7 @@ public class AllInvocationsFinder {
             invocationsInOrder.addAll(fromSingleMock);
         }
 
-        return new LinkedList<Invocation>(invocationsInOrder);
+        return new ArrayList<>(invocationsInOrder);
     }
 
     /**

--- a/src/main/java/org/mockito/internal/junit/DefaultStubbingLookupListener.java
+++ b/src/main/java/org/mockito/internal/junit/DefaultStubbingLookupListener.java
@@ -7,8 +7,8 @@ package org.mockito.internal.junit;
 import static org.mockito.internal.stubbing.StrictnessSelector.determineStrictness;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 
 import org.mockito.internal.exceptions.Reporter;
@@ -64,7 +64,7 @@ class DefaultStubbingLookupListener implements StubbingLookupListener, Serializa
 
     private static List<Invocation> potentialArgMismatches(
             Invocation invocation, Collection<Stubbing> stubbings) {
-        List<Invocation> matchingStubbings = new LinkedList<Invocation>();
+        List<Invocation> matchingStubbings = new ArrayList<>();
         for (Stubbing s : stubbings) {
             if (UnusedStubbingReporting.shouldBeReported(s)
                     && s.getInvocation()

--- a/src/main/java/org/mockito/internal/junit/MismatchReportingTestListener.java
+++ b/src/main/java/org/mockito/internal/junit/MismatchReportingTestListener.java
@@ -4,8 +4,8 @@
  */
 package org.mockito.internal.junit;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 
 import org.mockito.mock.MockCreationSettings;
@@ -17,7 +17,7 @@ import org.mockito.plugins.MockitoLogger;
 public class MismatchReportingTestListener implements MockitoTestListener {
 
     private final MockitoLogger logger;
-    private List<Object> mocks = new LinkedList<Object>();
+    private List<Object> mocks = new ArrayList<>();
 
     public MismatchReportingTestListener(MockitoLogger logger) {
         this.logger = logger;
@@ -29,7 +29,7 @@ public class MismatchReportingTestListener implements MockitoTestListener {
         // gc
         // TODO make it better, it's easy to forget to clean up mocks and we still create new
         // instance of list that nobody will read, it's also duplicated
-        mocks = new LinkedList<Object>();
+        mocks = new ArrayList<>();
 
         if (event.getFailure() != null) {
             // print unused stubbings only when test succeeds to avoid reporting multiple problems

--- a/src/main/java/org/mockito/internal/junit/UnnecessaryStubbingsReporter.java
+++ b/src/main/java/org/mockito/internal/junit/UnnecessaryStubbingsReporter.java
@@ -4,8 +4,8 @@
  */
 package org.mockito.internal.junit;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 
 import org.junit.runner.Description;
@@ -21,7 +21,7 @@ import org.mockito.mock.MockCreationSettings;
  */
 public class UnnecessaryStubbingsReporter implements MockCreationListener {
 
-    private List<Object> mocks = new LinkedList<Object>();
+    private List<Object> mocks = new ArrayList<>();
 
     public void validateUnusedStubs(Class<?> testClass, RunNotifier notifier) {
         Collection<Invocation> unused =

--- a/src/main/java/org/mockito/internal/junit/UnusedStubbings.java
+++ b/src/main/java/org/mockito/internal/junit/UnusedStubbings.java
@@ -4,8 +4,8 @@
  */
 package org.mockito.internal.junit;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 
 import org.mockito.internal.exceptions.Reporter;
@@ -52,12 +52,9 @@ public class UnusedStubbings {
             return;
         }
 
-        List<Invocation> invocations = new LinkedList<Invocation>();
+        List<Invocation> invocations = new ArrayList<>(unused.size());
         for (Stubbing stubbing : unused) {
             invocations.add(stubbing.getInvocation());
-        }
-        if (invocations.isEmpty()) {
-            return;
         }
 
         Reporter.unncessaryStubbingException(invocations);

--- a/src/main/java/org/mockito/internal/matchers/text/MatchersPrinter.java
+++ b/src/main/java/org/mockito/internal/matchers/text/MatchersPrinter.java
@@ -4,8 +4,8 @@
  */
 package org.mockito.internal.matchers.text;
 
+import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 
 import org.mockito.ArgumentMatcher;
@@ -27,7 +27,7 @@ public class MatchersPrinter {
 
     private Iterator<FormattedText> applyPrintSettings(
             List<ArgumentMatcher> matchers, PrintSettings printSettings) {
-        List<FormattedText> out = new LinkedList<FormattedText>();
+        List<FormattedText> out = new ArrayList<>();
         int i = 0;
         for (final ArgumentMatcher matcher : matchers) {
             if (matcher instanceof ContainsExtraTypeInfo && printSettings.extraTypeInfoFor(i)) {

--- a/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
+++ b/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
@@ -7,8 +7,8 @@ package org.mockito.internal.progress;
 import static org.mockito.internal.exceptions.Reporter.unfinishedStubbing;
 import static org.mockito.internal.exceptions.Reporter.unfinishedVerificationException;
 
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
@@ -173,7 +173,7 @@ public class MockingProgressImpl implements MockingProgress {
     }
 
     static void addListener(MockitoListener listener, Set<MockitoListener> listeners) {
-        List<MockitoListener> delete = new LinkedList<MockitoListener>();
+        List<MockitoListener> delete = new ArrayList<>();
         for (MockitoListener existing : listeners) {
             if (existing.getClass().equals(listener.getClass())) {
                 if (existing instanceof AutoCleanableListener

--- a/src/main/java/org/mockito/internal/reporting/PrintSettings.java
+++ b/src/main/java/org/mockito/internal/reporting/PrintSettings.java
@@ -4,8 +4,8 @@
  */
 package org.mockito.internal.reporting;
 
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 
 import org.mockito.ArgumentMatcher;
@@ -18,7 +18,7 @@ public class PrintSettings {
 
     public static final int MAX_LINE_LENGTH = 45;
     private boolean multiline;
-    private List<Integer> withTypeInfo = new LinkedList<Integer>();
+    private List<Integer> withTypeInfo = new ArrayList<>();
 
     public void setMultiline(boolean multiline) {
         this.multiline = multiline;

--- a/src/main/java/org/mockito/internal/stubbing/InvocationContainerImpl.java
+++ b/src/main/java/org/mockito/internal/stubbing/InvocationContainerImpl.java
@@ -7,6 +7,7 @@ package org.mockito.internal.stubbing;
 import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -157,7 +158,7 @@ public class InvocationContainerImpl implements InvocationContainer, Serializabl
      * Stubbings in ascending order, most recent last
      */
     public Collection<Stubbing> getStubbingsAscending() {
-        List<Stubbing> result = new LinkedList<Stubbing>(stubbed);
+        List<Stubbing> result = new ArrayList<>(stubbed);
         Collections.reverse(result);
         return result;
     }

--- a/src/main/java/org/mockito/internal/stubbing/StubberImpl.java
+++ b/src/main/java/org/mockito/internal/stubbing/StubberImpl.java
@@ -11,7 +11,7 @@ import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingPro
 import static org.mockito.internal.stubbing.answers.DoesNothing.doesNothing;
 import static org.mockito.internal.util.MockUtil.isMock;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.mockito.internal.stubbing.answers.CallsRealMethods;
@@ -31,7 +31,7 @@ public class StubberImpl implements Stubber {
         this.strictness = strictness;
     }
 
-    private final List<Answer<?>> answers = new LinkedList<Answer<?>>();
+    private final List<Answer<?>> answers = new ArrayList<>();
 
     @Override
     public <T> T when(T mock) {

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValues.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValues.java
@@ -89,7 +89,7 @@ public class ReturnsEmptyValues implements Answer<Object>, Serializable {
         } else if (type == Iterable.class) {
             return new ArrayList<Object>(0);
         } else if (type == Collection.class) {
-            return new LinkedList<Object>();
+            return new ArrayList<>();
         } else if (type == Set.class) {
             return new HashSet<Object>();
         } else if (type == HashSet.class) {
@@ -101,7 +101,7 @@ public class ReturnsEmptyValues implements Answer<Object>, Serializable {
         } else if (type == LinkedHashSet.class) {
             return new LinkedHashSet<Object>();
         } else if (type == List.class) {
-            return new LinkedList<Object>();
+            return new ArrayList<Object>();
         } else if (type == LinkedList.class) {
             return new LinkedList<Object>();
         } else if (type == ArrayList.class) {

--- a/src/main/java/org/mockito/internal/util/collections/IdentitySet.java
+++ b/src/main/java/org/mockito/internal/util/collections/IdentitySet.java
@@ -4,12 +4,11 @@
  */
 package org.mockito.internal.util.collections;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 
-@SuppressWarnings("unchecked")
 public class IdentitySet {
 
-    private final LinkedList list = new LinkedList();
+    private final ArrayList<Object> list = new ArrayList<>();
 
     public boolean contains(Object o) {
         for (Object existing : list) {

--- a/src/main/java/org/mockito/internal/util/collections/Iterables.java
+++ b/src/main/java/org/mockito/internal/util/collections/Iterables.java
@@ -4,9 +4,9 @@
  */
 package org.mockito.internal.util.collections;
 
+import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -18,7 +18,7 @@ public class Iterables {
      * Converts enumeration into iterable
      */
     public static <T> Iterable<T> toIterable(Enumeration<T> in) {
-        List<T> out = new LinkedList<T>();
+        List<T> out = new ArrayList<>();
         while (in.hasMoreElements()) {
             out.add(in.nextElement());
         }

--- a/src/main/java/org/mockito/internal/util/collections/ListUtil.java
+++ b/src/main/java/org/mockito/internal/util/collections/ListUtil.java
@@ -4,8 +4,9 @@
  */
 package org.mockito.internal.util.collections;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
+import java.util.List;
 
 /**
  * Basic list/collection operators.
@@ -15,8 +16,8 @@ import java.util.LinkedList;
  */
 public class ListUtil {
 
-    public static <T> LinkedList<T> filter(Collection<T> collection, Filter<T> filter) {
-        LinkedList<T> filtered = new LinkedList<T>();
+    public static <T> List<T> filter(Collection<T> collection, Filter<T> filter) {
+        ArrayList<T> filtered = new ArrayList<>();
         for (T t : collection) {
             if (!filter.isOut(t)) {
                 filtered.add(t);
@@ -25,9 +26,9 @@ public class ListUtil {
         return filtered;
     }
 
-    public static <From, To> LinkedList<To> convert(
+    public static <From, To> List<To> convert(
             Collection<From> collection, Converter<From, To> converter) {
-        LinkedList<To> converted = new LinkedList<To>();
+        ArrayList<To> converted = new ArrayList<>();
         for (From f : collection) {
             converted.add(converter.convert(f));
         }

--- a/src/main/java/org/mockito/internal/util/io/IOUtil.java
+++ b/src/main/java/org/mockito/internal/util/io/IOUtil.java
@@ -4,9 +4,16 @@
  */
 package org.mockito.internal.util.io;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 
 import org.mockito.exceptions.base.MockitoException;
@@ -32,7 +39,7 @@ public class IOUtil {
     }
 
     public static Collection<String> readLines(InputStream is) {
-        List<String> out = new LinkedList<String>();
+        List<String> out = new ArrayList<>();
         BufferedReader r = new BufferedReader(new InputStreamReader(is));
         String line;
         try {

--- a/src/main/java/org/mockito/internal/verification/DefaultRegisteredInvocations.java
+++ b/src/main/java/org/mockito/internal/verification/DefaultRegisteredInvocations.java
@@ -7,6 +7,7 @@ package org.mockito.internal.verification;
 import static org.mockito.internal.util.ObjectMethodsGuru.isToStringMethod;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -38,7 +39,7 @@ public class DefaultRegisteredInvocations implements RegisteredInvocations, Seri
     public List<Invocation> getAll() {
         List<Invocation> copiedList;
         synchronized (invocations) {
-            copiedList = new LinkedList<Invocation>(invocations);
+            copiedList = new ArrayList<>(invocations);
         }
 
         return ListUtil.filter(copiedList, new RemoveToString());

--- a/src/main/java/org/mockito/internal/verification/argumentmatching/ArgumentMatchingTool.java
+++ b/src/main/java/org/mockito/internal/verification/argumentmatching/ArgumentMatchingTool.java
@@ -4,7 +4,7 @@
  */
 package org.mockito.internal.verification.argumentmatching;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.mockito.ArgumentMatcher;
@@ -23,7 +23,7 @@ public class ArgumentMatchingTool {
             return new Integer[0];
         }
 
-        List<Integer> suspicious = new LinkedList<Integer>();
+        List<Integer> suspicious = new ArrayList<>();
         int i = 0;
         for (ArgumentMatcher m : matchers) {
             if (m instanceof ContainsExtraTypeInfo

--- a/src/test/java/org/concurrentmockito/ThreadsRunAllTestsHalfManualTest.java
+++ b/src/test/java/org/concurrentmockito/ThreadsRunAllTestsHalfManualTest.java
@@ -6,9 +6,9 @@ package org.concurrentmockito;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
@@ -152,7 +152,7 @@ public class ThreadsRunAllTestsHalfManualTest extends TestBase {
     }
 
     public static Set<Class<?>> runInMultipleThreads(int numberOfThreads) throws Exception {
-        List<AllTestsRunner> threads = new LinkedList<AllTestsRunner>();
+        List<AllTestsRunner> threads = new ArrayList<>();
         for (int i = 1; i <= numberOfThreads; i++) {
             threads.add(new AllTestsRunner());
         }

--- a/src/test/java/org/mockito/exceptions/base/TraceBuilder.java
+++ b/src/test/java/org/mockito/exceptions/base/TraceBuilder.java
@@ -4,8 +4,8 @@
  */
 package org.mockito.exceptions.base;
 
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 
 public class TraceBuilder {
@@ -22,7 +22,7 @@ public class TraceBuilder {
     private List<StackTraceElement> toTraceList() {
         assert methods.length == 0 || classes.length == 0;
 
-        List<StackTraceElement> trace = new LinkedList<StackTraceElement>();
+        List<StackTraceElement> trace = new ArrayList<>();
         for (String method : methods) {
             trace.add(new StackTraceElement("SomeClass", method, "SomeClass.java", 50));
         }

--- a/src/test/java/org/mockito/internal/creation/MockSettingsImplTest.java
+++ b/src/test/java/org/mockito/internal/creation/MockSettingsImplTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -156,7 +157,7 @@ public class MockSettingsImplTest extends TestBase {
                         new ThrowableAssert.ThrowingCallable() {
                             public void call() {
                                 mockSettingsImpl.addListeners(
-                                        new Object[] {}, new LinkedList<Object>(), "myListeners");
+                                        new Object[] {}, new ArrayList<Object>(), "myListeners");
                             }
                         })
                 .hasMessageContaining("myListeners() requires at least one listener");
@@ -165,7 +166,7 @@ public class MockSettingsImplTest extends TestBase {
                         new ThrowableAssert.ThrowingCallable() {
                             public void call() {
                                 mockSettingsImpl.addListeners(
-                                        null, new LinkedList<Object>(), "myListeners");
+                                        null, new ArrayList<Object>(), "myListeners");
                             }
                         })
                 .hasMessageContaining("myListeners() does not accept null vararg array");
@@ -175,7 +176,7 @@ public class MockSettingsImplTest extends TestBase {
                             public void call() {
                                 mockSettingsImpl.addListeners(
                                         new Object[] {null},
-                                        new LinkedList<Object>(),
+                                        new ArrayList<Object>(),
                                         "myListeners");
                             }
                         })

--- a/src/test/java/org/mockito/internal/invocation/InvocationBuilder.java
+++ b/src/test/java/org/mockito/internal/invocation/InvocationBuilder.java
@@ -5,11 +5,10 @@
 package org.mockito.internal.invocation;
 
 import static java.util.Arrays.asList;
-
 import static org.mockito.internal.invocation.InterceptedInvocation.NO_OP;
 
 import java.lang.reflect.Method;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.mockito.Mockito;
@@ -45,7 +44,7 @@ public class InvocationBuilder {
     public Invocation toInvocation() {
         if (method == null) {
             if (argTypes == null) {
-                argTypes = new LinkedList<Class<?>>();
+                argTypes = new ArrayList<>();
                 for (Object arg : args) {
                     if (arg == null) {
                         argTypes.add(Object.class);

--- a/src/test/java/org/mockito/internal/invocation/InvocationsFinderTest.java
+++ b/src/test/java/org/mockito/internal/invocation/InvocationsFinderTest.java
@@ -8,9 +8,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 
 import org.assertj.core.api.Assertions;
@@ -26,7 +26,7 @@ import org.mockitoutil.TestBase;
 
 public class InvocationsFinderTest extends TestBase {
 
-    private LinkedList<Invocation> invocations = new LinkedList<Invocation>();
+    private final List<Invocation> invocations = new ArrayList<>();
     private Invocation simpleMethodInvocation;
     private Invocation simpleMethodInvocationTwo;
     private Invocation differentMethodInvocation;

--- a/src/test/java/org/mockito/internal/stubbing/InvocationContainerImplTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/InvocationContainerImplTest.java
@@ -8,7 +8,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
 import org.junit.Test;
@@ -29,7 +30,7 @@ public class InvocationContainerImplTest {
     InvocationContainerImpl containerStubOnly =
             new InvocationContainerImpl((MockCreationSettings) new MockSettingsImpl().stubOnly());
     Invocation invocation = new InvocationBuilder().toInvocation();
-    LinkedList<Throwable> exceptions = new LinkedList<Throwable>();
+    List<Throwable> exceptions = new ArrayList<>();
 
     @Test
     public void should_be_thread_safe() throws Throwable {
@@ -78,7 +79,7 @@ public class InvocationContainerImplTest {
 
         // then
         if (exceptions.size() != 0) {
-            throw exceptions.getFirst();
+            throw exceptions.get(0);
         }
     }
 

--- a/src/test/java/org/mockito/internal/util/collections/HashCodeAndEqualsSafeSetTest.java
+++ b/src/test/java/org/mockito/internal/util/collections/HashCodeAndEqualsSafeSetTest.java
@@ -7,9 +7,9 @@ package org.mockito.internal.util.collections;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Observer;
 
@@ -96,7 +96,7 @@ public class HashCodeAndEqualsSafeSetTest {
     public void can_iterate() throws Exception {
         HashCodeAndEqualsSafeSet mocks = HashCodeAndEqualsSafeSet.of(mock1, mock(Observer.class));
 
-        LinkedList<Object> accumulator = new LinkedList<Object>();
+        ArrayList<Object> accumulator = new ArrayList<>();
         for (Object mock : mocks) {
             accumulator.add(mock);
         }

--- a/src/test/java/org/mockito/internal/util/collections/ListUtilTest.java
+++ b/src/test/java/org/mockito/internal/util/collections/ListUtilTest.java
@@ -5,10 +5,9 @@
 package org.mockito.internal.util.collections;
 
 import static java.util.Arrays.asList;
-
 import static org.junit.Assert.assertTrue;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.assertj.core.api.Assertions;
@@ -35,7 +34,7 @@ public class ListUtilTest extends TestBase {
 
     @Test
     public void shouldReturnEmptyIfEmptyListGiven() throws Exception {
-        List<Object> list = new LinkedList<Object>();
+        List<Object> list = new ArrayList<>();
         List<Object> filtered = ListUtil.filter(list, null);
         assertTrue(filtered.isEmpty());
     }

--- a/src/test/java/org/mockitousage/IMethods.java
+++ b/src/test/java/org/mockitousage/IMethods.java
@@ -183,7 +183,7 @@ public interface IMethods {
 
     List<String> listReturningMethod(Object... objects);
 
-    LinkedList<String> linkedListReturningMethod();
+    List<String> linkedListReturningMethod();
 
     String toString();
 

--- a/src/test/java/org/mockitousage/MethodsImpl.java
+++ b/src/test/java/org/mockitousage/MethodsImpl.java
@@ -345,7 +345,7 @@ public class MethodsImpl implements IMethods {
         return null;
     }
 
-    public LinkedList<String> linkedListReturningMethod() {
+    public List<String> linkedListReturningMethod() {
         return null;
     }
 

--- a/src/test/java/org/mockitousage/annotation/CaptorAnnotationBasicTest.java
+++ b/src/test/java/org/mockitousage/annotation/CaptorAnnotationBasicTest.java
@@ -8,7 +8,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.verify;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Test;
@@ -95,7 +95,7 @@ public class CaptorAnnotationBasicTest extends TestBase {
     @Test
     public void shouldCaptureGenericList() {
         // given
-        List<String> list = new LinkedList<String>();
+        List<String> list = new ArrayList<>();
         mock.listArgMethod(list);
 
         // when

--- a/src/test/java/org/mockitousage/bugs/InheritedGenericsPolimorphicCallTest.java
+++ b/src/test/java/org/mockitousage/bugs/InheritedGenericsPolimorphicCallTest.java
@@ -11,8 +11,8 @@ import static org.mockito.Mockito.verify;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 
 import org.junit.Test;
@@ -52,7 +52,7 @@ public class InheritedGenericsPolimorphicCallTest extends TestBase {
     @Test
     public void shouldWorkExactlyAsJavaProxyWould() {
         // given
-        final List<Method> methods = new LinkedList<Method>();
+        final List<Method> methods = new ArrayList<>();
         InvocationHandler handler =
                 new InvocationHandler() {
                     public Object invoke(Object proxy, Method method, Object[] args)

--- a/subprojects/deprecatedPluginsTest/src/test/java/org/mockitousage/plugins/MyDeprecatedInstantiatorProvider.java
+++ b/subprojects/deprecatedPluginsTest/src/test/java/org/mockitousage/plugins/MyDeprecatedInstantiatorProvider.java
@@ -4,14 +4,14 @@
  */
 package org.mockitousage.plugins;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.mockito.Mockito;
 import org.mockito.internal.creation.instance.InstantiationException;
 import org.mockito.internal.creation.instance.Instantiator;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.plugins.InstantiatorProvider;
-
-import java.util.LinkedList;
-import java.util.List;
 
 @SuppressWarnings("deprecation")
 public class MyDeprecatedInstantiatorProvider implements InstantiatorProvider {
@@ -25,7 +25,7 @@ public class MyDeprecatedInstantiatorProvider implements InstantiatorProvider {
         }
 
         if (invokedFor.get() == null) {
-            invokedFor.set(new LinkedList<>());
+            invokedFor.set(new ArrayList<>());
         }
         invokedFor.get().add(settings.getTypeToMock());
 

--- a/subprojects/extTest/src/test/java/org/mockitousage/plugins/switcher/MyPluginSwitch.java
+++ b/subprojects/extTest/src/test/java/org/mockitousage/plugins/switcher/MyPluginSwitch.java
@@ -4,14 +4,14 @@
  */
 package org.mockitousage.plugins.switcher;
 
-import org.mockito.plugins.PluginSwitch;
-
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
+
+import org.mockito.plugins.PluginSwitch;
 
 public class MyPluginSwitch implements PluginSwitch {
 
-    static List<String> invokedFor = new LinkedList<String>();
+    static List<String> invokedFor = new ArrayList<>();
 
     public boolean isEnabled(String pluginClassName) {
         invokedFor.add(pluginClassName);


### PR DESCRIPTION
It's known that ArrayList performance is almost always better than LinkedList:
1. Due to dense memory layout - elements of ArrayList are easier to cache by CPU. It gives really huge speedup compared to LinkedList
2. It has less overhead when it's empty: LinkedList has 4 fields (size, first, last, modCount) while ArrayList has 3 fields (size, elementData, modCount)
3. ArrayList is much more often used in application code and JDK, compared to LinkedList. So chances that its code will be already compiled by JIT when test/mock is executed is very high.

See examples of similar cleanup in other projects:
1. JDK https://bugs.openjdk.java.net/browse/JDK-8246048 
2. Spring https://github.com/spring-projects/spring-framework/issues/25650

This PR replaces usages of LinkedList with ArrayList and ArrayDeque where it's _convenient_. I intentionally didn't converted few places where LinkedList used as Dequeu to avoid making code more complex.