### PR TITLE
Do not pass static mocks to regular listener callback.

### DIFF
--- a/src/main/java/org/mockito/internal/invocation/InterceptedInvocation.java
+++ b/src/main/java/org/mockito/internal/invocation/InterceptedInvocation.java
@@ -141,6 +141,30 @@ public class InterceptedInvocation implements Invocation, VerificationAwareInvoc
         return realMethod.invoke();
     }
 
+    /**
+     * @deprecated Not used by Mockito but by mockito-scala
+     */
+    @Deprecated
+    public MockReference<Object> getMockRef() {
+        return mockRef;
+    }
+
+    /**
+     * @deprecated Not used by Mockito but by mockito-scala
+     */
+    @Deprecated
+    public MockitoMethod getMockitoMethod() {
+        return mockitoMethod;
+    }
+
+    /**
+     * @deprecated Not used by Mockito but by mockito-scala
+     */
+    @Deprecated
+    public RealMethod getRealMethod() {
+        return realMethod;
+    }
+
     @Override
     public int hashCode() {
         // TODO SF we need to provide hash code implementation so that there are no unexpected,

--- a/src/main/java/org/mockito/internal/progress/MockingProgress.java
+++ b/src/main/java/org/mockito/internal/progress/MockingProgress.java
@@ -43,6 +43,8 @@ public interface MockingProgress {
 
     void mockingStarted(Object mock, MockCreationSettings settings);
 
+    void mockingStarted(Class<?> mock, MockCreationSettings settings);
+
     void addListener(MockitoListener listener);
 
     void removeListener(MockitoListener listener);

--- a/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
+++ b/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
@@ -159,6 +159,15 @@ public class MockingProgressImpl implements MockingProgress {
         validateMostStuff();
     }
 
+    public void mockingStarted(Class<?> mock, MockCreationSettings settings) {
+        for (MockitoListener listener : listeners) {
+            if (listener instanceof MockCreationListener) {
+                ((MockCreationListener) listener).onStaticMockCreated(mock, settings);
+            }
+        }
+        validateMostStuff();
+    }
+
     public void addListener(MockitoListener listener) {
         addListener(listener, listeners);
     }

--- a/src/main/java/org/mockito/listeners/MockCreationListener.java
+++ b/src/main/java/org/mockito/listeners/MockCreationListener.java
@@ -19,4 +19,12 @@ public interface MockCreationListener extends MockitoListener {
      * @param settings the settings used for creation
      */
     void onMockCreated(Object mock, MockCreationSettings settings);
+
+    /**
+     * Static mock object was just created.
+     *
+     * @param mock the type being mocked
+     * @param settings the settings used for creation
+     */
+    default void onStaticMockCreated(Class<?> mock, MockCreationSettings settings) {}
 }

--- a/subprojects/inline/src/test/java/org/mockitoinline/StaticMockTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/StaticMockTest.java
@@ -11,20 +11,14 @@ import static org.mockito.Mockito.times;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockito.exceptions.verification.WantedButNotInvoked;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
 
 public final class StaticMockTest {
-
-    @Rule // Adding rule to assert properly managed life-cycle for static mocks
-    public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Test
     public void testStaticMockSimple() {

--- a/subprojects/inline/src/test/java/org/mockitoinline/StaticRuleTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/StaticRuleTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitoinline;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.UUID;
+
+import static junit.framework.TestCase.assertEquals;
+
+public final class StaticRuleTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private MockedStatic<UUID> mock;
+
+    @Test
+    public void runs() {
+        mock.when(UUID::randomUUID).thenReturn(new UUID(123, 456));
+        assertEquals(UUID.randomUUID(), new UUID(123, 456));
+    }
+}

--- a/subprojects/inline/src/test/java/org/mockitoinline/StaticRunnerTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/StaticRunnerTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2018 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitoinline;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.UUID;
+
+import static junit.framework.TestCase.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public final class StaticRunnerTest {
+
+    @Mock
+    private MockedStatic<UUID> mock;
+
+    @Test
+    public void runs() {
+        mock.when(UUID::randomUUID).thenReturn(new UUID(123, 456));
+        assertEquals(UUID.randomUUID(), new UUID(123, 456));
+    }
+}


### PR DESCRIPTION
Does not include static mocks in regular listener logic as it might distort existing mock collectors that do not expect scoped mocks. Fixes #1988.

We have passed `Class` objects to the listener to indicate a static mock. The class object is of course itself not a regular mock and it's cleaner to create a callback method of it's own. This way, existing listeners remain logically backwards compatible, including our own listener that is used within the JUnit runner (we have only tested the rule, I added a test for the runner, too).