### PR TITLE
Mockito.verify(): fix typo in Javadoc

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -2227,7 +2227,7 @@ public class Mockito extends ArgumentMatchers {
      * Although it is possible to verify a stubbed invocation, usually <b>it's just redundant</b>.
      * Let's say you've stubbed <code>foo.bar()</code>.
      * If your code cares what <code>foo.bar()</code> returns then something else breaks(often before even <code>verify()</code> gets executed).
-     * If your code doesn't care what <code>get(0)</code> returns then it should not be stubbed.
+     * If your code doesn't care what <code>foo.bar()</code> returns then it should not be stubbed.
      *
      * <p>
      * See examples in javadoc for {@link Mockito} class


### PR DESCRIPTION
I noted this while reading the Javadocs in my IDE; they were referring to a `get(0)` reference which isn't quite easy to grasp in this context. :see_no_evil: After looking at this class a bit more, I think it's just a copy-paste mistake from this line in the class-level Javadocs: https://github.com/mockito/mockito/blob/release/3.x/src/main/java/org/mockito/Mockito.java#L212