### PR TITLE
Initializes spies within constructors of a mock instance for the inline mock maker.

### DIFF
--- a/src/main/java/org/mockito/MockedConstruction.java
+++ b/src/main/java/org/mockito/MockedConstruction.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito;
+
+import java.lang.reflect.Constructor;
+import java.util.List;
+
+/**
+ * Represents a mock of any object construction of the represented type. Within the scope of the
+ * mocked construction, the invocation of any interceptor will generate a mock which will be
+ * prepared as specified when generating this scope. The mock can also be received via this
+ * instance.
+ * <p>
+ * If the {@link Mock} annotation is used on fields or method parameters of this type, a mocked
+ * construction is created instead of a regular mock. The mocked construction is activated and
+ * released upon completing any relevant test.
+ *
+ * @param <T> The type for which the construction is being mocked.
+ */
+@Incubating
+public interface MockedConstruction<T> extends ScopedMock {
+
+    List<T> constructed();
+
+    interface Context {
+
+        int getCount();
+
+        Constructor<?> constructor();
+
+        List<?> arguments();
+    }
+
+    interface MockInitializer<T> {
+
+        void prepare(T mock, Context context) throws Throwable;
+    }
+}

--- a/src/main/java/org/mockito/MockedStatic.java
+++ b/src/main/java/org/mockito/MockedStatic.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.*;
  * @param <T> The type being mocked.
  */
 @Incubating
-public interface MockedStatic<T> extends AutoCloseable {
+public interface MockedStatic<T> extends ScopedMock {
 
     /**
      * See {@link Mockito#when(Object)}.
@@ -62,24 +62,6 @@ public interface MockedStatic<T> extends AutoCloseable {
      * See {@link Mockito#verifyNoInteractions(Object...)}.
      */
     void verifyNoInteractions();
-
-    /**
-     * Checks if this mock is closed.
-     *
-     * @return {@code true} if this mock is closed.
-     */
-    boolean isClosed();
-
-    /**
-     * Releases this static mock and throws a {@link org.mockito.exceptions.base.MockitoException} if closed already.
-     */
-    @Override
-    void close();
-
-    /**
-     * Releases this static mock and is non-operational if already released.
-     */
-    void closeOnDemand();
 
     interface Verification {
 

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -28,18 +28,10 @@ import org.mockito.quality.MockitoHint;
 import org.mockito.quality.Strictness;
 import org.mockito.session.MockitoSessionBuilder;
 import org.mockito.session.MockitoSessionLogger;
-import org.mockito.stubbing.Answer;
-import org.mockito.stubbing.Answer1;
-import org.mockito.stubbing.LenientStubber;
-import org.mockito.stubbing.OngoingStubbing;
-import org.mockito.stubbing.Stubber;
-import org.mockito.stubbing.Stubbing;
-import org.mockito.stubbing.VoidAnswer1;
-import org.mockito.verification.After;
-import org.mockito.verification.Timeout;
-import org.mockito.verification.VerificationAfterDelay;
-import org.mockito.verification.VerificationMode;
-import org.mockito.verification.VerificationWithTimeout;
+import org.mockito.stubbing.*;
+import org.mockito.verification.*;
+
+import java.util.function.Function;
 
 /**
  * <p align="left"><img src="logo.png" srcset="logo@2x.png 2x" alt="Mockito logo"/></p>
@@ -106,6 +98,7 @@ import org.mockito.verification.VerificationWithTimeout;
  *      <a href="#46">46. New <code>Mockito.lenient()</code> and <code>MockSettings.lenient()</code> methods (Since 2.20.0)</a><br/>
  *      <a href="#47">47. New API for clearing mock state in inline mocking (Since 2.25.0)</a><br/>
  *      <a href="#48">48. New API for mocking static methods (Since 3.4.0)</a><br/>
+ *      <a href="#49">49. New API for mocking object construction (Since 3.5.0)</a><br/>
  * </b>
  *
  * <h3 id="0">0. <a class="meaningful_link" href="#mockito2" name="mockito2">Migrating to Mockito 2</a></h3>
@@ -1565,8 +1558,31 @@ import org.mockito.verification.VerificationWithTimeout;
  * assertEquals("foo", Foo.method());
  * </code></pre>
  *
- * Due to the defined scope of the static mock, it returns to its original behvior once the scope is released. To define mock
+ * Due to the defined scope of the static mock, it returns to its original behavior once the scope is released. To define mock
  * behavior and to verify static method invocations, use the <code>MockedStatic</code> that is returned.
+ * <p>
+ *
+ * <h3 id="49">49. <a class="meaningful_link" href="#mocked_construction" name="mocked_construction">Mocking object construction</a> (since 3.5.0)</h3>
+ *
+ * When using the <a href="#0.2">inline mock maker</a>, it is possible to generate mocks on constructor invocations within the current
+ * thread and a user-defined scope. This way, Mockito assures that concurrently and sequentially running tests do not interfere.
+ *
+ * To make sure a constructor mocks remain temporary, it is recommended to define the scope within a try-with-resources construct.
+ * In the following example, the <code>Foo</code> type's construction would generate a mock:
+ *
+ * <pre class="code"><code class="java">
+ * assertEquals("foo", Foo.method());
+ * try (MockedConstruction<Foo> mocked = mockConstruction(Foo.class)) {
+ * Foo foo = new Foo();
+ * when(foo.method()).thenReturn("bar");
+ * assertEquals("bar", foo.method());
+ * verify(foo).method();
+ * }
+ * assertEquals("foo", foo.method());
+ * </code></pre>
+ *
+ * Due to the defined scope of the mocked construction, object construction returns to its original behavior once the scope is
+ * released. To define mock behavior and to verify static method invocations, use the <code>MockedConstruction</code> that is returned.
  * <p>
  */
 @SuppressWarnings("unchecked")
@@ -2142,6 +2158,152 @@ public class Mockito extends ArgumentMatchers {
     @CheckReturnValue
     public static <T> MockedStatic<T> mockStatic(Class<T> classToMock, MockSettings mockSettings) {
         return MOCKITO_CORE.mockStatic(classToMock, mockSettings);
+    }
+
+    /**
+     * Creates a thread-local mock controller for all constructions of the given class.
+     * The returned object's {@link MockedConstruction#close()} method must be called upon completing the
+     * test or the mock will remain active on the current thread.
+     * <p>
+     * See examples in javadoc for {@link Mockito} class
+     *
+     * @param classToMock non-abstract class of which constructions should be mocked.
+     * @param defaultAnswer the default answer for the first created mock.
+     * @param additionalAnswers the default answer for all additional mocks. For any access mocks, the
+     *                         last answer is used. If this array is empty, the {@code defaultAnswer} is used.
+     * @return mock controller
+     */
+    @Incubating
+    @CheckReturnValue
+    public static <T> MockedConstruction<T> mockConstructionWithAnswer(
+            Class<T> classToMock, Answer defaultAnswer, Answer... additionalAnswers) {
+        return mockConstruction(
+                classToMock,
+                context -> {
+                    if (context.getCount() == 1 || additionalAnswers.length == 0) {
+                        return withSettings().defaultAnswer(defaultAnswer);
+                    } else if (context.getCount() >= additionalAnswers.length) {
+                        return withSettings()
+                                .defaultAnswer(additionalAnswers[additionalAnswers.length - 1]);
+                    } else {
+                        return withSettings()
+                                .defaultAnswer(additionalAnswers[context.getCount() - 2]);
+                    }
+                },
+                (mock, context) -> {});
+    }
+
+    /**
+     * Creates a thread-local mock controller for all constructions of the given class.
+     * The returned object's {@link MockedConstruction#close()} method must be called upon completing the
+     * test or the mock will remain active on the current thread.
+     * <p>
+     * See examples in javadoc for {@link Mockito} class
+     *
+     * @param classToMock non-abstract class of which constructions should be mocked.
+     * @return mock controller
+     */
+    @Incubating
+    @CheckReturnValue
+    public static <T> MockedConstruction<T> mockConstruction(Class<T> classToMock) {
+        return mockConstruction(classToMock, index -> withSettings(), (mock, context) -> {});
+    }
+
+    /**
+     * Creates a thread-local mock controller for all constructions of the given class.
+     * The returned object's {@link MockedConstruction#close()} method must be called upon completing the
+     * test or the mock will remain active on the current thread.
+     * <p>
+     * See examples in javadoc for {@link Mockito} class
+     *
+     * @param classToMock non-abstract class of which constructions should be mocked.
+     * @param mockInitializer a callback to prepare a mock's methods after its instantiation.
+     * @return mock controller
+     */
+    @Incubating
+    @CheckReturnValue
+    public static <T> MockedConstruction<T> mockConstruction(
+            Class<T> classToMock, MockedConstruction.MockInitializer<T> mockInitializer) {
+        return mockConstruction(classToMock, withSettings(), mockInitializer);
+    }
+
+    /**
+     * Creates a thread-local mock controller for all constructions of the given class.
+     * The returned object's {@link MockedConstruction#close()} method must be called upon completing the
+     * test or the mock will remain active on the current thread.
+     * <p>
+     * See examples in javadoc for {@link Mockito} class
+     *
+     * @param classToMock non-abstract class of which constructions should be mocked.
+     * @param mockSettings the mock settings to use.
+     * @return mock controller
+     */
+    @Incubating
+    @CheckReturnValue
+    public static <T> MockedConstruction<T> mockConstruction(
+            Class<T> classToMock, MockSettings mockSettings) {
+        return mockConstruction(classToMock, context -> mockSettings);
+    }
+
+    /**
+     * Creates a thread-local mock controller for all constructions of the given class.
+     * The returned object's {@link MockedConstruction#close()} method must be called upon completing the
+     * test or the mock will remain active on the current thread.
+     * <p>
+     * See examples in javadoc for {@link Mockito} class
+     *
+     * @param classToMock non-abstract class of which constructions should be mocked.
+     * @param mockSettingsFactory the mock settings to use.
+     * @return mock controller
+     */
+    @Incubating
+    @CheckReturnValue
+    public static <T> MockedConstruction<T> mockConstruction(
+            Class<T> classToMock,
+            Function<MockedConstruction.Context, MockSettings> mockSettingsFactory) {
+        return mockConstruction(classToMock, mockSettingsFactory, (mock, context) -> {});
+    }
+
+    /**
+     * Creates a thread-local mock controller for all constructions of the given class.
+     * The returned object's {@link MockedConstruction#close()} method must be called upon completing the
+     * test or the mock will remain active on the current thread.
+     * <p>
+     * See examples in javadoc for {@link Mockito} class
+     *
+     * @param classToMock non-abstract class of which constructions should be mocked.
+     * @param mockSettings the settings to use.
+     * @param mockInitializer a callback to prepare a mock's methods after its instantiation.
+     * @return mock controller
+     */
+    @Incubating
+    @CheckReturnValue
+    public static <T> MockedConstruction<T> mockConstruction(
+            Class<T> classToMock,
+            MockSettings mockSettings,
+            MockedConstruction.MockInitializer<T> mockInitializer) {
+        return mockConstruction(classToMock, index -> mockSettings, mockInitializer);
+    }
+
+    /**
+     * Creates a thread-local mock controller for all constructions of the given class.
+     * The returned object's {@link MockedConstruction#close()} method must be called upon completing the
+     * test or the mock will remain active on the current thread.
+     * <p>
+     * See examples in javadoc for {@link Mockito} class
+     *
+     * @param classToMock non-abstract class of which constructions should be mocked.
+     * @param mockSettingsFactory a function to create settings to use.
+     * @param mockInitializer a callback to prepare a mock's methods after its instantiation.
+     * @return mock controller
+     */
+    @Incubating
+    @CheckReturnValue
+    public static <T> MockedConstruction<T> mockConstruction(
+            Class<T> classToMock,
+            Function<MockedConstruction.Context, MockSettings> mockSettingsFactory,
+            MockedConstruction.MockInitializer<T> mockInitializer) {
+        return MOCKITO_CORE.mockConstruction(classToMock, mockSettingsFactory, mockInitializer);
     }
 
     /**

--- a/src/main/java/org/mockito/ScopedMock.java
+++ b/src/main/java/org/mockito/ScopedMock.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito;
+
+/**
+ * Represents a mock with a thread-local explicit scope. Scoped mocks must be closed by the entity
+ * that activates the scoped mock.
+ */
+@Incubating
+public interface ScopedMock extends AutoCloseable {
+
+    /**
+     * Checks if this mock is closed.
+     *
+     * @return {@code true} if this mock is closed.
+     */
+    boolean isClosed();
+
+    /**
+     * Closes this scoped mock and throws an exception if already closed.
+     */
+    @Override
+    void close();
+
+    /**
+     * Releases this scoped mock and is non-operational if already released.
+     */
+    void closeOnDemand();
+}

--- a/src/main/java/org/mockito/creation/instance/InstantiationException.java
+++ b/src/main/java/org/mockito/creation/instance/InstantiationException.java
@@ -14,6 +14,13 @@ import org.mockito.exceptions.base.MockitoException;
 public class InstantiationException extends MockitoException {
 
     /**
+     * @since 3.5.0
+     */
+    public InstantiationException(String message) {
+        super(message);
+    }
+
+    /**
      * @since 2.15.4
      */
     public InstantiationException(String message, Throwable cause) {

--- a/src/main/java/org/mockito/internal/MockedConstructionImpl.java
+++ b/src/main/java/org/mockito/internal/MockedConstructionImpl.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.mockito.MockedConstruction;
+import org.mockito.exceptions.base.MockitoException;
+import org.mockito.internal.debugging.LocationImpl;
+import org.mockito.invocation.Location;
+import org.mockito.plugins.MockMaker;
+
+import static org.mockito.internal.util.StringUtil.*;
+
+public final class MockedConstructionImpl<T> implements MockedConstruction<T> {
+
+    private final MockMaker.ConstructionMockControl<T> control;
+
+    private boolean closed;
+
+    private final Location location = new LocationImpl();
+
+    protected MockedConstructionImpl(MockMaker.ConstructionMockControl<T> control) {
+        this.control = control;
+    }
+
+    @Override
+    public List<T> constructed() {
+        return Collections.unmodifiableList(control.getMocks());
+    }
+
+    @Override
+    public boolean isClosed() {
+        return closed;
+    }
+
+    @Override
+    public void close() {
+        assertNotClosed();
+
+        closed = true;
+        control.disable();
+    }
+
+    @Override
+    public void closeOnDemand() {
+        if (!closed) {
+            close();
+        }
+    }
+
+    private void assertNotClosed() {
+        if (closed) {
+            throw new MockitoException(
+                    join(
+                            "The static mock created at",
+                            location.toString(),
+                            "is already resolved and cannot longer be used"));
+        }
+    }
+}

--- a/src/main/java/org/mockito/internal/MockedStaticImpl.java
+++ b/src/main/java/org/mockito/internal/MockedStaticImpl.java
@@ -4,8 +4,6 @@
  */
 package org.mockito.internal;
 
-import org.mockito.Incubating;
-import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.MockingDetails;
 import org.mockito.Mockito;
@@ -29,21 +27,6 @@ import static org.mockito.internal.util.MockUtil.*;
 import static org.mockito.internal.util.StringUtil.*;
 import static org.mockito.internal.verification.VerificationModeFactory.*;
 
-/**
- * Represents an active mock of a type's static methods. The mocking only affects the thread
- * on which this static mock was created and it is not safe to use this object from another
- * thread. The static mock is released when this object's {@link MockedStaticImpl#close()} method
- * is invoked. If this object is never closed, the static mock will remain active on the
- * initiating thread. It is therefore recommended to create this object within a try-with-resources
- * statement unless when managed explicitly, for example by using a JUnit rule or extension.
- * <p>
- * If the {@link Mock} annotation is used on fields or method parameters of this type, a static mock
- * is created instead of a regular mock. The static mock is activated and released upon completing any
- * relevant test.
- *
- * @param <T> The type being mocked.
- */
-@Incubating
 public final class MockedStaticImpl<T> implements MockedStatic<T> {
 
     private final MockMaker.StaticMockControl<T> control;

--- a/src/main/java/org/mockito/internal/configuration/IndependentAnnotationEngine.java
+++ b/src/main/java/org/mockito/internal/configuration/IndependentAnnotationEngine.java
@@ -16,8 +16,8 @@ import java.util.Map;
 
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
+import org.mockito.ScopedMock;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.plugins.AnnotationEngine;
 
@@ -64,14 +64,14 @@ public class IndependentAnnotationEngine
 
     @Override
     public AutoCloseable process(Class<?> clazz, Object testInstance) {
-        List<MockedStatic<?>> mockedStatics = new ArrayList<>();
+        List<ScopedMock> scopedMocks = new ArrayList<>();
         Field[] fields = clazz.getDeclaredFields();
         for (Field field : fields) {
             boolean alreadyAssigned = false;
             for (Annotation annotation : field.getAnnotations()) {
                 Object mock = createMockFor(annotation, field);
-                if (mock instanceof MockedStatic<?>) {
-                    mockedStatics.add((MockedStatic<?>) mock);
+                if (mock instanceof ScopedMock) {
+                    scopedMocks.add((ScopedMock) mock);
                 }
                 if (mock != null) {
                     throwIfAlreadyAssigned(field, alreadyAssigned);
@@ -79,8 +79,8 @@ public class IndependentAnnotationEngine
                     try {
                         setField(testInstance, field, mock);
                     } catch (Exception e) {
-                        for (MockedStatic<?> mockedStatic : mockedStatics) {
-                            mockedStatic.close();
+                        for (ScopedMock scopedMock : scopedMocks) {
+                            scopedMock.close();
                         }
                         throw new MockitoException(
                                 "Problems setting field "
@@ -93,8 +93,8 @@ public class IndependentAnnotationEngine
             }
         }
         return () -> {
-            for (MockedStatic<?> mockedStatic : mockedStatics) {
-                mockedStatic.closeOnDemand();
+            for (ScopedMock scopedMock : scopedMocks) {
+                scopedMock.closeOnDemand();
             }
         };
     }

--- a/src/main/java/org/mockito/internal/configuration/InjectingAnnotationEngine.java
+++ b/src/main/java/org/mockito/internal/configuration/InjectingAnnotationEngine.java
@@ -12,8 +12,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
+import org.mockito.ScopedMock;
 import org.mockito.internal.configuration.injection.scanner.InjectMocksScanner;
 import org.mockito.internal.configuration.injection.scanner.MockScanner;
 import org.mockito.plugins.AnnotationEngine;
@@ -119,8 +119,8 @@ public class InjectingAnnotationEngine
 
         return () -> {
             for (Object mock : mocks) {
-                if (mock instanceof MockedStatic<?>) {
-                    ((MockedStatic<?>) mock).closeOnDemand();
+                if (mock instanceof ScopedMock) {
+                    ((ScopedMock) mock).closeOnDemand();
                 }
             }
         };

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMaker.java
@@ -9,6 +9,7 @@ import org.mockito.MockedConstruction;
 import org.mockito.invocation.MockHandler;
 import org.mockito.mock.MockCreationSettings;
 
+import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -26,6 +27,12 @@ public class ByteBuddyMockMaker implements ClassCreatingMockMaker {
     @Override
     public <T> T createMock(MockCreationSettings<T> settings, MockHandler handler) {
         return defaultByteBuddyMockMaker.createMock(settings, handler);
+    }
+
+    @Override
+    public <T> Optional<T> createSpy(
+            MockCreationSettings<T> settings, MockHandler handler, T object) {
+        return defaultByteBuddyMockMaker.createSpy(settings, handler, object);
     }
 
     @Override

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMaker.java
@@ -5,8 +5,11 @@
 package org.mockito.internal.creation.bytebuddy;
 
 import org.mockito.Incubating;
+import org.mockito.MockedConstruction;
 import org.mockito.invocation.MockHandler;
 import org.mockito.mock.MockCreationSettings;
+
+import java.util.function.Function;
 
 /**
  * ByteBuddy MockMaker.
@@ -50,5 +53,15 @@ public class ByteBuddyMockMaker implements ClassCreatingMockMaker {
     public <T> StaticMockControl<T> createStaticMock(
             Class<T> type, MockCreationSettings<T> settings, MockHandler handler) {
         return defaultByteBuddyMockMaker.createStaticMock(type, settings, handler);
+    }
+
+    @Override
+    public <T> ConstructionMockControl<T> createConstructionMock(
+            Class<T> type,
+            Function<MockedConstruction.Context, MockCreationSettings<T>> settingsFactory,
+            Function<MockedConstruction.Context, MockHandler<T>> handlerFactory,
+            MockedConstruction.MockInitializer<T> mockInitializer) {
+        return defaultByteBuddyMockMaker.createConstructionMock(
+                type, settingsFactory, handlerFactory, mockInitializer);
     }
 }

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/BytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/BytecodeGenerator.java
@@ -8,5 +8,7 @@ public interface BytecodeGenerator {
 
     <T> Class<? extends T> mockClass(MockFeatures<T> features);
 
+    void mockClassConstruction(Class<?> type);
+
     void mockClassStatic(Class<?> type);
 }

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/ConstructionCallback.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/ConstructionCallback.java
@@ -6,5 +6,5 @@ package org.mockito.internal.creation.bytebuddy;
 
 public interface ConstructionCallback {
 
-    void accept(Class<?> type, Object object, Object[] arguments, String[] parameterTypeNames);
+    Object apply(Class<?> type, Object object, Object[] arguments, String[] parameterTypeNames);
 }

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/ConstructionCallback.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/ConstructionCallback.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2020 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.creation.bytebuddy;
+
+public interface ConstructionCallback {
+
+    void accept(Class<?> type, Object object, Object[] arguments, String[] parameterTypeNames);
+}

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
@@ -753,8 +753,7 @@ public class InlineByteBuddyMockMaker
         @Override
         public int getCount() {
             if (count == 0) {
-                throw new MockitoConfigurationException(
-                        "mocked construction context is not initialized");
+                throw new MockitoConfigurationException("mocked construction context is not initialized");
             }
             return count;
         }
@@ -768,8 +767,7 @@ public class InlineByteBuddyMockMaker
                     parameterTypes[index++] = PRIMITIVES.get(parameterTypeName);
                 } else {
                     try {
-                        parameterTypes[index++] =
-                                Class.forName(parameterTypeName, false, type.getClassLoader());
+                        parameterTypes[index++] = Class.forName(parameterTypeName, false, type.getClassLoader());
                     } catch (ClassNotFoundException e) {
                         throw new MockitoException(
                                 "Could not find parameter of type " + parameterTypeName, e);

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
@@ -350,8 +350,12 @@ public class InlineBytecodeGenerator implements BytecodeGenerator, ClassFileTran
                 return byteBuddy
                         .redefine(
                                 classBeingRedefined,
+                                //        new ClassFileLocator.Compound(
                                 ClassFileLocator.Simple.of(
-                                        classBeingRedefined.getName(), classfileBuffer))
+                                        classBeingRedefined.getName(), classfileBuffer)
+                                //            ,ClassFileLocator.ForClassLoader.ofSystemLoader()
+                                //        )
+                                )
                         // Note: The VM erases parameter meta data from the provided class file
                         // (bug). We just add this information manually.
                         .visit(new ParameterWritingVisitorWrapper(classBeingRedefined))

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassBytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassBytecodeGenerator.java
@@ -208,6 +208,12 @@ class SubclassBytecodeGenerator implements BytecodeGenerator {
         throw new MockitoException("The subclass byte code generator cannot create static mocks");
     }
 
+    @Override
+    public void mockClassConstruction(Class<?> type) {
+        throw new MockitoException(
+                "The subclass byte code generator cannot create construction mocks");
+    }
+
     private <T> Collection<Class<? super T>> getAllTypes(Class<T> type) {
         Collection<Class<? super T>> supertypes = new LinkedList<Class<? super T>>();
         supertypes.add(type);

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/TypeCachingBytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/TypeCachingBytecodeGenerator.java
@@ -62,6 +62,11 @@ class TypeCachingBytecodeGenerator extends ReferenceQueue<ClassLoader>
         bytecodeGenerator.mockClassStatic(type);
     }
 
+    @Override
+    public void mockClassConstruction(Class<?> type) {
+        bytecodeGenerator.mockClassConstruction(type);
+    }
+
     private static class MockitoMockKey extends TypeCache.SimpleKey {
 
         private final SerializableMode serializableMode;

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/inject/MockMethodDispatcher.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/inject/MockMethodDispatcher.java
@@ -36,6 +36,11 @@ public abstract class MockMethodDispatcher {
         DISPATCHERS.putIfAbsent(identifier, dispatcher);
     }
 
+    @SuppressWarnings("unused")
+    public static boolean isConstructorMock(String identifier, Class<?> type) {
+        return DISPATCHERS.get(identifier).isConstructorMock(type);
+    }
+
     public abstract Callable<?> handle(Object instance, Method origin, Object[] arguments)
             throws Throwable;
 
@@ -49,4 +54,6 @@ public abstract class MockMethodDispatcher {
     public abstract boolean isMockedStatic(Class<?> type);
 
     public abstract boolean isOverridden(Object instance, Method origin);
+
+    public abstract boolean isConstructorMock(Class<?> type);
 }

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/inject/MockMethodDispatcher.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/inject/MockMethodDispatcher.java
@@ -41,13 +41,16 @@ public abstract class MockMethodDispatcher {
         return DISPATCHERS.get(identifier).isConstructorMock(type);
     }
 
-    public static void handleConstruction(
+    @SuppressWarnings("unused")
+    public static Object handleConstruction(
             String identifier,
             Class<?> type,
             Object object,
             Object[] arguments,
             String[] parameterTypeNames) {
-        DISPATCHERS.get(identifier).handleConstruction(type, object, arguments, parameterTypeNames);
+        return DISPATCHERS
+                .get(identifier)
+                .handleConstruction(type, object, arguments, parameterTypeNames);
     }
 
     public abstract Callable<?> handle(Object instance, Method origin, Object[] arguments)
@@ -56,7 +59,7 @@ public abstract class MockMethodDispatcher {
     public abstract Callable<?> handleStatic(Class<?> type, Method origin, Object[] arguments)
             throws Throwable;
 
-    public abstract void handleConstruction(
+    public abstract Object handleConstruction(
             Class<?> type, Object object, Object[] arguments, String[] parameterTypeNames);
 
     public abstract boolean isMock(Object instance);

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/inject/MockMethodDispatcher.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/inject/MockMethodDispatcher.java
@@ -41,11 +41,23 @@ public abstract class MockMethodDispatcher {
         return DISPATCHERS.get(identifier).isConstructorMock(type);
     }
 
+    public static void handleConstruction(
+            String identifier,
+            Class<?> type,
+            Object object,
+            Object[] arguments,
+            String[] parameterTypeNames) {
+        DISPATCHERS.get(identifier).handleConstruction(type, object, arguments, parameterTypeNames);
+    }
+
     public abstract Callable<?> handle(Object instance, Method origin, Object[] arguments)
             throws Throwable;
 
     public abstract Callable<?> handleStatic(Class<?> type, Method origin, Object[] arguments)
             throws Throwable;
+
+    public abstract void handleConstruction(
+            Class<?> type, Object object, Object[] arguments, String[] parameterTypeNames);
 
     public abstract boolean isMock(Object instance);
 

--- a/src/main/java/org/mockito/internal/util/MockUtil.java
+++ b/src/main/java/org/mockito/internal/util/MockUtil.java
@@ -4,8 +4,7 @@
  */
 package org.mockito.internal.util;
 
-import static org.mockito.internal.handler.MockHandlerFactory.createMockHandler;
-
+import org.mockito.MockedConstruction;
 import org.mockito.Mockito;
 import org.mockito.exceptions.misusing.NotAMockException;
 import org.mockito.internal.configuration.plugins.Plugins;
@@ -17,6 +16,10 @@ import org.mockito.mock.MockCreationSettings;
 import org.mockito.mock.MockName;
 import org.mockito.plugins.MockMaker;
 import org.mockito.plugins.MockMaker.TypeMockability;
+
+import java.util.function.Function;
+
+import static org.mockito.internal.handler.MockHandlerFactory.createMockHandler;
 
 @SuppressWarnings("unchecked")
 public class MockUtil {
@@ -107,5 +110,15 @@ public class MockUtil {
             Class<T> type, MockCreationSettings<T> settings) {
         MockHandler<T> handler = createMockHandler(settings);
         return mockMaker.createStaticMock(type, settings, handler);
+    }
+
+    public static <T> MockMaker.ConstructionMockControl<T> createConstructionMock(
+            Class<T> type,
+            Function<MockedConstruction.Context, MockCreationSettings<T>> settingsFactory,
+            MockedConstruction.MockInitializer<T> mockInitializer) {
+        Function<MockedConstruction.Context, MockHandler<T>> handlerFactory =
+                context -> createMockHandler(settingsFactory.apply(context));
+        return mockMaker.createConstructionMock(
+                type, settingsFactory, handlerFactory, mockInitializer);
     }
 }

--- a/src/main/java/org/mockito/internal/util/MockUtil.java
+++ b/src/main/java/org/mockito/internal/util/MockUtil.java
@@ -35,11 +35,21 @@ public class MockUtil {
     public static <T> T createMock(MockCreationSettings<T> settings) {
         MockHandler mockHandler = createMockHandler(settings);
 
-        T mock = mockMaker.createMock(settings, mockHandler);
-
         Object spiedInstance = settings.getSpiedInstance();
+
+        T mock;
         if (spiedInstance != null) {
-            new LenientCopyTool().copyToMock(spiedInstance, mock);
+            mock =
+                    mockMaker
+                            .createSpy(settings, mockHandler, (T) spiedInstance)
+                            .orElseGet(
+                                    () -> {
+                                        T instance = mockMaker.createMock(settings, mockHandler);
+                                        new LenientCopyTool().copyToMock(spiedInstance, instance);
+                                        return instance;
+                                    });
+        } else {
+            mock = mockMaker.createMock(settings, mockHandler);
         }
 
         return mock;

--- a/src/main/java/org/mockito/plugins/MockMaker.java
+++ b/src/main/java/org/mockito/plugins/MockMaker.java
@@ -5,11 +5,15 @@
 package org.mockito.plugins;
 
 import org.mockito.Incubating;
+import org.mockito.MockedConstruction;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.invocation.MockHandler;
 import org.mockito.mock.MockCreationSettings;
 
-import static org.mockito.internal.util.StringUtil.*;
+import java.util.List;
+import java.util.function.Function;
+
+import static org.mockito.internal.util.StringUtil.join;
 
 /**
  * The facility to create mocks.
@@ -142,6 +146,39 @@ public interface MockMaker {
     }
 
     /**
+     * If you want to provide your own implementation of {@code MockMaker} this method should:
+     * <ul>
+     *     <li>Intercept all constructions of the specified type in the current thread</li>
+     *     <li>Only intercept the construction after being enabled.</li>
+     *     <li>Stops the interception when disabled.</li>
+     * </ul>
+     *
+     * @param settingsFactory Factory for mock creation settings like type to mock, extra interfaces and so on.
+     * @param handlerFactory Factory for settings. See {@link org.mockito.invocation.MockHandler}.
+     *                <b>Do not</b> provide your own implementation at this time. Make sure your implementation of
+     *                {@link #getHandler(Object)} will return this instance.
+     * @param <T> Type of the mock to return, actually the <code>settings.getTypeToMock</code>.
+     * @return A control for the mocked construction.
+     * @since 3.5.0
+     */
+    @Incubating
+    default <T> ConstructionMockControl<T> createConstructionMock(
+            Class<T> type,
+            Function<MockedConstruction.Context, MockCreationSettings<T>> settingsFactory,
+            Function<MockedConstruction.Context, MockHandler<T>> handlerFactory,
+            MockedConstruction.MockInitializer<T> mockInitializer) {
+        throw new MockitoException(
+                join(
+                        "The used MockMaker "
+                                + getClass().getSimpleName()
+                                + " does not support the creation of construction mocks",
+                        "",
+                        "Mockito's inline mock maker supports construction mocks based on the Instrumentation API.",
+                        "You can simply enable this mock mode, by placing the 'mockito-inline' artifact where you are currently using 'mockito-core'.",
+                        "Note that Mockito's inline mock maker is not supported on Android."));
+    }
+
+    /**
      * Carries the mockability information
      *
      * @since 2.1.0
@@ -167,5 +204,17 @@ public interface MockMaker {
         void enable();
 
         void disable();
+    }
+
+    @Incubating
+    interface ConstructionMockControl<T> {
+
+        Class<T> getType();
+
+        void enable();
+
+        void disable();
+
+        List<T> getMocks();
     }
 }

--- a/src/main/java/org/mockito/plugins/MockMaker.java
+++ b/src/main/java/org/mockito/plugins/MockMaker.java
@@ -11,6 +11,7 @@ import org.mockito.invocation.MockHandler;
 import org.mockito.mock.MockCreationSettings;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
 import static org.mockito.internal.util.StringUtil.join;
@@ -72,6 +73,25 @@ public interface MockMaker {
      * @since 1.9.5
      */
     <T> T createMock(MockCreationSettings<T> settings, MockHandler handler);
+
+    /**
+     * By implementing this method, a mock maker can optionally support the creation of spies where all fields
+     * are set within a constructor. This avoids problems when creating spies of classes that declare
+     * effectively final instance fields where setting field values from outside the constructor is prohibited.
+     *
+     * @param settings Mock creation settings like type to mock, extra interfaces and so on.
+     * @param handler See {@link org.mockito.invocation.MockHandler}.
+     *                <b>Do not</b> provide your own implementation at this time. Make sure your implementation of
+     *                {@link #getHandler(Object)} will return this instance.
+     * @param instance  The object to spy upon.
+     * @param <T> Type of the mock to return, actually the <code>settings.getTypeToMock</code>.
+     * @return
+     * @since 3.5.0
+     */
+    default <T> Optional<T> createSpy(
+            MockCreationSettings<T> settings, MockHandler handler, T instance) {
+        return Optional.empty();
+    }
 
     /**
      * Returns the handler for the {@code mock}. <b>Do not</b> provide your own implementations at this time

--- a/src/test/java/org/mockito/MockitoTest.java
+++ b/src/test/java/org/mockito/MockitoTest.java
@@ -71,6 +71,12 @@ public class MockitoTest {
         Mockito.mockStatic(Object.class);
     }
 
+    @SuppressWarnings({"CheckReturnValue", "MockitoUsage"})
+    @Test(expected = MockitoException.class)
+    public void shouldGiveExplantionOnConstructionMockingWithoutInlineMockMaker() {
+        Mockito.mockConstruction(Object.class);
+    }
+
     @Test
     public void shouldStartingMockSettingsContainDefaultBehavior() {
         // when

--- a/src/test/java/org/mockito/internal/configuration/MockAnnotationProcessorTest.java
+++ b/src/test/java/org/mockito/internal/configuration/MockAnnotationProcessorTest.java
@@ -26,24 +26,28 @@ public class MockAnnotationProcessorTest {
     @Test
     public void testNonGeneric() throws Exception {
         Class<?> type =
-                MockAnnotationProcessor.inferStaticMock(
+                MockAnnotationProcessor.inferParameterizedType(
                         MockAnnotationProcessorTest.class
                                 .getDeclaredField("nonGeneric")
                                 .getGenericType(),
-                        "nonGeneric");
+                        "nonGeneric",
+                        "Sample");
         assertThat(type).isEqualTo(Void.class);
     }
 
     @Test(expected = MockitoException.class)
     public void testGeneric() throws Exception {
-        MockAnnotationProcessor.inferStaticMock(
+        MockAnnotationProcessor.inferParameterizedType(
                 MockAnnotationProcessorTest.class.getDeclaredField("generic").getGenericType(),
-                "generic");
+                "generic",
+                "Sample");
     }
 
     @Test(expected = MockitoException.class)
     public void testRaw() throws Exception {
-        MockAnnotationProcessor.inferStaticMock(
-                MockAnnotationProcessorTest.class.getDeclaredField("raw").getGenericType(), "raw");
+        MockAnnotationProcessor.inferParameterizedType(
+                MockAnnotationProcessorTest.class.getDeclaredField("raw").getGenericType(),
+                "raw",
+                "Sample");
     }
 }

--- a/src/test/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMakerTest.java
+++ b/src/test/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMakerTest.java
@@ -58,6 +58,16 @@ public class InlineByteBuddyMockMakerTest
     }
 
     @Test
+    public void should_create_mock_from_non_constructable_class() throws Exception {
+        MockCreationSettings<NonConstructableClass> settings =
+                settingsFor(NonConstructableClass.class);
+        NonConstructableClass proxy =
+                mockMaker.createMock(
+                        settings, new MockHandlerImpl<NonConstructableClass>(settings));
+        assertThat(proxy.foo()).isEqualTo("bar");
+    }
+
+    @Test
     public void should_create_mock_from_final_class_in_the_JDK() throws Exception {
         MockCreationSettings<Pattern> settings = settingsFor(Pattern.class);
         Pattern proxy = mockMaker.createMock(settings, new MockHandlerImpl<Pattern>(settings));
@@ -400,6 +410,17 @@ public class InlineByteBuddyMockMakerTest
     }
 
     private static final class FinalClass {
+
+        public String foo() {
+            return "foo";
+        }
+    }
+
+    private static class NonConstructableClass {
+
+        private NonConstructableClass() {
+            throw new AssertionError();
+        }
 
         public String foo() {
             return "foo";

--- a/src/test/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMakerTest.java
+++ b/src/test/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMakerTest.java
@@ -11,11 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.Assume.assumeTrue;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Observable;
-import java.util.Observer;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.regex.Pattern;
 
@@ -55,6 +51,29 @@ public class InlineByteBuddyMockMakerTest
         FinalClass proxy =
                 mockMaker.createMock(settings, new MockHandlerImpl<FinalClass>(settings));
         assertThat(proxy.foo()).isEqualTo("bar");
+    }
+
+    @Test
+    public void should_create_mock_from_final_spy() throws Exception {
+        MockCreationSettings<FinalSpy> settings = settingsFor(FinalSpy.class);
+        Optional<FinalSpy> proxy =
+                mockMaker.createSpy(
+                        settings,
+                        new MockHandlerImpl<>(settings),
+                        new FinalSpy("value", true, (byte) 1, (short) 1, (char) 1, 1, 1L, 1f, 1d));
+        assertThat(proxy)
+                .hasValueSatisfying(
+                        spy -> {
+                            assertThat(spy.aString).isEqualTo("value");
+                            assertThat(spy.aBoolean).isTrue();
+                            assertThat(spy.aByte).isEqualTo((byte) 1);
+                            assertThat(spy.aShort).isEqualTo((short) 1);
+                            assertThat(spy.aChar).isEqualTo((char) 1);
+                            assertThat(spy.anInt).isEqualTo(1);
+                            assertThat(spy.aLong).isEqualTo(1L);
+                            assertThat(spy.aFloat).isEqualTo(1f);
+                            assertThat(spy.aDouble).isEqualTo(1d);
+                        });
     }
 
     @Test
@@ -413,6 +432,40 @@ public class InlineByteBuddyMockMakerTest
 
         public String foo() {
             return "foo";
+        }
+    }
+
+    private static final class FinalSpy {
+
+        private final String aString;
+        private final boolean aBoolean;
+        private final byte aByte;
+        private final short aShort;
+        private final char aChar;
+        private final int anInt;
+        private final long aLong;
+        private final float aFloat;
+        private final double aDouble;
+
+        private FinalSpy(
+                String aString,
+                boolean aBoolean,
+                byte aByte,
+                short aShort,
+                char aChar,
+                int anInt,
+                long aLong,
+                float aFloat,
+                double aDouble) {
+            this.aString = aString;
+            this.aBoolean = aBoolean;
+            this.aByte = aByte;
+            this.aShort = aShort;
+            this.aChar = aChar;
+            this.anInt = anInt;
+            this.aLong = aLong;
+            this.aFloat = aFloat;
+            this.aDouble = aDouble;
         }
     }
 

--- a/subprojects/inline/src/test/java/org/mockitoinline/ConstructionMockRuleTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/ConstructionMockRuleTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitoinline;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static junit.framework.TestCase.*;
+
+public final class ConstructionMockRuleTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private MockedConstruction<Dummy> dummy;
+
+    @Test
+    public void testConstructionMockSimple() {
+        assertNull(new Dummy().foo());
+    }
+
+    @Test
+    public void testConstructionMockCollection() {
+        assertEquals(0, dummy.constructed().size());
+        Dummy mock = new Dummy();
+        assertEquals(1, dummy.constructed().size());
+        assertTrue(dummy.constructed().contains(mock));
+    }
+
+    static class Dummy {
+
+        String foo() {
+            return "foo";
+        }
+    }
+}

--- a/subprojects/inline/src/test/java/org/mockitoinline/ConstructionMockTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/ConstructionMockTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2020 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitoinline;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+import org.mockito.exceptions.base.MockitoException;
+
+import static junit.framework.TestCase.*;
+import static org.mockito.Mockito.*;
+
+public final class ConstructionMockTest {
+
+    @Test
+    public void testConstructionMockSimple() {
+        assertEquals("foo", new Dummy().foo());
+        try (MockedConstruction<Dummy> ignored = Mockito.mockConstruction(Dummy.class)) {
+            assertNull(new Dummy().foo());
+        }
+        assertEquals("foo", new Dummy().foo());
+    }
+
+    @Test
+    public void testConstructionMockCollection() {
+        try (MockedConstruction<Dummy> dummy = Mockito.mockConstruction(Dummy.class)) {
+            assertEquals(0, dummy.constructed().size());
+            Dummy mock = new Dummy();
+            assertEquals(1, dummy.constructed().size());
+            assertTrue(dummy.constructed().contains(mock));
+        }
+    }
+
+    @Test
+    public void testConstructionMockDefaultAnswer() {
+        try (MockedConstruction<Dummy> ignored = Mockito.mockConstructionWithAnswer(Dummy.class, invocation -> "bar")) {
+            assertEquals("bar", new Dummy().foo());
+        }
+    }
+
+    @Test
+    public void testConstructionMockDefaultAnswerMultiple() {
+        try (MockedConstruction<Dummy> ignored = Mockito.mockConstructionWithAnswer(Dummy.class, invocation -> "bar", invocation -> "qux")) {
+            assertEquals("bar", new Dummy().foo());
+            assertEquals("qux", new Dummy().foo());
+            assertEquals("qux", new Dummy().foo());
+        }
+    }
+
+    @Test
+    public void testConstructionMockPrepared() {
+        try (MockedConstruction<Dummy> ignored = Mockito.mockConstruction(Dummy.class, (mock, context) -> when(mock.foo()).thenReturn("bar"))) {
+            assertEquals("bar", new Dummy().foo());
+        }
+    }
+
+
+    @Test
+    public void testConstructionMockContext() {
+        try (MockedConstruction<Dummy> ignored = Mockito.mockConstruction(Dummy.class, (mock, context) -> {
+            assertEquals(1, context.getCount());
+            assertEquals(Collections.singletonList("foobar"), context.arguments());
+            assertEquals(mock.getClass().getDeclaredConstructor(String.class), context.constructor());
+            when(mock.foo()).thenReturn("bar");
+        })) {
+            assertEquals("bar", new Dummy("foobar").foo());
+        }
+    }
+
+    @Test
+    public void testConstructionMockDoesNotAffectDifferentThread() throws InterruptedException {
+        try (MockedConstruction<Dummy> ignored = Mockito.mockConstruction(Dummy.class)) {
+            Dummy dummy = new Dummy();
+            when(dummy.foo()).thenReturn("bar");
+            assertEquals("bar", dummy.foo());
+            verify(dummy).foo();
+            AtomicReference<String> reference = new AtomicReference<>();
+            Thread thread = new Thread(() -> reference.set(new Dummy().foo()));
+            thread.start();
+            thread.join();
+            assertEquals("foo", reference.get());
+            when(dummy.foo()).thenReturn("bar");
+            assertEquals("bar", dummy.foo());
+            verify(dummy, times(2)).foo();
+        }
+    }
+
+    @Test
+    public void testConstructionMockCanCoexistWithMockInDifferentThread() throws InterruptedException {
+        try (MockedConstruction<Dummy> ignored = Mockito.mockConstruction(Dummy.class)) {
+            Dummy dummy = new Dummy();
+            when(dummy.foo()).thenReturn("bar");
+            assertEquals("bar", dummy.foo());
+            verify(dummy).foo();
+            AtomicReference<String> reference = new AtomicReference<>();
+            Thread thread = new Thread(() -> {
+                try (MockedConstruction<Dummy> ignored2 = Mockito.mockConstruction(Dummy.class)) {
+                    Dummy other = new Dummy();
+                    when(other.foo()).thenReturn("qux");
+                    reference.set(other.foo());
+                }
+            });
+            thread.start();
+            thread.join();
+            assertEquals("qux", reference.get());
+            assertEquals("bar", dummy.foo());
+            verify(dummy, times(2)).foo();
+        }
+    }
+
+    @Test(expected = MockitoException.class)
+    public void testConstructionMockMustBeExclusiveInScopeWithinThread() {
+        try (
+            MockedConstruction<Dummy> dummy = Mockito.mockConstruction(Dummy.class);
+            MockedConstruction<Dummy> duplicate = Mockito.mockConstruction(Dummy.class)
+        ) {
+            fail("Not supposed to allow duplicates");
+        }
+    }
+
+    @Test(expected = MockitoException.class)
+    public void testConstructionMockMustNotTargetAbstractClass() {
+        Mockito.mockConstruction(Runnable.class).close();
+    }
+
+    static class Dummy {
+
+
+        public Dummy() {
+        }
+
+        public Dummy(String value) {
+        }
+
+        String foo() {
+            return "foo";
+        }
+    }
+}

--- a/subprojects/inline/src/test/java/org/mockitoinline/StaticMockRuleTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/StaticMockRuleTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitoinline;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static junit.framework.TestCase.*;
+
+public final class StaticMockRuleTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private MockedStatic<Dummy> dummy;
+
+    @Test
+    public void testStaticMockSimple() {
+        assertNull(Dummy.foo());
+    }
+
+    @Test
+    public void testStaticMockWithVerification() {
+        dummy.when(Dummy::foo).thenReturn("bar");
+        assertEquals("bar", Dummy.foo());
+        dummy.verify(Dummy::foo);
+    }
+
+    static class Dummy {
+
+        static String foo() {
+            return "foo";
+        }
+    }
+}

--- a/subprojects/junitJupiterInlineMockMakerExtensionTest/src/test/java/org/mockitousage/NoExtendsTest.java
+++ b/subprojects/junitJupiterInlineMockMakerExtensionTest/src/test/java/org/mockitousage/NoExtendsTest.java
@@ -4,10 +4,9 @@
  */
 package org.mockitousage;
 
-import java.util.UUID;
-
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 
 import static org.assertj.core.api.Assertions.*;
@@ -15,11 +14,29 @@ import static org.assertj.core.api.Assertions.*;
 class NoExtendsTest {
 
     @Mock
-    private MockedStatic<UUID> mock;
+    private MockedStatic<Dummy> staticMethod;
+
+    @Mock
+    private MockedConstruction<Dummy> construction;
 
     @Test
-    void runs() {
-        mock.when(UUID::randomUUID).thenReturn(new UUID(123, 456));
-        assertThat(UUID.randomUUID()).isEqualTo(new UUID(123, 456));
+    void runsStaticMethods() {
+        assertThat(Dummy.foo()).isNull();
+    }
+
+    @Test
+    void runsConstruction() {
+        assertThat(new Dummy().bar()).isNull();
+    }
+
+    static class Dummy {
+
+        static String foo() {
+            return "foo";
+        }
+
+        String bar() {
+            return "foo";
+        }
     }
 }

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
 #Currently building Mockito version
-version=3.4.7
+version=3.5.0
 
 #Previous version used to generate release notes delta
 previousVersion=3.4.6


### PR DESCRIPTION
Doing so, Mockito initializes fields for a spy from within the spy instance's constructor. This avoids using setter reflection on `final` fields what will no longer work once effectively final fields prohibit setting final fields from outside a constructor.

Fixes #1782 and #1325.