### PR TITLE
Introduce animal sniffer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ plugins {
     id 'eclipse'
     id 'com.github.ben-manes.versions' version '0.28.0'
     id 'biz.aQute.bnd.builder' version '5.1.0'
+    id 'ru.vyarus.animalsniffer' version '1.5.1'
 }
 
 description = 'Mockito mock objects library core API and implementation'
@@ -98,6 +99,14 @@ dependencies {
     testRuntime configurations.compileOnly
 
     testUtil sourceSets.test.output
+
+    signature 'org.codehaus.mojo.signature:java18:1.0@signature'
+    signature 'net.sf.androidscents.signature:android-api-level-24:7.0_r2@signature'
+}
+
+animalsniffer {
+    sourceSets = [sourceSets.main]
+    annotation = 'org.mockito.internal.SuppressSignatureCheck'
 }
 
 wrapper {

--- a/src/main/java/org/mockito/internal/MockedStaticImpl.java
+++ b/src/main/java/org/mockito/internal/MockedStaticImpl.java
@@ -172,6 +172,6 @@ public final class MockedStaticImpl<T> implements MockedStatic<T> {
 
     @Override
     public String toString() {
-        return "static mock for " + control.getType().getTypeName();
+        return "static mock for " + control.getType().getName();
     }
 }

--- a/src/main/java/org/mockito/internal/SuppressSignatureCheck.java
+++ b/src/main/java/org/mockito/internal/SuppressSignatureCheck.java
@@ -8,4 +8,4 @@ import java.lang.annotation.*;
 
 @Retention(RetentionPolicy.CLASS)
 @Documented
-public @interface SuppressSignatureCheck { }
+public @interface SuppressSignatureCheck {}

--- a/src/main/java/org/mockito/internal/SuppressSignatureCheck.java
+++ b/src/main/java/org/mockito/internal/SuppressSignatureCheck.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2020 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.CLASS)
+@Documented
+public @interface SuppressSignatureCheck { }

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
@@ -28,6 +28,7 @@ import org.mockito.creation.instance.Instantiator;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.exceptions.base.MockitoInitializationException;
 import org.mockito.exceptions.misusing.MockitoConfigurationException;
+import org.mockito.internal.SuppressSignatureCheck;
 import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.internal.util.Platform;
 import org.mockito.internal.util.concurrent.DetachedThreadLocal;
@@ -99,6 +100,7 @@ import static org.mockito.internal.util.StringUtil.*;
  * support this feature.
  */
 @Incubating
+@SuppressSignatureCheck
 public class InlineByteBuddyMockMaker
         implements ClassCreatingMockMaker, InlineMockMaker, Instantiator {
 
@@ -506,7 +508,7 @@ public class InlineByteBuddyMockMaker
                 || ClassLoader.class.isAssignableFrom(type)) {
             throw new MockitoException(
                     "It is not possible to mock static methods of "
-                            + type.getTypeName()
+                            + type.getName()
                             + " to avoid interfering with class loading what leads to infinite loops");
         }
 
@@ -534,7 +536,7 @@ public class InlineByteBuddyMockMaker
         } else if (type.isPrimitive() || Modifier.isAbstract(type.getModifiers())) {
             throw new MockitoException(
                     "It is not possible to construct primitive types or abstract types: "
-                            + type.getTypeName());
+                            + type.getName());
         }
 
         bytecodeGenerator.mockClassConstruction(type);
@@ -555,7 +557,7 @@ public class InlineByteBuddyMockMaker
     public <T> T newInstance(Class<T> cls) throws InstantiationException {
         Constructor<?>[] constructors = cls.getDeclaredConstructors();
         if (constructors.length == 0) {
-            throw new InstantiationException(cls.getTypeName() + " does not define a constructor");
+            throw new InstantiationException(cls.getName() + " does not define a constructor");
         }
         Constructor<?> selected = constructors[0];
         for (Constructor<?> constructor : constructors) {
@@ -579,7 +581,7 @@ public class InlineByteBuddyMockMaker
                 mockitoConstruction.set(false);
             }
         } catch (Exception e) {
-            throw new InstantiationException("Could not instantiate " + cls.getTypeName(), e);
+            throw new InstantiationException("Could not instantiate " + cls.getName(), e);
         }
     }
 
@@ -754,14 +756,14 @@ public class InlineByteBuddyMockMaker
         private static final Map<String, Class<?>> PRIMITIVES = new HashMap<>();
 
         static {
-            PRIMITIVES.put(boolean.class.getTypeName(), boolean.class);
-            PRIMITIVES.put(byte.class.getTypeName(), byte.class);
-            PRIMITIVES.put(short.class.getTypeName(), short.class);
-            PRIMITIVES.put(char.class.getTypeName(), char.class);
-            PRIMITIVES.put(int.class.getTypeName(), int.class);
-            PRIMITIVES.put(long.class.getTypeName(), long.class);
-            PRIMITIVES.put(float.class.getTypeName(), float.class);
-            PRIMITIVES.put(double.class.getTypeName(), double.class);
+            PRIMITIVES.put(boolean.class.getName(), boolean.class);
+            PRIMITIVES.put(byte.class.getName(), byte.class);
+            PRIMITIVES.put(short.class.getName(), short.class);
+            PRIMITIVES.put(char.class.getName(), char.class);
+            PRIMITIVES.put(int.class.getName(), int.class);
+            PRIMITIVES.put(long.class.getName(), long.class);
+            PRIMITIVES.put(float.class.getName(), float.class);
+            PRIMITIVES.put(double.class.getName(), double.class);
         }
 
         private int count;
@@ -810,7 +812,7 @@ public class InlineByteBuddyMockMaker
                         join(
                                 "Could not resolve constructor of type",
                                 "",
-                                type.getTypeName(),
+                                type.getName(),
                                 "",
                                 "with arguments of types",
                                 Arrays.toString(parameterTypes)),

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
@@ -37,6 +37,7 @@ import net.bytebuddy.pool.TypePool;
 import net.bytebuddy.utility.OpenedClassReader;
 import net.bytebuddy.utility.RandomString;
 import org.mockito.exceptions.base.MockitoException;
+import org.mockito.internal.SuppressSignatureCheck;
 import org.mockito.internal.creation.bytebuddy.inject.MockMethodDispatcher;
 import org.mockito.internal.util.concurrent.DetachedThreadLocal;
 import org.mockito.internal.util.concurrent.WeakConcurrentMap;
@@ -48,6 +49,7 @@ import static net.bytebuddy.implementation.bind.annotation.TargetMethodAnnotatio
 import static net.bytebuddy.matcher.ElementMatchers.*;
 import static org.mockito.internal.util.StringUtil.*;
 
+@SuppressSignatureCheck
 public class InlineBytecodeGenerator implements BytecodeGenerator, ClassFileTransformer {
 
     private static final String PRELOAD = "org.mockito.inline.preload";

--- a/src/main/java/org/mockito/internal/util/reflection/InstrumentationMemberAccessor.java
+++ b/src/main/java/org/mockito/internal/util/reflection/InstrumentationMemberAccessor.java
@@ -9,6 +9,7 @@ import net.bytebuddy.agent.ByteBuddyAgent;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import net.bytebuddy.implementation.MethodCall;
 import org.mockito.exceptions.base.MockitoInitializationException;
+import org.mockito.internal.SuppressSignatureCheck;
 import org.mockito.plugins.MemberAccessor;
 
 import java.lang.instrument.Instrumentation;
@@ -21,6 +22,7 @@ import java.util.*;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static org.mockito.internal.util.StringUtil.join;
 
+@SuppressSignatureCheck
 class InstrumentationMemberAccessor implements MemberAccessor {
 
     private static final Map<Class<?>, Class<?>> WRAPPERS = new HashMap<>();


### PR DESCRIPTION
Introduces animal sniffer with exclusion of inline-mock-maker classes which would never be present on Android. Avoids calling invoke/invokeExact methods of handles directly but rather puts the invocations into generated code to avoid breaking Android builds.