### PR TITLE
Only enable mocking of types right before instantiation to avoid circular interception of constructor creation.

### DIFF
--- a/src/main/java/org/mockito/internal/util/reflection/ModuleMemberAccessor.java
+++ b/src/main/java/org/mockito/internal/util/reflection/ModuleMemberAccessor.java
@@ -31,6 +31,13 @@ public class ModuleMemberAccessor implements MemberAccessor {
     }
 
     @Override
+    public Object newInstance(
+            Constructor<?> constructor, OnConstruction onConstruction, Object... arguments)
+            throws InstantiationException, InvocationTargetException, IllegalAccessException {
+        return delegate.newInstance(constructor, onConstruction, arguments);
+    }
+
+    @Override
     public Object invoke(Method method, Object target, Object... arguments)
             throws InvocationTargetException, IllegalAccessException {
         return delegate.invoke(method, target, arguments);

--- a/src/main/java/org/mockito/internal/util/reflection/ReflectionMemberAccessor.java
+++ b/src/main/java/org/mockito/internal/util/reflection/ReflectionMemberAccessor.java
@@ -14,9 +14,16 @@ public class ReflectionMemberAccessor implements MemberAccessor {
     @Override
     public Object newInstance(Constructor<?> constructor, Object... arguments)
             throws InstantiationException, InvocationTargetException, IllegalAccessException {
+        return newInstance(constructor, ConstructionDispatcher::newInstance, arguments);
+    }
+
+    @Override
+    public Object newInstance(
+            Constructor<?> constructor, OnConstruction onConstruction, Object... arguments)
+            throws InstantiationException, InvocationTargetException, IllegalAccessException {
         silentSetAccessible(constructor, true);
         try {
-            return constructor.newInstance(arguments);
+            return onConstruction.invoke(() -> constructor.newInstance(arguments));
         } catch (InvocationTargetException
                 | IllegalAccessException
                 | InstantiationException

--- a/src/main/java/org/mockito/plugins/MemberAccessor.java
+++ b/src/main/java/org/mockito/plugins/MemberAccessor.java
@@ -21,10 +21,28 @@ public interface MemberAccessor {
     Object newInstance(Constructor<?> constructor, Object... arguments)
             throws InstantiationException, InvocationTargetException, IllegalAccessException;
 
+    default Object newInstance(
+            Constructor<?> constructor, OnConstruction onConstruction, Object... arguments)
+            throws InstantiationException, InvocationTargetException, IllegalAccessException {
+        return onConstruction.invoke(() -> newInstance(constructor, arguments));
+    }
+
     Object invoke(Method method, Object target, Object... arguments)
             throws InvocationTargetException, IllegalAccessException;
 
     Object get(Field field, Object target) throws IllegalAccessException;
 
     void set(Field field, Object target, Object value) throws IllegalAccessException;
+
+    interface OnConstruction {
+
+        Object invoke(ConstructionDispatcher dispatcher)
+                throws InstantiationException, InvocationTargetException, IllegalAccessException;
+    }
+
+    interface ConstructionDispatcher {
+
+        Object newInstance()
+                throws InstantiationException, InvocationTargetException, IllegalAccessException;
+    }
 }


### PR DESCRIPTION
Fixes #2015.