### PR TITLE
Constructor dispatch

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
@@ -265,12 +265,18 @@ public class InlineByteBuddyMockMaker
                         } else if (type.isInstance(spy)) {
                             return spy;
                         } else {
-                            // Unexpected construction of non-spied object
-                            throw new MockitoException(
-                                    "Unexpected spy for "
-                                            + type.getName()
-                                            + " on instance of "
-                                            + object.getClass().getName());
+                            isSuspended.set(true);
+                            try {
+                                // Unexpected construction of non-spied object
+                                throw new MockitoException(
+                                        "Unexpected spy for "
+                                                + type.getName()
+                                                + " on instance of "
+                                                + object.getClass().getName(),
+                                        object instanceof Throwable ? (Throwable) object : null);
+                            } finally {
+                                isSuspended.set(false);
+                            }
                         }
                     } else if (currentConstruction.get() != type) {
                         return null;

--- a/subprojects/inline/inline.gradle
+++ b/subprojects/inline/inline.gradle
@@ -12,3 +12,7 @@ tasks.javadoc.enabled = false
 //required by the "StressTest.java" and "OneLinerStubStressTest.java"
 test.maxHeapSize = "256m"
 retryTest.maxHeapSize = "256m"
+
+test {
+    jvmArgs '--illegal-access=debug'
+}


### PR DESCRIPTION
Fixes recursive constructor invocation.
Avoids reflective access warning when using instrumentation-based member accessor.