### PR TITLE
Only apply argument on illegal module access for inline tests if Java version is at least 9.

### DIFF
--- a/subprojects/inline/inline.gradle
+++ b/subprojects/inline/inline.gradle
@@ -13,6 +13,8 @@ tasks.javadoc.enabled = false
 test.maxHeapSize = "256m"
 retryTest.maxHeapSize = "256m"
 
-test {
-    jvmArgs '--illegal-access=debug'
+if (JavaVersion.current().java9Compatible) {
+    test {
+        jvmArgs '--illegal-access=deny'
+    }
 }


### PR DESCRIPTION
Build fails on Java 8 since the command line option is not supported there.