### PR TITLE
Initializes classes prior to instrumentation to avoid uncontrolled code execution.

### DIFF
--- a/subprojects/inline/src/test/java/org/mockitoinline/InitializationTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/InitializationTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2020 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitoinline;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class InitializationTest {
+
+    @Test
+    public void assure_initialization_prior_to_instrumentation() {
+        @SuppressWarnings("unused")
+        SampleEnum mock = Mockito.mock(SampleEnum.class);
+        SampleEnum[] values = SampleEnum.values();
+        assertEquals("VALUE", values[0].name());
+    }
+
+    public enum SampleEnum {
+        VALUE
+    }
+}

--- a/subprojects/inline/src/test/java/org/mockitoinline/PluginTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/PluginTest.java
@@ -7,14 +7,20 @@ package org.mockitoinline;
 import org.junit.Test;
 import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.internal.creation.bytebuddy.InlineByteBuddyMockMaker;
+import org.mockito.internal.util.reflection.ModuleMemberAccessor;
 
 import static org.junit.Assert.*;
 
 public class PluginTest {
 
     @Test
-    public void plugin_type_should_be_inline() throws Exception {
+    public void mock_maker_should_be_inline() throws Exception {
         assertTrue(Plugins.getMockMaker() instanceof InlineByteBuddyMockMaker);
+    }
+
+    @Test
+    public void member_accessor_should_be_module() throws Exception {
+        assertTrue(Plugins.getMemberAccessor() instanceof ModuleMemberAccessor);
     }
 
 }


### PR DESCRIPTION
Fixes #2011 - triggeres initializers explicitly.