### PR TITLE
Fixes #2007 : Downgrade objenesis version for mockito-android

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ dependencies {
     compile libraries.bytebuddy, libraries.bytebuddyagent
 
     compileOnly libraries.junit4, libraries.hamcrest, libraries.opentest4j
-    compile libraries.objenesis
+    compile libraries.objenesis3
 
     testCompile libraries.asm
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -25,7 +25,9 @@ libraries.errorproneTestApi = "com.google.errorprone:error_prone_test_helpers:${
 
 libraries.autoservice = "com.google.auto.service:auto-service:1.0-rc5"
 
-libraries.objenesis = 'org.objenesis:objenesis:3.1'
+// objenesis 3.x fails on android instrumentation test compile. https://github.com/mockito/mockito/issues/2007
+libraries.objenesis2 = 'org.objenesis:objenesis:2.6'
+libraries.objenesis3 = 'org.objenesis:objenesis:3.1'
 
 libraries.asm = 'org.ow2.asm:asm:7.0'
 

--- a/subprojects/android/android.gradle
+++ b/subprojects/android/android.gradle
@@ -21,7 +21,7 @@ dependencies {
                 'If you have mockito-core dependency with mockito-android, remove mockito-core.\n' +
                 'If you have mockito-kotlin, exclude mockito-core.\n' +
                 'implementation("com.nhaarman.mockitokotlin2:mockito-kotlin") {\n' +
-                '    exlcude group: "org.mockito", module: "mockito-core"\n' +
+                '    exclude group: "org.mockito", module: "mockito-core"\n' +
                 '}\n' +
                 'For more information please check; \n' +
                 '    https://github.com/mockito/mockito/pull/2024\n' +

--- a/subprojects/android/android.gradle
+++ b/subprojects/android/android.gradle
@@ -9,7 +9,7 @@ dependencies {
     compile libraries.bytebuddyandroid
     compile(libraries.objenesis2) {
         version {
-            strictly '2.6'
+            strictly '[2.6, 3.0['
         }
         because(
             '\n' +
@@ -17,11 +17,14 @@ dependencies {
                 '---------------------------------------\\   /--------------------------------------\n' +
                 '----------------------------------------\\ /---------------------------------------\n' +
                 '-----------------------------------------V----------------------------------------\n' +
-                'Objenesis 3.x version has method that is not supported by android api 25 and below.\n' +
+                'Objenesis 3.x does not work with android api 25 and below.\n' +
                 'If you have mockito-android or mockito-kotlin, exclude mockito-core from them.\n' +
                 'implementation("com.nhaarman.mockitokotlin2:mockito-kotlin") {\n' +
                 '    exlcude group: "org.mockito", module: "mockito-core"\n' +
                 '}\n' +
+                'For more information please check; \n' +
+                '    https://github.com/mockito/mockito/pull/2024\n' +
+                '    https://github.com/mockito/mockito/pull/2007\n' +
                 '-----------------------------------------A----------------------------------------\n' +
                 '----------------------------------------/ \\---------------------------------------\n' +
                 '---------------------------------------/   \\--------------------------------------\n' +

--- a/subprojects/android/android.gradle
+++ b/subprojects/android/android.gradle
@@ -17,8 +17,9 @@ dependencies {
                 '---------------------------------------\\   /--------------------------------------\n' +
                 '----------------------------------------\\ /---------------------------------------\n' +
                 '-----------------------------------------V----------------------------------------\n' +
-                'Objenesis 3.x does not work with android api 25 and below.\n' +
-                'If you have mockito-android or mockito-kotlin, exclude mockito-core from them.\n' +
+                'Mockito core uses Objenesis 3.x and Objenesis 3.x does not work with android api 25 and below.\n' +
+                'If you have mockito-core dependency with mockito-android, remove mockito-core.\n' +
+                'If you have mockito-kotlin, exclude mockito-core.\n' +
                 'implementation("com.nhaarman.mockitokotlin2:mockito-kotlin") {\n' +
                 '    exlcude group: "org.mockito", module: "mockito-core"\n' +
                 '}\n' +

--- a/subprojects/android/android.gradle
+++ b/subprojects/android/android.gradle
@@ -13,10 +13,8 @@ dependencies {
         }
         because(
             '\n' +
-                '--------------------------------------\\     /-------------------------------------\n' +
-                '---------------------------------------\\   /--------------------------------------\n' +
-                '----------------------------------------\\ /---------------------------------------\n' +
-                '-----------------------------------------V----------------------------------------\n' +
+                'MOCKITO DEPENDENCY PROBLEM:\n' +
+                '\n' +
                 'Mockito core uses Objenesis 3.x and Objenesis 3.x does not work with android api 25 and below.\n' +
                 'If you have mockito-core dependency with mockito-android, remove mockito-core.\n' +
                 'If you have mockito-kotlin, exclude mockito-core.\n' +
@@ -25,11 +23,7 @@ dependencies {
                 '}\n' +
                 'For more information please check; \n' +
                 '    https://github.com/mockito/mockito/pull/2024\n' +
-                '    https://github.com/mockito/mockito/pull/2007\n' +
-                '-----------------------------------------A----------------------------------------\n' +
-                '----------------------------------------/ \\---------------------------------------\n' +
-                '---------------------------------------/   \\--------------------------------------\n' +
-                '--------------------------------------/     \\-------------------------------------\n'
+                '    https://github.com/mockito/mockito/pull/2007\n'
         )
     }
 }

--- a/subprojects/android/android.gradle
+++ b/subprojects/android/android.gradle
@@ -3,7 +3,9 @@ description = "Mockito for Android"
 apply from: "$rootDir/gradle/java-library.gradle"
 
 dependencies {
-    compile project.rootProject
+    compile(project.rootProject) {
+        exclude group: 'org.objenesis', module: 'objenesis'
+    }
     compile libraries.bytebuddyandroid
     compile libraries.objenesis2
 }

--- a/subprojects/android/android.gradle
+++ b/subprojects/android/android.gradle
@@ -7,7 +7,27 @@ dependencies {
         exclude group: 'org.objenesis', module: 'objenesis'
     }
     compile libraries.bytebuddyandroid
-    compile libraries.objenesis2
+    compile(libraries.objenesis2) {
+        version {
+            strictly '2.6'
+        }
+        because(
+            '\n' +
+                '--------------------------------------\\     /-------------------------------------\n' +
+                '---------------------------------------\\   /--------------------------------------\n' +
+                '----------------------------------------\\ /---------------------------------------\n' +
+                '-----------------------------------------V----------------------------------------\n' +
+                'Objenesis 3.x version has method that is not supported by android api 25 and below.\n' +
+                'If you have mockito-android or mockito-kotlin, exclude mockito-core from them.\n' +
+                'implementation("org.mockito:mockito-core") {\n' +
+                '    exlcude group: "org.mockito", module: "mockito-core"\n' +
+                '}\n' +
+                '-----------------------------------------A----------------------------------------\n' +
+                '----------------------------------------/ \\---------------------------------------\n' +
+                '---------------------------------------/   \\--------------------------------------\n' +
+                '--------------------------------------/     \\-------------------------------------\n'
+        )
+    }
 }
 
 tasks.javadoc.enabled = false

--- a/subprojects/android/android.gradle
+++ b/subprojects/android/android.gradle
@@ -5,6 +5,7 @@ apply from: "$rootDir/gradle/java-library.gradle"
 dependencies {
     compile project.rootProject
     compile libraries.bytebuddyandroid
+    compile libraries.objenesis2
 }
 
 tasks.javadoc.enabled = false

--- a/subprojects/android/android.gradle
+++ b/subprojects/android/android.gradle
@@ -19,7 +19,7 @@ dependencies {
                 '-----------------------------------------V----------------------------------------\n' +
                 'Objenesis 3.x version has method that is not supported by android api 25 and below.\n' +
                 'If you have mockito-android or mockito-kotlin, exclude mockito-core from them.\n' +
-                'implementation("org.mockito:mockito-core") {\n' +
+                'implementation("com.nhaarman.mockitokotlin2:mockito-kotlin") {\n' +
                 '    exlcude group: "org.mockito", module: "mockito-core"\n' +
                 '}\n' +
                 '-----------------------------------------A----------------------------------------\n' +

--- a/subprojects/osgi-test/osgi-test.gradle
+++ b/subprojects/osgi-test/osgi-test.gradle
@@ -23,7 +23,7 @@ configurations {
 dependencies {
     testRuntimeBundles project.rootProject
     testRuntimeBundles libraries.bytebuddy
-    testRuntimeBundles libraries.objenesis
+    testRuntimeBundles libraries.objenesis3
     testRuntimeBundles tasks.testBundle.outputs.files
     testRuntimeBundles tasks.otherBundle.outputs.files
 }


### PR DESCRIPTION
check list

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/3.x/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [ ] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

Fixes #2007 

After building, mockito android pom includes objenesis 2.6 while mockito-core has objenesis 3.1.

Locally build version is Tested with our internal project to verify fix. 

```
  androidTestImplementation('com.nhaarman.mockitokotlin2:mockito-kotlin:x.y.z') {
    exclude group: 'org.mockito', module: 'mockito-core'
  }
```

pom of mockito-android.
```
<dependencies>
    <dependency>
      <groupId>org.mockito</groupId>
      <artifactId>mockito-core</artifactId>
      <version>3.5.8</version>
      <scope>compile</scope>
      <exclusions>
        <exclusion>
          <artifactId>objenesis</artifactId>
          <groupId>org.objenesis</groupId>
        </exclusion>
      </exclusions>
    </dependency>
    <dependency>
      <groupId>net.bytebuddy</groupId>
      <artifactId>byte-buddy-android</artifactId>
      <version>1.10.13</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.objenesis</groupId>
      <artifactId>objenesis</artifactId>
      <version>2.6</version>
      <scope>compile</scope>
    </dependency>
  </dependencies>
```

Side note: I had problem with animal sniffer on release/3.x branch. I had to disable android api 24 signature check to compile the app.
```
org.mockito.internal.creation.bytebuddy.InlineByteBuddyMockMaker:507  Undefined reference (android-api-level-24-7.0_r2): java.lang.instrument.Instrumentation
org.mockito.internal.creation.bytebuddy.InlineByteBuddyMockMaker:507  Undefined reference (android-api-level-24-7.0_r2): boolean java.lang.instrument.Instrumentation.isModifiableClass(Class)
```

Breaking changes solutions for android modules
## Solution 1

If you have motkito-kotlin with mockito-android, exclude mockito-core from mockito-kotlin.

```
        implementation("com.nhaarman.mockitokotlin2:mockito-kotlin:<version>") {
            exlcude group: "org.mockito", module: "mockito-core"
        }
```

## Solution 2
Don't add mockito-core with mockito-android

## Solution 3
Use dependency resolution

in root build.gradle

```
subprojects {
  configurations.configureEach {
    resolutionStrategy.eachDependency { details ->
      if (details.requested.group == 'org.objenesis') { 
        details.useVersion '2.6'
      }
    }
  }
}
```



