### PR TITLE
Escape mock during method dispatch on mock to avoid premature garbage collection.

### DIFF
--- a/src/test/java/org/mockito/PrematureGarbageCollectionTest.java
+++ b/src/test/java/org/mockito/PrematureGarbageCollectionTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito;
+
+import org.junit.Test;
+
+public class PrematureGarbageCollectionTest {
+
+    @Test
+    public void provoke_premature_garbage_collection() {
+        for (int i = 0; i < 500; i++) {
+            populateNodeList();
+        }
+    }
+
+    private static void populateNodeList() {
+        Node node = nodes();
+        while (node != null) {
+            Node next = node.next;
+            node.object.run();
+            node = next;
+        }
+    }
+
+    private static Node nodes() {
+        Node node = null;
+        for (int i = 0; i < 1_000; ++i) {
+            Node next = new Node();
+            next.next = node;
+            node = next;
+        }
+        return node;
+    }
+
+    private static class Node {
+
+        private Node next;
+
+        private final Runnable object = Mockito.mock(Runnable.class);
+    }
+}


### PR DESCRIPTION
Under heavy optimization mocks might get garbage collected during the dispatching of a mocked method if the mock instance is not used after this method dispatch. To avoid this, we escape the mock instance during the dispatch to make sure that the GC cannot collect the object.

Fixes #1802.