### PR TITLE
Mock resolver plugin

### DIFF
--- a/src/main/java/org/mockito/internal/configuration/plugins/PluginFinder.java
+++ b/src/main/java/org/mockito/internal/configuration/plugins/PluginFinder.java
@@ -6,6 +6,8 @@ package org.mockito.internal.configuration.plugins;
 
 import java.io.InputStream;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.util.io.IOUtil;
@@ -42,5 +44,31 @@ class PluginFinder {
             }
         }
         return null;
+    }
+
+    List<String> findPluginClasses(Iterable<URL> resources) {
+        List<String> pluginClassNames = new ArrayList<>();
+        for (URL resource : resources) {
+            InputStream s = null;
+            try {
+                s = resource.openStream();
+                String pluginClassName = new PluginFileReader().readPluginClass(s);
+                if (pluginClassName == null) {
+                    // For backwards compatibility
+                    // If the resource does not have plugin class name we're ignoring it
+                    continue;
+                }
+                if (!pluginSwitch.isEnabled(pluginClassName)) {
+                    continue;
+                }
+                pluginClassNames.add(pluginClassName);
+            } catch (Exception e) {
+                throw new MockitoException(
+                        "Problems reading plugin implementation from: " + resource, e);
+            } finally {
+                IOUtil.closeQuietly(s);
+            }
+        }
+        return pluginClassNames;
     }
 }

--- a/src/main/java/org/mockito/internal/configuration/plugins/PluginInitializer.java
+++ b/src/main/java/org/mockito/internal/configuration/plugins/PluginInitializer.java
@@ -6,7 +6,9 @@ package org.mockito.internal.configuration.plugins;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.List;
 
 import org.mockito.internal.util.collections.Iterables;
 import org.mockito.plugins.PluginSwitch;
@@ -51,6 +53,38 @@ class PluginInitializer {
                 return service.cast(plugin);
             }
             return null;
+        } catch (Exception e) {
+            throw new IllegalStateException(
+                    "Failed to load " + service + " implementation declared in " + resources, e);
+        }
+    }
+
+    public <T> List<T> loadImpls(Class<T> service) {
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        if (loader == null) {
+            loader = ClassLoader.getSystemClassLoader();
+        }
+        Enumeration<URL> resources;
+        try {
+            resources = loader.getResources("mockito-extensions/" + service.getName());
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to load " + service, e);
+        }
+
+        try {
+            List<String> classesOrAliases =
+                    new PluginFinder(pluginSwitch)
+                            .findPluginClasses(Iterables.toIterable(resources));
+            List<T> impls = new ArrayList<>();
+            for (String classOrAlias : classesOrAliases) {
+                if (classOrAlias.equals(alias)) {
+                    classOrAlias = plugins.getDefaultPluginClass(alias);
+                }
+                Class<?> pluginClass = loader.loadClass(classOrAlias);
+                Object plugin = pluginClass.getDeclaredConstructor().newInstance();
+                impls.add(service.cast(plugin));
+            }
+            return impls;
         } catch (Exception e) {
             throw new IllegalStateException(
                     "Failed to load " + service + " implementation declared in " + resources, e);

--- a/src/main/java/org/mockito/internal/configuration/plugins/PluginLoader.java
+++ b/src/main/java/org/mockito/internal/configuration/plugins/PluginLoader.java
@@ -7,6 +7,8 @@ package org.mockito.internal.configuration.plugins;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.List;
 
 import org.mockito.plugins.PluginSwitch;
 
@@ -88,6 +90,34 @@ class PluginLoader {
                                     t);
                         }
                     });
+        }
+    }
+
+    /**
+     * Scans the classpath for given {@code pluginType} and returns a list of its instances.
+     *
+     * @return An list of {@code pluginType} or an empty list if none was found.
+     */
+    @SuppressWarnings("unchecked")
+    <T> List<T> loadPlugins(final Class<T> pluginType) {
+        try {
+            return initializer.loadImpls(pluginType);
+        } catch (final Throwable t) {
+            return Collections.singletonList(
+                    (T)
+                            Proxy.newProxyInstance(
+                                    pluginType.getClassLoader(),
+                                    new Class<?>[] {pluginType},
+                                    new InvocationHandler() {
+                                        @Override
+                                        public Object invoke(
+                                                Object proxy, Method method, Object[] args)
+                                                throws Throwable {
+                                            throw new IllegalStateException(
+                                                    "Could not initialize plugin: " + pluginType,
+                                                    t);
+                                        }
+                                    }));
         }
     }
 }

--- a/src/main/java/org/mockito/internal/configuration/plugins/PluginRegistry.java
+++ b/src/main/java/org/mockito/internal/configuration/plugins/PluginRegistry.java
@@ -7,6 +7,8 @@ package org.mockito.internal.configuration.plugins;
 import org.mockito.internal.creation.instance.InstantiatorProviderAdapter;
 import org.mockito.plugins.*;
 
+import java.util.List;
+
 class PluginRegistry {
 
     private final PluginSwitch pluginSwitch =
@@ -30,6 +32,9 @@ class PluginRegistry {
 
     private final MockitoLogger mockitoLogger =
             new PluginLoader(pluginSwitch).loadPlugin(MockitoLogger.class);
+
+    private final List<MockResolver> mockResolvers =
+            new PluginLoader(pluginSwitch).loadPlugins(MockResolver.class);
 
     PluginRegistry() {
         Object impl =
@@ -99,5 +104,14 @@ class PluginRegistry {
      */
     MockitoLogger getMockitoLogger() {
         return mockitoLogger;
+    }
+
+    /**
+     * Returns a list of available mock resolvers if any.
+     *
+     * @return A list of available mock resolvers or an empty list if none are registered.
+     */
+    List<MockResolver> getMockResolvers() {
+        return mockResolvers;
     }
 }

--- a/src/main/java/org/mockito/internal/configuration/plugins/Plugins.java
+++ b/src/main/java/org/mockito/internal/configuration/plugins/Plugins.java
@@ -6,6 +6,8 @@ package org.mockito.internal.configuration.plugins;
 
 import org.mockito.plugins.*;
 
+import java.util.List;
+
 /**
  * Access to Mockito behavior that can be reconfigured by plugins
  */
@@ -69,6 +71,15 @@ public class Plugins {
      */
     public static MockitoLogger getMockitoLogger() {
         return registry.getMockitoLogger();
+    }
+
+    /**
+     * Returns a list of available mock resolvers if any.
+     *
+     * @return A list of available mock resolvers or an empty list if none are registered.
+     */
+    public static List<MockResolver> getMockResolvers() {
+        return registry.getMockResolvers();
     }
 
     /**

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
@@ -397,13 +397,17 @@ public class MockMethodAdvice extends MockMethodDispatcher {
                                 .getDeclaredMethods()
                                 .filter(isConstructor().and(not(isPrivate())));
                 int arguments = Integer.MAX_VALUE;
-                boolean visible = false;
+                boolean packagePrivate = true;
                 MethodDescription.InDefinedShape current = null;
                 for (MethodDescription.InDefinedShape constructor : constructors) {
+                    // We are choosing the shortest constructor with regards to arguments.
+                    // Yet, we prefer a non-package-private constructor since they require
+                    // the super class to be on the same class loader.
                     if (constructor.getParameters().size() < arguments
-                            && (!visible || constructor.isPackagePrivate())) {
+                            && (packagePrivate || !constructor.isPackagePrivate())) {
+                        arguments = constructor.getParameters().size();
+                        packagePrivate = constructor.isPackagePrivate();
                         current = constructor;
-                        visible = constructor.isPackagePrivate();
                     }
                 }
                 if (current != null) {

--- a/src/main/java/org/mockito/internal/util/DefaultMockingDetails.java
+++ b/src/main/java/org/mockito/internal/util/DefaultMockingDetails.java
@@ -73,7 +73,7 @@ public class DefaultMockingDetails implements MockingDetails {
         return toInspect;
     }
 
-    private MockHandler<Object> mockHandler() {
+    private MockHandler<?> mockHandler() {
         assertGoodMock();
         return MockUtil.getMockHandler(toInspect);
     }

--- a/src/main/java/org/mockito/internal/util/MockUtil.java
+++ b/src/main/java/org/mockito/internal/util/MockUtil.java
@@ -56,11 +56,12 @@ public class MockUtil {
         return mock;
     }
 
-    public static <T> void resetMock(T mock) {
+    public static void resetMock(Object mock) {
         MockHandler oldHandler = getMockHandler(mock);
         MockCreationSettings settings = oldHandler.getMockSettings();
         MockHandler newHandler = createMockHandler(settings);
 
+        mock = resolve(mock);
         mockMaker.resetMock(mock, newHandler, settings);
     }
 
@@ -110,6 +111,9 @@ public class MockUtil {
     }
 
     private static Object resolve(Object mock) {
+        if (mock instanceof Class<?>) { // static mocks are resolved by definition
+            return mock;
+        }
         for (MockResolver mockResolver : Plugins.getMockResolvers()) {
             mock = mockResolver.resolve(mock);
         }

--- a/src/main/java/org/mockito/plugins/MockMaker.java
+++ b/src/main/java/org/mockito/plugins/MockMaker.java
@@ -85,7 +85,7 @@ public interface MockMaker {
      *                {@link #getHandler(Object)} will return this instance.
      * @param instance  The object to spy upon.
      * @param <T> Type of the mock to return, actually the <code>settings.getTypeToMock</code>.
-     * @return
+     * @return The spy instance, if this mock maker supports direct spy creation.
      * @since 3.5.0
      */
     default <T> Optional<T> createSpy(

--- a/src/main/java/org/mockito/plugins/MockResolver.java
+++ b/src/main/java/org/mockito/plugins/MockResolver.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2020 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.plugins;
+
+/**
+ * A mock resolver offers an opportunity to resolve a mock from any instance that is
+ * provided to the {@link org.mockito.Mockito}-DSL. This mechanism can be used by
+ * frameworks that provide mocks that are implemented by Mockito but which are wrapped
+ * by other instances to enhance the proxy further.
+ */
+public interface MockResolver {
+
+    /**
+     * Returns the provided instance or the unwrapped mock that the provided
+     * instance represents. This method must not return {@code null}.
+     * @param instance The instance passed to the {@link org.mockito.Mockito}-DSL.
+     * @return The provided instance or the unwrapped mock.
+     */
+    Object resolve(Object instance);
+}

--- a/subprojects/extTest/src/test/java/org/mockitousage/plugins/resolver/MockResolverTest.java
+++ b/subprojects/extTest/src/test/java/org/mockitousage/plugins/resolver/MockResolverTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage.plugins.resolver;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@MockitoSettings(strictness = Strictness.WARN)
+@ExtendWith(MockitoExtension.class)
+class MockResolverTest {
+
+    @Test
+    void mock_resolver_can_unwrap_mocked_instance() {
+        Foo mock = mock(Foo.class), wrapper = new MockWrapper(mock);
+        when(wrapper.doIt()).thenReturn(123);
+        assertThat(mock.doIt()).isEqualTo(123);
+        assertThat(wrapper.doIt()).isEqualTo(123);
+        verify(wrapper, times(2)).doIt();
+    }
+
+    interface Foo {
+        int doIt();
+    }
+
+    static class MockWrapper implements Foo {
+
+        private final Foo mock;
+
+        MockWrapper(Foo mock) {
+            this.mock = mock;
+        }
+
+        Object getMock() {
+            return mock;
+        }
+
+        @Override
+        public int doIt() {
+            return mock.doIt();
+        }
+    }
+
+}

--- a/subprojects/extTest/src/test/java/org/mockitousage/plugins/resolver/MyMockResolver.java
+++ b/subprojects/extTest/src/test/java/org/mockitousage/plugins/resolver/MyMockResolver.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2020 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage.plugins.resolver;
+
+import org.mockito.plugins.MockResolver;
+
+public class MyMockResolver implements MockResolver {
+
+    @Override
+    public Object resolve(Object instance) {
+        if (instance instanceof MockResolverTest.MockWrapper) {
+            return ((MockResolverTest.MockWrapper) instance).getMock();
+        }
+        return instance;
+    }
+}

--- a/subprojects/extTest/src/test/java/org/mockitousage/plugins/switcher/PluginSwitchTest.java
+++ b/subprojects/extTest/src/test/java/org/mockitousage/plugins/switcher/PluginSwitchTest.java
@@ -7,6 +7,7 @@ package org.mockitousage.plugins.switcher;
 import org.junit.Test;
 import org.mockitousage.plugins.instantiator.MyInstantiatorProvider2;
 import org.mockitousage.plugins.logger.MyMockitoLogger;
+import org.mockitousage.plugins.resolver.MyMockResolver;
 import org.mockitousage.plugins.stacktrace.MyStackTraceCleanerProvider;
 
 import java.util.List;
@@ -25,6 +26,7 @@ public class PluginSwitchTest {
         assertEquals(MyPluginSwitch.invokedFor, asList(MyMockMaker.class.getName(),
             MyStackTraceCleanerProvider.class.getName(),
             MyMockitoLogger.class.getName(),
+            MyMockResolver.class.getName(),
             MyInstantiatorProvider2.class.getName()));
     }
 

--- a/subprojects/extTest/src/test/resources/mockito-extensions/org.mockito.plugins.MockResolver
+++ b/subprojects/extTest/src/test/resources/mockito-extensions/org.mockito.plugins.MockResolver
@@ -1,0 +1,1 @@
+org.mockitousage.plugins.resolver.MyMockResolver


### PR DESCRIPTION
Adds a plugin to allow for adding one or multiple mock resolvers. This way, instances that are provided to Mockito's DSL do no longer require to be the actual mocks but can also be proxies of mocks what is something already being applied by frameworks such as Spring.

This works today with the subclass mock maker by accident as we read the mock state from the mock instance via a method which gets proxied. If we ever find a more private appraoch this would however break Spring's Mockito use and it is already broken with the inline mock maker.

By this SPI, Spring could add an unproxy resolver to its Mockito build-up and make it's proxied mocks compatible with Mockito. Other frameworks could use the same approach if desired as this SPI is generic.

Closes #1980