### PR TITLE
Prefer non-synthetic constructors in MockMethodAdvice.ConstructorShortcut

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
@@ -396,6 +396,13 @@ public class MockMethodAdvice extends MockMethodDispatcher {
                                 .asErasure()
                                 .getDeclaredMethods()
                                 .filter(isConstructor().and(not(isPrivate())));
+                MethodList<MethodDescription.InDefinedShape> nonSynthetics =
+                        constructors.filter(not(isSynthetic()));
+                // Prefer non-synthetic constructors as a workaround to synthetic Robolectric
+                // generated constructors not being visited by AsmVisitorWrapper.ForDeclaredMethods.
+                if (nonSynthetics.size() > 0) {
+                    constructors = nonSynthetics;
+                }
                 int arguments = Integer.MAX_VALUE;
                 boolean visible = false;
                 MethodDescription.InDefinedShape current = null;


### PR DESCRIPTION
After moving spy creation to instrumenting constructor chains in
ByteBuddyMockMaker, creating spies for Robolectric-instrumented Android
classes started failing in some situations due to fields not being
copied on base classes (specifically, ContextWrapper.mBase). The problem
is that AsmVisitorWrapper.ForDeclaredMethods does not visit the
synthetic constructrs that are added by Robolectric during runtime.
While the visibility issuer is still being explored, a workaround is to
prefer non-synthetic constructors when selecting which parent
constructor to call in MockMethodAdvice.ConstructorShortcut.

Fixes #2040