### PR TITLE
Do not exclude synthetic constructors from instrumentation. Fixes #2040.

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
@@ -91,7 +91,8 @@ public class InlineBytecodeGenerator implements BytecodeGenerator, ClassFileTran
                 new ByteBuddy()
                         .with(TypeValidation.DISABLED)
                         .with(Implementation.Context.Disabled.Factory.INSTANCE)
-                        .with(MethodGraph.Compiler.ForDeclaredMethods.INSTANCE);
+                        .with(MethodGraph.Compiler.ForDeclaredMethods.INSTANCE)
+                        .ignore(isSynthetic().and(not(isConstructor())).or(isDefaultFinalizer()));
         mocked = new WeakConcurrentSet<>(WeakConcurrentSet.Cleaner.INLINE);
         flatMocked = new WeakConcurrentSet<>(WeakConcurrentSet.Cleaner.INLINE);
         String identifier = RandomString.make();

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
@@ -397,13 +397,14 @@ public class MockMethodAdvice extends MockMethodDispatcher {
                                 .getDeclaredMethods()
                                 .filter(isConstructor().and(not(isPrivate())));
                 int arguments = Integer.MAX_VALUE;
-                boolean visible = false;
+                boolean packagePrivate = true;
                 MethodDescription.InDefinedShape current = null;
                 for (MethodDescription.InDefinedShape constructor : constructors) {
                     if (constructor.getParameters().size() < arguments
-                            && (!visible || constructor.isPackagePrivate())) {
+                            && (packagePrivate || !constructor.isPackagePrivate())) {
+                        arguments = constructor.getParameters().size();
+                        packagePrivate = constructor.isPackagePrivate();
                         current = constructor;
-                        visible = constructor.isPackagePrivate();
                     }
                 }
                 if (current != null) {


### PR DESCRIPTION
Byte Buddy does exclude synthetic members by default as they normally provide necessary infrastructure outside of business logic (e.g. bridge methods). For constructor instrumentation, it is however crucial that no code is called during mock creation and that fields are copied during spy creation.