### PR TITLE
Fixes #1997 : make mockito-junit-jupiter workin in OSGiMockitoExtensi…

### DIFF
--- a/gradle/mockito-core/osgi.gradle
+++ b/gradle/mockito-core/osgi.gradle
@@ -1,12 +1,3 @@
-import java.nio.file.attribute.FileTime
-import java.util.jar.Attributes
-import java.util.jar.JarEntry
-import java.util.jar.JarFile
-import java.util.jar.JarOutputStream
-import java.util.jar.Manifest
-
-import static java.util.Calendar.FEBRUARY
-
 apply plugin: 'biz.aQute.bnd.builder'
 
 jar {
@@ -14,9 +5,9 @@ jar {
     bnd(
         'Bundle-Name': 'Mockito Mock Library for Java. Core bundle requires Byte Buddy and Objenesis.',
         'Bundle-SymbolicName': 'org.mockito.mockito-core',
-        'Bundle-Version': project.version.replace('-', '.'),
+        'Bundle-Version': "\${version_cleanup;${project.version}}",
         '-versionpolicy': '[${version;==;${@}},${version;+;${@}})',
-        'Export-Package': "!org.mockito.internal.*,org.mockito.*;version=${version}",
+        'Export-Package': "org.mockito.internal.*;status=INTERNAL;mandatory:=status;version=${version},org.mockito.*;version=${version}",
         'Import-Package': [
                 'net.bytebuddy.*;version="[1.6.0,2.0)"',
                 'junit.*;resolution:=optional',
@@ -27,89 +18,7 @@ jar {
                 'org.mockito.*'
         ].join(','),
         '-removeheaders': 'Private-Package',
-        'Automatic-Module-Name': 'org.mockito'
+        'Automatic-Module-Name': 'org.mockito',
+        '-noextraheaders': 'true'
     )
-}
-
-jar.doLast {
-    JarFile originalJar = new JarFile(jar.archivePath)
-
-    new RemoveOsgiLastModifiedHeader(originalJar)
-        .transform()
-        .renameTo jar.archivePath
-}
-
-
-/*
- * The OSGi plugin in Gradle 5.3 has a known issue (https://github.com/gradle/gradle/issues/6187) where it embeds
- * a Manifest entry "Bnd-LastModified" (set to the last modified time of the build directory) even if you ask it not to
- * using `-noextraheaders` or `-removeheaders`.
- *
- * It cannot be pinned or removed, and is a source of non-determinism in the build.
- *
- * This class addresses the problem by rewriting the JAR and removing that entry from the Manifest. A side-effect of this
- * is having to set `lastModifiedTime` for each entry to a fixed value, else this would also introduce non-determinism.
- *
- * The fixed value is the same as the default value for Gradle's fixed timestamps, and the rationale behind it is detailed
- * in https://github.com/gradle/gradle/blob/58538513a3bff3b7015718976fe1304e23f40694/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipCopyAction.java#L42-L57
- */
-
-class RemoveOsgiLastModifiedHeader {
-    private final long CONSTANT_TIME_FOR_ZIP_ENTRIES = new GregorianCalendar(1980, FEBRUARY, 1, 0, 0, 0).timeInMillis
-
-    private final JarFile artifact
-
-    RemoveOsgiLastModifiedHeader(JarFile artifact) {
-        this.artifact = artifact
-    }
-
-    File transform() {
-        File temp = File.createTempFile("temp",".jar")
-
-        temp.withOutputStream { os ->
-            JarOutputStream stream = new JarOutputStream(os)
-
-            this.artifact
-                .entries()
-                // Keep META-INF folder at the beginning to avoid https://github.com/mockito/mockito/issues/2108
-                .sort { (it.name.startsWith("META-INF") ? "A/" + it.name : "B/" + it.name) }
-                .each { JarEntry entry ->
-
-                    stream.putNextEntry(newJarEntry(entry))
-
-                    if (entry.name == "META-INF/MANIFEST.MF") {
-                        newManifest(entry).write(stream)
-                    } else {
-                        stream << this.artifact.getInputStream(entry)
-                    }
-
-                    stream.closeEntry()
-                }
-
-            stream.finish()
-        }
-
-        temp
-    }
-
-    Manifest newManifest(JarEntry entry) {
-        Manifest manifest = new Manifest()
-
-        manifest.read(this.artifact.getInputStream(entry))
-
-        manifest
-            .getMainAttributes()
-            .remove(new Attributes.Name("Bnd-LastModified"))
-
-        manifest
-    }
-
-    JarEntry newJarEntry(JarEntry original) {
-        JarEntry newEntry = new JarEntry(original.name)
-
-        newEntry.setLastModifiedTime(FileTime.fromMillis(CONSTANT_TIME_FOR_ZIP_ENTRIES))
-
-        newEntry
-    }
-
 }

--- a/subprojects/junit-jupiter/junit-jupiter.gradle
+++ b/subprojects/junit-jupiter/junit-jupiter.gradle
@@ -1,6 +1,11 @@
+import aQute.bnd.gradle.BundleTaskConvention
+import aQute.bnd.gradle.FileSetRepositoryConvention
+import aQute.bnd.gradle.Resolve
+
 description = "Mockito JUnit 5 support"
 
 apply from: "$rootDir/gradle/java-library.gradle"
+apply plugin: 'biz.aQute.bnd.builder'
 
 dependencies {
     compile project.rootProject
@@ -12,4 +17,44 @@ dependencies {
 
 tasks.withType(Test) {
     useJUnitPlatform()
+}
+
+jar {
+    classpath = project.configurations.runtimeClasspath
+    bnd(
+        'Bundle-Name': 'Mockito Extension Library for JUnit 5.',
+        'Bundle-SymbolicName': 'org.mockito.junit-jupiter',
+        'Bundle-Version': "\${version_cleanup;${project.version}}",
+        '-versionpolicy': '[${version;==;${@}},${version;+;${@}})',
+        'Export-Package': "org.mockito.junit.jupiter.*;version=${version}",
+        '-removeheaders': 'Private-Package',
+        'Automatic-Module-Name': 'org.mockito.junit.jupiter',
+        '-noextraheaders': 'true',
+        '-export-apiguardian': 'org.mockito.internal.*'
+    )
+}
+
+def osgiPropertiesFile = file("$buildDir/verifyOSGiProperties.bndrun")
+
+// Bnd's Resolve task uses a properties file for its configuration. This
+// task writes out the properties necessary for it to verify the OSGi
+// metadata.
+tasks.register('osgiProperties', WriteProperties) {
+  outputFile = osgiPropertiesFile
+  property('-standalone', true)
+  property('-runee', "JavaSE-${targetCompatibility}")
+  property('-runrequires', 'osgi.identity;filter:="(osgi.identity=org.mockito.junit-jupiter)"')
+}
+
+// Bnd's Resolve task is what verifies that a jar can be used in OSGi and
+// that its metadata is valid. If the metadata is invalid this task will
+// fail.
+tasks.register('verifyOSGi', Resolve) {
+  dependsOn(osgiProperties)
+  setBndrun(osgiPropertiesFile)
+  reportOptional = false
+}
+
+tasks.check {
+  dependsOn(verifyOSGi)
 }


### PR DESCRIPTION
…on

without
a) giving up the internal nature of some packages
b) resorting to substandard solutions like OSGi fragements

Signed-off-by: Raymond Augé <raymond.auge@liferay.com>

> Hey, 
> 
> Thanks for the contribution, this is awesome.
> As you may have read, project members have somehow an opinionated view on what and how should be
> Mockito, e.g. we don't want mockito to be a feature bloat.
> There may be a thorough review, with feedback -> code change loop.
> 
> Which branch : 
> - On mockito 3.x, make your pull request target `release/3.x`
> - On mockito 2.x, make your pull request target `release/2.x` (2.x is in maintenance mode)
>
> _This block can be removed_
> _Something wrong in the template fix it here `.github/PULL_REQUEST_TEMPLATE.md`


check list

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/3.x/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

