### PR TITLE
Use single version for strictly in mockito-android

### DIFF
--- a/subprojects/android/android.gradle
+++ b/subprojects/android/android.gradle
@@ -9,7 +9,7 @@ dependencies {
     compile libraries.bytebuddyandroid
     compile(libraries.objenesis2) {
         version {
-            strictly '[2.6, 3.0['
+            strictly '2.6'
         }
         because(
             '\n' +


### PR DESCRIPTION
check list

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/3.x/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [ ] At least one commit should mention `Fixes #<issue number>` _if relevant_

Fixes #2007 

In #2024, code review suggested to use `strictly '[2.6, 3.1['` instead if `strictly '2.6'`.  [Comment](https://github.com/mockito/mockito/pull/2024#discussion_r478326102)
Apparently I failed to test that suggestion and it broke the fix in #2007. 

Using `strictly '2.6'` works as expected. It fails the objenesis resolution and suggest to exclude mockito-core from mockito-kotlin. 
