### PR TITLE
Fixes #2083 : Modify casing of Bundle-Version manifest header

### DIFF
--- a/gradle/mockito-core/osgi.gradle
+++ b/gradle/mockito-core/osgi.gradle
@@ -14,7 +14,7 @@ jar {
     bnd(
         'Bundle-Name': 'Mockito Mock Library for Java. Core bundle requires Byte Buddy and Objenesis.',
         'Bundle-SymbolicName': 'org.mockito.mockito-core',
-        'Bundle-version': project.version.replace('-', '.'),
+        'Bundle-Version': project.version.replace('-', '.'),
         '-versionpolicy': '[${version;==;${@}},${version;+;${@}})',
         'Export-Package': "!org.mockito.internal.*,org.mockito.*;version=${version}",
         'Import-Package': [


### PR DESCRIPTION
OSGi specification may accept case insensitive headers but this is
causing problems for Eclipse PDE development with version constriants.

Switch to match casing of other headers and agree with name provided
at: https://www.osgi.org/bundle-headers-reference/