### PR TITLE
Update links; use HTTPS for links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,8 +6,8 @@
 
 **If looking for support**
 
-* Search / Ask question on [stackoverflow](http://stackoverflow.com/questions/tagged/mockito)
-* Go to the [mockito mailing-list](http://groups.google.com/group/mockito) (moderated)
+* Search / Ask question on [stackoverflow](https://stackoverflow.com/questions/tagged/mockito)
+* Go to the [mockito mailing-list](https://groups.google.com/group/mockito) (moderated)
 * Issues should always have a [Short, Self Contained, Correct (Compilable), Example](http://sscce.org) (same as any question on stackoverflow.com)
 
 # Contributing to Mockito
@@ -46,7 +46,7 @@ Things we pay attention in a PR :
 * On pull requests, please document the change, what it brings, what is the benefit.
 * **Clean commit history** in the topic branch in your fork of the repository, even during review. That means that commits are _rebased_ and _squashed_ if necessary, so that each commit clearly changes one things and there are no extraneous fix-ups.
 
-  For that matter it's possible to commit [_semantic_ changes](http://lemike-de.tumblr.com/post/79041908218/semantic-commits). _Tests are an asset, so is history_.
+  For that matter it's possible to commit [_semantic_ changes](https://lemike-de.tumblr.com/post/79041908218/semantic-commits). _Tests are an asset, so is history_.
 
   _Example gratia_:
 
@@ -80,7 +80,7 @@ But first of all, make sure that :
 * Line ending character is unix-style **`LF`**
 * New line is added at end of file: `IntelliJ setting > Editor > General > Ensure line feed at file end on save`
 
-For most editors, this should be automatically enforced by [EditorConfig](http://editorconfig.org/).
+For most editors, this should be automatically enforced by [EditorConfig](https://editorconfig.org/).
 Check if your editor has a built-in plugin or if you need to download one.
 IntelliJ has a built-in plugin, for Eclipse you need to download [this plugin](https://github.com/ncjones/editorconfig-eclipse#readme).
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,7 @@
 > 
 > If this is about mockito usage, the better way is to reach out to
 > 
->  - stackoverflow : http://stackoverflow.com/questions/tagged/mockito
+>  - stackoverflow : https://stackoverflow.com/questions/tagged/mockito
 >  - the mailing-list  : https://groups.google.com/forum/#!forum/mockito / mockito@googlegroups.com
 >    (Note mailing-list is moderated to avoid spam)
 >

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="http://site.mockito.org">
+<a href="https://site.mockito.org">
 <img src="https://raw.githubusercontent.com/mockito/mockito/release/3.x/src/javadoc/org/mockito/logo.png"
      srcset="https://raw.githubusercontent.com/mockito/mockito/release/3.x/src/javadoc/org/mockito/logo@2x.png 2x"
      alt="Mockito" />
@@ -27,16 +27,16 @@ The maintainers of org.mockito:mockito-core and thousands of other packages are 
 
 ## Development
 
-Mockito [continuously delivers](https://github.com/mockito/mockito/wiki/Continuous-Delivery-Overview) improvements using Shipkit library (http://shipkit.org). See the [latest release notes](https://github.com/mockito/mockito/blob/release/3.x/doc/release-notes/official.md) and [latest documentation](http://javadoc.io/page/org.mockito/mockito-core/latest/org/mockito/Mockito.html). Docs in javadoc.io are available 24h after release. Read also about [semantic versioning in Mockito](https://github.com/mockito/mockito/wiki/Semantic-Versioning). **Note: not every version is published to Maven Central.**
+Mockito [continuously delivers](https://github.com/mockito/mockito/wiki/Continuous-Delivery-Overview) improvements using Shipkit library (http://shipkit.org). See the [latest release notes](https://github.com/mockito/mockito/blob/release/3.x/doc/release-notes/official.md) and [latest documentation](https://javadoc.io/page/org.mockito/mockito-core/latest/org/mockito/Mockito.html). Docs in javadoc.io are available 24h after release. Read also about [semantic versioning in Mockito](https://github.com/mockito/mockito/wiki/Semantic-Versioning). **Note: not every version is published to Maven Central.**
 
 Older 1.x and 2.x releases are available in
-[Central Repository](http://search.maven.org/#artifactdetails|org.mockito|mockito-core|1.10.19|jar)
+[Central Repository](https://search.maven.org/artifact/org.mockito/mockito-core/1.10.19/jar)
 , [Bintray](https://bintray.com/mockito/maven/mockito/1.10.19/view)
-and [javadoc.io](http://javadoc.io/doc/org.mockito/mockito-core/1.10.19/org/mockito/Mockito.html) (documentation).
+and [javadoc.io](https://javadoc.io/doc/org.mockito/mockito-core/1.10.19/org/mockito/Mockito.html) (documentation).
 
 ## More information
 
-All you want to know about Mockito is hosted at [The Mockito Site](http://site.mockito.org) which is [Open Source](https://github.com/mockito/mockito.github.io) and likes [pull requests](https://github.com/mockito/mockito.github.io/pulls), too.
+All you want to know about Mockito is hosted at [The Mockito Site](https://site.mockito.org) which is [Open Source](https://github.com/mockito/mockito.github.io) and likes [pull requests](https://github.com/mockito/mockito.github.io/pulls), too.
 
 Want to contribute? Take a look at the [Contributing Guide](https://github.com/mockito/mockito/blob/release/3.x/.github/CONTRIBUTING.md).
 
@@ -44,8 +44,8 @@ Enjoy Mockito!
 
 ## Need help?
 
-* Search / Ask question on [stackoverflow](http://stackoverflow.com/questions/tagged/mockito)
-* Go to the [mockito mailing-list](http://groups.google.com/group/mockito) (moderated)
+* Search / Ask question on [stackoverflow](https://stackoverflow.com/questions/tagged/mockito)
+* Go to the [mockito mailing-list](https://groups.google.com/group/mockito) (moderated)
 * Open a ticket in GitHub [issue tracker](https://github.com/mockito/mockito/issues)
 
 ## How to develop Mockito?
@@ -67,7 +67,7 @@ Mockito [implements Continuous Delivery model](https://github.com/mockito/mockit
 Every change on main branch (for example merging a pull request) triggers a release build on Travis CI.
 The build publishes new version if specific criteria are met: all tests green, no 'ci skip release' used in commit message, see the build log for more information.
 Every new version is published to ["mockito/maven" Bintray repository](https://bintray.com/mockito/maven).
-New versions that Mockito team deems "notable" are additionally published to [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.mockito%22) and [JCenter](https://bintray.com/bintray/jcenter).
+New versions that Mockito team deems "notable" are additionally published to [Maven Central](https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.mockito%22) and [JCenter](https://bintray.com/bintray/jcenter).
 We used to publish every version to Maven Central but we changed this strategy based on feedback from the community ([#911](https://github.com/mockito/mockito/issues/911)).
 
 * Q: What's new in Mockito release model?

--- a/doc/release-notes/official.md
+++ b/doc/release-notes/official.md
@@ -795,7 +795,7 @@
  - 2018-07-27 - [2 commits](https://github.com/mockito/mockito/compare/v2.20.1...v2.20.2) by [Rafael Winterhalter](https://github.com/raphw) (1), [Szczepan Faber](https://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.20.2-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.20.2)
  - Updates Byte Buddy to add preliminary support for Java 12. [(#1448)](https://github.com/mockito/mockito/pull/1448)
 
-# 2.20.1 (2018-07-26) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.20.1)/[Maven Central](http://search.maven.org/#artifactdetails%7Corg.mockito%7Cmockito-core%7C2.20.1%7Cjar)
+# 2.20.1 (2018-07-26) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.20.1)/[Maven Central](https://search.maven.org/artifact/org.mockito/mockito-core/2.20.1/jar)
 
 Important changes since previous notable release:
  - new lenient() API - see blog post
@@ -919,10 +919,10 @@ __Deprecated__ because auxiliary artifacts were published with wrong identifiers
  - 2018-03-31 - [1 commit](https://github.com/mockito/mockito/compare/v2.17.3...v2.17.4) by [Erhard Pointl](https://github.com/epeee) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.17.4-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.17.4)
  - Make use of shipkit v2.0.13 [(#1354)](https://github.com/mockito/mockito/pull/1354)
 
-**2.17.3 (2018-03-29)** - [2 commits](https://github.com/mockito/mockito/compare/v2.17.2...v2.17.3) by [Rafael Winterhalter](http://github.com/raphw) (1), [Szczepan Faber](http://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.17.3-green.svg)](https://bintray.com/mockito/maven/mockito-development2.17.3)
+**2.17.3 (2018-03-29)** - [2 commits](https://github.com/mockito/mockito/compare/v2.17.2...v2.17.3) by [Rafael Winterhalter](https://github.com/raphw) (1), [Szczepan Faber](https://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.17.3-green.svg)](https://bintray.com/mockito/maven/mockito-development2.17.3)
  - Update Byte Buddy and ASM for bug fix releases [(#1351)](https://github.com/mockito/mockito/pull/1351)
 
-**2.17.2 (2018-03-26)** - [3 commits](https://github.com/mockito/mockito/compare/v2.17.1...v2.17.2) by [Erhard Pointl](https://github.com/epeee) (1), [Serge Bishyr](https://github.com/SeriyBg) (1), [Tim van der Lippe](http://github.com/TimvdLippe) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.17.2-green.svg)](https://bintray.com/mockito/maven/mockito-development2.17.2)
+**2.17.2 (2018-03-26)** - [3 commits](https://github.com/mockito/mockito/compare/v2.17.1...v2.17.2) by [Erhard Pointl](https://github.com/epeee) (1), [Serge Bishyr](https://github.com/SeriyBg) (1), [Tim van der Lippe](https://github.com/TimvdLippe) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.17.2-green.svg)](https://bintray.com/mockito/maven/mockito-development2.17.2)
  - [Bugfixes] Different mocks are used for @Mock and @InjectMock in the same test class with JUnit 5 extension [(#1346)](https://github.com/mockito/mockito/issues/1346)
  - Fix #1346 - Different mocks are used for @Mock and @InjectMock in the same test class with JUnit 5 extension [(#1349)](https://github.com/mockito/mockito/pull/1349)
  - Update shipkit to v2.0.12 [(#1347)](https://github.com/mockito/mockito/pull/1347)
@@ -933,68 +933,68 @@ __Deprecated__ because auxiliary artifacts were published with wrong identifiers
  - Fixes #1314 : Include all the invocation in mock verification error message [(#1319)](https://github.com/mockito/mockito/pull/1319)
  - Undesired invocation message improvements [(#1314)](https://github.com/mockito/mockito/issues/1314)
 
-**2.17.0 (2018-03-24)** - [1 commit](https://github.com/mockito/mockito/compare/v2.16.3...v2.17.0) by [Tim van der Lippe](http://github.com/TimvdLippe) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.17.0-green.svg)](https://bintray.com/mockito/maven/mockito2.17.0)
+**2.17.0 (2018-03-24)** - [1 commit](https://github.com/mockito/mockito/compare/v2.16.3...v2.17.0) by [Tim van der Lippe](https://github.com/TimvdLippe) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.17.0-green.svg)](https://bintray.com/mockito/maven/mockito2.17.0)
  - No pull requests referenced in commit messages.
 
 **2.16.3 (2018-03-24)** - [1 commit](https://github.com/mockito/mockito/compare/v2.16.2...v2.16.3) by [Christian Schwarz](https://github.com/ChristianSchwarz) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.16.3-green.svg)](https://bintray.com/mockito/maven/mockito-development2.16.3)
  - MockitoExtension for JUnit5  [(#1221)](https://github.com/mockito/mockito/pull/1221)
 
-**2.16.2 (2018-03-23)** - [5 commits](https://github.com/mockito/mockito/compare/v2.16.1...v2.16.2) by [Pascal Schumacher](https://github.com/PascalSchumacher) (3), [Rafael Winterhalter](http://github.com/raphw) (2) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.16.2-green.svg)](https://bintray.com/mockito/maven/mockito-development2.16.2)
+**2.16.2 (2018-03-23)** - [5 commits](https://github.com/mockito/mockito/compare/v2.16.1...v2.16.2) by [Pascal Schumacher](https://github.com/PascalSchumacher) (3), [Rafael Winterhalter](https://github.com/raphw) (2) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.16.2-green.svg)](https://bintray.com/mockito/maven/mockito-development2.16.2)
  - Update to AssertJ 2.9.0 [(#1342)](https://github.com/mockito/mockito/pull/1342)
  - Update to ASM 6.1 [(#1341)](https://github.com/mockito/mockito/pull/1341)
  - Update to Byte Buddy 1.8.0 [(#1340)](https://github.com/mockito/mockito/pull/1340)
 
-**2.16.1 (2018-03-15)** - [3 commits](https://github.com/mockito/mockito/compare/v2.16.0...v2.16.1) by [Szczepan Faber](http://github.com/mockitoguy) (2), [Rafael Winterhalter](http://github.com/raphw) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.16.1-green.svg)](https://bintray.com/mockito/maven/mockito-development2.16.1)
+**2.16.1 (2018-03-15)** - [3 commits](https://github.com/mockito/mockito/compare/v2.16.0...v2.16.1) by [Szczepan Faber](https://github.com/mockitoguy) (2), [Rafael Winterhalter](https://github.com/raphw) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.16.1-green.svg)](https://bintray.com/mockito/maven/mockito-development2.16.1)
  - Prevent class loading race condition [(#1258)](https://github.com/mockito/mockito/pull/1258)
  - Deadlock after upgrading to Mockito 2 and parallel tests execution [(#1067)](https://github.com/mockito/mockito/issues/1067)
 
-**2.16.0 (2018-03-13)** - [14 commits](https://github.com/mockito/mockito/compare/v2.15.6...v2.16.0) by [Szczepan Faber](http://github.com/mockitoguy) (13), [Philip P. Moltmann](https://github.com/moltmann) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.16.0-green.svg)](https://bintray.com/mockito/maven/mockito2.16.0)
+**2.16.0 (2018-03-13)** - [14 commits](https://github.com/mockito/mockito/compare/v2.15.6...v2.16.0) by [Szczepan Faber](https://github.com/mockitoguy) (13), [Philip P. Moltmann](https://github.com/moltmann) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.16.0-green.svg)](https://bintray.com/mockito/maven/mockito2.16.0)
  - Prevent memory leaks with inline MockMakers by using weak refs to mocks [(#1321)](https://github.com/mockito/mockito/pull/1321)
  - InlineByteBuddyMockMaker does not clean up stale mocks [(#1313)](https://github.com/mockito/mockito/issues/1313)
 
-**2.15.6 (2018-03-05)** - [2 commits](https://github.com/mockito/mockito/compare/v2.15.5...v2.15.6) by [Philip P. Moltmann](https://github.com/moltmann) (1), [Szczepan Faber](http://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.15.6-green.svg)](https://bintray.com/mockito/maven/mockito-development2.15.6)
+**2.15.6 (2018-03-05)** - [2 commits](https://github.com/mockito/mockito/compare/v2.15.5...v2.15.6) by [Philip P. Moltmann](https://github.com/moltmann) (1), [Szczepan Faber](https://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.15.6-green.svg)](https://bintray.com/mockito/maven/mockito-development2.15.6)
  - Avoid bytebuddy import Issue to enable repackaging without bytebuddy [(#1320)](https://github.com/mockito/mockito/pull/1320)
 
 **2.15.5 (2018-03-02)** - [1 commit](https://github.com/mockito/mockito/compare/v2.15.4...v2.15.5) by [Sanne Grinovero](https://github.com/Sanne) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.15.5-green.svg)](https://bintray.com/mockito/maven/mockito-development2.15.5)
  - Fixes #1326 : Reduce the allocation rate for the typical use of Locat… [(#1327)](https://github.com/mockito/mockito/pull/1327)
  - Reduce memory consumption of the typical LocationImpl [(#1326)](https://github.com/mockito/mockito/issues/1326)
 
-**2.15.4 (2018-02-19)** - [26 commits](https://github.com/mockito/mockito/compare/v2.15.3...v2.15.4) by [Szczepan Faber](http://github.com/mockitoguy) (20), [Philip P. Moltmann](https://github.com/moltmann) (5), [Tim van der Lippe](http://github.com/TimvdLippe) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.15.4-green.svg)](https://bintray.com/mockito/maven/mockito-development2.15.4)
+**2.15.4 (2018-02-19)** - [26 commits](https://github.com/mockito/mockito/compare/v2.15.3...v2.15.4) by [Szczepan Faber](https://github.com/mockitoguy) (20), [Philip P. Moltmann](https://github.com/moltmann) (5), [Tim van der Lippe](https://github.com/TimvdLippe) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.15.4-green.svg)](https://bintray.com/mockito/maven/mockito-development2.15.4)
  - Update Kotlin version to be compatible with the IntelliJ runtime version [(#1315)](https://github.com/mockito/mockito/pull/1315)
  - Make  org.mockito.internal.creation.instance.Instantiator a public API [(#1303)](https://github.com/mockito/mockito/issues/1303)
 
-**2.15.3 (2018-02-15)** - [4 commits](https://github.com/mockito/mockito/compare/v2.15.2...v2.15.3) by [Szczepan Faber](http://github.com/mockitoguy) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.15.3-green.svg)](https://bintray.com/mockito/maven/mockito-development2.15.3)
+**2.15.3 (2018-02-15)** - [4 commits](https://github.com/mockito/mockito/compare/v2.15.2...v2.15.3) by [Szczepan Faber](https://github.com/mockitoguy) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.15.3-green.svg)](https://bintray.com/mockito/maven/mockito-development2.15.3)
  - Clean up, removed dead code, rename job, documentation tidy up [(#1290)](https://github.com/mockito/mockito/pull/1290)
 
-**2.15.2 (2018-02-13)** - [2 commits](https://github.com/mockito/mockito/compare/v2.15.1...v2.15.2) by [Alberto Scotto](https://github.com/alb-i986) (1), [Szczepan Faber](http://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.15.2-green.svg)](https://bintray.com/mockito/maven/mockito-development2.15.2)
+**2.15.2 (2018-02-13)** - [2 commits](https://github.com/mockito/mockito/compare/v2.15.1...v2.15.2) by [Alberto Scotto](https://github.com/alb-i986) (1), [Szczepan Faber](https://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.15.2-green.svg)](https://bintray.com/mockito/maven/mockito-development2.15.2)
  - Javadoc: Improve discoverability of #ignoreStubs [(#1294)](https://github.com/mockito/mockito/pull/1294)
 
-**2.15.1 (2018-02-12)** - [8 commits](https://github.com/mockito/mockito/compare/v2.15.0...v2.15.1) by [Szczepan Faber](http://github.com/mockitoguy) (5), r-smirnov (3) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.15.1-green.svg)](https://bintray.com/mockito/maven/mockito-development2.15.1)
+**2.15.1 (2018-02-12)** - [8 commits](https://github.com/mockito/mockito/compare/v2.15.0...v2.15.1) by [Szczepan Faber](https://github.com/mockitoguy) (5), r-smirnov (3) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.15.1-green.svg)](https://bintray.com/mockito/maven/mockito-development2.15.1)
  - [Bugfixes] Ensure isolation of stubbings [(#1310)](https://github.com/mockito/mockito/pull/1310)
  - Cannot override stubbed method that calls a stubbed method [(#1279)](https://github.com/mockito/mockito/issues/1279)
 
-# 2.15.0 (2018-02-10) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.15.0)/[Maven Central](http://search.maven.org/#artifactdetails%7Corg.mockito%7Cmockito-core%7C2.15.0%7Cjar)
+# 2.15.0 (2018-02-10) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.15.0)/[Maven Central](https://search.maven.org/artifact/org.mockito/mockito-core/2.15.0/jar)
 
 Notable changes:
  - new APIs to ```MockitoSession``` feature that can be used by framework integrations such as JUnit Jupiter.
  - ```InvocationFactory``` API improvements driven by integrations with Android.
  - Javadoc updates.
 
-**2.15.0 (2018-02-10)** - [16 commits](https://github.com/mockito/mockito/compare/v2.14.0...v2.15.0) by [Marc Philipp](https://github.com/marcphilipp) (10), [Szczepan Faber](http://github.com/mockitoguy) (6) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.15.0-green.svg)](https://bintray.com/mockito/maven/mockito2.15.0)
+**2.15.0 (2018-02-10)** - [16 commits](https://github.com/mockito/mockito/compare/v2.14.0...v2.15.0) by [Marc Philipp](https://github.com/marcphilipp) (10), [Szczepan Faber](https://github.com/mockitoguy) (6) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.15.0-green.svg)](https://bintray.com/mockito/maven/mockito2.15.0)
  - Extend MockitoSession(Builder) API to enable usage by testing frameworks [(#1301)](https://github.com/mockito/mockito/pull/1301)
  - [JUnit Jupiter] MockitoSession#initMocks should support multiple test instances   [(#1232)](https://github.com/mockito/mockito/issues/1232)
  - Design MockitoSession API improvements for unit test frameworks [(#898)](https://github.com/mockito/mockito/issues/898)
 
 **2.14.0 (2018-02-09)** - [12 commits](https://github.com/mockito/mockito/compare/v2.13.3...v2.14.0) by 4 authors - published to [![Bintray](https://img.shields.io/badge/Bintray-2.14.0-green.svg)](https://bintray.com/mockito/maven/mockito-development2.14.0)
- - Commits: [Szczepan Faber](http://github.com/mockitoguy) (9), [Arend v. Reinersdorff](https://github.com/arend-von-reinersdorff) (1), Philip P. Moltmann (1), [Tim van der Lippe](http://github.com/TimvdLippe) (1)
+ - Commits: [Szczepan Faber](https://github.com/mockitoguy) (9), [Arend v. Reinersdorff](https://github.com/arend-von-reinersdorff) (1), Philip P. Moltmann (1), [Tim van der Lippe](https://github.com/TimvdLippe) (1)
  - Update public API of InvocationFactory needed for Android static mocking [(#1307)](https://github.com/mockito/mockito/pull/1307)
  - InvocationFactory.createInvocation's realmethod cannot throw a Throwable [(#1306)](https://github.com/mockito/mockito/issues/1306)
  - Fix link of Maven Central badge [(#1299)](https://github.com/mockito/mockito/pull/1299)
 
-**2.13.3 (2018-01-16)** - [3 commits](https://github.com/mockito/mockito/compare/v2.13.2...v2.13.3) by [Szczepan Faber](http://github.com/mockitoguy) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.13.3-green.svg)](https://bintray.com/mockito/maven/mockito-development2.13.3)
+**2.13.3 (2018-01-16)** - [3 commits](https://github.com/mockito/mockito/compare/v2.13.2...v2.13.3) by [Szczepan Faber](https://github.com/mockitoguy) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.13.3-green.svg)](https://bintray.com/mockito/maven/mockito-development2.13.3)
  - Extra test case, javadoc update [(#1282)](https://github.com/mockito/mockito/pull/1282)
 
-**2.13.2 (2018-01-16)** - [2 commits](https://github.com/mockito/mockito/compare/v2.13.1...v2.13.2) by [Serge Bishyr](https://github.com/SeriyBg) (1), [Szczepan Faber](http://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.13.2-green.svg)](https://bintray.com/mockito/maven/mockito-development2.13.2)
+**2.13.2 (2018-01-16)** - [2 commits](https://github.com/mockito/mockito/compare/v2.13.1...v2.13.2) by [Serge Bishyr](https://github.com/SeriyBg) (1), [Szczepan Faber](https://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.13.2-green.svg)](https://bintray.com/mockito/maven/mockito-development2.13.2)
  - [Documentation] Improve documentation about partial mocks and doReturn() style of stubbing [(#1262)](https://github.com/mockito/mockito/issues/1262)
  - Fixes #1262: update doc for Answers.CALLS_REAL_METHODS [(#1268)](https://github.com/mockito/mockito/pull/1268)
 
@@ -1002,46 +1002,46 @@ Notable changes:
  - [Documentation] Documentation update - MockitoJUnit.strictness(STRICT_STUBS) does not do verifyNoMoreInteractions [(#1086)](https://github.com/mockito/mockito/issues/1086)
  - Update STRICT_STUBS documentation for verifyNoMoreInteractions [(#1280)](https://github.com/mockito/mockito/pull/1280)
 
-# 2.13.0 (2017-12-06) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.13.0)/[Maven Central](http://search.maven.org/#artifactdetails%7Corg.mockito%7Cmockito-core%7C2.13.0%7Cjar)
+# 2.13.0 (2017-12-06) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.13.0)/[Maven Central](https://search.maven.org/artifact/org.mockito/mockito-core/2.13.0/jar)
 
- - [1 commit](https://github.com/mockito/mockito/compare/v2.12.2...v2.13.0) by [Tim van der Lippe](http://github.com/TimvdLippe)
+ - [1 commit](https://github.com/mockito/mockito/compare/v2.12.2...v2.13.0) by [Tim van der Lippe](https://github.com/TimvdLippe)
  - No pull requests referenced in commit messages.
 
-**2.12.2 (2017-11-28)** - [2 commits](https://github.com/mockito/mockito/compare/v2.12.1...v2.12.2) by [Rafael Winterhalter](http://github.com/raphw) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.12.2-green.svg)](https://bintray.com/mockito/maven/mockito-development2.12.2)
+**2.12.2 (2017-11-28)** - [2 commits](https://github.com/mockito/mockito/compare/v2.12.1...v2.12.2) by [Rafael Winterhalter](https://github.com/raphw) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.12.2-green.svg)](https://bintray.com/mockito/maven/mockito-development2.12.2)
  - [Bugfixes] Wanted but not invoked on 2.12.0, but not on 2.11.0 [(#1254)](https://github.com/mockito/mockito/issues/1254)
  - Fixes #1254 and #1256: improved check for self-invocation. [(#1257)](https://github.com/mockito/mockito/pull/1257)
  - Unbounded recursion when spying with `mockito-inline` [(#1256)](https://github.com/mockito/mockito/issues/1256)
 
-**2.12.1 (2017-11-28)** - [6 commits](https://github.com/mockito/mockito/compare/v2.12.0...v2.12.1) by epeee (3), [Tim van der Lippe](http://github.com/TimvdLippe) (2), [Szczepan Faber](http://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.12.1-green.svg)](https://bintray.com/mockito/maven/mockito-development2.12.1)
+**2.12.1 (2017-11-28)** - [6 commits](https://github.com/mockito/mockito/compare/v2.12.0...v2.12.1) by epeee (3), [Tim van der Lippe](https://github.com/TimvdLippe) (2), [Szczepan Faber](https://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.12.1-green.svg)](https://bintray.com/mockito/maven/mockito-development2.12.1)
  - Update shipkit and configure assertReleaseNeeded task [(#1265)](https://github.com/mockito/mockito/pull/1265)
  - Update Kotlin to latest version [(#1263)](https://github.com/mockito/mockito/pull/1263)
  - Remove several container classes and inline code [(#1247)](https://github.com/mockito/mockito/pull/1247)
 
-# 2.12.0 (2017-11-07) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.12.0)/[Maven Central](http://search.maven.org/#artifactdetails%7Corg.mockito%7Cmockito-core%7C2.12.0%7Cjar)
+# 2.12.0 (2017-11-07) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.12.0)/[Maven Central](https://search.maven.org/artifact/org.mockito/mockito-core/2.12.0/jar)
 
- - [4 commits](https://github.com/mockito/mockito/compare/v2.11.7...v2.12.0) by [Rafael Winterhalter](http://github.com/raphw) (2), [Tim van der Lippe](http://github.com/TimvdLippe) (2)
+ - [4 commits](https://github.com/mockito/mockito/compare/v2.11.7...v2.12.0) by [Rafael Winterhalter](https://github.com/raphw) (2), [Tim van der Lippe](https://github.com/TimvdLippe) (2)
  - No pull requests referenced in commit messages.
 
-**2.11.7 (2017-11-06)** - [2 commits](https://github.com/mockito/mockito/compare/v2.11.6...v2.11.7) by [Rafael Winterhalter](http://github.com/raphw) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.7-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.11.7)
+**2.11.7 (2017-11-06)** - [2 commits](https://github.com/mockito/mockito/compare/v2.11.6...v2.11.7) by [Rafael Winterhalter](https://github.com/raphw) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.7-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.11.7)
  - [Bugfixes] Provide Java 10 compatibility [(#1243)](https://github.com/mockito/mockito/issues/1243)
  - Fixes #1243: Support for new version number 10. [(#1250)](https://github.com/mockito/mockito/pull/1250)
 
-**2.11.6 (2017-11-05)** - [3 commits](https://github.com/mockito/mockito/compare/v2.11.5...v2.11.6) by [Tim van der Lippe](http://github.com/TimvdLippe) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.6-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.11.6)
+**2.11.6 (2017-11-05)** - [3 commits](https://github.com/mockito/mockito/compare/v2.11.5...v2.11.6) by [Tim van der Lippe](https://github.com/TimvdLippe) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.6-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.11.6)
  - [Enhancements] Enable jacoco coverage on subprojects [(#1229)](https://github.com/mockito/mockito/pull/1229)
  - Remove service-worker from Javadoc generation [(#1244)](https://github.com/mockito/mockito/pull/1244)
  - Enable Checkstyle for checking license headers [(#1242)](https://github.com/mockito/mockito/pull/1242)
 
-**2.11.5 (2017-10-31)** - [4 commits](https://github.com/mockito/mockito/compare/v2.11.4...v2.11.5) by [Tim van der Lippe](http://github.com/TimvdLippe) (3), [Szczepan Faber](http://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.5-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.11.5)
+**2.11.5 (2017-10-31)** - [4 commits](https://github.com/mockito/mockito/compare/v2.11.4...v2.11.5) by [Tim van der Lippe](https://github.com/TimvdLippe) (3), [Szczepan Faber](https://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.5-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.11.5)
  - Add @CheckReturnValue to stubbing/verification methods [(#1228)](https://github.com/mockito/mockito/pull/1228)
  - Add regression test for issue #1174 [(#1219)](https://github.com/mockito/mockito/pull/1219)
 
-**2.11.4 (2017-10-29)** - [2 commits](https://github.com/mockito/mockito/compare/v2.11.3...v2.11.4) by [Szczepan Faber](http://github.com/mockitoguy) (1), [Tim van der Lippe](http://github.com/TimvdLippe) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.4-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.11.4)
+**2.11.4 (2017-10-29)** - [2 commits](https://github.com/mockito/mockito/compare/v2.11.3...v2.11.4) by [Szczepan Faber](https://github.com/mockitoguy) (1), [Tim van der Lippe](https://github.com/TimvdLippe) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.4-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.11.4)
  - Update license plugin and add missing license headers [(#1227)](https://github.com/mockito/mockito/pull/1227)
 
 **2.11.3 (2017-10-28)** - [1 commit](https://github.com/mockito/mockito/compare/v2.11.2...v2.11.3) by [Allon Murienik](https://github.com/mureinik) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.3-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.11.3)
  - InvocationsPrinter string concatination [(#1231)](https://github.com/mockito/mockito/pull/1231)
 
-**2.11.2 (2017-10-22)** - [7 commits](https://github.com/mockito/mockito/compare/v2.11.1...v2.11.2) by [Rafael Winterhalter](http://github.com/raphw) (6), [Allon Murienik](https://github.com/mureinik) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.2-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.11.2)
+**2.11.2 (2017-10-22)** - [7 commits](https://github.com/mockito/mockito/compare/v2.11.1...v2.11.2) by [Rafael Winterhalter](https://github.com/raphw) (6), [Allon Murienik](https://github.com/mureinik) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.2-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.11.2)
  - Updated Byte Buddy and ASM dependencies. Fixes #1215. [(#1218)](https://github.com/mockito/mockito/pull/1218)
  - Fixes #1183: Make override check more forgiving to accomondate Kotlin compile patterns. [(#1217)](https://github.com/mockito/mockito/pull/1217)
  - Adresses #1206: allow opting out from annotation copying within mocks. [(#1216)](https://github.com/mockito/mockito/pull/1216)
@@ -1050,22 +1050,22 @@ Notable changes:
  - Mockito should not copy annotations in all cases [(#1206)](https://github.com/mockito/mockito/issues/1206)
  - UnfinishedVerificationException with Kotlin after updating to 2.9.0 [(#1183)](https://github.com/mockito/mockito/issues/1183)
 
-**2.11.1 (2017-10-20)** - [4 commits](https://github.com/mockito/mockito/compare/v2.11.0...v2.11.1) by [Szczepan Faber](http://github.com/mockitoguy) (2), [Allon Murienik](https://github.com/mureinik) (1), [rberghegger](https://github.com/rberghegger) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.1-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.11.1)
+**2.11.1 (2017-10-20)** - [4 commits](https://github.com/mockito/mockito/compare/v2.11.0...v2.11.1) by [Szczepan Faber](https://github.com/mockitoguy) (2), [Allon Murienik](https://github.com/mureinik) (1), [rberghegger](https://github.com/rberghegger) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.1-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.11.1)
  - Fixes #1211: Improve @deprecated JavaDoc [(#1214)](https://github.com/mockito/mockito/pull/1214)
  - improve @deprecated JavaDoc of MockitoDebugger [(#1211)](https://github.com/mockito/mockito/issues/1211)
  - Clean up JUnit imports [(#1209)](https://github.com/mockito/mockito/pull/1209)
  - Updated my GitHub user name [(#1208)](https://github.com/mockito/mockito/pull/1208)
 
-# 2.11.0 (2017-10-14) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.11.0)/[Maven Central](http://search.maven.org/#artifactdetails%7Corg.mockito%7Cmockito-core%7C2.11.0%7Cjar)
+# 2.11.0 (2017-10-14) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.11.0)/[Maven Central](https://search.maven.org/artifact/org.mockito/mockito-core/2.11.0/jar)
 
 New public API for Spring Boot integration will improve compatibility of Mockito and reduce version conflict problems. We carefully grow our public API for framework integrations. This time we added new "Verification Started Listener", needed to resolve [double proxy use case](https://github.com/mockito/mockito/issues/1191). Using this API, Spring Boot framework no longer needs to depend on internal Mockito API.
 
 We also added `Automatic-Module-Name` to mockito jar, useful in Java9 context [(#1189)](https://github.com/mockito/mockito/issues/1189).
 
-**2.11.0 (2017-10-14)** - [20 commits](https://github.com/mockito/mockito/compare/v2.10.5...v2.11.0) by [Szczepan Faber](http://github.com/szczepiq) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.0-green.svg)](https://bintray.com/mockito/maven/mockito/2.11.0)
+**2.11.0 (2017-10-14)** - [20 commits](https://github.com/mockito/mockito/compare/v2.10.5...v2.11.0) by [Szczepan Faber](https://github.com/szczepiq) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.0-green.svg)](https://bintray.com/mockito/maven/mockito/2.11.0)
  - Added new public API for spring-boot use case [(#1192)](https://github.com/mockito/mockito/pull/1192)
 
-**2.10.5 (2017-10-14)** - [12 commits](https://github.com/mockito/mockito/compare/v2.10.4...v2.10.5) by [Marcin Zajączkowski](https://github.com/szpak) (8), [Szczepan Faber](http://github.com/mockitoguy) (3), [Allon Murienik](https://github.com/mureinik) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.10.5-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.10.5)
+**2.10.5 (2017-10-14)** - [12 commits](https://github.com/mockito/mockito/compare/v2.10.4...v2.10.5) by [Marcin Zajączkowski](https://github.com/szpak) (8), [Szczepan Faber](https://github.com/mockitoguy) (3), [Allon Murienik](https://github.com/mureinik) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.10.5-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.10.5)
  - [Java 9 support] JDK9: set a stable module name with `Automatic-Module-Name` entry in MANIFEST [(#1189)](https://github.com/mockito/mockito/issues/1189)
  - Fixed documentation issue, added unit tests [(#1203)](https://github.com/mockito/mockito/pull/1203)
  - [#1202] Java 9 CI build for Mockito 2.x [(#1202)](https://github.com/mockito/mockito/pull/1202)
@@ -1086,68 +1086,68 @@ We also added `Automatic-Module-Name` to mockito jar, useful in Java9 context [(
 **2.10.1 (2017-10-04)** - [1 commit](https://github.com/mockito/mockito/compare/v2.10.0...v2.10.1) by [Dennis Cheung](https://github.com/hkdennis2k) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.10.1-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.10.1)
  - Enable stubOnly() on @Mock annotation [(#1146)](https://github.com/mockito/mockito/pull/1146)
 
-# 2.10.0 (2017-09-08) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.10.0)/[Maven Central](http://search.maven.org/#artifactdetails%7Corg.mockito%7Cmockito-core%7C2.10.0%7Cjar)
+# 2.10.0 (2017-09-08) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.10.0)/[Maven Central](https://search.maven.org/artifact/org.mockito/mockito-core/2.10.0/jar)
 
 The main highlight of this release is the additions to the public API to accommodate advanced framework integrations. It will help other frameworks to cleanly integrate with Mockito. For more details, see [#1121](https://github.com/mockito/mockito/pull/1121).
 
-**2.10.0 (2017-09-08)** - [42 commits](https://github.com/mockito/mockito/compare/v2.9.2...v2.10.0) by [Szczepan Faber](http://github.com/mockitoguy) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.10.0-green.svg)](https://bintray.com/mockito/maven/mockito/2.10.0)
+**2.10.0 (2017-09-08)** - [42 commits](https://github.com/mockito/mockito/compare/v2.9.2...v2.10.0) by [Szczepan Faber](https://github.com/mockitoguy) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.10.0-green.svg)](https://bintray.com/mockito/maven/mockito/2.10.0)
  - Improve and develop APIs required for framework integrators [(#1121)](https://github.com/mockito/mockito/pull/1121)
 
-**2.9.2 (2017-09-05)** - [2 commits](https://github.com/mockito/mockito/compare/v2.9.1...v2.9.2) by [Rafael Winterhalter](http://github.com/raphw) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.9.2-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.9.2)
+**2.9.2 (2017-09-05)** - [2 commits](https://github.com/mockito/mockito/compare/v2.9.1...v2.9.2) by [Rafael Winterhalter](https://github.com/raphw) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.9.2-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.9.2)
  - Compare method of graph to defined form of method. [(#1186)](https://github.com/mockito/mockito/pull/1186)
 
-**2.9.1 (2017-09-04)** - [11 commits](https://github.com/mockito/mockito/compare/v2.9.0...v2.9.1) by [Rafael Winterhalter](http://github.com/raphw) (9), [Szczepan Faber](http://github.com/mockitoguy) (2) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.9.1-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.9.1)
+**2.9.1 (2017-09-04)** - [11 commits](https://github.com/mockito/mockito/compare/v2.9.0...v2.9.1) by [Rafael Winterhalter](https://github.com/raphw) (9), [Szczepan Faber](https://github.com/mockitoguy) (2) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.9.1-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.9.1)
  - Travis [(#1184)](https://github.com/mockito/mockito/pull/1184)
  - #1179: Fix performance regression caused by use of method graph compiler. [(#1181)](https://github.com/mockito/mockito/pull/1181)
  - Mockito 2.9.0 is significantly slower [(#1179)](https://github.com/mockito/mockito/issues/1179)
  - Adds support for Java 9 in inline mock maker by Byte Buddy update. [(#1158)](https://github.com/mockito/mockito/pull/1158)
 
-# 2.9.0 (2017-08-26) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.9.0)/[Maven Central](http://search.maven.org/#artifactdetails%7Corg.mockito%7Cmockito-core%7C2.9.0%7Cjar)
+# 2.9.0 (2017-08-26) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.9.0)/[Maven Central](https://search.maven.org/artifact/org.mockito/mockito-core/2.9.0/jar)
 
 Notable changes:
  - bumped ByteBuddy 1.6.14 -> 1.7.0 (inline mocking, bugfixes)
  - bumped Objenesis 2.5 -> 2.6 (Java9, bugfixes)
 
-**2.9.0 (2017-08-26)** - [5 commits](https://github.com/mockito/mockito/compare/v2.8.55...v2.9.0) by [Szczepan Faber](http://github.com/mockitoguy) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.9.0-green.svg)](https://bintray.com/mockito/maven/mockito/2.9.0)
+**2.9.0 (2017-08-26)** - [5 commits](https://github.com/mockito/mockito/compare/v2.8.55...v2.9.0) by [Szczepan Faber](https://github.com/mockitoguy) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.9.0-green.svg)](https://bintray.com/mockito/maven/mockito/2.9.0)
  - Updated README.md wrt maven central release [(#1172)](https://github.com/mockito/mockito/pull/1172)
  - Bumped minor version so signify new Objenesis version [(#1171)](https://github.com/mockito/mockito/pull/1171)
 
-**2.8.55 (2017-08-21)** - [7 commits](https://github.com/mockito/mockito/compare/v2.8.54...v2.8.55) by [Szczepan Faber](http://github.com/mockitoguy) (6), [Pascal Schumacher](https://github.com/PascalSchumacher) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.55-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.55)
+**2.8.55 (2017-08-21)** - [7 commits](https://github.com/mockito/mockito/compare/v2.8.54...v2.8.55) by [Szczepan Faber](https://github.com/mockitoguy) (6), [Pascal Schumacher](https://github.com/PascalSchumacher) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.55-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.55)
  - Update objenesis version 2.5 -> 2.6 (Java9, bugfixes) [(#1170)](https://github.com/mockito/mockito/pull/1170)
  - Updated to latest Shipkit, tidied up configuration [(#1169)](https://github.com/mockito/mockito/pull/1169)
 
-**2.8.54 (2017-08-09)** - [5 commits](https://github.com/mockito/mockito/compare/v2.8.53...v2.8.54) by [Marcin Zajączkowski](https://github.com/szpak) (3), [Igor C. A. de Lima](https://github.com/igorcadelima) (1), [Szczepan Faber](http://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.54-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.54)
+**2.8.54 (2017-08-09)** - [5 commits](https://github.com/mockito/mockito/compare/v2.8.53...v2.8.54) by [Marcin Zajączkowski](https://github.com/szpak) (3), [Igor C. A. de Lima](https://github.com/igorcadelima) (1), [Szczepan Faber](https://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.54-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.54)
  - [Bugfixes] Unnecessary release was triggered [(#1144)](https://github.com/mockito/mockito/issues/1144)
  - Remove duplicated word in Javadoc [(#1161)](https://github.com/mockito/mockito/pull/1161)
  - [#1147] Provide version in release commit message [(#1147)](https://github.com/mockito/mockito/pull/1147)
  - Bumped shipkit to fix unnecessary releasing problem [(#1145)](https://github.com/mockito/mockito/pull/1145)
 
-**2.8.53 (2017-07-06)** - [6 commits](https://github.com/mockito/mockito/compare/v2.8.52...v2.8.53) by [Szczepan Faber](http://github.com/mockitoguy) (5), [Wojtek Wilk](https://github.com/wwilk) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.53-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.53)
+**2.8.53 (2017-07-06)** - [6 commits](https://github.com/mockito/mockito/compare/v2.8.52...v2.8.53) by [Szczepan Faber](https://github.com/mockitoguy) (5), [Wojtek Wilk](https://github.com/wwilk) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.53-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.53)
  - Bumped shipkit, simplified Travis file, removed unnecessary code [(#1141)](https://github.com/mockito/mockito/pull/1141)
  - org.shipkit.publications-comparator plugin applied [(#1139)](https://github.com/mockito/mockito/pull/1139)
 
-**2.8.52 (2017-06-24)** - [8 commits](https://github.com/mockito/mockito/compare/v2.8.51...v2.8.52) by [Szczepan Faber](http://github.com/mockitoguy) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.52-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.52)
+**2.8.52 (2017-06-24)** - [8 commits](https://github.com/mockito/mockito/compare/v2.8.51...v2.8.52) by [Szczepan Faber](https://github.com/mockitoguy) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.52-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.52)
  - Simplified and documented .travis.yml file [(#1133)](https://github.com/mockito/mockito/pull/1133)
 
 **2.8.51 (2017-06-24)** - [1 commit](https://github.com/mockito/mockito/compare/v2.8.50...v2.8.51) by [Allon Murienik](https://github.com/mureinik) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.51-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.51)
  - Don't use raw rypes in UnusedStubbingsTest [(#1137)](https://github.com/mockito/mockito/pull/1137)
 
-**2.8.50 (2017-06-24)** - [1 commit](https://github.com/mockito/mockito/compare/v2.8.49...v2.8.50) by [Rafael Winterhalter](http://github.com/raphw) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.50-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.50)
+**2.8.50 (2017-06-24)** - [1 commit](https://github.com/mockito/mockito/compare/v2.8.49...v2.8.50) by [Rafael Winterhalter](https://github.com/raphw) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.50-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.50)
  - Fixes #1135: Properly resolve visibility bridges. [(#1136)](https://github.com/mockito/mockito/pull/1136)
  - [mock-maker-inline] Method calls on mock forwarded to real instance [(#1135)](https://github.com/mockito/mockito/issues/1135)
 
-**2.8.49 (2017-06-22)** - [2 commits](https://github.com/mockito/mockito/compare/v2.8.48...v2.8.49) by [Rafael Winterhalter](http://github.com/raphw) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.49-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.49)
+**2.8.49 (2017-06-22)** - [2 commits](https://github.com/mockito/mockito/compare/v2.8.48...v2.8.49) by [Rafael Winterhalter](https://github.com/raphw) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.49-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.49)
  - Improve detection on non-mockable types - ByteBuddy bump 1.6.14->1.7.0 [(#1128)](https://github.com/mockito/mockito/pull/1128)
 
-**2.8.48 (2017-06-18)** - [2 commits](https://github.com/mockito/mockito/compare/v2.8.47...v2.8.48) by epeee (1), [Szczepan Faber](http://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.48-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.48)
+**2.8.48 (2017-06-18)** - [2 commits](https://github.com/mockito/mockito/compare/v2.8.47...v2.8.48) by epeee (1), [Szczepan Faber](https://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.48-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.48)
  - make use of shipkit v0.8.92 [(#1132)](https://github.com/mockito/mockito/pull/1132)
 
-# 2.8.47 (2017-06-15) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.8.47)/[Maven Central](http://search.maven.org/#artifactdetails%7Corg.mockito%7Cmockito-core%7C2.8.47%7Cjar)
+# 2.8.47 (2017-06-15) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.8.47)/[Maven Central](https://search.maven.org/artifact/org.mockito/mockito-core/2.8.47/jar)
 
 **2.8.47 (2017-06-15)** - [1 commit](https://github.com/mockito/mockito/compare/v2.8.46...v2.8.47) by [Marcin Zajączkowski](https://github.com/szpak) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.47-green.svg)](https://bintray.com/mockito/maven/mockito/2.8.47)
  - No pull requests referenced in commit messages.
 
-**2.8.46 (2017-06-15)** - [2 commits](https://github.com/mockito/mockito/compare/v2.8.45...v2.8.46) by [Szczepan Faber](http://github.com/mockitoguy) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.46-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.46)
+**2.8.46 (2017-06-15)** - [2 commits](https://github.com/mockito/mockito/compare/v2.8.45...v2.8.46) by [Szczepan Faber](https://github.com/mockitoguy) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.46-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.46)
  - Fixed issue with releases to Maven Central [(#1129)](https://github.com/mockito/mockito/pull/1129)
  - Version not released to Maven Central [(#1127)](https://github.com/mockito/mockito/issues/1127)
 
@@ -1157,55 +1157,55 @@ Notable changes:
 **2.8.44 (2017-06-12)** - [3 commits](https://github.com/mockito/mockito/compare/v2.8.43...v2.8.44) by [Marcin Zajaczkowski](https://github.com/szpak) (1), [Marcin Zajączkowski](https://github.com/szpak) (1), [Myrle Krantz](https://github.com/myrle-krantz) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.44-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.44)
  - [New features] Answer with delay in mock or spy to improve testing of asynchronous code [(#1117)](https://github.com/mockito/mockito/issues/1117)
 
-**2.8.43 (2017-06-10)** - [2 commits](https://github.com/mockito/mockito/compare/v2.8.42...v2.8.43) by [Szczepan Faber](http://github.com/mockitoguy) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.43-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.43)
+**2.8.43 (2017-06-10)** - [2 commits](https://github.com/mockito/mockito/compare/v2.8.42...v2.8.43) by [Szczepan Faber](https://github.com/mockitoguy) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.43-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.43)
  - No pull requests referenced in commit messages.
 
-**2.8.42 (2017-06-10)** - [3 commits](https://github.com/mockito/mockito/compare/v2.8.41...v2.8.42) by epeee (2), [Szczepan Faber](http://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.42-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.42)
+**2.8.42 (2017-06-10)** - [3 commits](https://github.com/mockito/mockito/compare/v2.8.41...v2.8.42) by epeee (2), [Szczepan Faber](https://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.42-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.42)
  - update to shipkit v0.8.72 [(#1115)](https://github.com/mockito/mockito/pull/1115)
 
 **2.8.41** - [1 commit](https://github.com/mockito/mockito/compare/v2.8.40...v2.8.41) by [Allon Murienik](https://github.com/mureinik) - *2017-06-10* - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.41-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.41)
  - ArgsMismatchFinder#getStubbingArgMismatches generics [(#1118)](https://github.com/mockito/mockito/pull/1118)
 
-**2.8.40** - [4 commits](https://github.com/mockito/mockito/compare/v2.8.39...v2.8.40) by [Szczepan Faber](http://github.com/mockitoguy) (2), [Alex Simkin](https://github.com/SimY4) (1), mkuster (1) - *2017-06-05* - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.40-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.40)
+**2.8.40** - [4 commits](https://github.com/mockito/mockito/compare/v2.8.39...v2.8.40) by [Szczepan Faber](https://github.com/mockitoguy) (2), [Alex Simkin](https://github.com/SimY4) (1), mkuster (1) - *2017-06-05* - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.40-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.40)
  - [Bugfixes] Fixed Travis configuration for matrix build [(#1109)](https://github.com/mockito/mockito/pull/1109)
  - Renamed configuration extension 'releasing' into 'shipkit' [(#1104)](https://github.com/mockito/mockito/pull/1104)
  - Made CaturingMatcher threadsafe [(#986)](https://github.com/mockito/mockito/pull/986)
 
-**2.8.39** - [1 commit](https://github.com/mockito/mockito/compare/v2.8.38...v2.8.39) by [Szczepan Faber](http://github.com/mockitoguy) - *2017-05-30* - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.39-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.39)
+**2.8.39** - [1 commit](https://github.com/mockito/mockito/compare/v2.8.38...v2.8.39) by [Szczepan Faber](https://github.com/mockitoguy) - *2017-05-30* - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.39-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.39)
  - Fixed contributor links and bintray badge in release notes [(#1103)](https://github.com/mockito/mockito/pull/1103)
 
-**2.8.38** - [1 commit](https://github.com/mockito/mockito/compare/v2.8.37...v2.8.38) by [Szczepan Faber](http://github.com/mockitoguy) - *2017-05-30* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development)
+**2.8.38** - [1 commit](https://github.com/mockito/mockito/compare/v2.8.37...v2.8.38) by [Szczepan Faber](https://github.com/mockitoguy) - *2017-05-30* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development)
  - [Documentation] Fixed broken link in Javadoc, improved console message [(#1100)](https://github.com/mockito/mockito/pull/1100)
 
-**2.8.37** - [4 commits](https://github.com/mockito/mockito/compare/v2.8.36...v2.8.37) by [epeee](https://github.com/epeee), [Szczepan Faber](http://github.com/mockitoguy) - *2017-05-28* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development)
+**2.8.37** - [4 commits](https://github.com/mockito/mockito/compare/v2.8.36...v2.8.37) by [epeee](https://github.com/epeee), [Szczepan Faber](https://github.com/mockitoguy) - *2017-05-28* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development)
  - update gradle to v3.5 [(#1099)](https://github.com/mockito/mockito/pull/1099)
  - Moved some more dependencies to dependencies.gradle [(#1098)](https://github.com/mockito/mockito/pull/1098)
 
 **2.8.36** - [1 commit](https://github.com/mockito/mockito/compare/v2.8.35...v2.8.36) by [Allon Murienik](https://github.com/mureinik) - *2017-05-27* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development)
  - InOrderImpl constructor signature [(#1096)](https://github.com/mockito/mockito/pull/1096)
 
-**2.8.35** - [4 commits](https://github.com/mockito/mockito/compare/v2.8.34...v2.8.35) by [Szczepan Faber](http://github.com/mockitoguy) - *2017-05-27* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development)
+**2.8.35** - [4 commits](https://github.com/mockito/mockito/compare/v2.8.34...v2.8.35) by [Szczepan Faber](https://github.com/mockitoguy) - *2017-05-27* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development)
  - Fixed bug with git push for tag during the release [(#1095)](https://github.com/mockito/mockito/pull/1095)
  - update assertj (v2.8.0) [(#1094)](https://github.com/mockito/mockito/pull/1094)
 
-**2.8.34** - [2 commits](https://github.com/mockito/mockito/compare/v2.8.33...v2.8.34) by [Szczepan Faber](http://github.com/mockitoguy) - *2017-05-27* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development)
+**2.8.34** - [2 commits](https://github.com/mockito/mockito/compare/v2.8.33...v2.8.34) by [Szczepan Faber](https://github.com/mockitoguy) - *2017-05-27* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development)
  - Updated build for latest release tools [(#1093)](https://github.com/mockito/mockito/pull/1093)
 
-**2.8.33** - [2 commits](https://github.com/mockito/mockito/compare/v2.8.32...v2.8.33) by [Szczepan Faber](http://github.com/mockitoguy) (1), Tim Cooke (1) - *2017-05-27* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development)
+**2.8.33** - [2 commits](https://github.com/mockito/mockito/compare/v2.8.32...v2.8.33) by [Szczepan Faber](https://github.com/mockitoguy) (1), Tim Cooke (1) - *2017-05-27* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development)
  - [Documentation] Javadoc Example Throws Unexpected Exception [(#1088)](https://github.com/mockito/mockito/issues/1088)
  - Fixes #1088 : Updating documentation of verify feature to correct a s… [(#1091)](https://github.com/mockito/mockito/pull/1091)
 
 **2.8.32** - [1 commit](https://github.com/mockito/mockito/compare/v2.8.31...v2.8.32) by Arend v. Reinersdorff - *2017-05-26* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development)
  - Fix link to Mockito JUnit rule heading [(#1092)](https://github.com/mockito/mockito/pull/1092)
 
-**2.8.31** - [1 commit](https://github.com/mockito/mockito/compare/v2.8.30...v2.8.31) by [Rafael Winterhalter](http://github.com/raphw) - *2017-05-22* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development)
+**2.8.31** - [1 commit](https://github.com/mockito/mockito/compare/v2.8.30...v2.8.31) by [Rafael Winterhalter](https://github.com/raphw) - *2017-05-22* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development)
  - Fixes #1083: Interfaces only declare toString implicitly and should t… [(#1090)](https://github.com/mockito/mockito/pull/1090)
  - Mockito 2 mock-maker-inline not able to mock Object methods on an interface [(#1083)](https://github.com/mockito/mockito/issues/1083)
 
-**2.8.30 (2017-05-18)** - [3 commits](https://github.com/mockito/mockito/compare/v2.8.29...v2.8.30) by epeee (2), [Szczepan Faber](http://github.com/mockitoguy) (1) - *2017-05-18* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development/2.8.30)
+**2.8.30 (2017-05-18)** - [3 commits](https://github.com/mockito/mockito/compare/v2.8.29...v2.8.30) by epeee (2), [Szczepan Faber](https://github.com/mockitoguy) (1) - *2017-05-18* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development/2.8.30)
  - Streamline assertj and junit4 usage in gradle files and update assertj (v2.7.0) [(#1075)](https://github.com/mockito/mockito/pull/1075)
 
-**2.8.29 (2017-05-15)** - [7 commits](https://github.com/mockito/mockito/compare/v2.8.28...v2.8.29) by [Szczepan Faber](http://github.com/mockitoguy) (5), Christian Schwarz (1), Serge Bishyr (1) - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development/2.8.29)
+**2.8.29 (2017-05-15)** - [7 commits](https://github.com/mockito/mockito/compare/v2.8.28...v2.8.29) by [Szczepan Faber](https://github.com/mockitoguy) (5), Christian Schwarz (1), Serge Bishyr (1) - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development/2.8.29)
  - Bumped version of tools to pick up release automation fixes [(#1084)](https://github.com/mockito/mockito/pull/1084)
  - More concise release notes and codecov issue fix [(#1080)](https://github.com/mockito/mockito/pull/1080)
  - Fixed #1065. Add information about doNothing() method to CannotStubVo… [(#1079)](https://github.com/mockito/mockito/pull/1079)
@@ -1236,13 +1236,13 @@ Notable changes:
   - Fixed problems with releases [(#1052)](https://github.com/mockito/mockito/pull/1052)
   - Fix some issues reported by SonarQube [(#1027)](https://github.com/mockito/mockito/pull/1027)
 
-# 2.8.9 (2017-04-26) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.8.9)/[Maven Central](http://search.maven.org/#artifactdetails%7Corg.mockito%7Cmockito-core%7C2.8.9%7Cjar)
+# 2.8.9 (2017-04-26) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.8.9)/[Maven Central](https://search.maven.org/artifact/org.mockito/mockito-core/2.8.9/jar)
 
 Notable changes sincle last release to Maven Central (2.7.22):
  - Updated ByteBuddy to 1.6.14, mostly for Java9
  - Fixed NPE with MockitoJUnitRunner [(#1035)](https://github.com/mockito/mockito/pull/1035)
 
-**2.8.9 (2017-04-26)** - [11 commits](https://github.com/mockito/mockito/compare/v2.8.8...v2.8.9) by [Rafael Winterhalter](https://github.com/raphw), published to: [JCenter](https://bintray.com/mockito/maven/mockito/2.8.9)/[Maven Central](http://search.maven.org/#artifactdetails%7Corg.mockito%7Cmockito-core%7C2.8.9%7Cjar)
+**2.8.9 (2017-04-26)** - [11 commits](https://github.com/mockito/mockito/compare/v2.8.8...v2.8.9) by [Rafael Winterhalter](https://github.com/raphw), published to: [JCenter](https://bintray.com/mockito/maven/mockito/2.8.9)/[Maven Central](https://search.maven.org/artifact/org.mockito/mockito-core/2.8.9/jar)
  - Updated ByteBuddy to 1.6.14, fixes agent attachment on Java 9 VM
 
 **2.8.8 (2017-04-24)** - [3 commits](https://github.com/mockito/mockito/compare/v2.8.7...v2.8.8) by [Szczepan Faber](https://github.com/mockitoguy), published to: [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development/2.8.8)
@@ -1276,7 +1276,7 @@ Notable changes sincle last release to Maven Central (2.7.22):
  - SmartPrinterTest toString() calls [(#1025)](https://github.com/mockito/mockito/pull/1025)
  - Enabled continuous delivery via robust mockito-release-tools project [(#1018)](https://github.com/mockito/mockito/pull/1018)
 
-# 2.7.22 (2017-04-07), published to [JCenter](https://bintray.com/mockito/maven/mockito/2.7.22)/[Maven Central](http://search.maven.org/#artifactdetails%7Corg.mockito%7Cmockito-core%7C2.7.22%7Cjar).
+# 2.7.22 (2017-04-07), published to [JCenter](https://bintray.com/mockito/maven/mockito/2.7.22)/[Maven Central](https://search.maven.org/artifact/org.mockito/mockito-core/2.7.22/jar).
 
 Last version published to Maven Central after the team adopted [Continuous Delivery Pipeline 2.0](https://github.com/mockito/mockito/issues/911).
 
@@ -2709,16 +2709,16 @@ Older implemented improvements were managed in the original issue tracker and ca
 
 Few minor bug fixes and a relatively small extension point added to improve the android experience.
 
-* **StackTraceCleaner API** - to improve the experience of mocking on android platform we've added an extension point for cleaning the stack traces. This allows the friends behind the [dexmaker](http://code.google.com/p/dexmaker) to implement custom stack trace filter and hence make the Mockito verification errors contain clean and tidy stack traces. Clean stack trace is something Mockito always cares about! Thanks a lot **Jesse Wilson** for reporting, submitting the initial patch and validating the final solution.
+* **StackTraceCleaner API** - to improve the experience of mocking on android platform we've added an extension point for cleaning the stack traces. This allows the friends behind the [dexmaker](https://code.google.com/p/dexmaker) to implement custom stack trace filter and hence make the Mockito verification errors contain clean and tidy stack traces. Clean stack trace is something Mockito always cares about! Thanks a lot **Jesse Wilson** for reporting, submitting the initial patch and validating the final solution.
 * javadoc fix (issue 356) - thanks **konigsberg** for reporting and patching and **Brice** for merging.
 * @InjectMocks inconsistency between java 6 and 7 (issue 353) - neat **Brice's** work.
 * Fixed a problem with auto boxed default return values, needed for the MockMaker extension point (issue 352). Thanks so much **Jesse Wilson** for reporting and the patch, and **Brice** for merging!
 
 ### 1.9.5 rc-1 (03-06-2012)
 
-Thanks a lot to all community members for reporting issues, submitting patches and ideas! The complete list of bug fixes and features is listed [here](http://code.google.com/p/mockito/issues/list?can=1&q=label%3AMilestone-Release1.9.5-rc1&colspec=ID+Type+Status+Priority+Milestone+Owner+Summary&cells=tiles).
+Thanks a lot to all community members for reporting issues, submitting patches and ideas! The complete list of bug fixes and features is listed [here](https://code.google.com/p/mockito/issues/list?can=1&q=label%3AMilestone-Release1.9.5-rc1&colspec=ID+Type+Status+Priority+Milestone+Owner+Summary&cells=tiles).
 
-* **MockMaker API**. The [MockMaker](http://docs.mockito.googlecode.com/hg/1.9.5-rc1/org/mockito/plugins/MockMaker.html) extension point enables replacing the default proxy-creation implementation (cglib) with... something else :) For example, with a help from [dexmaker](http://code.google.com/p/dexmaker) you will be able to use Mockito with Android tests. Special thanks to friends from Google: **Jesse Wilson** and **Crazy Bob** for initiating the whole idea, for the patches, and for friendly pings to get the new feature released.
+* **MockMaker API**. The [MockMaker](http://docs.mockito.googlecode.com/hg/1.9.5-rc1/org/mockito/plugins/MockMaker.html) extension point enables replacing the default proxy-creation implementation (cglib) with... something else :) For example, with a help from [dexmaker](https://code.google.com/p/dexmaker) you will be able to use Mockito with Android tests. Special thanks to friends from Google: **Jesse Wilson** and **Crazy Bob** for initiating the whole idea, for the patches, and for friendly pings to get the new feature released.
 * [**MockingDetails**](http://docs.mockito.googlecode.com/hg/1.9.5-rc1/org/mockito/Mockito.html#mocking_details) can be used to inspect objects and find out if they are Mockito mocks or spies. Special thanks to **David Wallace**, one of the new members of the Mockito team, who was championing the feature.
 * [**The delegating answer**](http://docs.mockito.googlecode.com/hg/1.9.5-rc1/org/mockito/Mockito.html#delegating_call_to_real_instance) is useful for spying some objects difficult to spy in the typical way. Thanks to **Brice Dutheil** (who is one of the most active contributors :) for making it happen!
 * Driven by changes needed by the MockMaker API we started externalizing some internal interfaces. Hence some new public types. Down the road it will make Mockito more flexible and extensible.
@@ -2730,7 +2730,7 @@ Thanks a lot to all community members for reporting issues, submitting patches a
 
 ### 1.9.0 (16-12-2011)
 
-If you're upgrading from 1.8.5 please read about all the goodies delivered by 1.9.0-rc1! This release contains 2 bug fixes and 1 awesome improvement. Full details of this release are listed [here](http://code.google.com/p/mockito/issues/list?can=1&q=label%3AMilestone-Release1.9&colspec=ID+Type+Status+Priority+Milestone+Owner+Summary&cells=tiles).
+If you're upgrading from 1.8.5 please read about all the goodies delivered by 1.9.0-rc1! This release contains 2 bug fixes and 1 awesome improvement. Full details of this release are listed [here](https://code.google.com/p/mockito/issues/list?can=1&q=label%3AMilestone-Release1.9&colspec=ID+Type+Status+Priority+Milestone+Owner+Summary&cells=tiles).
 
 * Thanks to our mysterious friend **Dharapvj**, we now have most beautiful documentation. Take a look [here](http://docs.mockito.googlecode.com/hg/latest/org/mockito/Mockito.html)
 * Credits to **Daniel Spilker** for helping out with the issue related to mocks in superclasses

--- a/doc/release-notes/official.md
+++ b/doc/release-notes/official.md
@@ -795,7 +795,7 @@
  - 2018-07-27 - [2 commits](https://github.com/mockito/mockito/compare/v2.20.1...v2.20.2) by [Rafael Winterhalter](https://github.com/raphw) (1), [Szczepan Faber](https://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.20.2-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.20.2)
  - Updates Byte Buddy to add preliminary support for Java 12. [(#1448)](https://github.com/mockito/mockito/pull/1448)
 
-# 2.20.1 (2018-07-26) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.20.1)/[Maven Central](https://search.maven.org/artifact/org.mockito/mockito-core/2.20.1/jar)
+# 2.20.1 (2018-07-26) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.20.1)/[Maven Central](http://search.maven.org/#artifactdetails%7Corg.mockito%7Cmockito-core%7C2.20.1%7Cjar)
 
 Important changes since previous notable release:
  - new lenient() API - see blog post
@@ -919,10 +919,10 @@ __Deprecated__ because auxiliary artifacts were published with wrong identifiers
  - 2018-03-31 - [1 commit](https://github.com/mockito/mockito/compare/v2.17.3...v2.17.4) by [Erhard Pointl](https://github.com/epeee) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.17.4-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.17.4)
  - Make use of shipkit v2.0.13 [(#1354)](https://github.com/mockito/mockito/pull/1354)
 
-**2.17.3 (2018-03-29)** - [2 commits](https://github.com/mockito/mockito/compare/v2.17.2...v2.17.3) by [Rafael Winterhalter](https://github.com/raphw) (1), [Szczepan Faber](https://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.17.3-green.svg)](https://bintray.com/mockito/maven/mockito-development2.17.3)
+**2.17.3 (2018-03-29)** - [2 commits](https://github.com/mockito/mockito/compare/v2.17.2...v2.17.3) by [Rafael Winterhalter](http://github.com/raphw) (1), [Szczepan Faber](http://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.17.3-green.svg)](https://bintray.com/mockito/maven/mockito-development2.17.3)
  - Update Byte Buddy and ASM for bug fix releases [(#1351)](https://github.com/mockito/mockito/pull/1351)
 
-**2.17.2 (2018-03-26)** - [3 commits](https://github.com/mockito/mockito/compare/v2.17.1...v2.17.2) by [Erhard Pointl](https://github.com/epeee) (1), [Serge Bishyr](https://github.com/SeriyBg) (1), [Tim van der Lippe](https://github.com/TimvdLippe) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.17.2-green.svg)](https://bintray.com/mockito/maven/mockito-development2.17.2)
+**2.17.2 (2018-03-26)** - [3 commits](https://github.com/mockito/mockito/compare/v2.17.1...v2.17.2) by [Erhard Pointl](https://github.com/epeee) (1), [Serge Bishyr](https://github.com/SeriyBg) (1), [Tim van der Lippe](http://github.com/TimvdLippe) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.17.2-green.svg)](https://bintray.com/mockito/maven/mockito-development2.17.2)
  - [Bugfixes] Different mocks are used for @Mock and @InjectMock in the same test class with JUnit 5 extension [(#1346)](https://github.com/mockito/mockito/issues/1346)
  - Fix #1346 - Different mocks are used for @Mock and @InjectMock in the same test class with JUnit 5 extension [(#1349)](https://github.com/mockito/mockito/pull/1349)
  - Update shipkit to v2.0.12 [(#1347)](https://github.com/mockito/mockito/pull/1347)
@@ -933,68 +933,68 @@ __Deprecated__ because auxiliary artifacts were published with wrong identifiers
  - Fixes #1314 : Include all the invocation in mock verification error message [(#1319)](https://github.com/mockito/mockito/pull/1319)
  - Undesired invocation message improvements [(#1314)](https://github.com/mockito/mockito/issues/1314)
 
-**2.17.0 (2018-03-24)** - [1 commit](https://github.com/mockito/mockito/compare/v2.16.3...v2.17.0) by [Tim van der Lippe](https://github.com/TimvdLippe) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.17.0-green.svg)](https://bintray.com/mockito/maven/mockito2.17.0)
+**2.17.0 (2018-03-24)** - [1 commit](https://github.com/mockito/mockito/compare/v2.16.3...v2.17.0) by [Tim van der Lippe](http://github.com/TimvdLippe) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.17.0-green.svg)](https://bintray.com/mockito/maven/mockito2.17.0)
  - No pull requests referenced in commit messages.
 
 **2.16.3 (2018-03-24)** - [1 commit](https://github.com/mockito/mockito/compare/v2.16.2...v2.16.3) by [Christian Schwarz](https://github.com/ChristianSchwarz) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.16.3-green.svg)](https://bintray.com/mockito/maven/mockito-development2.16.3)
  - MockitoExtension for JUnit5  [(#1221)](https://github.com/mockito/mockito/pull/1221)
 
-**2.16.2 (2018-03-23)** - [5 commits](https://github.com/mockito/mockito/compare/v2.16.1...v2.16.2) by [Pascal Schumacher](https://github.com/PascalSchumacher) (3), [Rafael Winterhalter](https://github.com/raphw) (2) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.16.2-green.svg)](https://bintray.com/mockito/maven/mockito-development2.16.2)
+**2.16.2 (2018-03-23)** - [5 commits](https://github.com/mockito/mockito/compare/v2.16.1...v2.16.2) by [Pascal Schumacher](https://github.com/PascalSchumacher) (3), [Rafael Winterhalter](http://github.com/raphw) (2) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.16.2-green.svg)](https://bintray.com/mockito/maven/mockito-development2.16.2)
  - Update to AssertJ 2.9.0 [(#1342)](https://github.com/mockito/mockito/pull/1342)
  - Update to ASM 6.1 [(#1341)](https://github.com/mockito/mockito/pull/1341)
  - Update to Byte Buddy 1.8.0 [(#1340)](https://github.com/mockito/mockito/pull/1340)
 
-**2.16.1 (2018-03-15)** - [3 commits](https://github.com/mockito/mockito/compare/v2.16.0...v2.16.1) by [Szczepan Faber](https://github.com/mockitoguy) (2), [Rafael Winterhalter](https://github.com/raphw) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.16.1-green.svg)](https://bintray.com/mockito/maven/mockito-development2.16.1)
+**2.16.1 (2018-03-15)** - [3 commits](https://github.com/mockito/mockito/compare/v2.16.0...v2.16.1) by [Szczepan Faber](http://github.com/mockitoguy) (2), [Rafael Winterhalter](http://github.com/raphw) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.16.1-green.svg)](https://bintray.com/mockito/maven/mockito-development2.16.1)
  - Prevent class loading race condition [(#1258)](https://github.com/mockito/mockito/pull/1258)
  - Deadlock after upgrading to Mockito 2 and parallel tests execution [(#1067)](https://github.com/mockito/mockito/issues/1067)
 
-**2.16.0 (2018-03-13)** - [14 commits](https://github.com/mockito/mockito/compare/v2.15.6...v2.16.0) by [Szczepan Faber](https://github.com/mockitoguy) (13), [Philip P. Moltmann](https://github.com/moltmann) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.16.0-green.svg)](https://bintray.com/mockito/maven/mockito2.16.0)
+**2.16.0 (2018-03-13)** - [14 commits](https://github.com/mockito/mockito/compare/v2.15.6...v2.16.0) by [Szczepan Faber](http://github.com/mockitoguy) (13), [Philip P. Moltmann](https://github.com/moltmann) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.16.0-green.svg)](https://bintray.com/mockito/maven/mockito2.16.0)
  - Prevent memory leaks with inline MockMakers by using weak refs to mocks [(#1321)](https://github.com/mockito/mockito/pull/1321)
  - InlineByteBuddyMockMaker does not clean up stale mocks [(#1313)](https://github.com/mockito/mockito/issues/1313)
 
-**2.15.6 (2018-03-05)** - [2 commits](https://github.com/mockito/mockito/compare/v2.15.5...v2.15.6) by [Philip P. Moltmann](https://github.com/moltmann) (1), [Szczepan Faber](https://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.15.6-green.svg)](https://bintray.com/mockito/maven/mockito-development2.15.6)
+**2.15.6 (2018-03-05)** - [2 commits](https://github.com/mockito/mockito/compare/v2.15.5...v2.15.6) by [Philip P. Moltmann](https://github.com/moltmann) (1), [Szczepan Faber](http://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.15.6-green.svg)](https://bintray.com/mockito/maven/mockito-development2.15.6)
  - Avoid bytebuddy import Issue to enable repackaging without bytebuddy [(#1320)](https://github.com/mockito/mockito/pull/1320)
 
 **2.15.5 (2018-03-02)** - [1 commit](https://github.com/mockito/mockito/compare/v2.15.4...v2.15.5) by [Sanne Grinovero](https://github.com/Sanne) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.15.5-green.svg)](https://bintray.com/mockito/maven/mockito-development2.15.5)
  - Fixes #1326 : Reduce the allocation rate for the typical use of Locat… [(#1327)](https://github.com/mockito/mockito/pull/1327)
  - Reduce memory consumption of the typical LocationImpl [(#1326)](https://github.com/mockito/mockito/issues/1326)
 
-**2.15.4 (2018-02-19)** - [26 commits](https://github.com/mockito/mockito/compare/v2.15.3...v2.15.4) by [Szczepan Faber](https://github.com/mockitoguy) (20), [Philip P. Moltmann](https://github.com/moltmann) (5), [Tim van der Lippe](https://github.com/TimvdLippe) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.15.4-green.svg)](https://bintray.com/mockito/maven/mockito-development2.15.4)
+**2.15.4 (2018-02-19)** - [26 commits](https://github.com/mockito/mockito/compare/v2.15.3...v2.15.4) by [Szczepan Faber](http://github.com/mockitoguy) (20), [Philip P. Moltmann](https://github.com/moltmann) (5), [Tim van der Lippe](http://github.com/TimvdLippe) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.15.4-green.svg)](https://bintray.com/mockito/maven/mockito-development2.15.4)
  - Update Kotlin version to be compatible with the IntelliJ runtime version [(#1315)](https://github.com/mockito/mockito/pull/1315)
  - Make  org.mockito.internal.creation.instance.Instantiator a public API [(#1303)](https://github.com/mockito/mockito/issues/1303)
 
-**2.15.3 (2018-02-15)** - [4 commits](https://github.com/mockito/mockito/compare/v2.15.2...v2.15.3) by [Szczepan Faber](https://github.com/mockitoguy) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.15.3-green.svg)](https://bintray.com/mockito/maven/mockito-development2.15.3)
+**2.15.3 (2018-02-15)** - [4 commits](https://github.com/mockito/mockito/compare/v2.15.2...v2.15.3) by [Szczepan Faber](http://github.com/mockitoguy) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.15.3-green.svg)](https://bintray.com/mockito/maven/mockito-development2.15.3)
  - Clean up, removed dead code, rename job, documentation tidy up [(#1290)](https://github.com/mockito/mockito/pull/1290)
 
-**2.15.2 (2018-02-13)** - [2 commits](https://github.com/mockito/mockito/compare/v2.15.1...v2.15.2) by [Alberto Scotto](https://github.com/alb-i986) (1), [Szczepan Faber](https://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.15.2-green.svg)](https://bintray.com/mockito/maven/mockito-development2.15.2)
+**2.15.2 (2018-02-13)** - [2 commits](https://github.com/mockito/mockito/compare/v2.15.1...v2.15.2) by [Alberto Scotto](https://github.com/alb-i986) (1), [Szczepan Faber](http://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.15.2-green.svg)](https://bintray.com/mockito/maven/mockito-development2.15.2)
  - Javadoc: Improve discoverability of #ignoreStubs [(#1294)](https://github.com/mockito/mockito/pull/1294)
 
-**2.15.1 (2018-02-12)** - [8 commits](https://github.com/mockito/mockito/compare/v2.15.0...v2.15.1) by [Szczepan Faber](https://github.com/mockitoguy) (5), r-smirnov (3) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.15.1-green.svg)](https://bintray.com/mockito/maven/mockito-development2.15.1)
+**2.15.1 (2018-02-12)** - [8 commits](https://github.com/mockito/mockito/compare/v2.15.0...v2.15.1) by [Szczepan Faber](http://github.com/mockitoguy) (5), r-smirnov (3) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.15.1-green.svg)](https://bintray.com/mockito/maven/mockito-development2.15.1)
  - [Bugfixes] Ensure isolation of stubbings [(#1310)](https://github.com/mockito/mockito/pull/1310)
  - Cannot override stubbed method that calls a stubbed method [(#1279)](https://github.com/mockito/mockito/issues/1279)
 
-# 2.15.0 (2018-02-10) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.15.0)/[Maven Central](https://search.maven.org/artifact/org.mockito/mockito-core/2.15.0/jar)
+# 2.15.0 (2018-02-10) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.15.0)/[Maven Central](http://search.maven.org/#artifactdetails%7Corg.mockito%7Cmockito-core%7C2.15.0%7Cjar)
 
 Notable changes:
  - new APIs to ```MockitoSession``` feature that can be used by framework integrations such as JUnit Jupiter.
  - ```InvocationFactory``` API improvements driven by integrations with Android.
  - Javadoc updates.
 
-**2.15.0 (2018-02-10)** - [16 commits](https://github.com/mockito/mockito/compare/v2.14.0...v2.15.0) by [Marc Philipp](https://github.com/marcphilipp) (10), [Szczepan Faber](https://github.com/mockitoguy) (6) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.15.0-green.svg)](https://bintray.com/mockito/maven/mockito2.15.0)
+**2.15.0 (2018-02-10)** - [16 commits](https://github.com/mockito/mockito/compare/v2.14.0...v2.15.0) by [Marc Philipp](https://github.com/marcphilipp) (10), [Szczepan Faber](http://github.com/mockitoguy) (6) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.15.0-green.svg)](https://bintray.com/mockito/maven/mockito2.15.0)
  - Extend MockitoSession(Builder) API to enable usage by testing frameworks [(#1301)](https://github.com/mockito/mockito/pull/1301)
  - [JUnit Jupiter] MockitoSession#initMocks should support multiple test instances   [(#1232)](https://github.com/mockito/mockito/issues/1232)
  - Design MockitoSession API improvements for unit test frameworks [(#898)](https://github.com/mockito/mockito/issues/898)
 
 **2.14.0 (2018-02-09)** - [12 commits](https://github.com/mockito/mockito/compare/v2.13.3...v2.14.0) by 4 authors - published to [![Bintray](https://img.shields.io/badge/Bintray-2.14.0-green.svg)](https://bintray.com/mockito/maven/mockito-development2.14.0)
- - Commits: [Szczepan Faber](https://github.com/mockitoguy) (9), [Arend v. Reinersdorff](https://github.com/arend-von-reinersdorff) (1), Philip P. Moltmann (1), [Tim van der Lippe](https://github.com/TimvdLippe) (1)
+ - Commits: [Szczepan Faber](http://github.com/mockitoguy) (9), [Arend v. Reinersdorff](https://github.com/arend-von-reinersdorff) (1), Philip P. Moltmann (1), [Tim van der Lippe](http://github.com/TimvdLippe) (1)
  - Update public API of InvocationFactory needed for Android static mocking [(#1307)](https://github.com/mockito/mockito/pull/1307)
  - InvocationFactory.createInvocation's realmethod cannot throw a Throwable [(#1306)](https://github.com/mockito/mockito/issues/1306)
  - Fix link of Maven Central badge [(#1299)](https://github.com/mockito/mockito/pull/1299)
 
-**2.13.3 (2018-01-16)** - [3 commits](https://github.com/mockito/mockito/compare/v2.13.2...v2.13.3) by [Szczepan Faber](https://github.com/mockitoguy) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.13.3-green.svg)](https://bintray.com/mockito/maven/mockito-development2.13.3)
+**2.13.3 (2018-01-16)** - [3 commits](https://github.com/mockito/mockito/compare/v2.13.2...v2.13.3) by [Szczepan Faber](http://github.com/mockitoguy) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.13.3-green.svg)](https://bintray.com/mockito/maven/mockito-development2.13.3)
  - Extra test case, javadoc update [(#1282)](https://github.com/mockito/mockito/pull/1282)
 
-**2.13.2 (2018-01-16)** - [2 commits](https://github.com/mockito/mockito/compare/v2.13.1...v2.13.2) by [Serge Bishyr](https://github.com/SeriyBg) (1), [Szczepan Faber](https://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.13.2-green.svg)](https://bintray.com/mockito/maven/mockito-development2.13.2)
+**2.13.2 (2018-01-16)** - [2 commits](https://github.com/mockito/mockito/compare/v2.13.1...v2.13.2) by [Serge Bishyr](https://github.com/SeriyBg) (1), [Szczepan Faber](http://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.13.2-green.svg)](https://bintray.com/mockito/maven/mockito-development2.13.2)
  - [Documentation] Improve documentation about partial mocks and doReturn() style of stubbing [(#1262)](https://github.com/mockito/mockito/issues/1262)
  - Fixes #1262: update doc for Answers.CALLS_REAL_METHODS [(#1268)](https://github.com/mockito/mockito/pull/1268)
 
@@ -1002,46 +1002,46 @@ Notable changes:
  - [Documentation] Documentation update - MockitoJUnit.strictness(STRICT_STUBS) does not do verifyNoMoreInteractions [(#1086)](https://github.com/mockito/mockito/issues/1086)
  - Update STRICT_STUBS documentation for verifyNoMoreInteractions [(#1280)](https://github.com/mockito/mockito/pull/1280)
 
-# 2.13.0 (2017-12-06) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.13.0)/[Maven Central](https://search.maven.org/artifact/org.mockito/mockito-core/2.13.0/jar)
+# 2.13.0 (2017-12-06) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.13.0)/[Maven Central](http://search.maven.org/#artifactdetails%7Corg.mockito%7Cmockito-core%7C2.13.0%7Cjar)
 
- - [1 commit](https://github.com/mockito/mockito/compare/v2.12.2...v2.13.0) by [Tim van der Lippe](https://github.com/TimvdLippe)
+ - [1 commit](https://github.com/mockito/mockito/compare/v2.12.2...v2.13.0) by [Tim van der Lippe](http://github.com/TimvdLippe)
  - No pull requests referenced in commit messages.
 
-**2.12.2 (2017-11-28)** - [2 commits](https://github.com/mockito/mockito/compare/v2.12.1...v2.12.2) by [Rafael Winterhalter](https://github.com/raphw) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.12.2-green.svg)](https://bintray.com/mockito/maven/mockito-development2.12.2)
+**2.12.2 (2017-11-28)** - [2 commits](https://github.com/mockito/mockito/compare/v2.12.1...v2.12.2) by [Rafael Winterhalter](http://github.com/raphw) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.12.2-green.svg)](https://bintray.com/mockito/maven/mockito-development2.12.2)
  - [Bugfixes] Wanted but not invoked on 2.12.0, but not on 2.11.0 [(#1254)](https://github.com/mockito/mockito/issues/1254)
  - Fixes #1254 and #1256: improved check for self-invocation. [(#1257)](https://github.com/mockito/mockito/pull/1257)
  - Unbounded recursion when spying with `mockito-inline` [(#1256)](https://github.com/mockito/mockito/issues/1256)
 
-**2.12.1 (2017-11-28)** - [6 commits](https://github.com/mockito/mockito/compare/v2.12.0...v2.12.1) by epeee (3), [Tim van der Lippe](https://github.com/TimvdLippe) (2), [Szczepan Faber](https://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.12.1-green.svg)](https://bintray.com/mockito/maven/mockito-development2.12.1)
+**2.12.1 (2017-11-28)** - [6 commits](https://github.com/mockito/mockito/compare/v2.12.0...v2.12.1) by epeee (3), [Tim van der Lippe](http://github.com/TimvdLippe) (2), [Szczepan Faber](http://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.12.1-green.svg)](https://bintray.com/mockito/maven/mockito-development2.12.1)
  - Update shipkit and configure assertReleaseNeeded task [(#1265)](https://github.com/mockito/mockito/pull/1265)
  - Update Kotlin to latest version [(#1263)](https://github.com/mockito/mockito/pull/1263)
  - Remove several container classes and inline code [(#1247)](https://github.com/mockito/mockito/pull/1247)
 
-# 2.12.0 (2017-11-07) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.12.0)/[Maven Central](https://search.maven.org/artifact/org.mockito/mockito-core/2.12.0/jar)
+# 2.12.0 (2017-11-07) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.12.0)/[Maven Central](http://search.maven.org/#artifactdetails%7Corg.mockito%7Cmockito-core%7C2.12.0%7Cjar)
 
- - [4 commits](https://github.com/mockito/mockito/compare/v2.11.7...v2.12.0) by [Rafael Winterhalter](https://github.com/raphw) (2), [Tim van der Lippe](https://github.com/TimvdLippe) (2)
+ - [4 commits](https://github.com/mockito/mockito/compare/v2.11.7...v2.12.0) by [Rafael Winterhalter](http://github.com/raphw) (2), [Tim van der Lippe](http://github.com/TimvdLippe) (2)
  - No pull requests referenced in commit messages.
 
-**2.11.7 (2017-11-06)** - [2 commits](https://github.com/mockito/mockito/compare/v2.11.6...v2.11.7) by [Rafael Winterhalter](https://github.com/raphw) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.7-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.11.7)
+**2.11.7 (2017-11-06)** - [2 commits](https://github.com/mockito/mockito/compare/v2.11.6...v2.11.7) by [Rafael Winterhalter](http://github.com/raphw) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.7-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.11.7)
  - [Bugfixes] Provide Java 10 compatibility [(#1243)](https://github.com/mockito/mockito/issues/1243)
  - Fixes #1243: Support for new version number 10. [(#1250)](https://github.com/mockito/mockito/pull/1250)
 
-**2.11.6 (2017-11-05)** - [3 commits](https://github.com/mockito/mockito/compare/v2.11.5...v2.11.6) by [Tim van der Lippe](https://github.com/TimvdLippe) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.6-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.11.6)
+**2.11.6 (2017-11-05)** - [3 commits](https://github.com/mockito/mockito/compare/v2.11.5...v2.11.6) by [Tim van der Lippe](http://github.com/TimvdLippe) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.6-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.11.6)
  - [Enhancements] Enable jacoco coverage on subprojects [(#1229)](https://github.com/mockito/mockito/pull/1229)
  - Remove service-worker from Javadoc generation [(#1244)](https://github.com/mockito/mockito/pull/1244)
  - Enable Checkstyle for checking license headers [(#1242)](https://github.com/mockito/mockito/pull/1242)
 
-**2.11.5 (2017-10-31)** - [4 commits](https://github.com/mockito/mockito/compare/v2.11.4...v2.11.5) by [Tim van der Lippe](https://github.com/TimvdLippe) (3), [Szczepan Faber](https://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.5-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.11.5)
+**2.11.5 (2017-10-31)** - [4 commits](https://github.com/mockito/mockito/compare/v2.11.4...v2.11.5) by [Tim van der Lippe](http://github.com/TimvdLippe) (3), [Szczepan Faber](http://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.5-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.11.5)
  - Add @CheckReturnValue to stubbing/verification methods [(#1228)](https://github.com/mockito/mockito/pull/1228)
  - Add regression test for issue #1174 [(#1219)](https://github.com/mockito/mockito/pull/1219)
 
-**2.11.4 (2017-10-29)** - [2 commits](https://github.com/mockito/mockito/compare/v2.11.3...v2.11.4) by [Szczepan Faber](https://github.com/mockitoguy) (1), [Tim van der Lippe](https://github.com/TimvdLippe) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.4-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.11.4)
+**2.11.4 (2017-10-29)** - [2 commits](https://github.com/mockito/mockito/compare/v2.11.3...v2.11.4) by [Szczepan Faber](http://github.com/mockitoguy) (1), [Tim van der Lippe](http://github.com/TimvdLippe) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.4-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.11.4)
  - Update license plugin and add missing license headers [(#1227)](https://github.com/mockito/mockito/pull/1227)
 
 **2.11.3 (2017-10-28)** - [1 commit](https://github.com/mockito/mockito/compare/v2.11.2...v2.11.3) by [Allon Murienik](https://github.com/mureinik) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.3-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.11.3)
  - InvocationsPrinter string concatination [(#1231)](https://github.com/mockito/mockito/pull/1231)
 
-**2.11.2 (2017-10-22)** - [7 commits](https://github.com/mockito/mockito/compare/v2.11.1...v2.11.2) by [Rafael Winterhalter](https://github.com/raphw) (6), [Allon Murienik](https://github.com/mureinik) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.2-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.11.2)
+**2.11.2 (2017-10-22)** - [7 commits](https://github.com/mockito/mockito/compare/v2.11.1...v2.11.2) by [Rafael Winterhalter](http://github.com/raphw) (6), [Allon Murienik](https://github.com/mureinik) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.2-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.11.2)
  - Updated Byte Buddy and ASM dependencies. Fixes #1215. [(#1218)](https://github.com/mockito/mockito/pull/1218)
  - Fixes #1183: Make override check more forgiving to accomondate Kotlin compile patterns. [(#1217)](https://github.com/mockito/mockito/pull/1217)
  - Adresses #1206: allow opting out from annotation copying within mocks. [(#1216)](https://github.com/mockito/mockito/pull/1216)
@@ -1050,22 +1050,22 @@ Notable changes:
  - Mockito should not copy annotations in all cases [(#1206)](https://github.com/mockito/mockito/issues/1206)
  - UnfinishedVerificationException with Kotlin after updating to 2.9.0 [(#1183)](https://github.com/mockito/mockito/issues/1183)
 
-**2.11.1 (2017-10-20)** - [4 commits](https://github.com/mockito/mockito/compare/v2.11.0...v2.11.1) by [Szczepan Faber](https://github.com/mockitoguy) (2), [Allon Murienik](https://github.com/mureinik) (1), [rberghegger](https://github.com/rberghegger) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.1-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.11.1)
+**2.11.1 (2017-10-20)** - [4 commits](https://github.com/mockito/mockito/compare/v2.11.0...v2.11.1) by [Szczepan Faber](http://github.com/mockitoguy) (2), [Allon Murienik](https://github.com/mureinik) (1), [rberghegger](https://github.com/rberghegger) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.1-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.11.1)
  - Fixes #1211: Improve @deprecated JavaDoc [(#1214)](https://github.com/mockito/mockito/pull/1214)
  - improve @deprecated JavaDoc of MockitoDebugger [(#1211)](https://github.com/mockito/mockito/issues/1211)
  - Clean up JUnit imports [(#1209)](https://github.com/mockito/mockito/pull/1209)
  - Updated my GitHub user name [(#1208)](https://github.com/mockito/mockito/pull/1208)
 
-# 2.11.0 (2017-10-14) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.11.0)/[Maven Central](https://search.maven.org/artifact/org.mockito/mockito-core/2.11.0/jar)
+# 2.11.0 (2017-10-14) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.11.0)/[Maven Central](http://search.maven.org/#artifactdetails%7Corg.mockito%7Cmockito-core%7C2.11.0%7Cjar)
 
 New public API for Spring Boot integration will improve compatibility of Mockito and reduce version conflict problems. We carefully grow our public API for framework integrations. This time we added new "Verification Started Listener", needed to resolve [double proxy use case](https://github.com/mockito/mockito/issues/1191). Using this API, Spring Boot framework no longer needs to depend on internal Mockito API.
 
 We also added `Automatic-Module-Name` to mockito jar, useful in Java9 context [(#1189)](https://github.com/mockito/mockito/issues/1189).
 
-**2.11.0 (2017-10-14)** - [20 commits](https://github.com/mockito/mockito/compare/v2.10.5...v2.11.0) by [Szczepan Faber](https://github.com/szczepiq) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.0-green.svg)](https://bintray.com/mockito/maven/mockito/2.11.0)
+**2.11.0 (2017-10-14)** - [20 commits](https://github.com/mockito/mockito/compare/v2.10.5...v2.11.0) by [Szczepan Faber](http://github.com/szczepiq) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.11.0-green.svg)](https://bintray.com/mockito/maven/mockito/2.11.0)
  - Added new public API for spring-boot use case [(#1192)](https://github.com/mockito/mockito/pull/1192)
 
-**2.10.5 (2017-10-14)** - [12 commits](https://github.com/mockito/mockito/compare/v2.10.4...v2.10.5) by [Marcin Zajączkowski](https://github.com/szpak) (8), [Szczepan Faber](https://github.com/mockitoguy) (3), [Allon Murienik](https://github.com/mureinik) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.10.5-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.10.5)
+**2.10.5 (2017-10-14)** - [12 commits](https://github.com/mockito/mockito/compare/v2.10.4...v2.10.5) by [Marcin Zajączkowski](https://github.com/szpak) (8), [Szczepan Faber](http://github.com/mockitoguy) (3), [Allon Murienik](https://github.com/mureinik) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.10.5-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.10.5)
  - [Java 9 support] JDK9: set a stable module name with `Automatic-Module-Name` entry in MANIFEST [(#1189)](https://github.com/mockito/mockito/issues/1189)
  - Fixed documentation issue, added unit tests [(#1203)](https://github.com/mockito/mockito/pull/1203)
  - [#1202] Java 9 CI build for Mockito 2.x [(#1202)](https://github.com/mockito/mockito/pull/1202)
@@ -1086,68 +1086,68 @@ We also added `Automatic-Module-Name` to mockito jar, useful in Java9 context [(
 **2.10.1 (2017-10-04)** - [1 commit](https://github.com/mockito/mockito/compare/v2.10.0...v2.10.1) by [Dennis Cheung](https://github.com/hkdennis2k) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.10.1-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.10.1)
  - Enable stubOnly() on @Mock annotation [(#1146)](https://github.com/mockito/mockito/pull/1146)
 
-# 2.10.0 (2017-09-08) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.10.0)/[Maven Central](https://search.maven.org/artifact/org.mockito/mockito-core/2.10.0/jar)
+# 2.10.0 (2017-09-08) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.10.0)/[Maven Central](http://search.maven.org/#artifactdetails%7Corg.mockito%7Cmockito-core%7C2.10.0%7Cjar)
 
 The main highlight of this release is the additions to the public API to accommodate advanced framework integrations. It will help other frameworks to cleanly integrate with Mockito. For more details, see [#1121](https://github.com/mockito/mockito/pull/1121).
 
-**2.10.0 (2017-09-08)** - [42 commits](https://github.com/mockito/mockito/compare/v2.9.2...v2.10.0) by [Szczepan Faber](https://github.com/mockitoguy) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.10.0-green.svg)](https://bintray.com/mockito/maven/mockito/2.10.0)
+**2.10.0 (2017-09-08)** - [42 commits](https://github.com/mockito/mockito/compare/v2.9.2...v2.10.0) by [Szczepan Faber](http://github.com/mockitoguy) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.10.0-green.svg)](https://bintray.com/mockito/maven/mockito/2.10.0)
  - Improve and develop APIs required for framework integrators [(#1121)](https://github.com/mockito/mockito/pull/1121)
 
-**2.9.2 (2017-09-05)** - [2 commits](https://github.com/mockito/mockito/compare/v2.9.1...v2.9.2) by [Rafael Winterhalter](https://github.com/raphw) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.9.2-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.9.2)
+**2.9.2 (2017-09-05)** - [2 commits](https://github.com/mockito/mockito/compare/v2.9.1...v2.9.2) by [Rafael Winterhalter](http://github.com/raphw) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.9.2-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.9.2)
  - Compare method of graph to defined form of method. [(#1186)](https://github.com/mockito/mockito/pull/1186)
 
-**2.9.1 (2017-09-04)** - [11 commits](https://github.com/mockito/mockito/compare/v2.9.0...v2.9.1) by [Rafael Winterhalter](https://github.com/raphw) (9), [Szczepan Faber](https://github.com/mockitoguy) (2) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.9.1-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.9.1)
+**2.9.1 (2017-09-04)** - [11 commits](https://github.com/mockito/mockito/compare/v2.9.0...v2.9.1) by [Rafael Winterhalter](http://github.com/raphw) (9), [Szczepan Faber](http://github.com/mockitoguy) (2) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.9.1-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.9.1)
  - Travis [(#1184)](https://github.com/mockito/mockito/pull/1184)
  - #1179: Fix performance regression caused by use of method graph compiler. [(#1181)](https://github.com/mockito/mockito/pull/1181)
  - Mockito 2.9.0 is significantly slower [(#1179)](https://github.com/mockito/mockito/issues/1179)
  - Adds support for Java 9 in inline mock maker by Byte Buddy update. [(#1158)](https://github.com/mockito/mockito/pull/1158)
 
-# 2.9.0 (2017-08-26) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.9.0)/[Maven Central](https://search.maven.org/artifact/org.mockito/mockito-core/2.9.0/jar)
+# 2.9.0 (2017-08-26) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.9.0)/[Maven Central](http://search.maven.org/#artifactdetails%7Corg.mockito%7Cmockito-core%7C2.9.0%7Cjar)
 
 Notable changes:
  - bumped ByteBuddy 1.6.14 -> 1.7.0 (inline mocking, bugfixes)
  - bumped Objenesis 2.5 -> 2.6 (Java9, bugfixes)
 
-**2.9.0 (2017-08-26)** - [5 commits](https://github.com/mockito/mockito/compare/v2.8.55...v2.9.0) by [Szczepan Faber](https://github.com/mockitoguy) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.9.0-green.svg)](https://bintray.com/mockito/maven/mockito/2.9.0)
+**2.9.0 (2017-08-26)** - [5 commits](https://github.com/mockito/mockito/compare/v2.8.55...v2.9.0) by [Szczepan Faber](http://github.com/mockitoguy) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.9.0-green.svg)](https://bintray.com/mockito/maven/mockito/2.9.0)
  - Updated README.md wrt maven central release [(#1172)](https://github.com/mockito/mockito/pull/1172)
  - Bumped minor version so signify new Objenesis version [(#1171)](https://github.com/mockito/mockito/pull/1171)
 
-**2.8.55 (2017-08-21)** - [7 commits](https://github.com/mockito/mockito/compare/v2.8.54...v2.8.55) by [Szczepan Faber](https://github.com/mockitoguy) (6), [Pascal Schumacher](https://github.com/PascalSchumacher) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.55-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.55)
+**2.8.55 (2017-08-21)** - [7 commits](https://github.com/mockito/mockito/compare/v2.8.54...v2.8.55) by [Szczepan Faber](http://github.com/mockitoguy) (6), [Pascal Schumacher](https://github.com/PascalSchumacher) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.55-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.55)
  - Update objenesis version 2.5 -> 2.6 (Java9, bugfixes) [(#1170)](https://github.com/mockito/mockito/pull/1170)
  - Updated to latest Shipkit, tidied up configuration [(#1169)](https://github.com/mockito/mockito/pull/1169)
 
-**2.8.54 (2017-08-09)** - [5 commits](https://github.com/mockito/mockito/compare/v2.8.53...v2.8.54) by [Marcin Zajączkowski](https://github.com/szpak) (3), [Igor C. A. de Lima](https://github.com/igorcadelima) (1), [Szczepan Faber](https://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.54-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.54)
+**2.8.54 (2017-08-09)** - [5 commits](https://github.com/mockito/mockito/compare/v2.8.53...v2.8.54) by [Marcin Zajączkowski](https://github.com/szpak) (3), [Igor C. A. de Lima](https://github.com/igorcadelima) (1), [Szczepan Faber](http://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.54-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.54)
  - [Bugfixes] Unnecessary release was triggered [(#1144)](https://github.com/mockito/mockito/issues/1144)
  - Remove duplicated word in Javadoc [(#1161)](https://github.com/mockito/mockito/pull/1161)
  - [#1147] Provide version in release commit message [(#1147)](https://github.com/mockito/mockito/pull/1147)
  - Bumped shipkit to fix unnecessary releasing problem [(#1145)](https://github.com/mockito/mockito/pull/1145)
 
-**2.8.53 (2017-07-06)** - [6 commits](https://github.com/mockito/mockito/compare/v2.8.52...v2.8.53) by [Szczepan Faber](https://github.com/mockitoguy) (5), [Wojtek Wilk](https://github.com/wwilk) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.53-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.53)
+**2.8.53 (2017-07-06)** - [6 commits](https://github.com/mockito/mockito/compare/v2.8.52...v2.8.53) by [Szczepan Faber](http://github.com/mockitoguy) (5), [Wojtek Wilk](https://github.com/wwilk) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.53-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.53)
  - Bumped shipkit, simplified Travis file, removed unnecessary code [(#1141)](https://github.com/mockito/mockito/pull/1141)
  - org.shipkit.publications-comparator plugin applied [(#1139)](https://github.com/mockito/mockito/pull/1139)
 
-**2.8.52 (2017-06-24)** - [8 commits](https://github.com/mockito/mockito/compare/v2.8.51...v2.8.52) by [Szczepan Faber](https://github.com/mockitoguy) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.52-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.52)
+**2.8.52 (2017-06-24)** - [8 commits](https://github.com/mockito/mockito/compare/v2.8.51...v2.8.52) by [Szczepan Faber](http://github.com/mockitoguy) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.52-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.52)
  - Simplified and documented .travis.yml file [(#1133)](https://github.com/mockito/mockito/pull/1133)
 
 **2.8.51 (2017-06-24)** - [1 commit](https://github.com/mockito/mockito/compare/v2.8.50...v2.8.51) by [Allon Murienik](https://github.com/mureinik) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.51-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.51)
  - Don't use raw rypes in UnusedStubbingsTest [(#1137)](https://github.com/mockito/mockito/pull/1137)
 
-**2.8.50 (2017-06-24)** - [1 commit](https://github.com/mockito/mockito/compare/v2.8.49...v2.8.50) by [Rafael Winterhalter](https://github.com/raphw) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.50-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.50)
+**2.8.50 (2017-06-24)** - [1 commit](https://github.com/mockito/mockito/compare/v2.8.49...v2.8.50) by [Rafael Winterhalter](http://github.com/raphw) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.50-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.50)
  - Fixes #1135: Properly resolve visibility bridges. [(#1136)](https://github.com/mockito/mockito/pull/1136)
  - [mock-maker-inline] Method calls on mock forwarded to real instance [(#1135)](https://github.com/mockito/mockito/issues/1135)
 
-**2.8.49 (2017-06-22)** - [2 commits](https://github.com/mockito/mockito/compare/v2.8.48...v2.8.49) by [Rafael Winterhalter](https://github.com/raphw) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.49-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.49)
+**2.8.49 (2017-06-22)** - [2 commits](https://github.com/mockito/mockito/compare/v2.8.48...v2.8.49) by [Rafael Winterhalter](http://github.com/raphw) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.49-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.49)
  - Improve detection on non-mockable types - ByteBuddy bump 1.6.14->1.7.0 [(#1128)](https://github.com/mockito/mockito/pull/1128)
 
-**2.8.48 (2017-06-18)** - [2 commits](https://github.com/mockito/mockito/compare/v2.8.47...v2.8.48) by epeee (1), [Szczepan Faber](https://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.48-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.48)
+**2.8.48 (2017-06-18)** - [2 commits](https://github.com/mockito/mockito/compare/v2.8.47...v2.8.48) by epeee (1), [Szczepan Faber](http://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.48-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.48)
  - make use of shipkit v0.8.92 [(#1132)](https://github.com/mockito/mockito/pull/1132)
 
-# 2.8.47 (2017-06-15) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.8.47)/[Maven Central](https://search.maven.org/artifact/org.mockito/mockito-core/2.8.47/jar)
+# 2.8.47 (2017-06-15) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.8.47)/[Maven Central](http://search.maven.org/#artifactdetails%7Corg.mockito%7Cmockito-core%7C2.8.47%7Cjar)
 
 **2.8.47 (2017-06-15)** - [1 commit](https://github.com/mockito/mockito/compare/v2.8.46...v2.8.47) by [Marcin Zajączkowski](https://github.com/szpak) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.47-green.svg)](https://bintray.com/mockito/maven/mockito/2.8.47)
  - No pull requests referenced in commit messages.
 
-**2.8.46 (2017-06-15)** - [2 commits](https://github.com/mockito/mockito/compare/v2.8.45...v2.8.46) by [Szczepan Faber](https://github.com/mockitoguy) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.46-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.46)
+**2.8.46 (2017-06-15)** - [2 commits](https://github.com/mockito/mockito/compare/v2.8.45...v2.8.46) by [Szczepan Faber](http://github.com/mockitoguy) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.46-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.46)
  - Fixed issue with releases to Maven Central [(#1129)](https://github.com/mockito/mockito/pull/1129)
  - Version not released to Maven Central [(#1127)](https://github.com/mockito/mockito/issues/1127)
 
@@ -1157,55 +1157,55 @@ Notable changes:
 **2.8.44 (2017-06-12)** - [3 commits](https://github.com/mockito/mockito/compare/v2.8.43...v2.8.44) by [Marcin Zajaczkowski](https://github.com/szpak) (1), [Marcin Zajączkowski](https://github.com/szpak) (1), [Myrle Krantz](https://github.com/myrle-krantz) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.44-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.44)
  - [New features] Answer with delay in mock or spy to improve testing of asynchronous code [(#1117)](https://github.com/mockito/mockito/issues/1117)
 
-**2.8.43 (2017-06-10)** - [2 commits](https://github.com/mockito/mockito/compare/v2.8.42...v2.8.43) by [Szczepan Faber](https://github.com/mockitoguy) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.43-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.43)
+**2.8.43 (2017-06-10)** - [2 commits](https://github.com/mockito/mockito/compare/v2.8.42...v2.8.43) by [Szczepan Faber](http://github.com/mockitoguy) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.43-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.43)
  - No pull requests referenced in commit messages.
 
-**2.8.42 (2017-06-10)** - [3 commits](https://github.com/mockito/mockito/compare/v2.8.41...v2.8.42) by epeee (2), [Szczepan Faber](https://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.42-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.42)
+**2.8.42 (2017-06-10)** - [3 commits](https://github.com/mockito/mockito/compare/v2.8.41...v2.8.42) by epeee (2), [Szczepan Faber](http://github.com/mockitoguy) (1) - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.42-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.42)
  - update to shipkit v0.8.72 [(#1115)](https://github.com/mockito/mockito/pull/1115)
 
 **2.8.41** - [1 commit](https://github.com/mockito/mockito/compare/v2.8.40...v2.8.41) by [Allon Murienik](https://github.com/mureinik) - *2017-06-10* - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.41-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.41)
  - ArgsMismatchFinder#getStubbingArgMismatches generics [(#1118)](https://github.com/mockito/mockito/pull/1118)
 
-**2.8.40** - [4 commits](https://github.com/mockito/mockito/compare/v2.8.39...v2.8.40) by [Szczepan Faber](https://github.com/mockitoguy) (2), [Alex Simkin](https://github.com/SimY4) (1), mkuster (1) - *2017-06-05* - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.40-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.40)
+**2.8.40** - [4 commits](https://github.com/mockito/mockito/compare/v2.8.39...v2.8.40) by [Szczepan Faber](http://github.com/mockitoguy) (2), [Alex Simkin](https://github.com/SimY4) (1), mkuster (1) - *2017-06-05* - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.40-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.40)
  - [Bugfixes] Fixed Travis configuration for matrix build [(#1109)](https://github.com/mockito/mockito/pull/1109)
  - Renamed configuration extension 'releasing' into 'shipkit' [(#1104)](https://github.com/mockito/mockito/pull/1104)
  - Made CaturingMatcher threadsafe [(#986)](https://github.com/mockito/mockito/pull/986)
 
-**2.8.39** - [1 commit](https://github.com/mockito/mockito/compare/v2.8.38...v2.8.39) by [Szczepan Faber](https://github.com/mockitoguy) - *2017-05-30* - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.39-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.39)
+**2.8.39** - [1 commit](https://github.com/mockito/mockito/compare/v2.8.38...v2.8.39) by [Szczepan Faber](http://github.com/mockitoguy) - *2017-05-30* - published to [![Bintray](https://img.shields.io/badge/Bintray-2.8.39-green.svg)](https://bintray.com/mockito/maven/mockito-development/2.8.39)
  - Fixed contributor links and bintray badge in release notes [(#1103)](https://github.com/mockito/mockito/pull/1103)
 
-**2.8.38** - [1 commit](https://github.com/mockito/mockito/compare/v2.8.37...v2.8.38) by [Szczepan Faber](https://github.com/mockitoguy) - *2017-05-30* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development)
+**2.8.38** - [1 commit](https://github.com/mockito/mockito/compare/v2.8.37...v2.8.38) by [Szczepan Faber](http://github.com/mockitoguy) - *2017-05-30* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development)
  - [Documentation] Fixed broken link in Javadoc, improved console message [(#1100)](https://github.com/mockito/mockito/pull/1100)
 
-**2.8.37** - [4 commits](https://github.com/mockito/mockito/compare/v2.8.36...v2.8.37) by [epeee](https://github.com/epeee), [Szczepan Faber](https://github.com/mockitoguy) - *2017-05-28* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development)
+**2.8.37** - [4 commits](https://github.com/mockito/mockito/compare/v2.8.36...v2.8.37) by [epeee](https://github.com/epeee), [Szczepan Faber](http://github.com/mockitoguy) - *2017-05-28* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development)
  - update gradle to v3.5 [(#1099)](https://github.com/mockito/mockito/pull/1099)
  - Moved some more dependencies to dependencies.gradle [(#1098)](https://github.com/mockito/mockito/pull/1098)
 
 **2.8.36** - [1 commit](https://github.com/mockito/mockito/compare/v2.8.35...v2.8.36) by [Allon Murienik](https://github.com/mureinik) - *2017-05-27* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development)
  - InOrderImpl constructor signature [(#1096)](https://github.com/mockito/mockito/pull/1096)
 
-**2.8.35** - [4 commits](https://github.com/mockito/mockito/compare/v2.8.34...v2.8.35) by [Szczepan Faber](https://github.com/mockitoguy) - *2017-05-27* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development)
+**2.8.35** - [4 commits](https://github.com/mockito/mockito/compare/v2.8.34...v2.8.35) by [Szczepan Faber](http://github.com/mockitoguy) - *2017-05-27* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development)
  - Fixed bug with git push for tag during the release [(#1095)](https://github.com/mockito/mockito/pull/1095)
  - update assertj (v2.8.0) [(#1094)](https://github.com/mockito/mockito/pull/1094)
 
-**2.8.34** - [2 commits](https://github.com/mockito/mockito/compare/v2.8.33...v2.8.34) by [Szczepan Faber](https://github.com/mockitoguy) - *2017-05-27* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development)
+**2.8.34** - [2 commits](https://github.com/mockito/mockito/compare/v2.8.33...v2.8.34) by [Szczepan Faber](http://github.com/mockitoguy) - *2017-05-27* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development)
  - Updated build for latest release tools [(#1093)](https://github.com/mockito/mockito/pull/1093)
 
-**2.8.33** - [2 commits](https://github.com/mockito/mockito/compare/v2.8.32...v2.8.33) by [Szczepan Faber](https://github.com/mockitoguy) (1), Tim Cooke (1) - *2017-05-27* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development)
+**2.8.33** - [2 commits](https://github.com/mockito/mockito/compare/v2.8.32...v2.8.33) by [Szczepan Faber](http://github.com/mockitoguy) (1), Tim Cooke (1) - *2017-05-27* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development)
  - [Documentation] Javadoc Example Throws Unexpected Exception [(#1088)](https://github.com/mockito/mockito/issues/1088)
  - Fixes #1088 : Updating documentation of verify feature to correct a s… [(#1091)](https://github.com/mockito/mockito/pull/1091)
 
 **2.8.32** - [1 commit](https://github.com/mockito/mockito/compare/v2.8.31...v2.8.32) by Arend v. Reinersdorff - *2017-05-26* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development)
  - Fix link to Mockito JUnit rule heading [(#1092)](https://github.com/mockito/mockito/pull/1092)
 
-**2.8.31** - [1 commit](https://github.com/mockito/mockito/compare/v2.8.30...v2.8.31) by [Rafael Winterhalter](https://github.com/raphw) - *2017-05-22* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development)
+**2.8.31** - [1 commit](https://github.com/mockito/mockito/compare/v2.8.30...v2.8.31) by [Rafael Winterhalter](http://github.com/raphw) - *2017-05-22* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development)
  - Fixes #1083: Interfaces only declare toString implicitly and should t… [(#1090)](https://github.com/mockito/mockito/pull/1090)
  - Mockito 2 mock-maker-inline not able to mock Object methods on an interface [(#1083)](https://github.com/mockito/mockito/issues/1083)
 
-**2.8.30 (2017-05-18)** - [3 commits](https://github.com/mockito/mockito/compare/v2.8.29...v2.8.30) by epeee (2), [Szczepan Faber](https://github.com/mockitoguy) (1) - *2017-05-18* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development/2.8.30)
+**2.8.30 (2017-05-18)** - [3 commits](https://github.com/mockito/mockito/compare/v2.8.29...v2.8.30) by epeee (2), [Szczepan Faber](http://github.com/mockitoguy) (1) - *2017-05-18* - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development/2.8.30)
  - Streamline assertj and junit4 usage in gradle files and update assertj (v2.7.0) [(#1075)](https://github.com/mockito/mockito/pull/1075)
 
-**2.8.29 (2017-05-15)** - [7 commits](https://github.com/mockito/mockito/compare/v2.8.28...v2.8.29) by [Szczepan Faber](https://github.com/mockitoguy) (5), Christian Schwarz (1), Serge Bishyr (1) - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development/2.8.29)
+**2.8.29 (2017-05-15)** - [7 commits](https://github.com/mockito/mockito/compare/v2.8.28...v2.8.29) by [Szczepan Faber](http://github.com/mockitoguy) (5), Christian Schwarz (1), Serge Bishyr (1) - published to [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development/2.8.29)
  - Bumped version of tools to pick up release automation fixes [(#1084)](https://github.com/mockito/mockito/pull/1084)
  - More concise release notes and codecov issue fix [(#1080)](https://github.com/mockito/mockito/pull/1080)
  - Fixed #1065. Add information about doNothing() method to CannotStubVo… [(#1079)](https://github.com/mockito/mockito/pull/1079)
@@ -1236,13 +1236,13 @@ Notable changes:
   - Fixed problems with releases [(#1052)](https://github.com/mockito/mockito/pull/1052)
   - Fix some issues reported by SonarQube [(#1027)](https://github.com/mockito/mockito/pull/1027)
 
-# 2.8.9 (2017-04-26) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.8.9)/[Maven Central](https://search.maven.org/artifact/org.mockito/mockito-core/2.8.9/jar)
+# 2.8.9 (2017-04-26) published to [JCenter](https://bintray.com/mockito/maven/mockito/2.8.9)/[Maven Central](http://search.maven.org/#artifactdetails%7Corg.mockito%7Cmockito-core%7C2.8.9%7Cjar)
 
 Notable changes sincle last release to Maven Central (2.7.22):
  - Updated ByteBuddy to 1.6.14, mostly for Java9
  - Fixed NPE with MockitoJUnitRunner [(#1035)](https://github.com/mockito/mockito/pull/1035)
 
-**2.8.9 (2017-04-26)** - [11 commits](https://github.com/mockito/mockito/compare/v2.8.8...v2.8.9) by [Rafael Winterhalter](https://github.com/raphw), published to: [JCenter](https://bintray.com/mockito/maven/mockito/2.8.9)/[Maven Central](https://search.maven.org/artifact/org.mockito/mockito-core/2.8.9/jar)
+**2.8.9 (2017-04-26)** - [11 commits](https://github.com/mockito/mockito/compare/v2.8.8...v2.8.9) by [Rafael Winterhalter](https://github.com/raphw), published to: [JCenter](https://bintray.com/mockito/maven/mockito/2.8.9)/[Maven Central](http://search.maven.org/#artifactdetails%7Corg.mockito%7Cmockito-core%7C2.8.9%7Cjar)
  - Updated ByteBuddy to 1.6.14, fixes agent attachment on Java 9 VM
 
 **2.8.8 (2017-04-24)** - [3 commits](https://github.com/mockito/mockito/compare/v2.8.7...v2.8.8) by [Szczepan Faber](https://github.com/mockitoguy), published to: [maven/mockito-development](https://bintray.com/mockito/maven/mockito-development/2.8.8)
@@ -1276,7 +1276,7 @@ Notable changes sincle last release to Maven Central (2.7.22):
  - SmartPrinterTest toString() calls [(#1025)](https://github.com/mockito/mockito/pull/1025)
  - Enabled continuous delivery via robust mockito-release-tools project [(#1018)](https://github.com/mockito/mockito/pull/1018)
 
-# 2.7.22 (2017-04-07), published to [JCenter](https://bintray.com/mockito/maven/mockito/2.7.22)/[Maven Central](https://search.maven.org/artifact/org.mockito/mockito-core/2.7.22/jar).
+# 2.7.22 (2017-04-07), published to [JCenter](https://bintray.com/mockito/maven/mockito/2.7.22)/[Maven Central](http://search.maven.org/#artifactdetails%7Corg.mockito%7Cmockito-core%7C2.7.22%7Cjar).
 
 Last version published to Maven Central after the team adopted [Continuous Delivery Pipeline 2.0](https://github.com/mockito/mockito/issues/911).
 
@@ -2709,16 +2709,16 @@ Older implemented improvements were managed in the original issue tracker and ca
 
 Few minor bug fixes and a relatively small extension point added to improve the android experience.
 
-* **StackTraceCleaner API** - to improve the experience of mocking on android platform we've added an extension point for cleaning the stack traces. This allows the friends behind the [dexmaker](https://code.google.com/p/dexmaker) to implement custom stack trace filter and hence make the Mockito verification errors contain clean and tidy stack traces. Clean stack trace is something Mockito always cares about! Thanks a lot **Jesse Wilson** for reporting, submitting the initial patch and validating the final solution.
+* **StackTraceCleaner API** - to improve the experience of mocking on android platform we've added an extension point for cleaning the stack traces. This allows the friends behind the [dexmaker](http://code.google.com/p/dexmaker) to implement custom stack trace filter and hence make the Mockito verification errors contain clean and tidy stack traces. Clean stack trace is something Mockito always cares about! Thanks a lot **Jesse Wilson** for reporting, submitting the initial patch and validating the final solution.
 * javadoc fix (issue 356) - thanks **konigsberg** for reporting and patching and **Brice** for merging.
 * @InjectMocks inconsistency between java 6 and 7 (issue 353) - neat **Brice's** work.
 * Fixed a problem with auto boxed default return values, needed for the MockMaker extension point (issue 352). Thanks so much **Jesse Wilson** for reporting and the patch, and **Brice** for merging!
 
 ### 1.9.5 rc-1 (03-06-2012)
 
-Thanks a lot to all community members for reporting issues, submitting patches and ideas! The complete list of bug fixes and features is listed [here](https://code.google.com/p/mockito/issues/list?can=1&q=label%3AMilestone-Release1.9.5-rc1&colspec=ID+Type+Status+Priority+Milestone+Owner+Summary&cells=tiles).
+Thanks a lot to all community members for reporting issues, submitting patches and ideas! The complete list of bug fixes and features is listed [here](http://code.google.com/p/mockito/issues/list?can=1&q=label%3AMilestone-Release1.9.5-rc1&colspec=ID+Type+Status+Priority+Milestone+Owner+Summary&cells=tiles).
 
-* **MockMaker API**. The [MockMaker](http://docs.mockito.googlecode.com/hg/1.9.5-rc1/org/mockito/plugins/MockMaker.html) extension point enables replacing the default proxy-creation implementation (cglib) with... something else :) For example, with a help from [dexmaker](https://code.google.com/p/dexmaker) you will be able to use Mockito with Android tests. Special thanks to friends from Google: **Jesse Wilson** and **Crazy Bob** for initiating the whole idea, for the patches, and for friendly pings to get the new feature released.
+* **MockMaker API**. The [MockMaker](http://docs.mockito.googlecode.com/hg/1.9.5-rc1/org/mockito/plugins/MockMaker.html) extension point enables replacing the default proxy-creation implementation (cglib) with... something else :) For example, with a help from [dexmaker](http://code.google.com/p/dexmaker) you will be able to use Mockito with Android tests. Special thanks to friends from Google: **Jesse Wilson** and **Crazy Bob** for initiating the whole idea, for the patches, and for friendly pings to get the new feature released.
 * [**MockingDetails**](http://docs.mockito.googlecode.com/hg/1.9.5-rc1/org/mockito/Mockito.html#mocking_details) can be used to inspect objects and find out if they are Mockito mocks or spies. Special thanks to **David Wallace**, one of the new members of the Mockito team, who was championing the feature.
 * [**The delegating answer**](http://docs.mockito.googlecode.com/hg/1.9.5-rc1/org/mockito/Mockito.html#delegating_call_to_real_instance) is useful for spying some objects difficult to spy in the typical way. Thanks to **Brice Dutheil** (who is one of the most active contributors :) for making it happen!
 * Driven by changes needed by the MockMaker API we started externalizing some internal interfaces. Hence some new public types. Down the road it will make Mockito more flexible and extensible.
@@ -2730,7 +2730,7 @@ Thanks a lot to all community members for reporting issues, submitting patches a
 
 ### 1.9.0 (16-12-2011)
 
-If you're upgrading from 1.8.5 please read about all the goodies delivered by 1.9.0-rc1! This release contains 2 bug fixes and 1 awesome improvement. Full details of this release are listed [here](https://code.google.com/p/mockito/issues/list?can=1&q=label%3AMilestone-Release1.9&colspec=ID+Type+Status+Priority+Milestone+Owner+Summary&cells=tiles).
+If you're upgrading from 1.8.5 please read about all the goodies delivered by 1.9.0-rc1! This release contains 2 bug fixes and 1 awesome improvement. Full details of this release are listed [here](http://code.google.com/p/mockito/issues/list?can=1&q=label%3AMilestone-Release1.9&colspec=ID+Type+Status+Priority+Milestone+Owner+Summary&cells=tiles).
 
 * Thanks to our mysterious friend **Dharapvj**, we now have most beautiful documentation. Take a look [here](http://docs.mockito.googlecode.com/hg/latest/org/mockito/Mockito.html)
 * Credits to **Daniel Spilker** for helping out with the issue related to mocks in superclasses

--- a/src/main/java/org/mockito/BDDMockito.java
+++ b/src/main/java/org/mockito/BDDMockito.java
@@ -13,7 +13,7 @@ import org.mockito.verification.VerificationMode;
  * Behavior Driven Development style of writing tests uses <b>//given //when //then</b> comments as fundamental parts of your test methods.
  * This is exactly how we write our tests and we warmly encourage you to do so!
  * <p>
- * Start learning about BDD here: <a href="http://en.wikipedia.org/wiki/Behavior_Driven_Development">http://en.wikipedia.org/wiki/Behavior_Driven_Development</a>
+ * Start learning about BDD here: <a href="https://en.wikipedia.org/wiki/Behavior-driven_development">https://en.wikipedia.org/wiki/Behavior-driven_development</a>
  * <p>
  * The problem is that current stubbing api with canonical role of <b>when</b> word does not integrate nicely with <b>//given //when //then</b> comments.
  * It's because stubbing belongs to <b>given</b> component of the test and not to the <b>when</b> component of the test.

--- a/src/main/java/org/mockito/CheckReturnValue.java
+++ b/src/main/java/org/mockito/CheckReturnValue.java
@@ -17,7 +17,7 @@ import java.lang.annotation.Target;
  * This annotation is public, because we have to use it in multiple packages.
  *
  * @see <a href="https://github.com/findbugsproject/findbugs/blob/264ae7baf890d2b347d91805c90057062b5dcb1e/findbugs/src/java/edu/umd/cs/findbugs/detect/BuildCheckReturnAnnotationDatabase.java#L120">Findbugs source code</a>
- * @see <a href="http://errorprone.info/bugpattern/CheckReturnValue">ErrorProne check</a>
+ * @see <a href="https://errorprone.info/bugpattern/CheckReturnValue">ErrorProne check</a>
  * @since 2.11.4
  */
 @Target({ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE, ElementType.TYPE})

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -38,7 +38,7 @@ import java.util.function.Function;
  * The Mockito library enables mock creation, verification and stubbing.
  *
  * <p>
- * This javadoc content is also available on the <a href="http://mockito.org">http://mockito.org</a> web page.
+ * This javadoc content is also available on the <a href="https://site.mockito.org/">https://site.mockito.org/</a> web page.
  * All documentation is kept in javadocs because it guarantees consistency between what's on the web and what's in the source code.
  * It allows access to documentation straight from the IDE even if you work offline.
  * It motivates Mockito developers to keep documentation up-to-date with the code that they write,
@@ -104,7 +104,7 @@ import java.util.function.Function;
  * <h3 id="0">0. <a class="meaningful_link" href="#mockito2" name="mockito2">Migrating to Mockito 2</a></h3>
  *
  * In order to continue improving Mockito and further improve the unit testing experience, we want you to upgrade to 2.1.0!
- * Mockito follows <a href="http://semver.org/">semantic versioning</a> and contains breaking changes only on major version upgrades.
+ * Mockito follows <a href="https://semver.org/">semantic versioning</a> and contains breaking changes only on major version upgrades.
  * In the lifecycle of a library, breaking changes are necessary
  * to roll out a set of brand new features that alter the existing behavior or even change the API.
  * For a comprehensive guide on the new release including incompatible changes,
@@ -767,7 +767,7 @@ import java.util.function.Function;
  * <a href="https://github.com/mockito/mockito/wiki/FAQ">https://github.com/mockito/mockito/wiki/FAQ</a>
  * <p>
  * In case of questions you may also post to mockito mailing list:
- * <a href="http://groups.google.com/group/mockito">http://groups.google.com/group/mockito</a>
+ * <a href="https://groups.google.com/group/mockito">https://groups.google.com/group/mockito</a>
  * <p>
  * Next, you should know that Mockito validates if you use it correctly <b>all the time</b>.
  * However, there's a gotcha so please read the javadoc for {@link Mockito#validateMockitoUsage()}
@@ -780,7 +780,7 @@ import java.util.function.Function;
  * Behavior Driven Development style of writing tests uses <b>//given //when //then</b> comments as fundamental parts of your test methods.
  * This is exactly how we write our tests and we warmly encourage you to do so!
  * <p>
- * Start learning about BDD here: <a href="http://en.wikipedia.org/wiki/Behavior_Driven_Development">http://en.wikipedia.org/wiki/Behavior_Driven_Development</a>
+ * Start learning about BDD here: <a href="https://en.wikipedia.org/wiki/Behavior-driven_development">https://en.wikipedia.org/wiki/Behavior-driven_development</a>
  * <p>
  * The problem is that current stubbing api with canonical role of <b>when</b> word does not integrate nicely with <b>//given //when //then</b> comments.
  * It's because stubbing belongs to <b>given</b> component of the test and not to the <b>when</b> component of the test.
@@ -823,7 +823,7 @@ import java.util.function.Function;
  *   List serializableMock = mock(List.class, withSettings().serializable());
  * </code></pre>
  * <p>
- * The mock can be serialized assuming all the normal <a href='http://java.sun.com/j2se/1.5.0/docs/api/java/io/Serializable.html'>
+ * The mock can be serialized assuming all the normal <a href='https://docs.oracle.com/javase/8/docs/api/java/io/Serializable.html'>
  * serialization requirements</a> are met by the class.
  * <p>
  * Making a real object spy serializable is a bit more effort as the spy(...) method does not have an overloaded version
@@ -1357,7 +1357,7 @@ import java.util.function.Function;
  *     </li>
  *     <li>This mock maker has been designed around Java Agent runtime attachment ; this require a compatible JVM,
  *     that is part of the JDK (or Java 9 VM). When running on a non-JDK VM prior to Java 9, it is however possible to
- *     manually add the <a href="http://bytebuddy.net">Byte Buddy Java agent jar</a> using the <code>-javaagent</code>
+ *     manually add the <a href="https://bytebuddy.net">Byte Buddy Java agent jar</a> using the <code>-javaagent</code>
  *     parameter upon starting the JVM.
  *     </li>
  * </ul>
@@ -1506,7 +1506,7 @@ import java.util.function.Function;
  * <h3 id="45">45. <a class="meaningful_link" href="#junit5_mockito" name="junit5_mockito">New JUnit Jupiter (JUnit5+) extension</a></h3>
  *
  * For integration with JUnit Jupiter (JUnit5+), use the `org.mockito:mockito-junit-jupiter` artifact.
- * For more information about the usage of the integration, see <a href="http://javadoc.io/doc/org.mockito/mockito-junit-jupiter/latest/org/mockito/junit/jupiter/MockitoExtension.html">the JavaDoc of <code>MockitoExtension</code></a>.
+ * For more information about the usage of the integration, see <a href="https://javadoc.io/doc/org.mockito/mockito-junit-jupiter/latest/org/mockito/junit/jupiter/MockitoExtension.html">the JavaDoc of <code>MockitoExtension</code></a>.
  *
  * <h3 id="46">46. <a class="meaningful_link" href="#mockito_lenient" name="mockito_lenient">
  *       New <code>Mockito.lenient()</code> and <code>MockSettings.lenient()</code> methods (Since 2.20.0)</a></h3>
@@ -3189,7 +3189,7 @@ public class Mockito extends ArgumentMatchers {
     /**
      * First of all, in case of any trouble, I encourage you to read the Mockito FAQ: <a href="https://github.com/mockito/mockito/wiki/FAQ">https://github.com/mockito/mockito/wiki/FAQ</a>
      * <p>
-     * In case of questions you may also post to mockito mailing list: <a href="http://groups.google.com/group/mockito">http://groups.google.com/group/mockito</a>
+     * In case of questions you may also post to mockito mailing list: <a href="https://groups.google.com/group/mockito">https://groups.google.com/group/mockito</a>
      * <p>
      * <code>validateMockitoUsage()</code> <b>explicitly validates</b> the framework state to detect invalid use of Mockito.
      * However, this feature is optional <b>because Mockito validates the usage all the time...</b> but there is a gotcha so read on.

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
@@ -95,7 +95,7 @@ import static org.mockito.internal.util.StringUtil.*;
  * Note that inline mocks require a Java agent to be attached. Mockito will attempt an attachment of a Java agent upon
  * loading the mock maker for creating inline mocks. Such runtime attachment is only possible when using a JVM that
  * is part of a JDK or when using a Java 9 VM. When running on a non-JDK VM prior to Java 9, it is however possible to
- * manually add the <a href="http://bytebuddy.net">Byte Buddy Java agent jar</a> using the <code>-javaagent</code>
+ * manually add the <a href="https://bytebuddy.net">Byte Buddy Java agent jar</a> using the <code>-javaagent</code>
  * parameter upon starting the JVM. Furthermore, the inlining mock maker requires the VM to support class retransformation
  * (also known as HotSwap). All major VM distributions such as HotSpot (OpenJDK), J9 (IBM/Websphere) or Zing (Azul)
  * support this feature.

--- a/src/main/java/org/mockito/internal/util/Platform.java
+++ b/src/main/java/org/mockito/internal/util/Platform.java
@@ -61,7 +61,7 @@ public abstract class Platform {
                             "",
                             "The regular Byte Buddy mock makers cannot generate code on an Android VM!",
                             "To resolve this, please use the 'mockito-android' dependency for your application:",
-                            "http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22mockito-android%22%20g%3A%22org.mockito%22",
+                            "https://search.maven.org/artifact/org.mockito/mockito-android",
                             "",
                             description);
         }

--- a/src/main/java/org/mockito/internal/util/reflection/GenericMetadataSupport.java
+++ b/src/main/java/org/mockito/internal/util/reflection/GenericMetadataSupport.java
@@ -197,7 +197,7 @@ public abstract class GenericMetadataSupport {
      */
     private BoundedType boundsOf(WildcardType wildCard) {
         /*
-         *  According to JLS(http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues.html#4.5.1):
+         *  According to JLS(https://docs.oracle.com/javase/specs/jls/se8/html/jls-4.html#jls-4.5.1):
          *  - Lower and upper can't coexist: (for instance, this is not allowed:
          *    <? extends List<String> & super MyInterface>)
          *  - Multiple concrete type bounds are not supported (for instance, this is not allowed:
@@ -594,9 +594,9 @@ public abstract class GenericMetadataSupport {
      * Type representing bounds of a type
      *
      * @see TypeVarBoundedType
-     * @see <a href="http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues.html#4.4">http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues.html#4.4</a>
+     * @see <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-4.html#jls-4.4">https://docs.oracle.com/javase/specs/jls/se8/html/jls-4.html#jls-4.4</a>
      * @see WildCardBoundedType
-     * @see <a href="http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues.html#4.5.1">http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues.html#4.5.1</a>
+     * @see <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-4.html#jls-4.5.1">https://docs.oracle.com/javase/specs/jls/se8/html/jls-4.html#jls-4.5.1</a>
      */
     public interface BoundedType extends Type {
         Type firstBound();
@@ -622,7 +622,7 @@ public abstract class GenericMetadataSupport {
      * </code></pre>
      * </p>
      *
-     * @see <a href="http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues.html#4.4">http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues.html#4.4</a>
+     * @see <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-4.html#jls-4.4">https://docs.oracle.com/javase/specs/jls/se8/html/jls-4.html#jls-4.4</a>
      */
     public static class TypeVarBoundedType implements BoundedType {
         private final TypeVariable<?> typeVariable;
@@ -689,7 +689,7 @@ public abstract class GenericMetadataSupport {
      * <p>The JLS says that lower bound and upper bound are mutually exclusive, and that multiple bounds
      * are not allowed.
      *
-     * @see <a href="http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues.html#4.4">http://docs.oracle.com/javase/specs/jls/se5.0/html/typesValues.html#4.4</a>
+     * @see <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-4.html#jls-4.4">https://docs.oracle.com/javase/specs/jls/se8/html/jls-4.html#jls-4.4</a>
      */
     public static class WildCardBoundedType implements BoundedType {
         private final WildcardType wildcard;

--- a/src/main/java/org/mockito/junit/MockitoJUnitRunner.java
+++ b/src/main/java/org/mockito/junit/MockitoJUnitRunner.java
@@ -46,7 +46,7 @@ import org.mockito.quality.Strictness;
  *      It drives cleaner tests and improves debugging experience.
  *      The only reason this feature is not turned on by default
  *      is because it would have been an incompatible change
- *      and Mockito strictly follows <a href="http://semver.org">semantic versioning</a>.
+ *      and Mockito strictly follows <a href="https://semver.org">semantic versioning</a>.
  * </ul>
  *
  * Runner is completely optional - there are other ways you can get &#064;Mock working, for example by writing a base class.

--- a/src/main/java/org/mockito/junit/MockitoRule.java
+++ b/src/main/java/org/mockito/junit/MockitoRule.java
@@ -46,7 +46,7 @@ import org.mockito.quality.Strictness;
  *      It drives cleaner tests and improves debugging experience.
  *      The only reason this feature is not turned on by default
  *      is because it would have been an incompatible change
- *      and Mockito strictly follows <a href="http://semver.org">semantic versioning</a>.
+ *      and Mockito strictly follows <a href="https://semver.org">semantic versioning</a>.
  *
  * </ul>
  * Example use:

--- a/src/test/java/org/mockito/internal/matchers/apachecommons/EqualsBuilderTest.java
+++ b/src/test/java/org/mockito/internal/matchers/apachecommons/EqualsBuilderTest.java
@@ -1064,7 +1064,7 @@ public class EqualsBuilderTest extends TestBase {
     }
 
     /**
-     * Test from http://issues.apache.org/bugzilla/show_bug.cgi?id=33067
+     * Test from https://issues.apache.org/jira/browse/LANG-42
      */
     @Test
     public void testNpeForNullElement() {
@@ -1072,7 +1072,7 @@ public class EqualsBuilderTest extends TestBase {
         Object[] x2 = new Object[] {new Integer(1), new Integer(2), new Integer(3)};
 
         // causes an NPE in 2.0 according to:
-        // http://issues.apache.org/bugzilla/show_bug.cgi?id=33067
+        // https://issues.apache.org/jira/browse/LANG-42
         new EqualsBuilder().append(x1, x2);
     }
 

--- a/src/test/java/org/mockito/internal/util/PlatformTest.java
+++ b/src/test/java/org/mockito/internal/util/PlatformTest.java
@@ -68,13 +68,13 @@ public class PlatformTest {
     public void should_parse_open_jdk_string_and_report_wether_below_or_nut_update_45() {
         // Given
         // Sources :
-        //  - http://www.oracle.com/technetwork/java/javase/versioning-naming-139433.html
-        //  - http://www.oracle.com/technetwork/java/javase/jdk7-naming-418744.html
-        //  - http://www.oracle.com/technetwork/java/javase/jdk8-naming-2157130.html
+        //  - https://www.oracle.com/java/technologies/javase/versioning-naming.html
+        //  - https://www.oracle.com/java/technologies/javase/jdk7-naming.html
+        //  - https://www.oracle.com/java/technologies/javase/jdk8-naming.html
         //  -
-        // http://stackoverflow.com/questions/35844985/how-do-we-get-sr-and-fp-of-ibm-jre-using-java
+        // https://stackoverflow.com/questions/35844985/how-do-we-get-sr-and-fp-of-ibm-jre-using-java
         //  -
-        // http://www.ibm.com/support/knowledgecenter/SSYKE2_6.0.0/com.ibm.java.doc.user.win32.60/user/java_version_check.html
+        // https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.80.doc/user/build_number.html
         Map<String, Boolean> versions =
                 new HashMap<String, Boolean>() {
                     {
@@ -103,7 +103,7 @@ public class PlatformTest {
 
         // Given
         // Sources :
-        //  - http://openjdk.java.net/jeps/223 (Java 9)
+        //  - https://openjdk.java.net/jeps/223 (Java 9)
         //
         // System Property                 Existing      Proposed
         // ------------------------------- ------------  --------

--- a/subprojects/junit-jupiter/src/test/java/org/mockitousage/JunitJupiterTest.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockitousage/JunitJupiterTest.java
@@ -80,7 +80,7 @@ class JunitJupiterTest {
     @Nested
     @ExtendWith(MockitoExtension.class)
         // ^^ duplicate registration should be ignored by JUnit
-        // see http://junit.org/junit5/docs/current/user-guide/#extensions-registration-inherita
+        // see https://junit.org/junit5/docs/current/user-guide/#extensions-registration-inheritance
     class DuplicateExtensionOnNestedTest {
 
         @Mock


### PR DESCRIPTION
Uses HTTPS for links (where supported). Additionally replaces some links which are currently redirecting with their destination.

Edit: I am not quite sure why Travis failed or why codecov thinks that the coverage has decreased.