### PR TITLE
Update animal-sniffer plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ plugins {
     id 'eclipse'
     id 'com.github.ben-manes.versions' version '0.28.0'
     id 'biz.aQute.bnd.builder' version '5.1.0'
-    id 'ru.vyarus.animalsniffer' version '1.5.1'
+    id 'ru.vyarus.animalsniffer' version '1.5.2'
 }
 
 description = 'Mockito mock objects library core API and implementation'


### PR DESCRIPTION
Updates the animal-sniffer plugin.

The new version fi<!-- Prevent GitHub from creating irritating issue links -->xes https://github.com/xvik/gradle-animalsniffer-plugin/issues/25 which caused build failures on Windows because class files were processed in an incorrect order causing the nested class `InlineByteBuddyMockMaker$1` (which has the forbidden access) to be processed before the enclosing class which has the `@SuppressSignatureCheck` annotation. Previously the tests failed for me with:
```
[Undefined reference (android-api-level-24-7.0_r2)] org.mockito.internal.creation.bytebuddy.(InlineByteBuddyMockMaker.java:507)
  >> java.lang.instrument.Instrumentation

[Undefined reference (android-api-level-24-7.0_r2)] org.mockito.internal.creation.bytebuddy.(InlineByteBuddyMockMaker.java:507)
  >> boolean java.lang.instrument.Instrumentation.isModifiableClass(Class)
```

(This problem has also been mentioned in the description of https://github.com/mockito/mockito/pull/2024)