### PR TITLE
Remove duplicated Gradle property setting

### DIFF
--- a/check_reproducibility.sh
+++ b/check_reproducibility.sh
@@ -10,7 +10,7 @@ export SOURCE_DATE_EPOCH=$(date +%s)
 function calculate_checksums() {
     OUTPUT=checksums/$1
 
-    ./gradlew --no-build-cache clean assemble --parallel
+    ./gradlew --no-build-cache clean assemble
 
     find ./build -name '*.jar' \
         | grep '/build/libs/' \


### PR DESCRIPTION
There is no need of specifying _--parallel_ explicitly as it is Gradle's default (the less code, the better).