### PR TITLE
Improve error message if initializer fails.

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -4,7 +4,7 @@ ext {
 
 def versions = [:]
 
-versions.bytebuddy = '1.10.15'
+versions.bytebuddy = '1.10.18'
 versions.junitJupiter = '5.4.2'
 versions.errorprone = '2.4.0'
 


### PR DESCRIPTION
Non-initializable classes can never be mocked, an error message should help guide on these issues.