### PR TITLE
Commit message directives for CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,10 @@
+#
+# CI build that assembles artifacts and runs tests.
+# If validation is successful this workflow releases from the main dev branch.
+#
+# - skipping CI: add [skip ci] to the commit message
+# - skipping release: add [skip release] to the commit message
+#
 name: CI
 
 on:
@@ -14,6 +21,7 @@ jobs:
   #
   build:
     runs-on: ubuntu-latest
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
     
     # Definition of the build matrix
     strategy:
@@ -61,10 +69,15 @@ jobs:
   # Release job, only for pushes to the main development branch
   #        
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest    
     needs: [build] # build job must pass before we can release
-    if: github.event_name == 'push' && github.ref == 'refs/heads/release/3.x'
+    
+    if: github.event_name == 'push' 
+        && github.ref == 'refs/heads/release/3.x'
+        && !contains(toJSON(github.event.commits.*.message), '[skip release]')
+    
     steps:
+   
     - name: Check out code
       uses: actions/checkout@v2 # https://github.com/actions/checkout
       with:


### PR DESCRIPTION
Added standard idioms for avoiding unnecessary jobs: [skip ci] and [skip release] directives can be added in the commit message, bypassing the CI or release from CI.

Fixes #2095