### PR TITLE
Avoided parallel workflow execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ name: CI
 
 on:
   push:
-    branches: ['**']
+    branches: ['release/3.x']
     tags-ignore: [v*] # release tags are automatically generated after a successful CI build, no need to run CI against them
   pull_request:
     branches: ['**']


### PR DESCRIPTION
Avoided parallel execution of the workflow so that:
 - we get better UX (the "checks" view in PR does not have duplicated jobs - [example](https://github.com/mockito/mockito/pull/2098))
 - we run less builds (conserves build quota)

We *no longer* run CI for ordinary push to any remote branch. We run CI for pushes to the main dev branch or PRs.

Preventing parallel workflows is reported to GitHub and hopefully it will be resolved eventually: https://github.community/t/prevent-parallel-workflows/16370

Fixes #2097