### PR TITLE
Avoid CI failures in forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
 
     if: github.event_name == 'push'
         && github.ref == 'refs/heads/release/3.x'
+        && github.repository == 'mockito/mockito'
         && !contains(toJSON(github.event.commits.*.message), '[skip release]')
 
     steps:


### PR DESCRIPTION
When contributors fork the repo, they get GH actions that run when they push code to their forks. This change prevents GH Action "release" job failures. Example failure: https://github.com/shestee/mockito/actions/runs/375185562