### PR TITLE
Fixed incorrect comment type in properties file

### DIFF
--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-//Used by Shipkit Auto Version Gradle plugin: https://github.com/shipkit/shipkit-auto-version
+# Used by Shipkit Auto Version Gradle plugin: https://github.com/shipkit/shipkit-auto-version
 version=3.6.*


### PR DESCRIPTION
There is wrong comment type used in version.properties (*.properties files use '#' for comments, not '//'). This PR fixes it with the right one.

