### PR TITLE
Keep META-INF folder at top of published mockito-core jar

### DIFF
--- a/gradle/mockito-core/osgi.gradle
+++ b/gradle/mockito-core/osgi.gradle
@@ -71,7 +71,8 @@ class RemoveOsgiLastModifiedHeader {
 
             this.artifact
                 .entries()
-                .sort { it.name }
+                // Keep META-INF folder at the beginning to avoid https://github.com/mockito/mockito/issues/2108
+                .sort { (it.name.startsWith("META-INF") ? "A/" + it.name : "B/" + it.name) }
                 .each { JarEntry entry ->
 
                     stream.putNextEntry(newJarEntry(entry))


### PR DESCRIPTION
This solves issue #2108 by adapting the Jar entries sorting order in the OSGI plugin workaround. As a result META-INF folder is kept at the top of the Jar as expected by JarInputStream:
```
Archive:  build/libs/mockito-core-3.6.24.jar
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  02-01-1980 00:00   META-INF/
     4619  02-01-1980 00:00   META-INF/MANIFEST.MF
     1080  02-01-1980 00:00   LICENSE
        0  02-01-1980 00:00   org/

```
instead of:
```
Archive:  ~/.gradle/caches/modules-2/files-2.1/org.mockito/mockito-core/3.6.0/48657987075fea2e2176634ae35aaa5e93c929ef/mockito-core-3.6.0.jar
  Length      Date    Time    Name
---------  ---------- -----   ----
     1080  02-01-1980 01:00   LICENSE
        0  02-01-1980 01:00   META-INF/
     4606  02-01-1980 01:00   META-INF/MANIFEST.MF
        0  02-01-1980 01:00   org/

```