### PR TITLE
Enabled releases to Maven Central

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,5 +91,6 @@ jobs:
     - name: Build and publish
       run: ./gradlew bintrayUpload githubRelease --scan
       env:
+        MAVEN_CENTRAL_RELEASE: ${{contains(toJSON(github.event.commits.*.message), '[ci maven-central-release]')}}
         GH_WRITE_TOKEN: ${{secrets.GH_WRITE_TOKEN}}
         BINTRAY_API_KEY: ${{secrets.BINTRAY_API_KEY}}

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -28,7 +28,7 @@ ext.mavenCentralRelease = shouldReleaseToCentral(project)
  * To test this logic, run build with '-i' (info logging) and inspect the build output.
  */
 static boolean shouldReleaseToCentral(project) {
-    boolean centralReleaseByCommit = System.getenv("TRAVIS_COMMIT_MESSAGE")?.contains("[ci maven-central-release]")
+    boolean centralReleaseByCommit = 'true' == System.getenv("MAVEN_CENTRAL_RELEASE")
     boolean centralReleaseByProjectProperty = project.hasProperty("maven-central-release")
     boolean centralRelease = centralReleaseByCommit || centralReleaseByProjectProperty
     def message = """Bintray publish was using following settings:


### PR DESCRIPTION
Fixed the bug with how we controlled Maven Central releases via commit messages.

Testing done: Ran the workflow in a forked repository and b) observed that the information from the commit message is passed to the environment variable.

Fixes #2110