### PR TITLE
Fix in the doc for "Mocking object construction"

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -1582,7 +1582,7 @@ import java.util.function.Function;
  * </code></pre>
  *
  * Due to the defined scope of the mocked construction, object construction returns to its original behavior once the scope is
- * released. To define mock behavior and to verify static method invocations, use the <code>MockedConstruction</code> that is returned.
+ * released. To define mock behavior and to verify method invocations, use the <code>MockedConstruction</code> that is returned.
  * <p>
  */
 @SuppressWarnings("unchecked")


### PR DESCRIPTION
This is a suggestion for changing the documentation for "Mocking object
construction".  Previously, the documentation has suggested that
`MockedConstruction` can define mock behavior and to verify static method
invocations.  However, it is meant for defining mock behavior and verifying
non-static method invocations.

 - [X] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/3.x/.github/CONTRIBUTING.md)
 - [X] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [ ] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [ ] Avoid other runtime dependencies
 - [X] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [X] The pull request follows coding style
 - [ ] Mention `Fixes #<issue number>` in the description _if relevant_
 - [ ] At least one commit should mention `Fixes #<issue number>` _if relevant_

