### PR TITLE
Avoid Gradle module files

### DIFF
--- a/gradle/java-publication.gradle
+++ b/gradle/java-publication.gradle
@@ -25,6 +25,10 @@ artifacts {
     archives javadocJar
 }
 
+tasks.withType(GenerateModuleMetadata) {
+    enabled = false
+}
+
 //Gradle Maven publishing plugin configuration (https://docs.gradle.org/current/userguide/publishing_maven.html)
 apply plugin: "maven-publish"
 publishing {


### PR DESCRIPTION
Avoid Gradle module files until there is a use case for them. The less we publish the less complexity.

Fixes: #2159

Tested by running `./gradlew publishToMavenLocal' and inspecting files / poms.