### PR TITLE
Fixed build on Java 15

### DIFF
--- a/gradle/mockito-core/javadoc.gradle
+++ b/gradle/mockito-core/javadoc.gradle
@@ -41,8 +41,7 @@ javadoc {
     options.noNavBar = false
     options.noTree = false
     options.links = ['https://docs.oracle.com/javase/6/docs/api/',
-                     'http://junit.org/junit4/javadoc/4.12/',
-                     'http://hamcrest.org/JavaHamcrest/javadoc/1.3/']
+                     'http://junit.org/junit4/javadoc/4.12/']
     options.header("""<em id="mockito-version-header-javadoc7-header"><strong>Mockito ${project.version} API</strong></em>""")
     options.footer("""<em id="mockito-version-header-javadoc7-footer"><strong>Mockito ${project.version} API</strong></em>""")
     options.bottom("""


### PR DESCRIPTION
Attempted to fix the build by removing dead link that Javadoc generation was complaining about.