### PR TITLE
Apply new Shipkit Changelog plugin properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ buildscript {
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:1.3.0'
 
         //Using buildscript.classpath so that we can resolve plugins from maven local, during local testing
-        classpath "org.shipkit:shipkit-auto-version:0.0.+"
-        classpath "org.shipkit:shipkit-changelog:0.0.+"
+        classpath "org.shipkit:shipkit-auto-version:0.+"
+        classpath "org.shipkit:shipkit-changelog:0.+"
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.+"
 
         classpath 'com.google.googlejavaformat:google-java-format:1.9'

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -4,7 +4,7 @@ apply plugin: "org.shipkit.shipkit-gh-release"
 
 tasks.named("generateChangelog") {
     previousRevision = project.ext.'shipkit-auto-version.previous-tag'
-    readOnlyToken = System.getenv("GITHUB_TOKEN")
+    githubToken = System.getenv("GITHUB_TOKEN")
     repository = "mockito/mockito"
 }
 
@@ -13,7 +13,8 @@ tasks.named("githubRelease") {
     dependsOn genTask
     repository = genTask.repository
     changelog = genTask.outputFile
-    writeToken = System.getenv("GITHUB_TOKEN")
+    newTagRevision = System.getenv("GITHUB_SHA")
+    githubToken = System.getenv("GITHUB_TOKEN")
 }
 
 /**


### PR DESCRIPTION
Two new properties has been recently added to **Shipkit Changelog** plugin that is used by Mockito:
1. `newTagRevision` eliminates problem with wrong tagging, when release is tagged with revision reference that the release does not come from, but is the latest one on master branch. To get the commit SHA that triggered the workflow _'GITHUB_SHA'_ env var is used.
2. `githubToken` is used both to fetch and post via GH API, instead of `readOnlyToken` and `writeToken`. As the token assigned to _'githubToken'_ should have write access to the repository, it should be supplied by the env variable to keep things safe. Using this property simplifies configuration. Deprecated properties should be replaced with the new one.

