### PR TITLE
Bump Shipkit plugins versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ buildscript {
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:1.3.0'
 
         //Using buildscript.classpath so that we can resolve plugins from maven local, during local testing
-        classpath "org.shipkit:shipkit-auto-version:0.+"
-        classpath "org.shipkit:shipkit-changelog:0.+"
+        classpath "org.shipkit:shipkit-auto-version:1.1.1"
+        classpath "org.shipkit:shipkit-changelog:1.1.1"
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.+"
 
         classpath 'com.google.googlejavaformat:google-java-format:1.9'


### PR DESCRIPTION
Recently new versions of Shipkit Auto Version and Shipkit Changelog were released. The plugins' versions in the project can now be bumped.