### PR TITLE
Fix reversed order of verify parameters

### DIFF
--- a/src/main/java/org/mockito/MockedStatic.java
+++ b/src/main/java/org/mockito/MockedStatic.java
@@ -35,13 +35,20 @@ public interface MockedStatic<T> extends ScopedMock {
      * See {@link Mockito#verify(Object)}.
      */
     default void verify(Verification verification) {
-        verify(times(1), verification);
+        verify(verification, times(1));
     }
 
     /**
      * See {@link Mockito#verify(Object, VerificationMode)}.
+     *
+     * @deprecated Please use {@link MockedStatic#verify(Verification, VerificationMode) instead
      */
     void verify(VerificationMode mode, Verification verification);
+
+    /**
+     * See {@link Mockito#verify(Object, VerificationMode)}.
+     */
+    void verify(Verification verification, VerificationMode mode);
 
     /**
      * See {@link Mockito#reset(Object[])}.

--- a/src/main/java/org/mockito/internal/MockedStaticImpl.java
+++ b/src/main/java/org/mockito/internal/MockedStaticImpl.java
@@ -61,6 +61,11 @@ public final class MockedStaticImpl<T> implements MockedStatic<T> {
 
     @Override
     public void verify(VerificationMode mode, Verification verification) {
+        verify(verification, mode);
+    }
+
+    @Override
+    public void verify(Verification verification, VerificationMode mode) {
         assertNotClosed();
 
         MockingDetails mockingDetails = Mockito.mockingDetails(control.getType());


### PR DESCRIPTION
For consistency the parameters of the method
MockedStatic.verify(VerificationMode, Verification)
have been swapped to
MockedStatic.verify(Verification, VerificationMode)
as this order is already used in
Mockito.verify(T, VerificationMode)

Fixes: #2173

check list

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/3.x/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_