### PR TITLE
Fix typo in Javadocs of MockedConstruction

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -1573,14 +1573,14 @@ import java.util.function.Function;
  * In the following example, the <code>Foo</code> type's construction would generate a mock:
  *
  * <pre class="code"><code class="java">
- * assertEquals("foo", Foo.method());
+ * assertEquals("foo", new Foo().method());
  * try (MockedConstruction<Foo> mocked = mockConstruction(Foo.class)) {
  * Foo foo = new Foo();
  * when(foo.method()).thenReturn("bar");
  * assertEquals("bar", foo.method());
  * verify(foo).method();
  * }
- * assertEquals("foo", foo.method());
+ * assertEquals("foo", new Foo().method());
  * </code></pre>
  *
  * Due to the defined scope of the mocked construction, object construction returns to its original behavior once the scope is


### PR DESCRIPTION
Hi 🖐

I noted this while reading the Javadocs of MockedConstruction.

They were referring to static method and out of scope variable. It isn't quite easy to grasp in this context.
 
I think it's just a copy-paste mistake.

