### PR TITLE
Fixed 2154 : java.lang.Object is now instrumented again

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
@@ -269,9 +269,6 @@ public class InlineBytecodeGenerator implements BytecodeGenerator, ClassFileTran
             throw t;
         }
 
-        // The object type does not ever need instrumentation.
-        targets.remove(Object.class);
-
         if (!targets.isEmpty()) {
             try {
                 assureCanReadMockito(targets);

--- a/src/test/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMakerTest.java
+++ b/src/test/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMakerTest.java
@@ -220,6 +220,19 @@ public class InlineByteBuddyMockMakerTest
         assertThat(proxy.toString()).isEqualTo("foo");
     }
 
+    /**
+     * @see <a href="https://github.com/mockito/mockito/issues/2154">https://github.com/mockito/mockito/issues/2154</a>
+     */
+    @Test
+    public void should_mock_class_to_string() {
+        MockSettingsImpl<Object> mockSettings = new MockSettingsImpl<Object>();
+        mockSettings.setTypeToMock(Object.class);
+        mockSettings.defaultAnswer(new Returns("foo"));
+        Object proxy = mockMaker.createMock(mockSettings, new MockHandlerImpl<Object>(mockSettings));
+
+        assertThat(proxy.toString()).isEqualTo("foo");
+    }
+
     @Test
     public void should_remove_recursive_self_call_from_stack_trace() throws Exception {
         StackTraceElement[] stack =


### PR DESCRIPTION
Seems like 

```
// The object type does not ever need instrumentation.
targets.remove(Object.class);
```

in `org.mockito.internal.creation.bytebuddy.InlineBytecodeGenerator.triggerRetransformation(Set<Class<?>>, boolean)` was a bit over the top, i. e. it does seem to break mocking of toString when inherited from `java.lang.Object`.

I added a test for this which should have been there in the first place. Due to this, I am still not sure if removing the line is safe, even if the whole test suite is green. Please review carefully.

