### PR TITLE
Add API for clearing mocks.

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -2462,6 +2462,17 @@ public class Mockito extends ArgumentMatchers {
     }
 
     /**
+     * Clears all mocks, type caches and instrumentations.
+     * <p>
+     * By clearing Mockito's state, previously created mocks might begin to malfunction. This option can be used if
+     * Mockito's caches take up too much space or if the inline mock maker's instrumentation is causing performance
+     * issues in code where mocks are no longer used. Normally, you would not need to use this option.
+     */
+    public static void clearAllCaches() {
+        MOCKITO_CORE.clearAllCaches();
+    }
+
+    /**
      * Use this method in order to only clear invocations, when stubbing is non-trivial. Use-cases can be:
      * <ul>
      *     <li>You are using a dependency injection framework to inject your mocks.</li>

--- a/src/main/java/org/mockito/internal/MockitoCore.java
+++ b/src/main/java/org/mockito/internal/MockitoCore.java
@@ -15,6 +15,7 @@ import org.mockito.internal.stubbing.InvocationContainerImpl;
 import org.mockito.internal.stubbing.OngoingStubbingImpl;
 import org.mockito.internal.stubbing.StubberImpl;
 import org.mockito.internal.util.DefaultMockingDetails;
+import org.mockito.internal.util.MockUtil;
 import org.mockito.internal.verification.MockAwareVerificationMode;
 import org.mockito.internal.verification.VerificationDataImpl;
 import org.mockito.internal.verification.VerificationModeFactory;
@@ -278,5 +279,9 @@ public class MockitoCore {
 
     public LenientStubber lenient() {
         return new DefaultLenientStubber();
+    }
+
+    public void clearAllCaches() {
+        MockUtil.clearAllCaches();
     }
 }

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMaker.java
@@ -71,4 +71,9 @@ public class ByteBuddyMockMaker implements ClassCreatingMockMaker {
         return defaultByteBuddyMockMaker.createConstructionMock(
                 type, settingsFactory, handlerFactory, mockInitializer);
     }
+
+    @Override
+    public void clearAllCaches() {
+        defaultByteBuddyMockMaker.clearAllCaches();
+    }
 }

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/BytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/BytecodeGenerator.java
@@ -11,4 +11,6 @@ public interface BytecodeGenerator {
     void mockClassConstruction(Class<?> type);
 
     void mockClassStatic(Class<?> type);
+
+    default void clearAllCaches() {}
 }

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
@@ -483,6 +483,12 @@ public class InlineByteBuddyMockMaker
     }
 
     @Override
+    public void clearAllCaches() {
+        clearAllMocks();
+        bytecodeGenerator.clearAllCaches();
+    }
+
+    @Override
     public void clearMock(Object mock) {
         if (mock instanceof Class<?>) {
             for (Map<Class<?>, ?> entry : mockedStatics.getBackingMap().target.values()) {

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassByteBuddyMockMaker.java
@@ -179,4 +179,9 @@ public class SubclassByteBuddyMockMaker implements ClassCreatingMockMaker {
             }
         };
     }
+
+    @Override
+    public void clearAllCaches() {
+        cachingMockBytecodeGenerator.clearAllCaches();
+    }
 }

--- a/src/main/java/org/mockito/internal/util/MockUtil.java
+++ b/src/main/java/org/mockito/internal/util/MockUtil.java
@@ -152,4 +152,8 @@ public class MockUtil {
         return mockMaker.createConstructionMock(
                 type, settingsFactory, handlerFactory, mockInitializer);
     }
+
+    public static void clearAllCaches() {
+        mockMaker.clearAllCaches();
+    }
 }

--- a/src/main/java/org/mockito/plugins/MockMaker.java
+++ b/src/main/java/org/mockito/plugins/MockMaker.java
@@ -199,6 +199,12 @@ public interface MockMaker {
     }
 
     /**
+     * Clears all cashes for mocked types and removes all byte code alterations, if possible.
+     */
+    @Incubating
+    default void clearAllCaches() {}
+
+    /**
      * Carries the mockability information
      *
      * @since 2.1.0

--- a/src/test/java/org/mockito/MockitoClearTest.java
+++ b/src/test/java/org/mockito/MockitoClearTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2021 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MockitoClearTest {
+
+    @Test
+    public void can_clear_mock() {
+        Base mock = Mockito.mock(Base.class);
+        assertThat(Mockito.mock(Base.class).getClass()).isEqualTo(mock.getClass());
+
+        Mockito.clearAllCaches();
+
+        assertThat(Mockito.mock(Base.class).getClass()).isNotEqualTo(mock.getClass());
+    }
+
+    abstract static class Base {}
+}

--- a/subprojects/android/src/main/java/org/mockito/android/internal/creation/AndroidByteBuddyMockMaker.java
+++ b/subprojects/android/src/main/java/org/mockito/android/internal/creation/AndroidByteBuddyMockMaker.java
@@ -53,4 +53,9 @@ public class AndroidByteBuddyMockMaker implements MockMaker {
     public TypeMockability isTypeMockable(Class<?> type) {
         return delegate.isTypeMockable(type);
     }
+
+    @Override
+    public void clearAllCaches() {
+        delegate.clearAllCaches();
+    }
 }


### PR DESCRIPTION
By clearing mocks, caches are emptied and instrumentations are reversed.