### PR TITLE
Fixes #2204: Ignore Groovy methods annotated with Internal

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -35,6 +35,8 @@ libraries.osgi = 'org.osgi:osgi.core:8.0.0'
 libraries.equinox = 'org.eclipse.platform:org.eclipse.osgi:3.16.100'
 libraries.bndGradle =  'biz.aQute.bnd:biz.aQute.bnd.gradle:5.2.0'
 
+libraries.groovy = 'org.codehaus.groovy:groovy:3.0.7'
+
 def kotlinVersion = '1.4.30'
 libraries.kotlin = [
     version: kotlinVersion,

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 include("deprecatedPluginsTest",
     "inline",
     "extTest",
+    "groovyTest",
     "kotlinTest",
     "kotlinReleaseCoroutinesTest",
     "android",

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassBytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassBytecodeGenerator.java
@@ -226,7 +226,8 @@ class SubclassBytecodeGenerator implements BytecodeGenerator {
     }
 
     private static ElementMatcher<MethodDescription> isGroovyMethod() {
-        return isDeclaredBy(named("groovy.lang.GroovyObjectSupport"));
+        return isDeclaredBy(named("groovy.lang.GroovyObjectSupport"))
+                .or(isAnnotatedWith(named("groovy.transform.Internal")));
     }
 
     private boolean isComingFromJDK(Class<?> type) {

--- a/subprojects/groovyTest/groovyTest.gradle
+++ b/subprojects/groovyTest/groovyTest.gradle
@@ -1,0 +1,11 @@
+apply plugin: 'groovy'
+
+description = "Integration test for using Mockito from Groovy."
+
+apply from: "$rootDir/gradle/dependencies.gradle"
+
+dependencies {
+    testCompile project(":")
+    testCompile libraries.groovy
+    testCompile libraries.junit4
+}

--- a/subprojects/groovyTest/src/test/groovy/org/mockito/groovy/GroovyMockitoTest.groovy
+++ b/subprojects/groovyTest/src/test/groovy/org/mockito/groovy/GroovyMockitoTest.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.groovy
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+
+import static org.mockito.Mockito.verify
+
+@RunWith(MockitoJUnitRunner)
+class GroovyMockitoTest {
+
+    @Mock Helper helper
+    @InjectMocks ClassUnderTest classUnderTest
+
+    /**
+     * Test that the Groovy class under test can call methods on a mocked Groovy
+     * helper class.
+     */
+    @Test
+    void testCallGroovyFromGroovy() {
+        classUnderTest.methodUnderTest()
+        verify(helper).helperMethod()
+    }
+
+    static class ClassUnderTest {
+        private final Helper helper
+
+        ClassUnderTest(Helper helper) {
+            this.helper = helper
+        }
+
+        void methodUnderTest() {
+            helper.helperMethod()
+        }
+    }
+
+    static class Helper {
+        void helperMethod() { }
+    }
+}


### PR DESCRIPTION
Starting from Groovy 3.0, compiler-generated methods such as `getMetaClass()` [are no longer marked synthetic](https://issues.apache.org/jira/browse/GROOVY-8495), therefore ByteBuddy stopped automatically ignoring them. Instead they are now annotated with `@groovy.transform.Internal`. Update `isGroovyMethod()` to also check this new annotation.

#2204 has a test case, and this change fixes it.