### PR TITLE
Use java.lang.StackWalker instead of sun.misc.*

### DIFF
--- a/subprojects/memory-test/memory-test.gradle
+++ b/subprojects/memory-test/memory-test.gradle
@@ -14,6 +14,6 @@ dependencies {
 tasks.javadoc.enabled = false
 
 test {
-    maxHeapSize = "128m"
-    jvmArgs = ["-XX:MaxPermSize=128m"]
+    maxHeapSize = "64m"
+    jvmArgs = ["-XX:MaxMetaspaceSize=64m"]
 }

--- a/subprojects/memory-test/src/test/java/org/mockito/memorytest/ShouldNotStarveMemoryOnLargeStackTraceInvocationsTest.java
+++ b/subprojects/memory-test/src/test/java/org/mockito/memorytest/ShouldNotStarveMemoryOnLargeStackTraceInvocationsTest.java
@@ -14,19 +14,14 @@ import org.junit.Test;
 
 public class ShouldNotStarveMemoryOnLargeStackTraceInvocationsTest {
 
-    private static final int STACK_TRACE_DEPTH = 1000;
+    private static final int STACK_TRACE_DEPTH = 10000;
     private static final int INVOCATIONS_ON_STACK_TRACE_LEVEL = 100;
 
     private static boolean supported = false;
 
     static {
         try {
-            Class.forName("sun.misc.SharedSecrets")
-                .getMethod("getJavaLangAccess")
-                .invoke(null);
-            Class.forName("sun.misc.JavaLangAccess")
-                .getMethod("getStackTraceElement", Throwable.class, int.class);
-
+            Class.forName("java.lang.StackWalker").getMethod("getInstance").invoke(null);
             supported = true;
         } catch (Exception ignored) {
         }


### PR DESCRIPTION
`java.lang.StackWalker` is the public API shipped in Java 9. Tentatively opening this PR to see whether the memory improvements are still there.