### PR TITLE
Bugfix/2235 verify on a wrapped mock fails

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,6 +12,7 @@ libraries.junit4 = 'junit:junit:4.13.2'
 libraries.junitJupiterApi = "org.junit.jupiter:junit-jupiter-api:${versions.junitJupiter}"
 libraries.junitPlatformLauncher = 'org.junit.platform:junit-platform-launcher:1.7.1'
 libraries.junitJupiterEngine = "org.junit.jupiter:junit-jupiter-engine:${versions.junitJupiter}"
+libraries.junitVintageEngine = "org.junit.vintage:junit-vintage-engine:${versions.junitJupiter}"
 libraries.assertj = 'org.assertj:assertj-core:3.19.0'
 libraries.hamcrest = 'org.hamcrest:hamcrest-core:2.2'
 libraries.opentest4j = 'org.opentest4j:opentest4j:1.2.0'

--- a/src/main/java/org/mockito/internal/handler/MockHandlerImpl.java
+++ b/src/main/java/org/mockito/internal/handler/MockHandlerImpl.java
@@ -14,6 +14,7 @@ import org.mockito.internal.stubbing.InvocationContainerImpl;
 import org.mockito.internal.stubbing.OngoingStubbingImpl;
 import org.mockito.internal.stubbing.StubbedInvocationMatcher;
 import org.mockito.internal.stubbing.answers.DefaultAnswerValidator;
+import org.mockito.internal.util.MockUtil;
 import org.mockito.internal.verification.MockAwareVerificationMode;
 import org.mockito.internal.verification.VerificationDataImpl;
 import org.mockito.invocation.Invocation;
@@ -65,7 +66,7 @@ public class MockHandlerImpl<T> implements MockHandler<T> {
         if (verificationMode != null) {
             // We need to check if verification was started on the correct mock
             // - see VerifyingWithAnExtraCallToADifferentMockTest (bug 138)
-            if (((MockAwareVerificationMode) verificationMode).getMock() == invocation.getMock()) {
+            if (MockUtil.areSameMocks(((MockAwareVerificationMode) verificationMode).getMock(), invocation.getMock())) {
                 VerificationDataImpl data =
                         new VerificationDataImpl(invocationContainer, invocationMatcher);
                 verificationMode.verify(data);

--- a/src/main/java/org/mockito/internal/handler/MockHandlerImpl.java
+++ b/src/main/java/org/mockito/internal/handler/MockHandlerImpl.java
@@ -66,7 +66,9 @@ public class MockHandlerImpl<T> implements MockHandler<T> {
         if (verificationMode != null) {
             // We need to check if verification was started on the correct mock
             // - see VerifyingWithAnExtraCallToADifferentMockTest (bug 138)
-            if (MockUtil.areSameMocks(((MockAwareVerificationMode) verificationMode).getMock(), invocation.getMock())) {
+            if (MockUtil.areSameMocks(
+                    ((MockAwareVerificationMode) verificationMode).getMock(),
+                    invocation.getMock())) {
                 VerificationDataImpl data =
                         new VerificationDataImpl(invocationContainer, invocationMatcher);
                 verificationMode.verify(data);

--- a/src/main/java/org/mockito/internal/util/MockUtil.java
+++ b/src/main/java/org/mockito/internal/util/MockUtil.java
@@ -120,7 +120,7 @@ public class MockUtil {
         return mock;
     }
 
-    public static boolean areSameMocks(Object mockA, Object mockB){
+    public static boolean areSameMocks(Object mockA, Object mockB) {
         return mockA == mockB || resolve(mockA) == resolve(mockB);
     }
 

--- a/src/main/java/org/mockito/internal/util/MockUtil.java
+++ b/src/main/java/org/mockito/internal/util/MockUtil.java
@@ -120,6 +120,10 @@ public class MockUtil {
         return mock;
     }
 
+    public static boolean areSameMocks(Object mockA, Object mockB){
+        return mockA == mockB || resolve(mockA) == resolve(mockB);
+    }
+
     public static MockName getMockName(Object mock) {
         return getMockHandler(mock).getMockSettings().getMockName();
     }

--- a/subprojects/extTest/extTest.gradle
+++ b/subprojects/extTest/extTest.gradle
@@ -14,6 +14,12 @@ dependencies {
     testCompile libraries.junit4
     testCompile libraries.assertj
     testCompile libraries.junitJupiterApi
+    testRuntime libraries.junitJupiterEngine
+    testRuntime libraries.junitVintageEngine
+}
+
+tasks.withType(Test) {
+    useJUnitPlatform()
 }
 
 configurations.all {


### PR DESCRIPTION
PR for #2235: verify() on a wrapped mock fails with UnfinishedVerificationException