### PR TITLE
Fixes #2238: Do not omit stack frames of causing class

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
@@ -347,11 +347,7 @@ public class MockMethodAdvice extends MockMethodDispatcher {
             }
 
             new ConditionalStackTraceFilter()
-                    .filter(
-                            hideRecursiveCall(
-                                    cause,
-                                    skip,
-                                    origin.getDeclaringClass()));
+                    .filter(hideRecursiveCall(cause, skip, origin.getDeclaringClass()));
             throw cause;
         }
     }

--- a/src/test/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMakerTest.java
+++ b/src/test/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMakerTest.java
@@ -250,10 +250,8 @@ public class InlineByteBuddyMockMakerTest
         settings.defaultAnswer(Answers.CALLS_REAL_METHODS);
 
         Optional<ExceptionThrowingClass> proxy =
-            mockMaker.createSpy(
-                settings,
-                new MockHandlerImpl<>(settings),
-                new ExceptionThrowingClass());
+                mockMaker.createSpy(
+                        settings, new MockHandlerImpl<>(settings), new ExceptionThrowingClass());
 
         StackTraceElement[] returnedStack = null;
         try {
@@ -592,9 +590,11 @@ public class InlineByteBuddyMockMakerTest
             }
             return null;
         }
+
         public void throwException() throws IOException {
             internalThrowException(1);
         }
+
         void internalThrowException(int test) throws IOException {
             // some lines of code, so the exception is not thrown in the first line of the method
             int i = 0;


### PR DESCRIPTION
This PR will fix this problems described in #2238. 

The main cause wasn't the `hideRecursiveCall` method but `tryInvoke` method.
In `tryInvoke` the original stacktrace will be passed through the configured filter after it has been modified by `hideRecursiveCall`.

When calling `hideRecursiveCall` the second argument (`current`) is set the the length of the stack trace of the causing exception.
This will omit too much stack frames, ultimately skipping the lines containing of the root exception cause.

In this patch, `tryInvoke` will try to find a better starting frame when an exception is caught.
It will do this by investigating the created stack trace and look for the first entry matching the class name of the `instance` object given to `tryInvoke`. This offset will then be given to `hideRecursiveCall` as `current` argument instead of using the stack trace length.
If there is no `instance` object (`null`), the length of the stack trace is used (like before). 