### PR TITLE
Comment out sections of pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,19 +1,18 @@
-> Hey, 
-> 
-> Thanks for the contribution, this is awesome.
-> As you may have read, project members have somehow an opinionated view on what and how should be
-> Mockito, e.g. we don't want mockito to be a feature bloat.
-> There may be a thorough review, with feedback -> code change loop.
-> 
-> Which branch : 
-> - On mockito 3.x, make your pull request target `release/3.x`
-> - On mockito 2.x, make your pull request target `release/2.x` (2.x is in maintenance mode)
->
-> _This block can be removed_
-> _Something wrong in the template fix it here `.github/PULL_REQUEST_TEMPLATE.md`
-
-
-check list
+<!-- Hey, 
+Thanks for the contribution, this is awesome.
+As you may have read, project members have somehow an opinionated view on what and how should be
+Mockito, e.g. we don't want mockito to be a feature bloat.
+There may be a thorough review, with feedback -> code change loop.
+-->
+<!--
+Which branch : 
+- On mockito 3.x, make your pull request target `release/3.x`
+- On mockito 2.x, make your pull request target `release/2.x` (2.x is in maintenance mode)
+-->
+<!--
+If you have a suggestion for this template you can fix it in the .github/PULL_REQUEST_TEMPLATE.md file
+-->
+## Checklist
 
  - [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/3.x/.github/CONTRIBUTING.md)
  - [ ] PR should be motivated, i.e. what does it fix, why, and if relevant how


### PR DESCRIPTION
This commit comments out some guidance sections on the pull request template, so that it is visible to contributors submitting a pull request but it is not visible if they submit the request and forget to delete it.

Checklist

 - [X] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/3.x/.github/CONTRIBUTING.md)
 - [X] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [X] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [X] Avoid other runtime dependencies
 - [X] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [X] The pull request follows coding style
 - [X] Mention `Fixes #<issue number>` in the description _if relevant_
 - [X] At least one commit should mention `Fixes #<issue number>` _if relevant_

