### PR TITLE
Replace usage of Function with custom FunctionalInterface

### DIFF
--- a/src/main/java/org/mockito/MockSettings.java
+++ b/src/main/java/org/mockito/MockSettings.java
@@ -368,4 +368,9 @@ public interface MockSettings extends Serializable {
      */
     @Incubating
     MockSettings lenient();
+
+    @FunctionalInterface
+    interface MockSettingsFactory {
+        MockSettings apply(MockedConstruction.Context context);
+    }
 }

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -31,8 +31,6 @@ import org.mockito.session.MockitoSessionLogger;
 import org.mockito.stubbing.*;
 import org.mockito.verification.*;
 
-import java.util.function.Function;
-
 /**
  * <p align="left"><img src="logo.png" srcset="logo@2x.png 2x" alt="Mockito logo"/></p>
  * The Mockito library enables mock creation, verification and stubbing.
@@ -2261,8 +2259,7 @@ public class Mockito extends ArgumentMatchers {
     @Incubating
     @CheckReturnValue
     public static <T> MockedConstruction<T> mockConstruction(
-            Class<T> classToMock,
-            Function<MockedConstruction.Context, MockSettings> mockSettingsFactory) {
+            Class<T> classToMock, MockSettings.MockSettingsFactory mockSettingsFactory) {
         return mockConstruction(classToMock, mockSettingsFactory, (mock, context) -> {});
     }
 
@@ -2303,7 +2300,7 @@ public class Mockito extends ArgumentMatchers {
     @CheckReturnValue
     public static <T> MockedConstruction<T> mockConstruction(
             Class<T> classToMock,
-            Function<MockedConstruction.Context, MockSettings> mockSettingsFactory,
+            MockSettings.MockSettingsFactory mockSettingsFactory,
             MockedConstruction.MockInitializer<T> mockInitializer) {
         return MOCKITO_CORE.mockConstruction(classToMock, mockSettingsFactory, mockInitializer);
     }

--- a/src/main/java/org/mockito/internal/MockitoCore.java
+++ b/src/main/java/org/mockito/internal/MockitoCore.java
@@ -82,7 +82,7 @@ public class MockitoCore {
 
     public <T> MockedConstruction<T> mockConstruction(
             Class<T> typeToMock,
-            Function<MockedConstruction.Context, ? extends MockSettings> settingsFactory,
+            MockSettings.MockSettingsFactory settingsFactory,
             MockedConstruction.MockInitializer<T> mockInitializer) {
         Function<MockedConstruction.Context, MockCreationSettings<T>> creationSettings =
                 context -> {


### PR DESCRIPTION
`java.util.function.Function` is not available in older versions of
Android. We can replace it with a custom `@FunctionalInterface`
interface that serves the same purpose.