### PR TITLE
Fix thread race condition

### DIFF
--- a/src/main/java/org/mockito/internal/stubbing/StubbedInvocationMatcher.java
+++ b/src/main/java/org/mockito/internal/stubbing/StubbedInvocationMatcher.java
@@ -22,7 +22,7 @@ public class StubbedInvocationMatcher extends InvocationMatcher implements Seria
     private static final long serialVersionUID = 4919105134123672727L;
     private final Queue<Answer> answers = new ConcurrentLinkedQueue<Answer>();
     private final Strictness strictness;
-    private final Object usedAtLock = new Object();
+    private final Object usedAtLock = new Object[0];
     private DescribedInvocation usedAt;
 
     public StubbedInvocationMatcher(

--- a/src/main/java/org/mockito/internal/stubbing/StubbedInvocationMatcher.java
+++ b/src/main/java/org/mockito/internal/stubbing/StubbedInvocationMatcher.java
@@ -22,6 +22,7 @@ public class StubbedInvocationMatcher extends InvocationMatcher implements Seria
     private static final long serialVersionUID = 4919105134123672727L;
     private final Queue<Answer> answers = new ConcurrentLinkedQueue<Answer>();
     private final Strictness strictness;
+    private final Object usedAtLock = new Object();
     private DescribedInvocation usedAt;
 
     public StubbedInvocationMatcher(
@@ -45,11 +46,15 @@ public class StubbedInvocationMatcher extends InvocationMatcher implements Seria
     }
 
     public void markStubUsed(DescribedInvocation usedAt) {
-        this.usedAt = usedAt;
+        synchronized (usedAtLock) {
+            this.usedAt = usedAt;
+        }
     }
 
     public boolean wasUsed() {
-        return usedAt != null;
+        synchronized (usedAtLock) {
+            return usedAt != null;
+        }
     }
 
     @Override


### PR DESCRIPTION
Discovered internally at Google. The culprit was a thread race condition
around the usage of usedAt, which could race between setting the field
and retrieving it.