### PR TITLE
Fixes #2007 : Update objenesis dep to 3.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     compile libraries.bytebuddy, libraries.bytebuddyagent
 
     compileOnly libraries.junit4, libraries.hamcrest, libraries.opentest4j
-    compile libraries.objenesis3
+    compile libraries.objenesis
 
     testCompile libraries.asm
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -26,7 +26,7 @@ libraries.errorproneTestApi = "com.google.errorprone:error_prone_test_helpers:${
 
 libraries.autoservice = "com.google.auto.service:auto-service:1.0-rc7"
 
-libraries.objenesis = 'org.objenesis:objenesis:3.1'
+libraries.objenesis = 'org.objenesis:objenesis:3.2'
 
 libraries.asm = 'org.ow2.asm:asm:7.0'
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -26,9 +26,7 @@ libraries.errorproneTestApi = "com.google.errorprone:error_prone_test_helpers:${
 
 libraries.autoservice = "com.google.auto.service:auto-service:1.0-rc7"
 
-// objenesis 3.x fails on android instrumentation test compile. https://github.com/mockito/mockito/issues/2007
-libraries.objenesis2 = 'org.objenesis:objenesis:2.6'
-libraries.objenesis3 = 'org.objenesis:objenesis:3.1'
+libraries.objenesis = 'org.objenesis:objenesis:3.1'
 
 libraries.asm = 'org.ow2.asm:asm:7.0'
 

--- a/subprojects/android/android.gradle
+++ b/subprojects/android/android.gradle
@@ -3,29 +3,8 @@ description = "Mockito for Android"
 apply from: "$rootDir/gradle/java-library.gradle"
 
 dependencies {
-    compile(project.rootProject) {
-        exclude group: 'org.objenesis', module: 'objenesis'
-    }
+    compile project.rootProject
     compile libraries.bytebuddyandroid
-    compile(libraries.objenesis2) {
-        version {
-            strictly '2.6'
-        }
-        because(
-            '\n' +
-                'MOCKITO DEPENDENCY PROBLEM:\n' +
-                '\n' +
-                'Mockito core uses Objenesis 3.x and Objenesis 3.x does not work with android api 25 and below.\n' +
-                'If you have mockito-core dependency with mockito-android, remove mockito-core.\n' +
-                'If you have mockito-kotlin, exclude mockito-core.\n' +
-                'implementation("com.nhaarman.mockitokotlin2:mockito-kotlin") {\n' +
-                '    exclude group: "org.mockito", module: "mockito-core"\n' +
-                '}\n' +
-                'For more information please check; \n' +
-                '    https://github.com/mockito/mockito/pull/2024\n' +
-                '    https://github.com/mockito/mockito/pull/2007\n'
-        )
-    }
 }
 
 tasks.javadoc.enabled = false

--- a/subprojects/osgi-test/osgi-test.gradle
+++ b/subprojects/osgi-test/osgi-test.gradle
@@ -23,7 +23,7 @@ configurations {
 dependencies {
     testRuntimeBundles project.rootProject
     testRuntimeBundles libraries.bytebuddy
-    testRuntimeBundles libraries.objenesis3
+    testRuntimeBundles libraries.objenesis
     testRuntimeBundles tasks.testBundle.outputs.files
     testRuntimeBundles tasks.otherBundle.outputs.files
 }


### PR DESCRIPTION
Allows for building android instrumentation tests with minsdk < 26

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/3.x/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

