### PR TITLE
Fixes #2242 : Make exceptions for Inorder.verify more standard / spec…

### DIFF
--- a/src/main/java/org/mockito/internal/InOrderImpl.java
+++ b/src/main/java/org/mockito/internal/InOrderImpl.java
@@ -4,12 +4,11 @@
  */
 package org.mockito.internal;
 
-import static org.mockito.internal.exceptions.Reporter.inOrderRequiresFamiliarMock;
-
 import java.util.LinkedList;
 import java.util.List;
 
 import org.mockito.InOrder;
+import org.mockito.MockingDetails;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.verification.InOrderContextImpl;
 import org.mockito.internal.verification.InOrderWrapper;
@@ -20,6 +19,9 @@ import org.mockito.internal.verification.api.InOrderContext;
 import org.mockito.internal.verification.api.VerificationInOrderMode;
 import org.mockito.invocation.Invocation;
 import org.mockito.verification.VerificationMode;
+
+import static org.mockito.Mockito.mockingDetails;
+import static org.mockito.internal.exceptions.Reporter.*;
 
 /**
  * Allows verifying in order. This class should not be exposed, hence default access.
@@ -43,6 +45,13 @@ public class InOrderImpl implements InOrder, InOrderContext {
     }
 
     public <T> T verify(T mock, VerificationMode mode) {
+        if (mock == null) {
+            throw nullPassedToVerify();
+        }
+        MockingDetails mockingDetails = mockingDetails(mock);
+        if (!mockingDetails.isMock()) {
+            throw notAMockPassedToVerify(mock.getClass());
+        }
         if (!mocksToBeVerifiedInOrder.contains(mock)) {
             throw inOrderRequiresFamiliarMock();
         }

--- a/src/test/java/org/mockitousage/verification/BasicVerificationInOrderTest.java
+++ b/src/test/java/org/mockitousage/verification/BasicVerificationInOrderTest.java
@@ -4,6 +4,7 @@
  */
 package org.mockitousage.verification;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
@@ -11,6 +12,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.exceptions.base.MockitoException;
+import org.mockito.exceptions.misusing.NotAMockException;
+import org.mockito.exceptions.misusing.NullInsteadOfMockException;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockito.exceptions.verification.VerificationInOrderFailure;
 import org.mockito.exceptions.verification.WantedButNotInvoked;
@@ -272,5 +275,26 @@ public class BasicVerificationInOrderTest extends TestBase {
     @Test(expected = MockitoException.class)
     public void shouldScreamWhenNullPassed() {
         inOrder((Object[]) null);
+    }
+
+    @Test
+    public void shouldThrowNullPassedToVerifyException(){
+        try {
+            inOrder.verify(null);
+            fail();
+        } catch (NullInsteadOfMockException e) {
+            assertThat(e).hasMessageContaining("Argument passed to verify() should be a mock but is null!");
+        }
+    }
+
+    @Test
+    public void shouldThrowNotAMockPassedToVerifyException(){
+        Object object = new Object();
+        try {
+            inOrder.verify(object);
+            fail();
+        } catch (NotAMockException e) {
+            assertThat(e).hasMessageContaining("Argument passed to verify() is of type Object and is not a mock!");
+        }
     }
 }


### PR DESCRIPTION
…ific

*Adds NullInsteadOfMockException and NotAMockException checks to Inorder.verify() *before* checking if mocks were passed in during creation of Inorder

See https://github.com/mockito/mockito/issues/2242 for a description of the issue.

Inorder.verify(mock) now first checks if the passed argument is null, and if the mock is in fact a mock, and gives appropriate Exception messages, before checking if the passed in argument was passed during creation of Inorder object, and therefore giving a less specific error message.

<!-- Hey, 
Thanks for the contribution, this is awesome.
As you may have read, project members have somehow an opinionated view on what and how should be
Mockito, e.g. we don't want mockito to be a feature bloat.
There may be a thorough review, with feedback -> code change loop.
-->
<!--
Which branch : 
- On mockito 3.x, make your pull request target `release/3.x`
- On mockito 2.x, make your pull request target `release/2.x` (2.x is in maintenance mode)
-->
<!--
If you have a suggestion for this template you can fix it in the .github/PULL_REQUEST_TEMPLATE.md file
-->
## Checklist

 - [x ] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/3.x/.github/CONTRIBUTING.md)
 - [ x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [ x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x ] Avoid other runtime dependencies
 - [x ] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x ] The pull request follows coding style
 - [ x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [ x] At least one commit should mention `Fixes #<issue number>` _if relevant_

