### PR TITLE
Fixes #2273 : Add missing parenthesis to javadoc example

### DIFF
--- a/src/main/java/org/mockito/ArgumentMatcher.java
+++ b/src/main/java/org/mockito/ArgumentMatcher.java
@@ -61,7 +61,7 @@ package org.mockito;
  *
  * List mock = mock(List.class);
  *
- * when(mock.addAll(argThat(new ListOfTwoElements))).thenReturn(true);
+ * when(mock.addAll(argThat(new ListOfTwoElements()))).thenReturn(true);
  *
  * mock.addAll(Arrays.asList(&quot;one&quot;, &quot;two&quot;));
  *


### PR DESCRIPTION
Adds the missing parenthesis to the ArgumentMatcher javadoc example

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/3.x/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

