### PR TITLE
Apply automated ErrorProne fixes

### DIFF
--- a/src/main/java/org/mockito/AdditionalAnswers.java
+++ b/src/main/java/org/mockito/AdditionalAnswers.java
@@ -39,7 +39,7 @@ import org.mockito.stubbing.VoidAnswer6;
  * @since 1.9.5
  */
 @SuppressWarnings("unchecked")
-public class AdditionalAnswers {
+public final class AdditionalAnswers {
     /**
      * Returns the first parameter of an invocation.
      *
@@ -529,4 +529,6 @@ public class AdditionalAnswers {
     public static <A, B, C, D, E, F> Answer<Void> answerVoid(VoidAnswer6<A, B, C, D, E, F> answer) {
         return toAnswer(answer);
     }
+
+    private AdditionalAnswers() {}
 }

--- a/src/main/java/org/mockito/AdditionalMatchers.java
+++ b/src/main/java/org/mockito/AdditionalMatchers.java
@@ -38,7 +38,7 @@ import org.mockito.internal.matchers.LessThan;
  * Scroll down to see all methods - full list of matchers.
  */
 @SuppressWarnings("ALL")
-public class AdditionalMatchers {
+public final class AdditionalMatchers {
 
     /**
      * argument greater than or equal the given value.
@@ -1054,4 +1054,6 @@ public class AdditionalMatchers {
     private static void reportMatcher(ArgumentMatcher<?> matcher) {
         mockingProgress().getArgumentMatcherStorage().reportMatcher(matcher);
     }
+
+    private AdditionalMatchers() {}
 }

--- a/src/main/java/org/mockito/Answers.java
+++ b/src/main/java/org/mockito/Answers.java
@@ -94,6 +94,7 @@ public enum Answers implements Answer<Object> {
         return this;
     }
 
+    @Override
     public Object answer(InvocationOnMock invocation) throws Throwable {
         return implementation.answer(invocation);
     }

--- a/src/main/java/org/mockito/ArgumentMatchers.java
+++ b/src/main/java/org/mockito/ArgumentMatchers.java
@@ -951,7 +951,9 @@ public class ArgumentMatchers {
      */
     public static <T> T same(T value) {
         reportMatcher(new Same(value));
-        if (value == null) return null;
+        if (value == null) {
+            return null;
+        }
         return (T) Primitives.defaultValue(value.getClass());
     }
 
@@ -1094,7 +1096,7 @@ public class ArgumentMatchers {
      */
     public static <T> T nullable(Class<T> clazz) {
         AdditionalMatchers.or(isNull(), isA(clazz));
-        return (T) Primitives.defaultValue(clazz);
+        return Primitives.defaultValue(clazz);
     }
 
     /**

--- a/src/main/java/org/mockito/Captor.java
+++ b/src/main/java/org/mockito/Captor.java
@@ -4,7 +4,11 @@
  */
 package org.mockito;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * Allows shorthand {@link org.mockito.ArgumentCaptor} creation on fields.

--- a/src/main/java/org/mockito/MockedStatic.java
+++ b/src/main/java/org/mockito/MockedStatic.java
@@ -4,10 +4,10 @@
  */
 package org.mockito;
 
+import static org.mockito.Mockito.times;
+
 import org.mockito.stubbing.OngoingStubbing;
 import org.mockito.verification.VerificationMode;
-
-import static org.mockito.Mockito.*;
 
 /**
  * Represents an active mock of a type's static methods. The mocking only affects the thread

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -28,10 +28,17 @@ import org.mockito.quality.MockitoHint;
 import org.mockito.quality.Strictness;
 import org.mockito.session.MockitoSessionBuilder;
 import org.mockito.session.MockitoSessionLogger;
-import org.mockito.stubbing.*;
-import org.mockito.verification.*;
 
 import java.util.function.Function;
+import org.mockito.stubbing.Answer;
+import org.mockito.stubbing.LenientStubber;
+import org.mockito.stubbing.OngoingStubbing;
+import org.mockito.stubbing.Stubber;
+import org.mockito.verification.After;
+import org.mockito.verification.Timeout;
+import org.mockito.verification.VerificationAfterDelay;
+import org.mockito.verification.VerificationMode;
+import org.mockito.verification.VerificationWithTimeout;
 
 /**
  * <p align="left"><img src="logo.png" srcset="logo@2x.png 2x" alt="Mockito logo"/></p>

--- a/src/main/java/org/mockito/MockitoAnnotations.java
+++ b/src/main/java/org/mockito/MockitoAnnotations.java
@@ -4,12 +4,12 @@
  */
 package org.mockito;
 
+import static org.mockito.internal.util.StringUtil.join;
+
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.configuration.GlobalConfiguration;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.plugins.AnnotationEngine;
-
-import static org.mockito.internal.util.StringUtil.*;
 
 /**
  * MockitoAnnotations.openMocks(this); initializes fields annotated with Mockito annotations.
@@ -61,7 +61,7 @@ import static org.mockito.internal.util.StringUtil.*;
  * If static method mocks are used, it is required to close the initialization. Additionally, if using third-party
  * mock-makers, other life-cycles might be handled by the open-release routine.
  */
-public class MockitoAnnotations {
+public final class MockitoAnnotations {
 
     /**
      * Initializes objects annotated with Mockito annotations for given testClass:
@@ -107,4 +107,6 @@ public class MockitoAnnotations {
                     e);
         }
     }
+
+    private MockitoAnnotations() {}
 }

--- a/src/main/java/org/mockito/configuration/DefaultMockitoConfiguration.java
+++ b/src/main/java/org/mockito/configuration/DefaultMockitoConfiguration.java
@@ -17,6 +17,7 @@ import org.mockito.stubbing.Answer;
  */
 public class DefaultMockitoConfiguration implements IMockitoConfiguration {
 
+    @Override
     public Answer<Object> getDefaultAnswer() {
         return new ReturnsEmptyValues();
     }
@@ -31,6 +32,7 @@ public class DefaultMockitoConfiguration implements IMockitoConfiguration {
     /* (non-Javadoc)
      * @see org.mockito.configuration.IMockitoConfiguration#cleansStackTrace()
      */
+    @Override
     public boolean cleansStackTrace() {
         return true;
     }
@@ -38,6 +40,7 @@ public class DefaultMockitoConfiguration implements IMockitoConfiguration {
     /* (non-Javadoc)
      * @see org.mockito.configuration.IMockitoConfiguration#enableClassCache()
      */
+    @Override
     public boolean enableClassCache() {
         return true;
     }

--- a/src/main/java/org/mockito/creation/instance/Instantiator.java
+++ b/src/main/java/org/mockito/creation/instance/Instantiator.java
@@ -17,5 +17,5 @@ public interface Instantiator {
      *
      * @since 2.15.4
      */
-    <T> T newInstance(Class<T> cls) throws InstantiationException;
+    <T> T newInstance(Class<T> cls);
 }

--- a/src/main/java/org/mockito/exceptions/verification/ArgumentsAreDifferent.java
+++ b/src/main/java/org/mockito/exceptions/verification/ArgumentsAreDifferent.java
@@ -30,7 +30,7 @@ public class ArgumentsAreDifferent extends MockitoAssertionError {
     }
 
     @Override
-    public String toString() {
+    public String getMessage() {
         return removeFirstLine(super.toString());
     }
 }

--- a/src/main/java/org/mockito/hamcrest/MockitoHamcrest.java
+++ b/src/main/java/org/mockito/hamcrest/MockitoHamcrest.java
@@ -45,7 +45,7 @@ import org.mockito.internal.hamcrest.HamcrestArgumentMatcher;
  *
  * @since 2.1.0
  */
-public class MockitoHamcrest {
+public final class MockitoHamcrest {
 
     /**
      * Allows matching arguments with hamcrest matchers.
@@ -179,4 +179,6 @@ public class MockitoHamcrest {
                 .getArgumentMatcherStorage()
                 .reportMatcher(new HamcrestArgumentMatcher<T>(matcher));
     }
+
+    private MockitoHamcrest() {}
 }

--- a/src/main/java/org/mockito/internal/InOrderImpl.java
+++ b/src/main/java/org/mockito/internal/InOrderImpl.java
@@ -4,6 +4,8 @@
  */
 package org.mockito.internal;
 
+import static org.mockito.internal.exceptions.Reporter.inOrderRequiresFamiliarMock;
+
 import java.util.LinkedList;
 import java.util.List;
 
@@ -29,7 +31,7 @@ import static org.mockito.internal.exceptions.Reporter.*;
 public class InOrderImpl implements InOrder, InOrderContext {
 
     private final MockitoCore mockitoCore = new MockitoCore();
-    private final List<Object> mocksToBeVerifiedInOrder = new LinkedList<Object>();
+    private final List<Object> mocksToBeVerifiedInOrder = new LinkedList<>();
     private final InOrderContext inOrderContext = new InOrderContextImpl();
 
     public List<Object> getMocksToBeVerifiedInOrder() {
@@ -40,10 +42,12 @@ public class InOrderImpl implements InOrder, InOrderContext {
         this.mocksToBeVerifiedInOrder.addAll(mocksToBeVerifiedInOrder);
     }
 
+    @Override
     public <T> T verify(T mock) {
         return this.verify(mock, VerificationModeFactory.times(1));
     }
 
+    @Override
     public <T> T verify(T mock, VerificationMode mode) {
         if (mock == null) {
             throw nullPassedToVerify();
@@ -65,14 +69,17 @@ public class InOrderImpl implements InOrder, InOrderContext {
         return mockitoCore.verify(mock, new InOrderWrapper((VerificationInOrderMode) mode, this));
     }
 
+    @Override
     public boolean isVerified(Invocation i) {
         return inOrderContext.isVerified(i);
     }
 
+    @Override
     public void markVerified(Invocation i) {
         inOrderContext.markVerified(i);
     }
 
+    @Override
     public void verifyNoMoreInteractions() {
         mockitoCore.verifyNoMoreInteractionsInOrder(mocksToBeVerifiedInOrder, this);
     }

--- a/src/main/java/org/mockito/internal/MockedConstructionImpl.java
+++ b/src/main/java/org/mockito/internal/MockedConstructionImpl.java
@@ -4,6 +4,8 @@
  */
 package org.mockito.internal;
 
+import static org.mockito.internal.util.StringUtil.join;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -12,8 +14,6 @@ import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.debugging.LocationImpl;
 import org.mockito.invocation.Location;
 import org.mockito.plugins.MockMaker;
-
-import static org.mockito.internal.util.StringUtil.*;
 
 public final class MockedConstructionImpl<T> implements MockedConstruction<T> {
 

--- a/src/main/java/org/mockito/internal/MockedStaticImpl.java
+++ b/src/main/java/org/mockito/internal/MockedStaticImpl.java
@@ -4,6 +4,14 @@
  */
 package org.mockito.internal;
 
+import static org.mockito.internal.exceptions.Reporter.missingMethodInvocation;
+import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
+import static org.mockito.internal.util.MockUtil.getInvocationContainer;
+import static org.mockito.internal.util.MockUtil.resetMock;
+import static org.mockito.internal.util.StringUtil.join;
+import static org.mockito.internal.verification.VerificationModeFactory.noInteractions;
+import static org.mockito.internal.verification.VerificationModeFactory.noMoreInteractions;
+
 import org.mockito.MockedStatic;
 import org.mockito.MockingDetails;
 import org.mockito.Mockito;
@@ -20,12 +28,6 @@ import org.mockito.invocation.MockHandler;
 import org.mockito.plugins.MockMaker;
 import org.mockito.stubbing.OngoingStubbing;
 import org.mockito.verification.VerificationMode;
-
-import static org.mockito.internal.exceptions.Reporter.*;
-import static org.mockito.internal.progress.ThreadSafeMockingProgress.*;
-import static org.mockito.internal.util.MockUtil.*;
-import static org.mockito.internal.util.StringUtil.*;
-import static org.mockito.internal.verification.VerificationModeFactory.*;
 
 public final class MockedStaticImpl<T> implements MockedStatic<T> {
 

--- a/src/main/java/org/mockito/internal/MockitoCore.java
+++ b/src/main/java/org/mockito/internal/MockitoCore.java
@@ -4,7 +4,35 @@
  */
 package org.mockito.internal;
 
-import org.mockito.*;
+import static org.mockito.internal.exceptions.Reporter.missingMethodInvocation;
+import static org.mockito.internal.exceptions.Reporter.mocksHaveToBePassedToVerifyNoMoreInteractions;
+import static org.mockito.internal.exceptions.Reporter.mocksHaveToBePassedWhenCreatingInOrder;
+import static org.mockito.internal.exceptions.Reporter.notAMockPassedToVerify;
+import static org.mockito.internal.exceptions.Reporter.notAMockPassedToVerifyNoMoreInteractions;
+import static org.mockito.internal.exceptions.Reporter.notAMockPassedWhenCreatingInOrder;
+import static org.mockito.internal.exceptions.Reporter.nullPassedToVerify;
+import static org.mockito.internal.exceptions.Reporter.nullPassedToVerifyNoMoreInteractions;
+import static org.mockito.internal.exceptions.Reporter.nullPassedWhenCreatingInOrder;
+import static org.mockito.internal.exceptions.Reporter.stubPassedToVerify;
+import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
+import static org.mockito.internal.util.MockUtil.createConstructionMock;
+import static org.mockito.internal.util.MockUtil.createMock;
+import static org.mockito.internal.util.MockUtil.createStaticMock;
+import static org.mockito.internal.util.MockUtil.getInvocationContainer;
+import static org.mockito.internal.util.MockUtil.getMockHandler;
+import static org.mockito.internal.util.MockUtil.isMock;
+import static org.mockito.internal.util.MockUtil.resetMock;
+import static org.mockito.internal.util.MockUtil.typeMockabilityOf;
+import static org.mockito.internal.verification.VerificationModeFactory.noInteractions;
+import static org.mockito.internal.verification.VerificationModeFactory.noMoreInteractions;
+
+import java.util.Arrays;
+import java.util.List;
+import org.mockito.InOrder;
+import org.mockito.MockSettings;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.MockingDetails;
 import org.mockito.exceptions.misusing.NotAMockException;
 import org.mockito.internal.creation.MockSettingsImpl;
 import org.mockito.internal.invocation.finder.VerifiableInvocationsFinder;
@@ -36,12 +64,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 
-import static org.mockito.internal.exceptions.Reporter.*;
-import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
-import static org.mockito.internal.util.MockUtil.*;
-import static org.mockito.internal.verification.VerificationModeFactory.noInteractions;
-import static org.mockito.internal.verification.VerificationModeFactory.noMoreInteractions;
-
 @SuppressWarnings("unchecked")
 public class MockitoCore {
 
@@ -50,14 +72,14 @@ public class MockitoCore {
     }
 
     public <T> T mock(Class<T> typeToMock, MockSettings settings) {
-        if (!MockSettingsImpl.class.isInstance(settings)) {
+        if (!(settings instanceof MockSettingsImpl)) {
             throw new IllegalArgumentException(
                     "Unexpected implementation of '"
                             + settings.getClass().getCanonicalName()
                             + "'\n"
                             + "At the moment, you cannot provide your own implementations of that class.");
         }
-        MockSettingsImpl impl = MockSettingsImpl.class.cast(settings);
+        MockSettingsImpl impl = (MockSettingsImpl) settings;
         MockCreationSettings<T> creationSettings = impl.build(typeToMock);
         T mock = createMock(creationSettings);
         mockingProgress().mockingStarted(mock, creationSettings);

--- a/src/main/java/org/mockito/internal/SuppressSignatureCheck.java
+++ b/src/main/java/org/mockito/internal/SuppressSignatureCheck.java
@@ -4,7 +4,9 @@
  */
 package org.mockito.internal;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 
 @Retention(RetentionPolicy.CLASS)
 @Documented

--- a/src/main/java/org/mockito/internal/configuration/CaptorAnnotationProcessor.java
+++ b/src/main/java/org/mockito/internal/configuration/CaptorAnnotationProcessor.java
@@ -15,6 +15,7 @@ import org.mockito.internal.util.reflection.GenericMaster;
  * Instantiate {@link ArgumentCaptor} a field annotated by &#64;Captor.
  */
 public class CaptorAnnotationProcessor implements FieldAnnotationProcessor<Captor> {
+    @Override
     public Object process(Captor annotation, Field field) {
         Class<?> type = field.getType();
         if (!ArgumentCaptor.class.isAssignableFrom(type)) {

--- a/src/main/java/org/mockito/internal/configuration/GlobalConfiguration.java
+++ b/src/main/java/org/mockito/internal/configuration/GlobalConfiguration.java
@@ -19,7 +19,7 @@ public class GlobalConfiguration implements IMockitoConfiguration, Serializable 
     private static final long serialVersionUID = -2860353062105505938L;
 
     private static final ThreadLocal<IMockitoConfiguration> GLOBAL_CONFIGURATION =
-            new ThreadLocal<IMockitoConfiguration>();
+            new ThreadLocal<>();
 
     // back door for testing
     IMockitoConfiguration getIt() {
@@ -59,14 +59,17 @@ public class GlobalConfiguration implements IMockitoConfiguration, Serializable 
         return configuration.getAnnotationEngine();
     }
 
+    @Override
     public boolean cleansStackTrace() {
         return GLOBAL_CONFIGURATION.get().cleansStackTrace();
     }
 
+    @Override
     public boolean enableClassCache() {
         return GLOBAL_CONFIGURATION.get().enableClassCache();
     }
 
+    @Override
     public Answer<Object> getDefaultAnswer() {
         return GLOBAL_CONFIGURATION.get().getDefaultAnswer();
     }

--- a/src/main/java/org/mockito/internal/configuration/IndependentAnnotationEngine.java
+++ b/src/main/java/org/mockito/internal/configuration/IndependentAnnotationEngine.java
@@ -34,8 +34,7 @@ import org.mockito.plugins.MemberAccessor;
 public class IndependentAnnotationEngine
         implements AnnotationEngine, org.mockito.configuration.AnnotationEngine {
     private final Map<Class<? extends Annotation>, FieldAnnotationProcessor<?>>
-            annotationProcessorMap =
-                    new HashMap<Class<? extends Annotation>, FieldAnnotationProcessor<?>>();
+            annotationProcessorMap = new HashMap<>();
 
     public IndependentAnnotationEngine() {
         registerAnnotationProcessor(Mock.class, new MockAnnotationProcessor());
@@ -52,6 +51,7 @@ public class IndependentAnnotationEngine
                     annotationProcessorMap.get(annotation.annotationType());
         }
         return new FieldAnnotationProcessor<A>() {
+            @Override
             public Object process(A annotation, Field field) {
                 return null;
             }

--- a/src/main/java/org/mockito/internal/configuration/InjectingAnnotationEngine.java
+++ b/src/main/java/org/mockito/internal/configuration/InjectingAnnotationEngine.java
@@ -42,6 +42,7 @@ public class InjectingAnnotationEngine
      *
      * @see org.mockito.plugins.AnnotationEngine#process(Class, Object)
      */
+    @Override
     public AutoCloseable process(Class<?> clazz, Object testInstance) {
         List<AutoCloseable> closeables = new ArrayList<>();
         closeables.addAll(processIndependentAnnotations(testInstance.getClass(), testInstance));
@@ -104,7 +105,7 @@ public class InjectingAnnotationEngine
      */
     private AutoCloseable injectCloseableMocks(final Object testClassInstance) {
         Class<?> clazz = testClassInstance.getClass();
-        Set<Field> mockDependentFields = new HashSet<Field>();
+        Set<Field> mockDependentFields = new HashSet<>();
         Set<Object> mocks = newMockSafeHashSet();
 
         while (clazz != Object.class) {

--- a/src/main/java/org/mockito/internal/configuration/SpyAnnotationEngine.java
+++ b/src/main/java/org/mockito/internal/configuration/SpyAnnotationEngine.java
@@ -140,7 +140,8 @@ public class SpyAnnotationEngine
             throw new MockitoException(
                     "Please ensure that the type '"
                             + type.getSimpleName()
-                            + "' has a no-arg constructor.");
+                            + "' has a no-arg constructor.",
+                    e);
         }
         return constructor;
     }

--- a/src/main/java/org/mockito/internal/configuration/injection/ConstructorInjection.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/ConstructorInjection.java
@@ -39,6 +39,7 @@ public class ConstructorInjection extends MockInjectionStrategy {
 
     public ConstructorInjection() {}
 
+    @Override
     public boolean processInjection(Field field, Object fieldOwner, Set<Object> mockCandidates) {
         try {
             SimpleArgumentResolver simpleArgumentResolver =
@@ -67,8 +68,9 @@ public class ConstructorInjection extends MockInjectionStrategy {
             this.objects = objects;
         }
 
+        @Override
         public Object[] resolveTypeInstances(Class<?>... argTypes) {
-            List<Object> argumentInstances = new ArrayList<Object>(argTypes.length);
+            List<Object> argumentInstances = new ArrayList<>(argTypes.length);
             for (Class<?> argType : argTypes) {
                 argumentInstances.add(objectThatIsAssignableFrom(argType));
             }
@@ -77,7 +79,9 @@ public class ConstructorInjection extends MockInjectionStrategy {
 
         private Object objectThatIsAssignableFrom(Class<?> argType) {
             for (Object object : objects) {
-                if (argType.isAssignableFrom(object.getClass())) return object;
+                if (argType.isAssignableFrom(object.getClass())) {
+                    return object;
+                }
             }
             return null;
         }

--- a/src/main/java/org/mockito/internal/configuration/injection/MockInjection.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/MockInjection.java
@@ -16,12 +16,9 @@ import java.util.Set;
 /**
  * Internal injection configuration utility.
  *
- * <p>
- * Allow the user of this class to configure the way the injection of mocks will happen.
- * </p>
- *
+ * <p>Allow the user of this class to configure the way the injection of mocks will happen.
  */
-public class MockInjection {
+public final class MockInjection {
 
     /**
      * Create a new configuration setup for a field
@@ -51,7 +48,7 @@ public class MockInjection {
      * Ongoing configuration of the mock injector.
      */
     public static class OngoingMockInjection {
-        private final Set<Field> fields = new HashSet<Field>();
+        private final Set<Field> fields = new HashSet<>();
         private final Set<Object> mocks = newMockSafeHashSet();
         private final Object fieldOwner;
         private final MockInjectionStrategy injectionStrategies = MockInjectionStrategy.nop();
@@ -93,4 +90,6 @@ public class MockInjection {
             }
         }
     }
+
+    private MockInjection() {}
 }

--- a/src/main/java/org/mockito/internal/configuration/injection/MockInjectionStrategy.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/MockInjectionStrategy.java
@@ -17,6 +17,7 @@ public abstract class MockInjectionStrategy {
      */
     public static MockInjectionStrategy nop() {
         return new MockInjectionStrategy() {
+            @Override
             protected boolean processInjection(
                     Field field, Object fieldOwner, Set<Object> mockCandidates) {
                 return false;

--- a/src/main/java/org/mockito/internal/configuration/injection/PropertyAndSetterInjection.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/PropertyAndSetterInjection.java
@@ -68,12 +68,14 @@ public class PropertyAndSetterInjection extends MockInjectionStrategy {
 
     private final ListUtil.Filter<Field> notFinalOrStatic =
             new ListUtil.Filter<Field>() {
+                @Override
                 public boolean isOut(Field object) {
                     return Modifier.isFinal(object.getModifiers())
                             || Modifier.isStatic(object.getModifiers());
                 }
             };
 
+    @Override
     public boolean processInjection(
             Field injectMocksField, Object injectMocksFieldOwner, Set<Object> mockCandidates) {
         FieldInitializationReport report =

--- a/src/main/java/org/mockito/internal/configuration/injection/filter/NameBasedCandidateFilter.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/filter/NameBasedCandidateFilter.java
@@ -18,6 +18,7 @@ public class NameBasedCandidateFilter implements MockCandidateFilter {
         this.next = next;
     }
 
+    @Override
     public OngoingInjector filterCandidate(
             final Collection<Object> mocks,
             final Field candidateFieldToBeInjected,
@@ -42,7 +43,7 @@ public class NameBasedCandidateFilter implements MockCandidateFilter {
 
     private List<Object> selectMatchingName(
             Collection<Object> mocks, Field candidateFieldToBeInjected) {
-        List<Object> mockNameMatches = new ArrayList<Object>();
+        List<Object> mockNameMatches = new ArrayList<>();
         for (Object mock : mocks) {
             if (candidateFieldToBeInjected.getName().equals(getMockName(mock).toString())) {
                 mockNameMatches.add(mock);

--- a/src/main/java/org/mockito/internal/configuration/injection/filter/OngoingInjector.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/filter/OngoingInjector.java
@@ -25,6 +25,7 @@ public interface OngoingInjector {
      */
     OngoingInjector nop =
             new OngoingInjector() {
+                @Override
                 public Object thenInject() {
                     return null;
                 }

--- a/src/main/java/org/mockito/internal/configuration/injection/filter/TerminalMockCandidateFilter.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/filter/TerminalMockCandidateFilter.java
@@ -23,6 +23,7 @@ import org.mockito.plugins.MemberAccessor;
  * </ul>
  */
 public class TerminalMockCandidateFilter implements MockCandidateFilter {
+    @Override
     public OngoingInjector filterCandidate(
             final Collection<Object> mocks,
             final Field candidateFieldToBeInjected,

--- a/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
@@ -17,12 +17,13 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
         this.next = next;
     }
 
+    @Override
     public OngoingInjector filterCandidate(
             final Collection<Object> mocks,
             final Field candidateFieldToBeInjected,
             final List<Field> allRemainingCandidateFields,
             final Object injectee) {
-        List<Object> mockTypeMatches = new ArrayList<Object>();
+        List<Object> mockTypeMatches = new ArrayList<>();
         for (Object mock : mocks) {
             if (candidateFieldToBeInjected.getType().isAssignableFrom(mock.getClass())) {
                 mockTypeMatches.add(mock);

--- a/src/main/java/org/mockito/internal/configuration/injection/scanner/InjectMocksScanner.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/scanner/InjectMocksScanner.java
@@ -46,7 +46,7 @@ public class InjectMocksScanner {
      */
     @SuppressWarnings("unchecked")
     private Set<Field> scan() {
-        Set<Field> mockDependentFields = new HashSet<Field>();
+        Set<Field> mockDependentFields = new HashSet<>();
         Field[] fields = clazz.getDeclaredFields();
         for (Field field : fields) {
             if (null != field.getAnnotation(InjectMocks.class)) {

--- a/src/main/java/org/mockito/internal/configuration/plugins/DefaultMockitoPlugins.java
+++ b/src/main/java/org/mockito/internal/configuration/plugins/DefaultMockitoPlugins.java
@@ -6,13 +6,20 @@ package org.mockito.internal.configuration.plugins;
 
 import java.util.HashMap;
 import java.util.Map;
-
 import org.mockito.internal.creation.instance.InstantiatorProvider2Adapter;
-import org.mockito.plugins.*;
+import org.mockito.plugins.AnnotationEngine;
+import org.mockito.plugins.InstantiatorProvider;
+import org.mockito.plugins.InstantiatorProvider2;
+import org.mockito.plugins.MemberAccessor;
+import org.mockito.plugins.MockMaker;
+import org.mockito.plugins.MockitoLogger;
+import org.mockito.plugins.MockitoPlugins;
+import org.mockito.plugins.PluginSwitch;
+import org.mockito.plugins.StackTraceCleanerProvider;
 
 class DefaultMockitoPlugins implements MockitoPlugins {
 
-    private static final Map<String, String> DEFAULT_PLUGINS = new HashMap<String, String>();
+    private static final Map<String, String> DEFAULT_PLUGINS = new HashMap<>();
     static final String INLINE_ALIAS = "mock-maker-inline";
     static final String MODULE_ALIAS = "member-accessor-module";
 

--- a/src/main/java/org/mockito/internal/configuration/plugins/DefaultPluginSwitch.java
+++ b/src/main/java/org/mockito/internal/configuration/plugins/DefaultPluginSwitch.java
@@ -7,6 +7,7 @@ package org.mockito.internal.configuration.plugins;
 import org.mockito.plugins.PluginSwitch;
 
 class DefaultPluginSwitch implements PluginSwitch {
+    @Override
     public boolean isEnabled(String pluginClassName) {
         return true;
     }

--- a/src/main/java/org/mockito/internal/configuration/plugins/PluginLoader.java
+++ b/src/main/java/org/mockito/internal/configuration/plugins/PluginLoader.java
@@ -58,11 +58,11 @@ class PluginLoader {
      * @return An object of either {@code preferredPluginType} or {@code alternatePluginType}
      */
     @SuppressWarnings("unchecked")
-    <PreferredType, AlternateType> Object loadPlugin(
-            final Class<PreferredType> preferredPluginType,
+    <PreferredT, AlternateType> Object loadPlugin(
+            final Class<PreferredT> preferredPluginType,
             final Class<AlternateType> alternatePluginType) {
         try {
-            PreferredType preferredPlugin = initializer.loadImpl(preferredPluginType);
+            PreferredT preferredPlugin = initializer.loadImpl(preferredPluginType);
             if (preferredPlugin != null) {
                 return preferredPlugin;
             } else if (alternatePluginType != null) {

--- a/src/main/java/org/mockito/internal/configuration/plugins/PluginRegistry.java
+++ b/src/main/java/org/mockito/internal/configuration/plugins/PluginRegistry.java
@@ -4,10 +4,17 @@
  */
 package org.mockito.internal.configuration.plugins;
 
-import org.mockito.internal.creation.instance.InstantiatorProviderAdapter;
-import org.mockito.plugins.*;
-
 import java.util.List;
+import org.mockito.internal.creation.instance.InstantiatorProviderAdapter;
+import org.mockito.plugins.AnnotationEngine;
+import org.mockito.plugins.InstantiatorProvider;
+import org.mockito.plugins.InstantiatorProvider2;
+import org.mockito.plugins.MemberAccessor;
+import org.mockito.plugins.MockMaker;
+import org.mockito.plugins.MockResolver;
+import org.mockito.plugins.MockitoLogger;
+import org.mockito.plugins.PluginSwitch;
+import org.mockito.plugins.StackTraceCleanerProvider;
 
 class PluginRegistry {
 

--- a/src/main/java/org/mockito/internal/configuration/plugins/Plugins.java
+++ b/src/main/java/org/mockito/internal/configuration/plugins/Plugins.java
@@ -4,14 +4,18 @@
  */
 package org.mockito.internal.configuration.plugins;
 
-import org.mockito.plugins.*;
-
 import java.util.List;
+import org.mockito.plugins.AnnotationEngine;
+import org.mockito.plugins.InstantiatorProvider2;
+import org.mockito.plugins.MemberAccessor;
+import org.mockito.plugins.MockMaker;
+import org.mockito.plugins.MockResolver;
+import org.mockito.plugins.MockitoLogger;
+import org.mockito.plugins.MockitoPlugins;
+import org.mockito.plugins.StackTraceCleanerProvider;
 
-/**
- * Access to Mockito behavior that can be reconfigured by plugins
- */
-public class Plugins {
+/** Access to Mockito behavior that can be reconfigured by plugins */
+public final class Plugins {
 
     private static final PluginRegistry registry = new PluginRegistry();
 
@@ -88,4 +92,6 @@ public class Plugins {
     public static MockitoPlugins getPlugins() {
         return new DefaultMockitoPlugins();
     }
+
+    private Plugins() {}
 }

--- a/src/main/java/org/mockito/internal/creation/DelegatingMethod.java
+++ b/src/main/java/org/mockito/internal/creation/DelegatingMethod.java
@@ -20,30 +20,37 @@ public class DelegatingMethod implements MockitoMethod {
         this.parameterTypes = SuspendMethod.trimSuspendParameterTypes(method.getParameterTypes());
     }
 
+    @Override
     public Class<?>[] getExceptionTypes() {
         return method.getExceptionTypes();
     }
 
+    @Override
     public Method getJavaMethod() {
         return method;
     }
 
+    @Override
     public String getName() {
         return method.getName();
     }
 
+    @Override
     public Class<?>[] getParameterTypes() {
         return parameterTypes;
     }
 
+    @Override
     public Class<?> getReturnType() {
         return method.getReturnType();
     }
 
+    @Override
     public boolean isVarArgs() {
         return method.isVarArgs();
     }
 
+    @Override
     public boolean isAbstract() {
         return (method.getModifiers() & Modifier.ABSTRACT) != 0;
     }

--- a/src/main/java/org/mockito/internal/creation/MockSettingsImpl.java
+++ b/src/main/java/org/mockito/internal/creation/MockSettingsImpl.java
@@ -157,7 +157,7 @@ public class MockSettingsImpl<T> extends CreationSettings<T>
         if (outerClassInstance == null) {
             return constructorArgs;
         }
-        List<Object> resultArgs = new ArrayList<Object>(constructorArgs.length + 1);
+        List<Object> resultArgs = new ArrayList<>(constructorArgs.length + 1);
         resultArgs.add(outerClassInstance);
         resultArgs.addAll(asList(constructorArgs));
         return resultArgs.toArray(new Object[constructorArgs.length + 1]);
@@ -228,13 +228,13 @@ public class MockSettingsImpl<T> extends CreationSettings<T>
     }
 
     @Override
-    public <T> MockCreationSettings<T> build(Class<T> typeToMock) {
-        return validatedSettings(typeToMock, (CreationSettings<T>) this);
+    public <T2> MockCreationSettings<T2> build(Class<T2> typeToMock) {
+        return validatedSettings(typeToMock, (CreationSettings<T2>) this);
     }
 
     @Override
-    public <T> MockCreationSettings<T> buildStatic(Class<T> classToMock) {
-        return validatedStaticSettings(classToMock, (CreationSettings<T>) this);
+    public <T2> MockCreationSettings<T2> buildStatic(Class<T2> classToMock) {
+        return validatedStaticSettings(classToMock, (CreationSettings<T2>) this);
     }
 
     @Override
@@ -289,7 +289,7 @@ public class MockSettingsImpl<T> extends CreationSettings<T>
     }
 
     private static Set<Class<?>> prepareExtraInterfaces(CreationSettings settings) {
-        Set<Class<?>> interfaces = new HashSet<Class<?>>(settings.getExtraInterfaces());
+        Set<Class<?>> interfaces = new HashSet<>(settings.getExtraInterfaces());
         if (settings.isSerializable()) {
             interfaces.add(Serializable.class);
         }

--- a/src/main/java/org/mockito/internal/creation/SuspendMethod.java
+++ b/src/main/java/org/mockito/internal/creation/SuspendMethod.java
@@ -10,15 +10,16 @@ import java.util.Arrays;
  * Utilities for Kotlin Continuation-Passing-Style suspending function, detecting and trimming last hidden parameter.
  * See <a href="https://github.com/Kotlin/kotlin-coroutines/blob/master/kotlin-coroutines-informal.md#continuation-passing-style">Design docs for details</a>.
  */
-public class SuspendMethod {
+public final class SuspendMethod {
     private static final String KOTLIN_EXPERIMENTAL_CONTINUATION =
             "kotlin.coroutines.experimental.Continuation";
     private static final String KOTLIN_CONTINUATION = "kotlin.coroutines.Continuation";
 
     public static Class<?>[] trimSuspendParameterTypes(Class<?>[] parameterTypes) {
         int n = parameterTypes.length;
-        if (n > 0 && isContinuationType(parameterTypes[n - 1]))
+        if (n > 0 && isContinuationType(parameterTypes[n - 1])) {
             return Arrays.copyOf(parameterTypes, n - 1);
+        }
         return parameterTypes;
     }
 
@@ -26,4 +27,6 @@ public class SuspendMethod {
         String name = parameterType.getName();
         return name.equals(KOTLIN_CONTINUATION) || name.equals(KOTLIN_EXPERIMENTAL_CONTINUATION);
     }
+
+    private SuspendMethod() {}
 }

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyCrossClassLoaderSerializationSupport.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyCrossClassLoaderSerializationSupport.java
@@ -7,7 +7,15 @@ package org.mockito.internal.creation.bytebuddy;
 import static org.mockito.internal.creation.bytebuddy.MockMethodInterceptor.ForWriteReplace;
 import static org.mockito.internal.util.StringUtil.join;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodInterceptor.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodInterceptor.java
@@ -100,12 +100,14 @@ public class MockMethodInterceptor implements Serializable {
         return serializationSupport;
     }
 
-    public static class ForHashCode {
+    public static final class ForHashCode {
 
         @SuppressWarnings("unused")
         public static int doIdentityHashCode(@This Object thiz) {
             return System.identityHashCode(thiz);
         }
+
+        private ForHashCode() {}
     }
 
     public static class ForEquals {
@@ -116,11 +118,13 @@ public class MockMethodInterceptor implements Serializable {
         }
     }
 
-    public static class ForWriteReplace {
+    public static final class ForWriteReplace {
 
         public static Object doWriteReplace(@This MockAccess thiz) throws ObjectStreamException {
             return thiz.getMockitoInterceptor().getSerializationSupport().writeReplace(thiz);
         }
+
+        private ForWriteReplace() {}
     }
 
     public static class DispatcherDefaultingToRealMethod {

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassBytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassBytecodeGenerator.java
@@ -5,12 +5,21 @@
 package org.mockito.internal.creation.bytebuddy;
 
 import static java.lang.Thread.currentThread;
-
 import static net.bytebuddy.description.modifier.Visibility.PRIVATE;
 import static net.bytebuddy.dynamic.Transformer.ForMethod.withModifiers;
 import static net.bytebuddy.implementation.MethodDelegation.to;
 import static net.bytebuddy.implementation.attribute.MethodAttributeAppender.ForInstrumentedMethod.INCLUDING_RECEIVER;
-import static net.bytebuddy.matcher.ElementMatchers.*;
+import static net.bytebuddy.matcher.ElementMatchers.any;
+import static net.bytebuddy.matcher.ElementMatchers.hasParameters;
+import static net.bytebuddy.matcher.ElementMatchers.hasType;
+import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
+import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
+import static net.bytebuddy.matcher.ElementMatchers.isEquals;
+import static net.bytebuddy.matcher.ElementMatchers.isHashCode;
+import static net.bytebuddy.matcher.ElementMatchers.isPackagePrivate;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.returns;
+import static net.bytebuddy.matcher.ElementMatchers.whereAny;
 import static org.mockito.internal.util.StringUtil.join;
 
 import java.io.IOException;
@@ -23,7 +32,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Random;
-
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.modifier.SynchronizationState;
@@ -107,8 +115,8 @@ class SubclassBytecodeGenerator implements BytecodeGenerator {
                                 || handler.isOpened(features.mockedType, MockAccess.class));
         String typeName;
         if (localMock
-                || loader instanceof MultipleParentClassLoader
-                        && !isComingFromJDK(features.mockedType)) {
+                || (loader instanceof MultipleParentClassLoader
+                        && !isComingFromJDK(features.mockedType))) {
             typeName = features.mockedType.getName();
         } else {
             typeName =
@@ -215,7 +223,7 @@ class SubclassBytecodeGenerator implements BytecodeGenerator {
     }
 
     private <T> Collection<Class<? super T>> getAllTypes(Class<T> type) {
-        Collection<Class<? super T>> supertypes = new LinkedList<Class<? super T>>();
+        Collection<Class<? super T>> supertypes = new LinkedList<>();
         supertypes.add(type);
         Class<? super T> superType = type;
         while (superType != null) {
@@ -234,9 +242,9 @@ class SubclassBytecodeGenerator implements BytecodeGenerator {
         // Comes from the manifest entry :
         // Implementation-Title: Java Runtime Environment
         // This entry is not necessarily present in every jar of the JDK
-        return type.getPackage() != null
+        return (type.getPackage() != null
                         && "Java Runtime Environment"
-                                .equalsIgnoreCase(type.getPackage().getImplementationTitle())
+                                .equalsIgnoreCase(type.getPackage().getImplementationTitle()))
                 || type.getName().startsWith("java.")
                 || type.getName().startsWith("javax.");
     }

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/inject/MockMethodDispatcher.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/inject/MockMethodDispatcher.java
@@ -57,6 +57,8 @@ public abstract class MockMethodDispatcher {
         return DISPATCHERS.get(identifier).isConstructorMock(type);
     }
 
+    public abstract boolean isConstructorMock(Class<?> type);
+
     @SuppressWarnings("unused")
     public static Object handleConstruction(
             String identifier,
@@ -85,6 +87,4 @@ public abstract class MockMethodDispatcher {
     public abstract boolean isMockedStatic(Class<?> type);
 
     public abstract boolean isOverridden(Object instance, Method origin);
-
-    public abstract boolean isConstructorMock(Class<?> type);
 }

--- a/src/main/java/org/mockito/internal/creation/instance/ConstructorInstantiator.java
+++ b/src/main/java/org/mockito/internal/creation/instance/ConstructorInstantiator.java
@@ -34,12 +34,13 @@ public class ConstructorInstantiator implements Instantiator {
         this.constructorArgs = constructorArgs;
     }
 
+    @Override
     public <T> T newInstance(Class<T> cls) {
         return withParams(cls, constructorArgs);
     }
 
     private <T> T withParams(Class<T> cls, Object... params) {
-        List<Constructor<?>> matchingConstructors = new LinkedList<Constructor<?>>();
+        List<Constructor<?>> matchingConstructors = new LinkedList<>();
         try {
             for (Constructor<?> constructor : cls.getDeclaredConstructors()) {
                 Class<?>[] types = constructor.getParameterTypes();
@@ -54,7 +55,7 @@ public class ConstructorInstantiator implements Instantiator {
         } catch (Exception e) {
             throw paramsException(cls, e);
         }
-        if (matchingConstructors.size() == 0) {
+        if (matchingConstructors.isEmpty()) {
             throw noMatchingConstructor(cls);
         } else {
             throw multipleMatchingConstructors(cls, matchingConstructors);

--- a/src/main/java/org/mockito/internal/creation/instance/DefaultInstantiatorProvider.java
+++ b/src/main/java/org/mockito/internal/creation/instance/DefaultInstantiatorProvider.java
@@ -12,6 +12,7 @@ public class DefaultInstantiatorProvider implements InstantiatorProvider2 {
 
     private static final Instantiator INSTANCE = new ObjenesisInstantiator();
 
+    @Override
     public Instantiator getInstantiator(MockCreationSettings<?> settings) {
         if (settings != null && settings.getConstructorArgs() != null) {
             return new ConstructorInstantiator(

--- a/src/main/java/org/mockito/internal/creation/instance/Instantiator.java
+++ b/src/main/java/org/mockito/internal/creation/instance/Instantiator.java
@@ -14,8 +14,6 @@ package org.mockito.internal.creation.instance;
 @Deprecated
 public interface Instantiator {
 
-    /**
-     * Creates instance of given class
-     */
-    <T> T newInstance(Class<T> cls) throws InstantiationException;
+    /** Creates instance of given class */
+    <T> T newInstance(Class<T> cls);
 }

--- a/src/main/java/org/mockito/internal/creation/instance/InstantiatorProvider2Adapter.java
+++ b/src/main/java/org/mockito/internal/creation/instance/InstantiatorProvider2Adapter.java
@@ -22,7 +22,7 @@ public class InstantiatorProvider2Adapter implements InstantiatorProvider {
     public Instantiator getInstantiator(final MockCreationSettings<?> settings) {
         return new Instantiator() {
             @Override
-            public <T> T newInstance(Class<T> cls) throws InstantiationException {
+            public <T> T newInstance(Class<T> cls) {
                 try {
                     return provider.getInstantiator(settings).newInstance(cls);
                 } catch (org.mockito.creation.instance.InstantiationException e) {

--- a/src/main/java/org/mockito/internal/creation/instance/InstantiatorProviderAdapter.java
+++ b/src/main/java/org/mockito/internal/creation/instance/InstantiatorProviderAdapter.java
@@ -24,7 +24,7 @@ public class InstantiatorProviderAdapter implements InstantiatorProvider2 {
     public Instantiator getInstantiator(final MockCreationSettings<?> settings) {
         return new Instantiator() {
             @Override
-            public <T> T newInstance(Class<T> cls) throws InstantiationException {
+            public <T> T newInstance(Class<T> cls) {
                 try {
                     return provider.getInstantiator(settings).newInstance(cls);
                 } catch (org.mockito.internal.creation.instance.InstantiationException e) {

--- a/src/main/java/org/mockito/internal/creation/instance/ObjenesisInstantiator.java
+++ b/src/main/java/org/mockito/internal/creation/instance/ObjenesisInstantiator.java
@@ -17,6 +17,7 @@ class ObjenesisInstantiator implements Instantiator {
     private final ObjenesisStd objenesis =
             new ObjenesisStd(new GlobalConfiguration().enableClassCache());
 
+    @Override
     public <T> T newInstance(Class<T> cls) {
         return objenesis.newInstance(cls);
     }

--- a/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
+++ b/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
@@ -24,23 +24,21 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
     private static final long serialVersionUID = -6789800638070123629L;
 
     protected Class<T> typeToMock;
-    protected Set<Class<?>> extraInterfaces = new LinkedHashSet<Class<?>>();
+    protected Set<Class<?>> extraInterfaces = new LinkedHashSet<>();
     protected String name;
     protected Object spiedInstance;
     protected Answer<Object> defaultAnswer;
     protected MockName mockName;
     protected SerializableMode serializableMode = SerializableMode.NONE;
-    protected List<InvocationListener> invocationListeners = new ArrayList<InvocationListener>();
+    protected List<InvocationListener> invocationListeners = new ArrayList<>();
 
     // Other listeners in this class may also need concurrency-safe implementation. However, no
     // issue was reported about it.
     // If we do it, we need to understand usage patterns and choose the right concurrent
     // implementation.
-    protected List<StubbingLookupListener> stubbingLookupListeners =
-            new CopyOnWriteArrayList<StubbingLookupListener>();
+    protected List<StubbingLookupListener> stubbingLookupListeners = new CopyOnWriteArrayList<>();
 
-    protected List<VerificationStartedListener> verificationStartedListeners =
-            new LinkedList<VerificationStartedListener>();
+    protected List<VerificationStartedListener> verificationStartedListeners = new LinkedList<>();
     protected boolean stubOnly;
     protected boolean stripAnnotations;
     private boolean useConstructor;
@@ -115,6 +113,7 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
         return this;
     }
 
+    @Override
     public boolean isSerializable() {
         return serializableMode != SerializableMode.NONE;
     }
@@ -139,6 +138,7 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
         return verificationStartedListeners;
     }
 
+    @Override
     public List<StubbingLookupListener> getStubbingLookupListeners() {
         return stubbingLookupListeners;
     }

--- a/src/main/java/org/mockito/internal/debugging/InvocationsPrinter.java
+++ b/src/main/java/org/mockito/internal/debugging/InvocationsPrinter.java
@@ -30,7 +30,7 @@ public class InvocationsPrinter {
             if (x == 1) {
                 sb.append("[Mockito] Interactions of: ").append(mock).append("\n");
             }
-            sb.append(" ").append(x++).append(". ").append(i.toString()).append("\n");
+            sb.append(" ").append(x++).append(". ").append(i).append("\n");
             sb.append("  ").append(i.getLocation()).append("\n");
             if (i.stubInfo() != null) {
                 sb.append("   - stubbed ").append(i.stubInfo().stubbedAt()).append("\n");
@@ -41,6 +41,7 @@ public class InvocationsPrinter {
                 ListUtil.filter(
                         stubbings,
                         new ListUtil.Filter<Stubbing>() {
+                            @Override
                             public boolean isOut(Stubbing s) {
                                 return s.wasUsed();
                             }

--- a/src/main/java/org/mockito/internal/debugging/LocationImpl.java
+++ b/src/main/java/org/mockito/internal/debugging/LocationImpl.java
@@ -55,7 +55,7 @@ public class LocationImpl implements Location, Serializable {
             this.stackTraceLine = "-> at <<unknown line>>";
             this.sourceFile = "<unknown source file>";
         } else {
-            this.stackTraceLine = "-> at " + filtered.toString();
+            this.stackTraceLine = "-> at " + filtered;
             this.sourceFile = filtered.getFileName();
         }
     }

--- a/src/main/java/org/mockito/internal/debugging/LoggingListener.java
+++ b/src/main/java/org/mockito/internal/debugging/LoggingListener.java
@@ -15,14 +15,15 @@ import org.mockito.invocation.Invocation;
 public class LoggingListener implements FindingsListener {
     private final boolean warnAboutUnstubbed;
 
-    private final List<String> argMismatchStubs = new LinkedList<String>();
-    private final List<String> unusedStubs = new LinkedList<String>();
-    private final List<String> unstubbedCalls = new LinkedList<String>();
+    private final List<String> argMismatchStubs = new LinkedList<>();
+    private final List<String> unusedStubs = new LinkedList<>();
+    private final List<String> unstubbedCalls = new LinkedList<>();
 
     public LoggingListener(boolean warnAboutUnstubbed) {
         this.warnAboutUnstubbed = warnAboutUnstubbed;
     }
 
+    @Override
     public void foundStubCalledWithDifferentArgs(Invocation unused, InvocationMatcher unstubbed) {
         // TODO there is not good reason we should get Invocation and InvocationMatcher here
         // we should pass 2 InvocationMatchers and testing is easier
@@ -41,10 +42,12 @@ public class LoggingListener implements FindingsListener {
         return (collectionSize / 2) + 1;
     }
 
+    @Override
     public void foundUnusedStub(Invocation unused) {
         unusedStubs.add((unusedStubs.size() + 1) + ". " + unused.getLocation());
     }
 
+    @Override
     public void foundUnstubbed(InvocationMatcher unstubbed) {
         if (warnAboutUnstubbed) {
             unstubbedCalls.add(
@@ -57,7 +60,7 @@ public class LoggingListener implements FindingsListener {
             return "";
         }
 
-        List<String> lines = new LinkedList<String>();
+        List<String> lines = new LinkedList<>();
         lines.add(
                 "[Mockito] Additional stubbing information (see javadoc for StubbingInfo class):");
 

--- a/src/main/java/org/mockito/internal/debugging/MockitoDebuggerImpl.java
+++ b/src/main/java/org/mockito/internal/debugging/MockitoDebuggerImpl.java
@@ -31,7 +31,7 @@ public class MockitoDebuggerImpl implements MockitoDebugger {
             out += line(i.toString());
             out += line(" invoked: " + i.getLocation());
             if (i.stubInfo() != null) {
-                out += line(" stubbed: " + i.stubInfo().stubbedAt().toString());
+                out += line(" stubbed: " + i.stubInfo().stubbedAt());
             }
         }
 

--- a/src/main/java/org/mockito/internal/debugging/VerboseMockInvocationLogger.java
+++ b/src/main/java/org/mockito/internal/debugging/VerboseMockInvocationLogger.java
@@ -30,6 +30,7 @@ public class VerboseMockInvocationLogger implements InvocationListener {
         this.printStream = printStream;
     }
 
+    @Override
     public void reportInvocation(MethodInvocationReport methodInvocationReport) {
         printHeader();
         printStubInfo(methodInvocationReport);
@@ -73,13 +74,13 @@ public class VerboseMockInvocationLogger implements InvocationListener {
     }
 
     private void printInvocation(DescribedInvocation invocation) {
-        printStream.println(invocation.toString());
+        printStream.println(invocation);
         //        printStream.println("Handling method call on a mock/spy.");
-        printlnIndented("invoked: " + invocation.getLocation().toString());
+        printlnIndented("invoked: " + invocation.getLocation());
     }
 
     private void printFooter() {
-        printStream.println("");
+        printStream.println();
     }
 
     private void printlnIndented(String message) {

--- a/src/main/java/org/mockito/internal/debugging/WarningsCollector.java
+++ b/src/main/java/org/mockito/internal/debugging/WarningsCollector.java
@@ -18,7 +18,7 @@ public class WarningsCollector {
     private final List<Object> createdMocks;
 
     public WarningsCollector() {
-        createdMocks = new LinkedList<Object>();
+        createdMocks = new LinkedList<>();
     }
 
     public String getWarnings() {

--- a/src/main/java/org/mockito/internal/debugging/WarningsFinder.java
+++ b/src/main/java/org/mockito/internal/debugging/WarningsFinder.java
@@ -21,9 +21,8 @@ public class WarningsFinder {
     }
 
     public void find(FindingsListener findingsListener) {
-        List<Invocation> unusedStubs = new LinkedList<Invocation>(this.baseUnusedStubs);
-        List<InvocationMatcher> allInvocations =
-                new LinkedList<InvocationMatcher>(this.baseAllInvocations);
+        List<Invocation> unusedStubs = new LinkedList<>(this.baseUnusedStubs);
+        List<InvocationMatcher> allInvocations = new LinkedList<>(this.baseAllInvocations);
 
         Iterator<Invocation> unusedIterator = unusedStubs.iterator();
         while (unusedIterator.hasNext()) {

--- a/src/main/java/org/mockito/internal/exceptions/Reporter.java
+++ b/src/main/java/org/mockito/internal/exceptions/Reporter.java
@@ -11,7 +11,6 @@ import static org.mockito.internal.util.StringUtil.join;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.*;
-
 import org.mockito.exceptions.base.MockitoAssertionError;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.exceptions.misusing.*;
@@ -300,8 +299,10 @@ public class Reporter {
     }
 
     private static Object locationsOf(Collection<LocalizedMatcher> matchers) {
-        List<String> description = new ArrayList<String>();
-        for (LocalizedMatcher matcher : matchers) description.add(matcher.getLocation().toString());
+        List<String> description = new ArrayList<>();
+        for (LocalizedMatcher matcher : matchers) {
+            description.add(matcher.getLocation().toString());
+        }
         return join(description.toArray());
     }
 
@@ -349,12 +350,11 @@ public class Reporter {
             allInvocations = "Actually, there were zero interactions with this mock.\n";
         } else {
             StringBuilder sb =
-                    new StringBuilder(
-                            "\nHowever, there "
-                                    + were_exactly_x_interactions(invocations.size())
-                                    + " with this mock:\n");
+                    new StringBuilder("\nHowever, there ")
+                            .append(were_exactly_x_interactions(invocations.size()))
+                            .append(" with this mock:\n");
             for (DescribedInvocation i : invocations) {
-                sb.append(i.toString()).append("\n").append(i.getLocation()).append("\n\n");
+                sb.append(i).append("\n").append(i.getLocation()).append("\n\n");
             }
             allInvocations = sb.toString();
         }
@@ -519,7 +519,7 @@ public class Reporter {
         ScenarioPrinter scenarioPrinter = new ScenarioPrinter();
         String scenario = scenarioPrinter.print(invocations);
 
-        List<Location> locations = new ArrayList<Location>();
+        List<Location> locations = new ArrayList<>();
         for (VerificationAwareInvocation invocation : invocations) {
             locations.add(invocation.getLocation());
         }
@@ -537,7 +537,7 @@ public class Reporter {
     public static MockitoException cannotMockClass(Class<?> clazz, String reason) {
         return new MockitoException(
                 join(
-                        "Cannot mock/spy " + clazz.toString(),
+                        "Cannot mock/spy " + clazz,
                         "Mockito cannot mock/spy because :",
                         " - " + reason));
     }

--- a/src/main/java/org/mockito/internal/exceptions/stacktrace/DefaultStackTraceCleanerProvider.java
+++ b/src/main/java/org/mockito/internal/exceptions/stacktrace/DefaultStackTraceCleanerProvider.java
@@ -12,6 +12,7 @@ import org.mockito.plugins.StackTraceCleanerProvider;
  */
 public class DefaultStackTraceCleanerProvider implements StackTraceCleanerProvider {
 
+    @Override
     public StackTraceCleaner getStackTraceCleaner(StackTraceCleaner defaultCleaner) {
         return defaultCleaner;
     }

--- a/src/main/java/org/mockito/internal/exceptions/stacktrace/StackTraceFilter.java
+++ b/src/main/java/org/mockito/internal/exceptions/stacktrace/StackTraceFilter.java
@@ -47,7 +47,7 @@ public class StackTraceFilter implements Serializable {
     public StackTraceElement[] filter(StackTraceElement[] target, boolean keepTop) {
         // TODO: profile
         // TODO: investigate "keepTop" commit history - no effect!
-        final List<StackTraceElement> filtered = new ArrayList<StackTraceElement>();
+        final List<StackTraceElement> filtered = new ArrayList<>();
         for (StackTraceElement element : target) {
             if (CLEANER.isIn(element)) {
                 filtered.add(element);

--- a/src/main/java/org/mockito/internal/framework/DefaultMockitoFramework.java
+++ b/src/main/java/org/mockito/internal/framework/DefaultMockitoFramework.java
@@ -18,12 +18,14 @@ import org.mockito.plugins.MockitoPlugins;
 
 public class DefaultMockitoFramework implements MockitoFramework {
 
+    @Override
     public MockitoFramework addListener(MockitoListener listener) {
         Checks.checkNotNull(listener, "listener");
         mockingProgress().addListener(listener);
         return this;
     }
 
+    @Override
     public MockitoFramework removeListener(MockitoListener listener) {
         Checks.checkNotNull(listener, "listener");
         mockingProgress().removeListener(listener);

--- a/src/main/java/org/mockito/internal/hamcrest/HamcrestArgumentMatcher.java
+++ b/src/main/java/org/mockito/internal/hamcrest/HamcrestArgumentMatcher.java
@@ -17,6 +17,7 @@ public class HamcrestArgumentMatcher<T> implements ArgumentMatcher<T> {
         this.matcher = matcher;
     }
 
+    @Override
     public boolean matches(Object argument) {
         return this.matcher.matches(argument);
     }
@@ -25,6 +26,7 @@ public class HamcrestArgumentMatcher<T> implements ArgumentMatcher<T> {
         return matcher instanceof VarargMatcher;
     }
 
+    @Override
     public String toString() {
         // TODO SF add unit tests and integ test coverage for toString()
         return StringDescription.toString(matcher);

--- a/src/main/java/org/mockito/internal/hamcrest/MatcherGenericTypeExtractor.java
+++ b/src/main/java/org/mockito/internal/hamcrest/MatcherGenericTypeExtractor.java
@@ -9,10 +9,8 @@ import static org.mockito.internal.util.reflection.GenericTypeExtractor.genericT
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Matcher;
 
-/**
- * Extracts generic type of matcher
- */
-public class MatcherGenericTypeExtractor {
+/** Extracts generic type of matcher */
+public final class MatcherGenericTypeExtractor {
 
     /**
      * Gets the generic type of given matcher. For example,
@@ -22,4 +20,6 @@ public class MatcherGenericTypeExtractor {
         // TODO SF check if we can reuse it for Mockito ArgumentMatcher
         return genericTypeOf(matcherClass, BaseMatcher.class, Matcher.class);
     }
+
+    private MatcherGenericTypeExtractor() {}
 }

--- a/src/main/java/org/mockito/internal/handler/InvocationNotifierHandler.java
+++ b/src/main/java/org/mockito/internal/handler/InvocationNotifierHandler.java
@@ -28,6 +28,7 @@ class InvocationNotifierHandler<T> implements MockHandler<T> {
         this.invocationListeners = settings.getInvocationListeners();
     }
 
+    @Override
     public Object handle(Invocation invocation) throws Throwable {
         try {
             Object returnedValue = mockHandler.handle(invocation);
@@ -61,10 +62,12 @@ class InvocationNotifierHandler<T> implements MockHandler<T> {
         }
     }
 
+    @Override
     public MockCreationSettings<T> getMockSettings() {
         return mockHandler.getMockSettings();
     }
 
+    @Override
     public InvocationContainer getInvocationContainer() {
         return mockHandler.getInvocationContainer();
     }

--- a/src/main/java/org/mockito/internal/handler/MockHandlerFactory.java
+++ b/src/main/java/org/mockito/internal/handler/MockHandlerFactory.java
@@ -7,14 +7,14 @@ package org.mockito.internal.handler;
 import org.mockito.invocation.MockHandler;
 import org.mockito.mock.MockCreationSettings;
 
-/**
- * by Szczepan Faber, created at: 5/21/12
- */
-public class MockHandlerFactory {
+/** by Szczepan Faber, created at: 5/21/12 */
+public final class MockHandlerFactory {
 
     public static <T> MockHandler<T> createMockHandler(MockCreationSettings<T> settings) {
         MockHandler<T> handler = new MockHandlerImpl<T>(settings);
         MockHandler<T> nullResultGuardian = new NullResultGuardian<T>(handler);
         return new InvocationNotifierHandler<T>(nullResultGuardian, settings);
     }
+
+    private MockHandlerFactory() {}
 }

--- a/src/main/java/org/mockito/internal/handler/MockHandlerImpl.java
+++ b/src/main/java/org/mockito/internal/handler/MockHandlerImpl.java
@@ -45,6 +45,7 @@ public class MockHandlerImpl<T> implements MockHandler<T> {
         this.invocationContainer = new InvocationContainerImpl(mockSettings);
     }
 
+    @Override
     public Object handle(Invocation invocation) throws Throwable {
         if (invocationContainer.hasAnswersForStubbing()) {
             // stubbing voids with doThrow() or doAnswer() style
@@ -121,10 +122,12 @@ public class MockHandlerImpl<T> implements MockHandler<T> {
         }
     }
 
+    @Override
     public MockCreationSettings<T> getMockSettings() {
         return mockSettings;
     }
 
+    @Override
     public InvocationContainer getInvocationContainer() {
         return invocationContainer;
     }

--- a/src/main/java/org/mockito/internal/handler/NotifiedMethodInvocationReport.java
+++ b/src/main/java/org/mockito/internal/handler/NotifiedMethodInvocationReport.java
@@ -44,31 +44,41 @@ public class NotifiedMethodInvocationReport implements MethodInvocationReport {
         this.throwable = throwable;
     }
 
+    @Override
     public DescribedInvocation getInvocation() {
         return invocation;
     }
 
+    @Override
     public Object getReturnedValue() {
         return returnedValue;
     }
 
+    @Override
     public Throwable getThrowable() {
         return throwable;
     }
 
+    @Override
     public boolean threwException() {
         return throwable != null;
     }
 
+    @Override
     public String getLocationOfStubbing() {
         return (invocation.stubInfo() == null)
                 ? null
                 : invocation.stubInfo().stubbedAt().toString();
     }
 
+    @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         NotifiedMethodInvocationReport that = (NotifiedMethodInvocationReport) o;
 
@@ -77,6 +87,7 @@ public class NotifiedMethodInvocationReport implements MethodInvocationReport {
                 && areEqual(throwable, that.throwable);
     }
 
+    @Override
     public int hashCode() {
         int result = invocation != null ? invocation.hashCode() : 0;
         result = 31 * result + (returnedValue != null ? returnedValue.hashCode() : 0);

--- a/src/main/java/org/mockito/internal/invocation/ArgumentsProcessor.java
+++ b/src/main/java/org/mockito/internal/invocation/ArgumentsProcessor.java
@@ -12,20 +12,16 @@ import org.mockito.ArgumentMatcher;
 import org.mockito.internal.matchers.ArrayEquals;
 import org.mockito.internal.matchers.Equals;
 
-/**
- * by Szczepan Faber, created at: 3/31/12
- */
-public class ArgumentsProcessor {
+/** by Szczepan Faber, created at: 3/31/12 */
+public final class ArgumentsProcessor {
     // drops hidden synthetic parameters (last continuation parameter from Kotlin suspending
     // functions)
     // and expands varargs
     public static Object[] expandArgs(MockitoMethod method, Object[] args) {
         int nParams = method.getParameterTypes().length;
-        if (args != null && args.length > nParams)
-            args =
-                    Arrays.copyOf(
-                            args,
-                            nParams); // drop extra args (currently -- Kotlin continuation synthetic
+        if (args != null && args.length > nParams) {
+            args = Arrays.copyOf(args, nParams);
+        } // drop extra args (currently -- Kotlin continuation synthetic
         // arg)
         return expandVarArgs(method.isVarArgs(), args);
     }
@@ -35,7 +31,7 @@ public class ArgumentsProcessor {
     private static Object[] expandVarArgs(final boolean isVarArgs, final Object[] args) {
         if (!isVarArgs
                 || isNullOrEmpty(args)
-                || args[args.length - 1] != null && !args[args.length - 1].getClass().isArray()) {
+                || (args[args.length - 1] != null && !args[args.length - 1].getClass().isArray())) {
             return args == null ? new Object[0] : args;
         }
 
@@ -59,7 +55,7 @@ public class ArgumentsProcessor {
     }
 
     public static List<ArgumentMatcher> argumentsToMatchers(Object[] arguments) {
-        List<ArgumentMatcher> matchers = new ArrayList<ArgumentMatcher>(arguments.length);
+        List<ArgumentMatcher> matchers = new ArrayList<>(arguments.length);
         for (Object arg : arguments) {
             if (arg != null && arg.getClass().isArray()) {
                 matchers.add(new ArrayEquals(arg));
@@ -69,4 +65,6 @@ public class ArgumentsProcessor {
         }
         return matchers;
     }
+
+    private ArgumentsProcessor() {}
 }

--- a/src/main/java/org/mockito/internal/invocation/DefaultInvocationFactory.java
+++ b/src/main/java/org/mockito/internal/invocation/DefaultInvocationFactory.java
@@ -28,6 +28,7 @@ public class DefaultInvocationFactory implements InvocationFactory {
         return createInvocation(target, settings, method, superMethod, args);
     }
 
+    @Override
     public Invocation createInvocation(
             Object target,
             MockCreationSettings settings,

--- a/src/main/java/org/mockito/internal/invocation/InterceptedInvocation.java
+++ b/src/main/java/org/mockito/internal/invocation/InterceptedInvocation.java
@@ -25,7 +25,8 @@ public class InterceptedInvocation implements Invocation, VerificationAwareInvoc
 
     private final MockReference<Object> mockRef;
     private final MockitoMethod mockitoMethod;
-    private final Object[] arguments, rawArguments;
+    private final Object[] arguments;
+    private final Object[] rawArguments;
     private final RealMethod realMethod;
 
     private final int sequenceNumber;
@@ -124,13 +125,13 @@ public class InterceptedInvocation implements Invocation, VerificationAwareInvoc
     }
 
     @Override
-    public List<ArgumentMatcher> getArgumentsAsMatchers() {
-        return argumentsToMatchers(getArguments());
+    public <T> T getArgument(int index, Class<T> clazz) {
+        return clazz.cast(arguments[index]);
     }
 
     @Override
-    public <T> T getArgument(int index, Class<T> clazz) {
-        return clazz.cast(arguments[index]);
+    public List<ArgumentMatcher> getArgumentsAsMatchers() {
+        return argumentsToMatchers(getArguments());
     }
 
     @Override
@@ -174,7 +175,7 @@ public class InterceptedInvocation implements Invocation, VerificationAwareInvoc
 
     @Override
     public boolean equals(Object o) {
-        if (o == null || !o.getClass().equals(this.getClass())) {
+        if (!(o instanceof InterceptedInvocation)) {
             return false;
         }
         InterceptedInvocation other = (InterceptedInvocation) o;
@@ -187,12 +188,14 @@ public class InterceptedInvocation implements Invocation, VerificationAwareInvoc
         return Arrays.equals(arguments, this.arguments);
     }
 
+    @Override
     public String toString() {
         return new PrintSettings().print(getArgumentsAsMatchers(), this);
     }
 
     public static final RealMethod NO_OP =
             new RealMethod() {
+                @Override
                 public boolean isInvokable() {
                     return false;
                 }

--- a/src/main/java/org/mockito/internal/invocation/InvocationComparator.java
+++ b/src/main/java/org/mockito/internal/invocation/InvocationComparator.java
@@ -12,7 +12,8 @@ import org.mockito.invocation.Invocation;
  * Compares invocations based on the sequence number
  */
 public class InvocationComparator implements Comparator<Invocation> {
+    @Override
     public int compare(Invocation o1, Invocation o2) {
-        return Integer.valueOf(o1.getSequenceNumber()).compareTo(o2.getSequenceNumber());
+        return Integer.compare(o1.getSequenceNumber(), o2.getSequenceNumber());
     }
 }

--- a/src/main/java/org/mockito/internal/invocation/InvocationMatcher.java
+++ b/src/main/java/org/mockito/internal/invocation/InvocationMatcher.java
@@ -47,7 +47,7 @@ public class InvocationMatcher implements MatchableInvocation, DescribedInvocati
     }
 
     public static List<InvocationMatcher> createFrom(List<Invocation> invocations) {
-        LinkedList<InvocationMatcher> out = new LinkedList<InvocationMatcher>();
+        LinkedList<InvocationMatcher> out = new LinkedList<>();
         for (Invocation i : invocations) {
             out.add(new InvocationMatcher(i));
         }

--- a/src/main/java/org/mockito/internal/invocation/InvocationsFinder.java
+++ b/src/main/java/org/mockito/internal/invocation/InvocationsFinder.java
@@ -63,7 +63,7 @@ public class InvocationsFinder {
 
     private static List<Invocation> getFirstMatchingChunk(
             MatchableInvocation wanted, List<Invocation> unverified) {
-        List<Invocation> firstChunk = new LinkedList<Invocation>();
+        List<Invocation> firstChunk = new LinkedList<>();
         for (Invocation invocation : unverified) {
             if (wanted.matches(invocation)) {
                 firstChunk.add(invocation);
@@ -139,7 +139,7 @@ public class InvocationsFinder {
 
     private static List<Invocation> removeVerifiedInOrder(
             List<Invocation> invocations, InOrderContext orderingContext) {
-        List<Invocation> unverified = new LinkedList<Invocation>();
+        List<Invocation> unverified = new LinkedList<>();
         for (Invocation i : invocations) {
             if (orderingContext.isVerified(i)) {
                 unverified.clear();
@@ -151,7 +151,7 @@ public class InvocationsFinder {
     }
 
     public static List<Location> getAllLocations(List<Invocation> invocations) {
-        List<Location> locations = new LinkedList<Location>();
+        List<Location> locations = new LinkedList<>();
         for (Invocation invocation : invocations) {
             locations.add(invocation.getLocation());
         }
@@ -165,6 +165,7 @@ public class InvocationsFinder {
             this.wanted = wanted;
         }
 
+        @Override
         public boolean isOut(Invocation invocation) {
             return !wanted.matches(invocation);
         }
@@ -177,6 +178,7 @@ public class InvocationsFinder {
             this.orderingContext = orderingContext;
         }
 
+        @Override
         public boolean isOut(Invocation invocation) {
             return !orderingContext.isVerified(invocation);
         }

--- a/src/main/java/org/mockito/internal/invocation/MatcherApplicationStrategy.java
+++ b/src/main/java/org/mockito/internal/invocation/MatcherApplicationStrategy.java
@@ -74,7 +74,9 @@ public class MatcherApplicationStrategy {
      *         </ul>
      */
     public boolean forEachMatcherAndArgument(ArgumentMatcherAction action) {
-        if (matchingType == ERROR_UNSUPPORTED_NUMBER_OF_MATCHERS) return false;
+        if (matchingType == ERROR_UNSUPPORTED_NUMBER_OF_MATCHERS) {
+            return false;
+        }
 
         Object[] arguments = invocation.getArguments();
         for (int i = 0; i < arguments.length; i++) {

--- a/src/main/java/org/mockito/internal/invocation/MatchersBinder.java
+++ b/src/main/java/org/mockito/internal/invocation/MatchersBinder.java
@@ -23,7 +23,7 @@ public class MatchersBinder implements Serializable {
         List<LocalizedMatcher> lastMatchers = argumentMatcherStorage.pullLocalizedMatchers();
         validateMatchers(invocation, lastMatchers);
 
-        List<ArgumentMatcher> matchers = new LinkedList<ArgumentMatcher>();
+        List<ArgumentMatcher> matchers = new LinkedList<>();
         for (LocalizedMatcher m : lastMatchers) {
             matchers.add(m.getMatcher());
         }

--- a/src/main/java/org/mockito/internal/invocation/SerializableMethod.java
+++ b/src/main/java/org/mockito/internal/invocation/SerializableMethod.java
@@ -37,30 +37,37 @@ public class SerializableMethod implements Serializable, MockitoMethod {
         isAbstract = (method.getModifiers() & Modifier.ABSTRACT) != 0;
     }
 
+    @Override
     public String getName() {
         return methodName;
     }
 
+    @Override
     public Class<?> getReturnType() {
         return returnType;
     }
 
+    @Override
     public Class<?>[] getParameterTypes() {
         return parameterTypes;
     }
 
+    @Override
     public Class<?>[] getExceptionTypes() {
         return exceptionTypes;
     }
 
+    @Override
     public boolean isVarArgs() {
         return isVarArgs;
     }
 
+    @Override
     public boolean isAbstract() {
         return isAbstract;
     }
 
+    @Override
     public Method getJavaMethod() {
         if (method != null) {
             return method;
@@ -92,20 +99,40 @@ public class SerializableMethod implements Serializable, MockitoMethod {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) return true;
-        if (obj == null) return false;
-        if (getClass() != obj.getClass()) return false;
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
         SerializableMethod other = (SerializableMethod) obj;
         if (declaringClass == null) {
-            if (other.declaringClass != null) return false;
-        } else if (!declaringClass.equals(other.declaringClass)) return false;
+            if (other.declaringClass != null) {
+                return false;
+            }
+        } else if (!declaringClass.equals(other.declaringClass)) {
+            return false;
+        }
         if (methodName == null) {
-            if (other.methodName != null) return false;
-        } else if (!methodName.equals(other.methodName)) return false;
-        if (!Arrays.equals(parameterTypes, other.parameterTypes)) return false;
+            if (other.methodName != null) {
+                return false;
+            }
+        } else if (!methodName.equals(other.methodName)) {
+            return false;
+        }
+        if (!Arrays.equals(parameterTypes, other.parameterTypes)) {
+            return false;
+        }
         if (returnType == null) {
-            if (other.returnType != null) return false;
-        } else if (!returnType.equals(other.returnType)) return false;
+            if (other.returnType != null) {
+                return false;
+            }
+        } else if (!returnType.equals(other.returnType)) {
+            return false;
+        }
         return true;
     }
 }

--- a/src/main/java/org/mockito/internal/invocation/StubInfoImpl.java
+++ b/src/main/java/org/mockito/internal/invocation/StubInfoImpl.java
@@ -18,6 +18,7 @@ public class StubInfoImpl implements StubInfo, Serializable {
         this.stubbedAt = stubbedAt;
     }
 
+    @Override
     public Location stubbedAt() {
         return stubbedAt.getLocation();
     }

--- a/src/main/java/org/mockito/internal/invocation/TypeSafeMatching.java
+++ b/src/main/java/org/mockito/internal/invocation/TypeSafeMatching.java
@@ -30,7 +30,9 @@ public class TypeSafeMatching implements ArgumentMatcherAction {
      * {@link ClassCastException}.
      */
     private static boolean isCompatible(ArgumentMatcher<?> argumentMatcher, Object argument) {
-        if (argument == null) return true;
+        if (argument == null) {
+            return true;
+        }
 
         Class<?> expectedArgumentType = getArgumentType(argumentMatcher);
 

--- a/src/main/java/org/mockito/internal/invocation/UnusedStubsFinder.java
+++ b/src/main/java/org/mockito/internal/invocation/UnusedStubsFinder.java
@@ -20,7 +20,7 @@ public class UnusedStubsFinder {
      * @param mocks full list of mocks
      */
     public List<Invocation> find(List<?> mocks) {
-        List<Invocation> unused = new LinkedList<Invocation>();
+        List<Invocation> unused = new LinkedList<>();
         for (Object mock : mocks) {
             List<Stubbing> fromSingleMock =
                     MockUtil.getInvocationContainer(mock).getStubbingsDescending();

--- a/src/main/java/org/mockito/internal/invocation/finder/AllInvocationsFinder.java
+++ b/src/main/java/org/mockito/internal/invocation/finder/AllInvocationsFinder.java
@@ -4,8 +4,11 @@
  */
 package org.mockito.internal.invocation.finder;
 
-import java.util.*;
-
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import org.mockito.internal.invocation.InvocationComparator;
 import org.mockito.internal.stubbing.StubbingComparator;
 import org.mockito.internal.util.DefaultMockingDetails;
@@ -23,14 +26,14 @@ public class AllInvocationsFinder {
      * @return invocations
      */
     public static List<Invocation> find(Iterable<?> mocks) {
-        Set<Invocation> invocationsInOrder = new TreeSet<Invocation>(new InvocationComparator());
+        Set<Invocation> invocationsInOrder = new TreeSet<>(new InvocationComparator());
         for (Object mock : mocks) {
             Collection<Invocation> fromSingleMock =
                     new DefaultMockingDetails(mock).getInvocations();
             invocationsInOrder.addAll(fromSingleMock);
         }
 
-        return new LinkedList<Invocation>(invocationsInOrder);
+        return new LinkedList<>(invocationsInOrder);
     }
 
     /**
@@ -40,7 +43,7 @@ public class AllInvocationsFinder {
      * @return stubbings
      */
     public static Set<Stubbing> findStubbings(Iterable<?> mocks) {
-        Set<Stubbing> stubbings = new TreeSet<Stubbing>(new StubbingComparator());
+        Set<Stubbing> stubbings = new TreeSet<>(new StubbingComparator());
         for (Object mock : mocks) {
             // TODO due to the limited scope of static mocks they cannot be processed
             //  it would rather be required to trigger this stubbing control upon releasing

--- a/src/main/java/org/mockito/internal/invocation/finder/VerifiableInvocationsFinder.java
+++ b/src/main/java/org/mockito/internal/invocation/finder/VerifiableInvocationsFinder.java
@@ -23,6 +23,7 @@ public class VerifiableInvocationsFinder {
     }
 
     private static class RemoveIgnoredForVerification implements Filter<Invocation> {
+        @Override
         public boolean isOut(Invocation invocation) {
             return invocation.isIgnoredForVerification();
         }

--- a/src/main/java/org/mockito/internal/junit/DefaultStubbingLookupListener.java
+++ b/src/main/java/org/mockito/internal/junit/DefaultStubbingLookupListener.java
@@ -34,6 +34,7 @@ class DefaultStubbingLookupListener implements StubbingLookupListener, Serializa
         this.currentStrictness = strictness;
     }
 
+    @Override
     public void onStubbingLookup(StubbingLookupEvent event) {
         Strictness actualStrictness =
                 determineStrictness(
@@ -64,7 +65,7 @@ class DefaultStubbingLookupListener implements StubbingLookupListener, Serializa
 
     private static List<Invocation> potentialArgMismatches(
             Invocation invocation, Collection<Stubbing> stubbings) {
-        List<Invocation> matchingStubbings = new LinkedList<Invocation>();
+        List<Invocation> matchingStubbings = new LinkedList<>();
         for (Stubbing s : stubbings) {
             if (UnusedStubbingReporting.shouldBeReported(s)
                     && s.getInvocation()

--- a/src/main/java/org/mockito/internal/junit/JUnitRule.java
+++ b/src/main/java/org/mockito/internal/junit/JUnitRule.java
@@ -27,10 +27,12 @@ public final class JUnitRule implements MockitoRule {
                 base, target.getClass().getSimpleName() + "." + method.getName(), target);
     }
 
+    @Override
     public MockitoRule silent() {
         return strictness(Strictness.LENIENT);
     }
 
+    @Override
     public MockitoRule strictness(Strictness strictness) {
         sessionStore.setStrictness(strictness);
         return this;

--- a/src/main/java/org/mockito/internal/junit/JUnitSessionStore.java
+++ b/src/main/java/org/mockito/internal/junit/JUnitSessionStore.java
@@ -25,6 +25,7 @@ class JUnitSessionStore {
 
     Statement createStatement(final Statement base, final String methodName, final Object target) {
         return new Statement() {
+            @Override
             public void evaluate() throws Throwable {
                 AutoCloseable closeable;
                 if (session == null) {

--- a/src/main/java/org/mockito/internal/junit/JUnitTestRule.java
+++ b/src/main/java/org/mockito/internal/junit/JUnitTestRule.java
@@ -25,10 +25,12 @@ public final class JUnitTestRule implements MockitoTestRule {
         return sessionStore.createStatement(base, description.getDisplayName(), this.testInstance);
     }
 
+    @Override
     public MockitoTestRule silent() {
         return strictness(Strictness.LENIENT);
     }
 
+    @Override
     public MockitoTestRule strictness(Strictness strictness) {
         sessionStore.setStrictness(strictness);
         return this;

--- a/src/main/java/org/mockito/internal/junit/MismatchReportingTestListener.java
+++ b/src/main/java/org/mockito/internal/junit/MismatchReportingTestListener.java
@@ -17,19 +17,20 @@ import org.mockito.plugins.MockitoLogger;
 public class MismatchReportingTestListener implements MockitoTestListener {
 
     private final MockitoLogger logger;
-    private List<Object> mocks = new LinkedList<Object>();
+    private List<Object> mocks = new LinkedList<>();
 
     public MismatchReportingTestListener(MockitoLogger logger) {
         this.logger = logger;
     }
 
+    @Override
     public void testFinished(TestFinishedEvent event) {
         Collection<Object> createdMocks = mocks;
         // At this point, we don't need the mocks any more and we can mark all collected mocks for
         // gc
         // TODO make it better, it's easy to forget to clean up mocks and we still create new
         // instance of list that nobody will read, it's also duplicated
-        mocks = new LinkedList<Object>();
+        mocks = new LinkedList<>();
 
         if (event.getFailure() != null) {
             // print unused stubbings only when test succeeds to avoid reporting multiple problems
@@ -40,6 +41,7 @@ public class MismatchReportingTestListener implements MockitoTestListener {
         }
     }
 
+    @Override
     public void onMockCreated(Object mock, MockCreationSettings settings) {
         this.mocks.add(mock);
     }

--- a/src/main/java/org/mockito/internal/junit/NoOpTestListener.java
+++ b/src/main/java/org/mockito/internal/junit/NoOpTestListener.java
@@ -8,7 +8,9 @@ import org.mockito.mock.MockCreationSettings;
 
 public class NoOpTestListener implements MockitoTestListener {
 
+    @Override
     public void testFinished(TestFinishedEvent event) {}
 
+    @Override
     public void onMockCreated(Object mock, MockCreationSettings settings) {}
 }

--- a/src/main/java/org/mockito/internal/junit/StubbingArgMismatches.java
+++ b/src/main/java/org/mockito/internal/junit/StubbingArgMismatches.java
@@ -17,15 +17,12 @@ import org.mockito.plugins.MockitoLogger;
  */
 class StubbingArgMismatches {
 
-    final Map<Invocation, Set<Invocation>> mismatches =
-            new LinkedHashMap<Invocation, Set<Invocation>>();
+    final Map<Invocation, Set<Invocation>> mismatches = new LinkedHashMap<>();
 
     public void add(Invocation invocation, Invocation stubbing) {
-        Set<Invocation> matchingInvocations = mismatches.get(stubbing);
-        if (matchingInvocations == null) {
-            matchingInvocations = new LinkedHashSet<Invocation>();
-            mismatches.put(stubbing, matchingInvocations);
-        }
+        Set<Invocation> matchingInvocations =
+                mismatches.computeIfAbsent(
+                        stubbing, (Invocation k) -> new LinkedHashSet<Invocation>());
         matchingInvocations.add(invocation);
     }
 
@@ -50,6 +47,7 @@ class StubbingArgMismatches {
         return mismatches.size();
     }
 
+    @Override
     public String toString() {
         return "" + mismatches;
     }

--- a/src/main/java/org/mockito/internal/junit/StubbingHint.java
+++ b/src/main/java/org/mockito/internal/junit/StubbingHint.java
@@ -25,7 +25,8 @@ class StubbingHint {
         }
     }
 
+    @Override
     public String toString() {
-        return hint.toString() + "\n";
+        return hint + "\n";
     }
 }

--- a/src/main/java/org/mockito/internal/junit/UniversalTestListener.java
+++ b/src/main/java/org/mockito/internal/junit/UniversalTestListener.java
@@ -6,8 +6,6 @@ package org.mockito.internal.junit;
 
 import java.util.Collection;
 import java.util.IdentityHashMap;
-import java.util.Map;
-
 import org.mockito.internal.creation.settings.CreationSettings;
 import org.mockito.internal.listeners.AutoCleanableListener;
 import org.mockito.mock.MockCreationSettings;
@@ -24,9 +22,8 @@ public class UniversalTestListener implements MockitoTestListener, AutoCleanable
     private Strictness currentStrictness;
     private final MockitoLogger logger;
 
-    private Map<Object, MockCreationSettings> mocks =
-            new IdentityHashMap<Object, MockCreationSettings>();
-    private DefaultStubbingLookupListener stubbingLookupListener;
+    private IdentityHashMap mocks = new IdentityHashMap<Object, MockCreationSettings>();
+    private final DefaultStubbingLookupListener stubbingLookupListener;
     private boolean listenerDirty;
 
     public UniversalTestListener(Strictness initialStrictness, MockitoLogger logger) {
@@ -47,7 +44,7 @@ public class UniversalTestListener implements MockitoTestListener, AutoCleanable
         // TODO make it better, it's easy to forget to clean up mocks and we still create new
         // instance of list that nobody will read, it's also duplicated
         // TODO clean up all other state, null out stubbingLookupListener
-        mocks = new IdentityHashMap<Object, MockCreationSettings>();
+        mocks = new IdentityHashMap<>();
 
         switch (currentStrictness) {
             case WARN:

--- a/src/main/java/org/mockito/internal/junit/UnnecessaryStubbingsReporter.java
+++ b/src/main/java/org/mockito/internal/junit/UnnecessaryStubbingsReporter.java
@@ -21,7 +21,7 @@ import org.mockito.mock.MockCreationSettings;
  */
 public class UnnecessaryStubbingsReporter implements MockCreationListener {
 
-    private List<Object> mocks = new LinkedList<Object>();
+    private final List<Object> mocks = new LinkedList<Object>();
 
     public void validateUnusedStubs(Class<?> testClass, RunNotifier notifier) {
         Collection<Invocation> unused =

--- a/src/main/java/org/mockito/internal/junit/UnusedStubbings.java
+++ b/src/main/java/org/mockito/internal/junit/UnusedStubbings.java
@@ -43,6 +43,7 @@ public class UnusedStubbings {
         return unused.size();
     }
 
+    @Override
     public String toString() {
         return unused.toString();
     }
@@ -52,7 +53,7 @@ public class UnusedStubbings {
             return;
         }
 
-        List<Invocation> invocations = new LinkedList<Invocation>();
+        List<Invocation> invocations = new LinkedList<>();
         for (Stubbing stubbing : unused) {
             invocations.add(stubbing.getInvocation());
         }

--- a/src/main/java/org/mockito/internal/junit/UnusedStubbingsFinder.java
+++ b/src/main/java/org/mockito/internal/junit/UnusedStubbingsFinder.java
@@ -35,6 +35,7 @@ public class UnusedStubbingsFinder {
                 filter(
                         stubbings,
                         new Filter<Stubbing>() {
+                            @Override
                             public boolean isOut(Stubbing s) {
                                 return !UnusedStubbingReporting.shouldBeReported(s);
                             }
@@ -58,7 +59,7 @@ public class UnusedStubbingsFinder {
 
         // 1st pass, collect all the locations of the stubbings that were used
         // note that those are _not_ locations where the stubbings was used
-        Set<String> locationsOfUsedStubbings = new HashSet<String>();
+        Set<String> locationsOfUsedStubbings = new HashSet<>();
         for (Stubbing s : stubbings) {
             if (!UnusedStubbingReporting.shouldBeReported(s)) {
                 String location = s.getInvocation().getLocation().toString();
@@ -71,7 +72,7 @@ public class UnusedStubbingsFinder {
         // Also, using map to deduplicate reported unused stubbings
         // if unused stubbing appear in the setup method / constructor we don't want to report it
         // per each test case
-        Map<String, Invocation> out = new LinkedHashMap<String, Invocation>();
+        Map<String, Invocation> out = new LinkedHashMap<>();
         for (Stubbing s : stubbings) {
             String location = s.getInvocation().getLocation().toString();
             if (!locationsOfUsedStubbings.contains(location)) {

--- a/src/main/java/org/mockito/internal/junit/VerificationCollectorImpl.java
+++ b/src/main/java/org/mockito/internal/junit/VerificationCollectorImpl.java
@@ -27,6 +27,7 @@ public class VerificationCollectorImpl implements VerificationCollector {
         this.resetBuilder();
     }
 
+    @Override
     public Statement apply(final Statement base, final Description description) {
         return new Statement() {
             @Override
@@ -60,10 +61,12 @@ public class VerificationCollectorImpl implements VerificationCollector {
         }
     }
 
+    @Override
     public VerificationCollector assertLazily() {
         mockingProgress()
                 .setVerificationStrategy(
                         new VerificationStrategy() {
+                            @Override
                             public VerificationMode maybeVerifyLazily(VerificationMode mode) {
                                 return new VerificationWrapper(mode);
                             }
@@ -94,6 +97,7 @@ public class VerificationCollectorImpl implements VerificationCollector {
             this.delegate = delegate;
         }
 
+        @Override
         public void verify(VerificationData data) {
             try {
                 this.delegate.verify(data);
@@ -102,6 +106,7 @@ public class VerificationCollectorImpl implements VerificationCollector {
             }
         }
 
+        @Override
         public VerificationMode description(String description) {
             throw new IllegalStateException("Should not fail in this mode");
         }

--- a/src/main/java/org/mockito/internal/listeners/StubbingLookupNotifier.java
+++ b/src/main/java/org/mockito/internal/listeners/StubbingLookupNotifier.java
@@ -14,7 +14,7 @@ import org.mockito.listeners.StubbingLookupListener;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.stubbing.Stubbing;
 
-public class StubbingLookupNotifier {
+public final class StubbingLookupNotifier {
 
     public static void notifyStubbedAnswerLookup(
             Invocation invocation,
@@ -69,4 +69,6 @@ public class StubbingLookupNotifier {
             return mockSettings;
         }
     }
+
+    private StubbingLookupNotifier() {}
 }

--- a/src/main/java/org/mockito/internal/listeners/VerificationStartedNotifier.java
+++ b/src/main/java/org/mockito/internal/listeners/VerificationStartedNotifier.java
@@ -15,7 +15,7 @@ import org.mockito.listeners.VerificationStartedEvent;
 import org.mockito.listeners.VerificationStartedListener;
 import org.mockito.mock.MockCreationSettings;
 
-public class VerificationStartedNotifier {
+public final class VerificationStartedNotifier {
 
     public static Object notifyVerificationStarted(
             List<VerificationStartedListener> listeners, MockingDetails originalMockingDetails) {
@@ -38,6 +38,7 @@ public class VerificationStartedNotifier {
             this.mock = originalMockingDetails.getMock();
         }
 
+        @Override
         public void setMock(Object mock) {
             if (mock == null) {
                 throw Reporter.methodDoesNotAcceptParameter(
@@ -58,6 +59,7 @@ public class VerificationStartedNotifier {
             this.mock = mock;
         }
 
+        @Override
         public Object getMock() {
             return mock;
         }
@@ -94,4 +96,6 @@ public class VerificationStartedNotifier {
             }
         }
     }
+
+    private VerificationStartedNotifier() {}
 }

--- a/src/main/java/org/mockito/internal/matchers/And.java
+++ b/src/main/java/org/mockito/internal/matchers/And.java
@@ -10,18 +10,20 @@ import org.mockito.ArgumentMatcher;
 
 @SuppressWarnings({"unchecked", "serial", "rawtypes"})
 public class And implements ArgumentMatcher<Object>, Serializable {
-    private ArgumentMatcher m1;
-    private ArgumentMatcher m2;
+    private final ArgumentMatcher m1;
+    private final ArgumentMatcher m2;
 
     public And(ArgumentMatcher<?> m1, ArgumentMatcher<?> m2) {
         this.m1 = m1;
         this.m2 = m2;
     }
 
+    @Override
     public boolean matches(Object actual) {
         return m1.matches(actual) && m2.matches(actual);
     }
 
+    @Override
     public String toString() {
         return "and(" + m1 + ", " + m2 + ")";
     }

--- a/src/main/java/org/mockito/internal/matchers/Any.java
+++ b/src/main/java/org/mockito/internal/matchers/Any.java
@@ -12,10 +12,12 @@ public class Any implements ArgumentMatcher<Object>, VarargMatcher, Serializable
 
     public static final Any ANY = new Any();
 
+    @Override
     public boolean matches(Object actual) {
         return true;
     }
 
+    @Override
     public String toString() {
         return "<any>";
     }

--- a/src/main/java/org/mockito/internal/matchers/ArrayEquals.java
+++ b/src/main/java/org/mockito/internal/matchers/ArrayEquals.java
@@ -13,6 +13,7 @@ public class ArrayEquals extends Equals {
         super(wanted);
     }
 
+    @Override
     public boolean matches(Object actual) {
         Object wanted = getWanted();
         if (wanted == null || actual == null) {
@@ -39,6 +40,7 @@ public class ArrayEquals extends Equals {
         return false;
     }
 
+    @Override
     public String toString() {
         if (getWanted() != null && getWanted().getClass().isArray()) {
             return appendArray(createObjectArray(getWanted()));
@@ -51,7 +53,7 @@ public class ArrayEquals extends Equals {
         // TODO SF overlap with ValuePrinter
         StringBuilder out = new StringBuilder("[");
         for (int i = 0; i < array.length; i++) {
-            out.append(new Equals(array[i]).toString());
+            out.append(new Equals(array[i]));
             if (i != array.length - 1) {
                 out.append(", ");
             }

--- a/src/main/java/org/mockito/internal/matchers/CapturingMatcher.java
+++ b/src/main/java/org/mockito/internal/matchers/CapturingMatcher.java
@@ -19,16 +19,18 @@ import org.mockito.ArgumentMatcher;
 public class CapturingMatcher<T>
         implements ArgumentMatcher<T>, CapturesArguments, VarargMatcher, Serializable {
 
-    private final List<Object> arguments = new ArrayList<Object>();
+    private final List<Object> arguments = new ArrayList<>();
 
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
     private final Lock readLock = lock.readLock();
     private final Lock writeLock = lock.writeLock();
 
+    @Override
     public boolean matches(Object argument) {
         return true;
     }
 
+    @Override
     public String toString() {
         return "<Capturing argument>";
     }
@@ -55,6 +57,7 @@ public class CapturingMatcher<T>
         }
     }
 
+    @Override
     public void captureFrom(Object argument) {
         writeLock.lock();
         try {

--- a/src/main/java/org/mockito/internal/matchers/Contains.java
+++ b/src/main/java/org/mockito/internal/matchers/Contains.java
@@ -16,10 +16,12 @@ public class Contains implements ArgumentMatcher<String>, Serializable {
         this.substring = substring;
     }
 
+    @Override
     public boolean matches(String actual) {
         return actual != null && actual.contains(substring);
     }
 
+    @Override
     public String toString() {
         return "contains(\"" + substring + "\")";
     }

--- a/src/main/java/org/mockito/internal/matchers/EndsWith.java
+++ b/src/main/java/org/mockito/internal/matchers/EndsWith.java
@@ -16,10 +16,12 @@ public class EndsWith implements ArgumentMatcher<String>, Serializable {
         this.suffix = suffix;
     }
 
+    @Override
     public boolean matches(String actual) {
         return actual != null && actual.endsWith(suffix);
     }
 
+    @Override
     public String toString() {
         return "endsWith(\"" + suffix + "\")";
     }

--- a/src/main/java/org/mockito/internal/matchers/Equality.java
+++ b/src/main/java/org/mockito/internal/matchers/Equality.java
@@ -7,7 +7,7 @@ package org.mockito.internal.matchers;
 import java.lang.reflect.Array;
 
 // stolen from hamcrest because I didn't want to have more dependency than Matcher class
-public class Equality {
+public final class Equality {
 
     public static boolean areEqual(Object o1, Object o2) {
         if (o1 == o2) {
@@ -31,7 +31,9 @@ public class Equality {
 
     static boolean areArrayElementsEqual(Object o1, Object o2) {
         for (int i = 0; i < Array.getLength(o1); i++) {
-            if (!areEqual(Array.get(o1, i), Array.get(o2, i))) return false;
+            if (!areEqual(Array.get(o1, i), Array.get(o2, i))) {
+                return false;
+            }
         }
         return true;
     }
@@ -39,4 +41,6 @@ public class Equality {
     static boolean isArray(Object o) {
         return o.getClass().isArray();
     }
+
+    private Equality() {}
 }

--- a/src/main/java/org/mockito/internal/matchers/Equals.java
+++ b/src/main/java/org/mockito/internal/matchers/Equals.java
@@ -17,10 +17,12 @@ public class Equals implements ArgumentMatcher<Object>, ContainsExtraTypeInfo, S
         this.wanted = wanted;
     }
 
+    @Override
     public boolean matches(Object actual) {
         return Equality.areEqual(this.wanted, actual);
     }
 
+    @Override
     public String toString() {
         return describe(wanted);
     }
@@ -35,11 +37,11 @@ public class Equals implements ArgumentMatcher<Object>, ContainsExtraTypeInfo, S
 
     @Override
     public boolean equals(Object o) {
-        if (o == null || !this.getClass().equals(o.getClass())) {
+        if (!(o instanceof Equals)) {
             return false;
         }
         Equals other = (Equals) o;
-        return this.wanted == null && other.wanted == null
+        return (this.wanted == null && other.wanted == null)
                 || this.wanted != null && this.wanted.equals(other.wanted);
     }
 
@@ -48,10 +50,12 @@ public class Equals implements ArgumentMatcher<Object>, ContainsExtraTypeInfo, S
         return 1;
     }
 
+    @Override
     public String toStringWithType() {
         return "(" + wanted.getClass().getSimpleName() + ") " + describe(wanted);
     }
 
+    @Override
     public boolean typeMatches(Object target) {
         return wanted != null && target != null && target.getClass() == wanted.getClass();
     }

--- a/src/main/java/org/mockito/internal/matchers/EqualsWithDelta.java
+++ b/src/main/java/org/mockito/internal/matchers/EqualsWithDelta.java
@@ -18,6 +18,7 @@ public class EqualsWithDelta implements ArgumentMatcher<Number>, Serializable {
         this.delta = delta;
     }
 
+    @Override
     public boolean matches(Number actual) {
         if (wanted == null ^ actual == null) {
             return false;
@@ -31,6 +32,7 @@ public class EqualsWithDelta implements ArgumentMatcher<Number>, Serializable {
                 && actual.doubleValue() <= wanted.doubleValue() + delta.doubleValue();
     }
 
+    @Override
     public String toString() {
         return "eq(" + wanted + ", " + delta + ")";
     }

--- a/src/main/java/org/mockito/internal/matchers/Find.java
+++ b/src/main/java/org/mockito/internal/matchers/Find.java
@@ -17,11 +17,13 @@ public class Find implements ArgumentMatcher<String>, Serializable {
         this.regex = regex;
     }
 
+    @Override
     public boolean matches(String actual) {
         return actual != null && Pattern.compile(regex).matcher(actual).find();
     }
 
+    @Override
     public String toString() {
-        return "find(\"" + regex.replaceAll("\\\\", "\\\\\\\\") + "\")";
+        return "find(\"" + regex.replace("\\", "\\\\") + "\")";
     }
 }

--- a/src/main/java/org/mockito/internal/matchers/InstanceOf.java
+++ b/src/main/java/org/mockito/internal/matchers/InstanceOf.java
@@ -12,7 +12,7 @@ import org.mockito.internal.util.Primitives;
 public class InstanceOf implements ArgumentMatcher<Object>, Serializable {
 
     private final Class<?> clazz;
-    private String description;
+    private final String description;
 
     public InstanceOf(Class<?> clazz) {
         this(clazz, "isA(" + clazz.getCanonicalName() + ")");
@@ -23,12 +23,14 @@ public class InstanceOf implements ArgumentMatcher<Object>, Serializable {
         this.description = describedAs;
     }
 
+    @Override
     public boolean matches(Object actual) {
         return (actual != null)
                 && (Primitives.isAssignableFromWrapper(actual.getClass(), clazz)
                         || clazz.isAssignableFrom(actual.getClass()));
     }
 
+    @Override
     public String toString() {
         return description;
     }

--- a/src/main/java/org/mockito/internal/matchers/Matches.java
+++ b/src/main/java/org/mockito/internal/matchers/Matches.java
@@ -21,11 +21,13 @@ public class Matches implements ArgumentMatcher<Object>, Serializable {
         this.pattern = pattern;
     }
 
+    @Override
     public boolean matches(Object actual) {
         return (actual instanceof String) && pattern.matcher((String) actual).find();
     }
 
+    @Override
     public String toString() {
-        return "matches(\"" + pattern.pattern().replaceAll("\\\\", "\\\\\\\\") + "\")";
+        return "matches(\"" + pattern.pattern().replace("\\", "\\\\") + "\")";
     }
 }

--- a/src/main/java/org/mockito/internal/matchers/Not.java
+++ b/src/main/java/org/mockito/internal/matchers/Not.java
@@ -17,10 +17,12 @@ public class Not implements ArgumentMatcher<Object>, Serializable {
         this.matcher = matcher;
     }
 
+    @Override
     public boolean matches(Object actual) {
         return !matcher.matches(actual);
     }
 
+    @Override
     public String toString() {
         return "not(" + matcher + ")";
     }

--- a/src/main/java/org/mockito/internal/matchers/NotNull.java
+++ b/src/main/java/org/mockito/internal/matchers/NotNull.java
@@ -14,10 +14,12 @@ public class NotNull implements ArgumentMatcher<Object>, Serializable {
 
     private NotNull() {}
 
+    @Override
     public boolean matches(Object actual) {
         return actual != null;
     }
 
+    @Override
     public String toString() {
         return "notNull()";
     }

--- a/src/main/java/org/mockito/internal/matchers/Null.java
+++ b/src/main/java/org/mockito/internal/matchers/Null.java
@@ -14,10 +14,12 @@ public class Null implements ArgumentMatcher<Object>, Serializable {
 
     private Null() {}
 
+    @Override
     public boolean matches(Object actual) {
         return actual == null;
     }
 
+    @Override
     public String toString() {
         return "isNull()";
     }

--- a/src/main/java/org/mockito/internal/matchers/Or.java
+++ b/src/main/java/org/mockito/internal/matchers/Or.java
@@ -18,10 +18,12 @@ public class Or implements ArgumentMatcher<Object>, Serializable {
         this.m2 = m2;
     }
 
+    @Override
     public boolean matches(Object actual) {
         return m1.matches(actual) || m2.matches(actual);
     }
 
+    @Override
     public String toString() {
         return "or(" + m1 + ", " + m2 + ")";
     }

--- a/src/main/java/org/mockito/internal/matchers/Same.java
+++ b/src/main/java/org/mockito/internal/matchers/Same.java
@@ -17,10 +17,12 @@ public class Same implements ArgumentMatcher<Object>, Serializable {
         this.wanted = wanted;
     }
 
+    @Override
     public boolean matches(Object actual) {
         return wanted == actual;
     }
 
+    @Override
     public String toString() {
         return "same(" + ValuePrinter.print(wanted) + ")";
     }

--- a/src/main/java/org/mockito/internal/matchers/StartsWith.java
+++ b/src/main/java/org/mockito/internal/matchers/StartsWith.java
@@ -16,10 +16,12 @@ public class StartsWith implements ArgumentMatcher<String>, Serializable {
         this.prefix = prefix;
     }
 
+    @Override
     public boolean matches(String actual) {
         return actual != null && actual.startsWith(prefix);
     }
 
+    @Override
     public String toString() {
         return "startsWith(\"" + prefix + "\")";
     }

--- a/src/main/java/org/mockito/internal/matchers/apachecommons/EqualsBuilder.java
+++ b/src/main/java/org/mockito/internal/matchers/apachecommons/EqualsBuilder.java
@@ -9,6 +9,7 @@ import org.mockito.plugins.MemberAccessor;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -297,7 +298,7 @@ class EqualsBuilder {
             if (!excludedFieldList.contains(f.getName())
                     && (f.getName().indexOf('$') == -1)
                     && (useTransients || !Modifier.isTransient(f.getModifiers()))
-                    && (!Modifier.isStatic(f.getModifiers()))) {
+                    && !Modifier.isStatic(f.getModifiers())) {
                 try {
                     builder.append(accessor.get(f, lhs), accessor.get(f, rhs));
                 } catch (RuntimeException | IllegalAccessException ignored) {
@@ -350,9 +351,8 @@ class EqualsBuilder {
         }
         Class<?> lhsClass = lhs.getClass();
         if (!lhsClass.isArray()) {
-            if (lhs instanceof java.math.BigDecimal && rhs instanceof java.math.BigDecimal) {
-                isEquals =
-                        (((java.math.BigDecimal) lhs).compareTo((java.math.BigDecimal) rhs) == 0);
+            if (lhs instanceof BigDecimal && rhs instanceof BigDecimal) {
+                isEquals = (((BigDecimal) lhs).compareTo((BigDecimal) rhs) == 0);
             } else {
                 // The simple case, not an array, just test the element
                 isEquals = lhs.equals(rhs);

--- a/src/main/java/org/mockito/internal/matchers/apachecommons/ReflectionEquals.java
+++ b/src/main/java/org/mockito/internal/matchers/apachecommons/ReflectionEquals.java
@@ -18,10 +18,12 @@ public class ReflectionEquals implements ArgumentMatcher<Object>, Serializable {
         this.excludeFields = excludeFields;
     }
 
+    @Override
     public boolean matches(Object actual) {
         return EqualsBuilder.reflectionEquals(wanted, actual, excludeFields);
     }
 
+    @Override
     public String toString() {
         return "refEq(" + wanted + ")";
     }

--- a/src/main/java/org/mockito/internal/matchers/text/MatcherToString.java
+++ b/src/main/java/org/mockito/internal/matchers/text/MatcherToString.java
@@ -11,10 +11,8 @@ import java.lang.reflect.Method;
 
 import org.mockito.ArgumentMatcher;
 
-/**
- * Provides better toString() text for matcher that don't have toString() method declared.
- */
-class MatcherToString {
+/** Provides better toString() text for matcher that don't have toString() method declared. */
+final class MatcherToString {
 
     /**
      * Attempts to provide more descriptive toString() for given matcher.
@@ -50,4 +48,6 @@ class MatcherToString {
 
         return decamelizeMatcherName(matcherName);
     }
+
+    private MatcherToString() {}
 }

--- a/src/main/java/org/mockito/internal/matchers/text/MatchersPrinter.java
+++ b/src/main/java/org/mockito/internal/matchers/text/MatchersPrinter.java
@@ -27,7 +27,7 @@ public class MatchersPrinter {
 
     private Iterator<FormattedText> applyPrintSettings(
             List<ArgumentMatcher> matchers, PrintSettings printSettings) {
-        List<FormattedText> out = new LinkedList<FormattedText>();
+        List<FormattedText> out = new LinkedList<>();
         int i = 0;
         for (final ArgumentMatcher matcher : matchers) {
             if (matcher instanceof ContainsExtraTypeInfo && printSettings.extraTypeInfoFor(i)) {

--- a/src/main/java/org/mockito/internal/matchers/text/ValuePrinter.java
+++ b/src/main/java/org/mockito/internal/matchers/text/ValuePrinter.java
@@ -4,8 +4,6 @@
  */
 package org.mockito.internal.matchers.text;
 
-import static java.lang.String.valueOf;
-
 import java.lang.reflect.Array;
 import java.util.Iterator;
 import java.util.Map;
@@ -58,6 +56,7 @@ public class ValuePrinter {
                     new Iterator<Object>() {
                         private int currentIndex = 0;
 
+                        @Override
                         public boolean hasNext() {
                             return currentIndex < Array.getLength(value);
                         }
@@ -89,7 +88,7 @@ public class ValuePrinter {
                 result.append(", ");
             }
         }
-        return "{" + result.toString() + "}";
+        return "{" + result + "}";
     }
 
     /**
@@ -149,8 +148,8 @@ public class ValuePrinter {
 
     private static String descriptionOf(Object value) {
         try {
-            return valueOf(value);
-        } catch (Exception e) {
+            return String.valueOf(value);
+        } catch (RuntimeException e) {
             return value.getClass().getName() + "@" + Integer.toHexString(value.hashCode());
         }
     }

--- a/src/main/java/org/mockito/internal/progress/ArgumentMatcherStorageImpl.java
+++ b/src/main/java/org/mockito/internal/progress/ArgumentMatcherStorageImpl.java
@@ -10,8 +10,9 @@ import static org.mockito.internal.exceptions.Reporter.incorrectUseOfAdditionalM
 import static org.mockito.internal.exceptions.Reporter.misplacedArgumentMatcher;
 import static org.mockito.internal.exceptions.Reporter.reportNoSubMatchersFound;
 
-import java.util.*;
-
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Stack;
 import org.mockito.ArgumentMatcher;
 import org.mockito.internal.matchers.And;
 import org.mockito.internal.matchers.LocalizedMatcher;
@@ -22,19 +23,20 @@ public class ArgumentMatcherStorageImpl implements ArgumentMatcherStorage {
 
     private static final int TWO_SUB_MATCHERS = 2;
     private static final int ONE_SUB_MATCHER = 1;
-    private final Stack<LocalizedMatcher> matcherStack = new Stack<LocalizedMatcher>();
+    private final Stack<LocalizedMatcher> matcherStack = new Stack<>();
 
+    @Override
     public void reportMatcher(ArgumentMatcher<?> matcher) {
         matcherStack.push(new LocalizedMatcher(matcher));
     }
 
+    @Override
     public List<LocalizedMatcher> pullLocalizedMatchers() {
         if (matcherStack.isEmpty()) {
             return emptyList();
         }
 
-        List<LocalizedMatcher> lastMatchers = resetStack();
-        return lastMatchers;
+        return resetStack();
     }
 
     public void reportAnd() {
@@ -46,6 +48,7 @@ public class ArgumentMatcherStorageImpl implements ArgumentMatcherStorage {
         reportMatcher(new And(m1, m2));
     }
 
+    @Override
     public void reportOr() {
         assertStateFor("Or(?)", TWO_SUB_MATCHERS);
 
@@ -55,6 +58,7 @@ public class ArgumentMatcherStorageImpl implements ArgumentMatcherStorage {
         reportMatcher(new Or(m1, m2));
     }
 
+    @Override
     public void reportNot() {
         assertStateFor("Not(?)", ONE_SUB_MATCHER);
 
@@ -63,6 +67,7 @@ public class ArgumentMatcherStorageImpl implements ArgumentMatcherStorage {
         reportMatcher(new Not(m));
     }
 
+    @Override
     public void validateState() {
         if (!matcherStack.isEmpty()) {
             List<LocalizedMatcher> lastMatchers = resetStack();
@@ -70,6 +75,7 @@ public class ArgumentMatcherStorageImpl implements ArgumentMatcherStorage {
         }
     }
 
+    @Override
     public void reset() {
         matcherStack.clear();
     }
@@ -90,7 +96,7 @@ public class ArgumentMatcherStorageImpl implements ArgumentMatcherStorage {
     }
 
     private List<LocalizedMatcher> resetStack() {
-        ArrayList<LocalizedMatcher> lastMatchers = new ArrayList<LocalizedMatcher>(matcherStack);
+        ArrayList<LocalizedMatcher> lastMatchers = new ArrayList<>(matcherStack);
         reset();
         return lastMatchers;
     }

--- a/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
+++ b/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
@@ -35,7 +35,7 @@ public class MockingProgressImpl implements MockingProgress {
     private Localized<VerificationMode> verificationMode;
     private Location stubbingInProgress = null;
     private VerificationStrategy verificationStrategy;
-    private final Set<MockitoListener> listeners = new LinkedHashSet<MockitoListener>();
+    private final Set<MockitoListener> listeners = new LinkedHashSet<>();
 
     public MockingProgressImpl() {
         this.verificationStrategy = getDefaultVerificationStrategy();
@@ -43,16 +43,19 @@ public class MockingProgressImpl implements MockingProgress {
 
     public static VerificationStrategy getDefaultVerificationStrategy() {
         return new VerificationStrategy() {
+            @Override
             public VerificationMode maybeVerifyLazily(VerificationMode mode) {
                 return mode;
             }
         };
     }
 
+    @Override
     public void reportOngoingStubbing(OngoingStubbing ongoingStubbing) {
         this.ongoingStubbing = ongoingStubbing;
     }
 
+    @Override
     public OngoingStubbing<?> pullOngoingStubbing() {
         OngoingStubbing<?> temp = ongoingStubbing;
         ongoingStubbing = null;
@@ -61,8 +64,7 @@ public class MockingProgressImpl implements MockingProgress {
 
     @Override
     public Set<VerificationListener> verificationListeners() {
-        final LinkedHashSet<VerificationListener> verificationListeners =
-                new LinkedHashSet<VerificationListener>();
+        final LinkedHashSet<VerificationListener> verificationListeners = new LinkedHashSet<>();
 
         for (MockitoListener listener : listeners) {
             if (listener instanceof VerificationListener) {
@@ -73,19 +75,23 @@ public class MockingProgressImpl implements MockingProgress {
         return verificationListeners;
     }
 
+    @Override
     public void verificationStarted(VerificationMode verify) {
         validateState();
         resetOngoingStubbing();
         verificationMode = new Localized(verify);
     }
 
-    /* (non-Javadoc)
+    /**
+     * (non-Javadoc)
+     *
      * @see org.mockito.internal.progress.MockingProgress#resetOngoingStubbing()
      */
     public void resetOngoingStubbing() {
         ongoingStubbing = null;
     }
 
+    @Override
     public VerificationMode pullVerificationMode() {
         if (verificationMode == null) {
             return null;
@@ -96,11 +102,13 @@ public class MockingProgressImpl implements MockingProgress {
         return temp;
     }
 
+    @Override
     public void stubbingStarted() {
         validateState();
         stubbingInProgress = new LocationImpl();
     }
 
+    @Override
     public void validateState() {
         validateMostStuff();
 
@@ -127,10 +135,12 @@ public class MockingProgressImpl implements MockingProgress {
         getArgumentMatcherStorage().validateState();
     }
 
+    @Override
     public void stubbingCompleted() {
         stubbingInProgress = null;
     }
 
+    @Override
     public String toString() {
         return "ongoingStubbing: "
                 + ongoingStubbing
@@ -140,16 +150,19 @@ public class MockingProgressImpl implements MockingProgress {
                 + stubbingInProgress;
     }
 
+    @Override
     public void reset() {
         stubbingInProgress = null;
         verificationMode = null;
         getArgumentMatcherStorage().reset();
     }
 
+    @Override
     public ArgumentMatcherStorage getArgumentMatcherStorage() {
         return argumentMatcherStorage;
     }
 
+    @Override
     public void mockingStarted(Object mock, MockCreationSettings settings) {
         for (MockitoListener listener : listeners) {
             if (listener instanceof MockCreationListener) {
@@ -159,6 +172,7 @@ public class MockingProgressImpl implements MockingProgress {
         validateMostStuff();
     }
 
+    @Override
     public void mockingStarted(Class<?> mock, MockCreationSettings settings) {
         for (MockitoListener listener : listeners) {
             if (listener instanceof MockCreationListener) {
@@ -168,12 +182,13 @@ public class MockingProgressImpl implements MockingProgress {
         validateMostStuff();
     }
 
+    @Override
     public void addListener(MockitoListener listener) {
         addListener(listener, listeners);
     }
 
     static void addListener(MockitoListener listener, Set<MockitoListener> listeners) {
-        List<MockitoListener> delete = new LinkedList<MockitoListener>();
+        List<MockitoListener> delete = new LinkedList<>();
         for (MockitoListener existing : listeners) {
             if (existing.getClass().equals(listener.getClass())) {
                 if (existing instanceof AutoCleanableListener
@@ -189,24 +204,26 @@ public class MockingProgressImpl implements MockingProgress {
             }
         }
         // delete dirty listeners so they don't occupy state/memory and don't receive notifications
-        for (MockitoListener toDelete : delete) {
-            listeners.remove(toDelete);
-        }
+        listeners.removeAll(delete);
         listeners.add(listener);
     }
 
+    @Override
     public void removeListener(MockitoListener listener) {
         this.listeners.remove(listener);
     }
 
+    @Override
     public void setVerificationStrategy(VerificationStrategy strategy) {
         this.verificationStrategy = strategy;
     }
 
+    @Override
     public VerificationMode maybeVerifyLazily(VerificationMode mode) {
         return this.verificationStrategy.maybeVerifyLazily(mode);
     }
 
+    @Override
     public void clearListeners() {
         listeners.clear();
     }

--- a/src/main/java/org/mockito/internal/progress/SequenceNumber.java
+++ b/src/main/java/org/mockito/internal/progress/SequenceNumber.java
@@ -4,11 +4,13 @@
  */
 package org.mockito.internal.progress;
 
-public class SequenceNumber {
+public final class SequenceNumber {
 
     private static int sequenceNumber = 1;
 
     public static synchronized int next() {
         return sequenceNumber++;
     }
+
+    private SequenceNumber() {}
 }

--- a/src/main/java/org/mockito/internal/reporting/Pluralizer.java
+++ b/src/main/java/org/mockito/internal/reporting/Pluralizer.java
@@ -4,7 +4,7 @@
  */
 package org.mockito.internal.reporting;
 
-public class Pluralizer {
+public final class Pluralizer {
 
     public static String pluralize(int number) {
         return number == 1 ? "1 time" : number + " times";
@@ -17,4 +17,6 @@ public class Pluralizer {
             return "were exactly " + x + " interactions";
         }
     }
+
+    private Pluralizer() {}
 }

--- a/src/main/java/org/mockito/internal/reporting/PrintSettings.java
+++ b/src/main/java/org/mockito/internal/reporting/PrintSettings.java
@@ -18,7 +18,7 @@ public class PrintSettings {
 
     public static final int MAX_LINE_LENGTH = 45;
     private boolean multiline;
-    private List<Integer> withTypeInfo = new LinkedList<Integer>();
+    private List<Integer> withTypeInfo = new LinkedList<>();
 
     public void setMultiline(boolean multiline) {
         this.multiline = multiline;

--- a/src/main/java/org/mockito/internal/reporting/SmartPrinter.java
+++ b/src/main/java/org/mockito/internal/reporting/SmartPrinter.java
@@ -42,7 +42,7 @@ public class SmartPrinter {
 
         this.wanted = printSettings.print(wanted);
 
-        List<String> actuals = new ArrayList<String>();
+        List<String> actuals = new ArrayList<>();
         for (Invocation actual : allActualInvocations) {
             actuals.add(printSettings.print(actual));
         }

--- a/src/main/java/org/mockito/internal/runners/DefaultInternalRunner.java
+++ b/src/main/java/org/mockito/internal/runners/DefaultInternalRunner.java
@@ -33,6 +33,7 @@ public class DefaultInternalRunner implements InternalRunner {
                     public Object target;
                     private MockitoTestListener mockitoTestListener;
 
+                    @Override
                     protected Statement withBefores(
                             FrameworkMethod method, final Object target, Statement statement) {
                         this.target = target;
@@ -101,14 +102,17 @@ public class DefaultInternalRunner implements InternalRunner {
                 };
     }
 
+    @Override
     public void run(final RunNotifier notifier) {
         runner.run(notifier);
     }
 
+    @Override
     public Description getDescription() {
         return runner.getDescription();
     }
 
+    @Override
     public void filter(Filter filter) throws NoTestsRemainException {
         runner.filter(filter);
     }

--- a/src/main/java/org/mockito/internal/runners/RunnerFactory.java
+++ b/src/main/java/org/mockito/internal/runners/RunnerFactory.java
@@ -22,9 +22,7 @@ import org.mockito.internal.util.Supplier;
  */
 public class RunnerFactory {
 
-    /**
-     * Creates silent runner implementation
-     */
+    /** Creates silent runner implementation */
     public InternalRunner create(Class<?> klass) throws InvocationTargetException {
         return create(
                 klass,

--- a/src/main/java/org/mockito/internal/runners/StrictRunner.java
+++ b/src/main/java/org/mockito/internal/runners/StrictRunner.java
@@ -27,6 +27,7 @@ public class StrictRunner implements InternalRunner {
         this.testClass = testClass;
     }
 
+    @Override
     public void run(RunNotifier notifier) {
         // TODO need to be able to opt in for full stack trace instead of just relying on the stack
         // trace filter
@@ -53,10 +54,12 @@ public class StrictRunner implements InternalRunner {
         }
     }
 
+    @Override
     public Description getDescription() {
         return runner.getDescription();
     }
 
+    @Override
     public void filter(Filter filter) throws NoTestsRemainException {
         filterRequested = true;
         runner.filter(filter);

--- a/src/main/java/org/mockito/internal/session/DefaultMockitoSessionBuilder.java
+++ b/src/main/java/org/mockito/internal/session/DefaultMockitoSessionBuilder.java
@@ -19,7 +19,7 @@ import org.mockito.session.MockitoSessionLogger;
 
 public class DefaultMockitoSessionBuilder implements MockitoSessionBuilder {
 
-    private List<Object> testClassInstances = new ArrayList<Object>();
+    private final List<Object> testClassInstances = new ArrayList<Object>();
     private String name;
     private Strictness strictness;
     private MockitoSessionLogger logger;
@@ -69,7 +69,7 @@ public class DefaultMockitoSessionBuilder implements MockitoSessionBuilder {
             effectiveTestClassInstances = emptyList();
             effectiveName = this.name == null ? "<Unnamed Session>" : this.name;
         } else {
-            effectiveTestClassInstances = new ArrayList<Object>(testClassInstances);
+            effectiveTestClassInstances = new ArrayList<>(testClassInstances);
             Object lastTestClassInstance = testClassInstances.get(testClassInstances.size() - 1);
             effectiveName =
                     this.name == null ? lastTestClassInstance.getClass().getName() : this.name;

--- a/src/main/java/org/mockito/internal/stubbing/ConsecutiveStubbing.java
+++ b/src/main/java/org/mockito/internal/stubbing/ConsecutiveStubbing.java
@@ -16,6 +16,7 @@ public class ConsecutiveStubbing<T> extends BaseStubbing<T> {
         this.invocationContainer = invocationContainer;
     }
 
+    @Override
     public OngoingStubbing<T> thenAnswer(Answer<?> answer) {
         invocationContainer.addConsecutiveAnswer(answer);
         return this;

--- a/src/main/java/org/mockito/internal/stubbing/DoAnswerStyleStubbing.java
+++ b/src/main/java/org/mockito/internal/stubbing/DoAnswerStyleStubbing.java
@@ -16,7 +16,7 @@ import org.mockito.stubbing.Answer;
  */
 class DoAnswerStyleStubbing implements Serializable {
 
-    private final List<Answer<?>> answers = new ArrayList<Answer<?>>();
+    private final List<Answer<?>> answers = new ArrayList<>();
     private Strictness stubbingStrictness;
 
     void setAnswers(List<Answer<?>> answers, Strictness stubbingStrictness) {

--- a/src/main/java/org/mockito/internal/stubbing/InvocationContainerImpl.java
+++ b/src/main/java/org/mockito/internal/stubbing/InvocationContainerImpl.java
@@ -29,8 +29,7 @@ import org.mockito.stubbing.ValidableAnswer;
 public class InvocationContainerImpl implements InvocationContainer, Serializable {
 
     private static final long serialVersionUID = -5334301962749537177L;
-    private final LinkedList<StubbedInvocationMatcher> stubbed =
-            new LinkedList<StubbedInvocationMatcher>();
+    private final LinkedList<StubbedInvocationMatcher> stubbed = new LinkedList<>();
     private final DoAnswerStyleStubbing doAnswerStyleStubbing;
     private final RegisteredInvocations registeredInvocations;
     private final Strictness mockStrictness;
@@ -57,13 +56,7 @@ public class InvocationContainerImpl implements InvocationContainer, Serializabl
         addAnswer(answer, false, stubbingStrictness);
     }
 
-    public void addConsecutiveAnswer(Answer answer) {
-        addAnswer(answer, true, null);
-    }
-
-    /**
-     * Adds new stubbed answer and returns the invocation matcher the answer was added to.
-     */
+    /** Adds new stubbed answer and returns the invocation matcher the answer was added to. */
     public StubbedInvocationMatcher addAnswer(
             Answer answer, boolean isConsecutive, Strictness stubbingStrictness) {
         Invocation invocation = invocationForStubbing.getInvocation();
@@ -84,6 +77,10 @@ public class InvocationContainerImpl implements InvocationContainer, Serializabl
             }
             return stubbed.getFirst();
         }
+    }
+
+    public void addConsecutiveAnswer(Answer answer) {
+        addAnswer(answer, true, null);
     }
 
     Object answerTo(Invocation invocation) throws Throwable {
@@ -157,7 +154,7 @@ public class InvocationContainerImpl implements InvocationContainer, Serializabl
      * Stubbings in ascending order, most recent last
      */
     public Collection<Stubbing> getStubbingsAscending() {
-        List<Stubbing> result = new LinkedList<Stubbing>(stubbed);
+        List<Stubbing> result = new LinkedList<>(stubbed);
         Collections.reverse(result);
         return result;
     }

--- a/src/main/java/org/mockito/internal/stubbing/StrictnessSelector.java
+++ b/src/main/java/org/mockito/internal/stubbing/StrictnessSelector.java
@@ -11,7 +11,7 @@ import org.mockito.stubbing.Stubbing;
 /**
  * Helps determining the actual strictness given that it can be configured in multiple ways (at mock, at stubbing, in rule)
  */
-public class StrictnessSelector {
+public final class StrictnessSelector {
 
     /**
      * Determines the actual strictness in the following importance order:
@@ -37,4 +37,6 @@ public class StrictnessSelector {
 
         return testLevelStrictness;
     }
+
+    private StrictnessSelector() {}
 }

--- a/src/main/java/org/mockito/internal/stubbing/StubbedInvocationMatcher.java
+++ b/src/main/java/org/mockito/internal/stubbing/StubbedInvocationMatcher.java
@@ -20,7 +20,7 @@ import org.mockito.stubbing.Stubbing;
 public class StubbedInvocationMatcher extends InvocationMatcher implements Serializable, Stubbing {
 
     private static final long serialVersionUID = 4919105134123672727L;
-    private final Queue<Answer> answers = new ConcurrentLinkedQueue<Answer>();
+    private final Queue<Answer> answers = new ConcurrentLinkedQueue<>();
     private final Strictness strictness;
     private final Object usedAtLock = new Object[0];
     private DescribedInvocation usedAt;
@@ -32,6 +32,7 @@ public class StubbedInvocationMatcher extends InvocationMatcher implements Seria
         this.answers.add(answer);
     }
 
+    @Override
     public Object answer(InvocationOnMock invocation) throws Throwable {
         // see ThreadsShareGenerouslyStubbedMockTest
         Answer a;
@@ -51,6 +52,7 @@ public class StubbedInvocationMatcher extends InvocationMatcher implements Seria
         }
     }
 
+    @Override
     public boolean wasUsed() {
         synchronized (usedAtLock) {
             return usedAt != null;

--- a/src/main/java/org/mockito/internal/stubbing/StubberImpl.java
+++ b/src/main/java/org/mockito/internal/stubbing/StubberImpl.java
@@ -31,7 +31,7 @@ public class StubberImpl implements Stubber {
         this.strictness = strictness;
     }
 
-    private final List<Answer<?>> answers = new LinkedList<Answer<?>>();
+    private final List<Answer<?>> answers = new LinkedList<>();
 
     @Override
     public <T> T when(T mock) {

--- a/src/main/java/org/mockito/internal/stubbing/StubbingComparator.java
+++ b/src/main/java/org/mockito/internal/stubbing/StubbingComparator.java
@@ -16,6 +16,7 @@ public class StubbingComparator implements Comparator<Stubbing> {
 
     private final InvocationComparator invocationComparator = new InvocationComparator();
 
+    @Override
     public int compare(Stubbing o1, Stubbing o2) {
         return invocationComparator.compare(o1.getInvocation(), o2.getInvocation());
     }

--- a/src/main/java/org/mockito/internal/stubbing/UnusedStubbingReporting.java
+++ b/src/main/java/org/mockito/internal/stubbing/UnusedStubbingReporting.java
@@ -7,10 +7,8 @@ package org.mockito.internal.stubbing;
 import org.mockito.quality.Strictness;
 import org.mockito.stubbing.Stubbing;
 
-/**
- * Helps determining if stubbing should be reported as unused
- */
-public class UnusedStubbingReporting {
+/** Helps determining if stubbing should be reported as unused */
+public final class UnusedStubbingReporting {
 
     /**
      * Decides if the stubbing should be reported as unused.
@@ -19,4 +17,6 @@ public class UnusedStubbingReporting {
     public static boolean shouldBeReported(Stubbing stubbing) {
         return !stubbing.wasUsed() && stubbing.getStrictness() != Strictness.LENIENT;
     }
+
+    private UnusedStubbingReporting() {}
 }

--- a/src/main/java/org/mockito/internal/stubbing/answers/AbstractThrowsException.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/AbstractThrowsException.java
@@ -19,6 +19,7 @@ public abstract class AbstractThrowsException implements Answer<Object>, Validab
 
     protected abstract Throwable getThrowable();
 
+    @Override
     public Object answer(InvocationOnMock invocation) throws Throwable {
         Throwable throwable = getThrowable();
         if (throwable == null) {

--- a/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java
@@ -39,6 +39,7 @@ public class AnswerFunctionalInterfaces {
      */
     public static <T, A> Answer<T> toAnswer(final Answer1<T, A> answer) {
         return new Answer<T>() {
+            @Override
             @SuppressWarnings("unchecked")
             public T answer(InvocationOnMock invocation) throws Throwable {
                 return answer.answer((A) invocation.getArgument(0));
@@ -54,6 +55,7 @@ public class AnswerFunctionalInterfaces {
      */
     public static <A> Answer<Void> toAnswer(final VoidAnswer1<A> answer) {
         return new Answer<Void>() {
+            @Override
             @SuppressWarnings("unchecked")
             public Void answer(InvocationOnMock invocation) throws Throwable {
                 answer.answer((A) invocation.getArgument(0));
@@ -72,6 +74,7 @@ public class AnswerFunctionalInterfaces {
      */
     public static <T, A, B> Answer<T> toAnswer(final Answer2<T, A, B> answer) {
         return new Answer<T>() {
+            @Override
             @SuppressWarnings("unchecked")
             public T answer(InvocationOnMock invocation) throws Throwable {
                 return answer.answer((A) invocation.getArgument(0), (B) invocation.getArgument(1));
@@ -88,6 +91,7 @@ public class AnswerFunctionalInterfaces {
      */
     public static <A, B> Answer<Void> toAnswer(final VoidAnswer2<A, B> answer) {
         return new Answer<Void>() {
+            @Override
             @SuppressWarnings("unchecked")
             public Void answer(InvocationOnMock invocation) throws Throwable {
                 answer.answer((A) invocation.getArgument(0), (B) invocation.getArgument(1));
@@ -107,6 +111,7 @@ public class AnswerFunctionalInterfaces {
      */
     public static <T, A, B, C> Answer<T> toAnswer(final Answer3<T, A, B, C> answer) {
         return new Answer<T>() {
+            @Override
             @SuppressWarnings("unchecked")
             public T answer(InvocationOnMock invocation) throws Throwable {
                 return answer.answer(
@@ -127,6 +132,7 @@ public class AnswerFunctionalInterfaces {
      */
     public static <A, B, C> Answer<Void> toAnswer(final VoidAnswer3<A, B, C> answer) {
         return new Answer<Void>() {
+            @Override
             @SuppressWarnings("unchecked")
             public Void answer(InvocationOnMock invocation) throws Throwable {
                 answer.answer(
@@ -150,6 +156,7 @@ public class AnswerFunctionalInterfaces {
      */
     public static <T, A, B, C, D> Answer<T> toAnswer(final Answer4<T, A, B, C, D> answer) {
         return new Answer<T>() {
+            @Override
             @SuppressWarnings("unchecked")
             public T answer(InvocationOnMock invocation) throws Throwable {
                 return answer.answer(
@@ -172,6 +179,7 @@ public class AnswerFunctionalInterfaces {
      */
     public static <A, B, C, D> Answer<Void> toAnswer(final VoidAnswer4<A, B, C, D> answer) {
         return new Answer<Void>() {
+            @Override
             @SuppressWarnings("unchecked")
             public Void answer(InvocationOnMock invocation) throws Throwable {
                 answer.answer(
@@ -197,6 +205,7 @@ public class AnswerFunctionalInterfaces {
      */
     public static <T, A, B, C, D, E> Answer<T> toAnswer(final Answer5<T, A, B, C, D, E> answer) {
         return new Answer<T>() {
+            @Override
             @SuppressWarnings("unchecked")
             public T answer(InvocationOnMock invocation) throws Throwable {
                 return answer.answer(
@@ -221,6 +230,7 @@ public class AnswerFunctionalInterfaces {
      */
     public static <A, B, C, D, E> Answer<Void> toAnswer(final VoidAnswer5<A, B, C, D, E> answer) {
         return new Answer<Void>() {
+            @Override
             @SuppressWarnings("unchecked")
             public Void answer(InvocationOnMock invocation) throws Throwable {
                 answer.answer(
@@ -250,6 +260,7 @@ public class AnswerFunctionalInterfaces {
     public static <T, A, B, C, D, E, F> Answer<T> toAnswer(
             final Answer6<T, A, B, C, D, E, F> answer) {
         return new Answer<T>() {
+            @Override
             @SuppressWarnings("unchecked")
             public T answer(InvocationOnMock invocation) throws Throwable {
                 return answer.answer(
@@ -278,6 +289,7 @@ public class AnswerFunctionalInterfaces {
     public static <A, B, C, D, E, F> Answer<Void> toAnswer(
             final VoidAnswer6<A, B, C, D, E, F> answer) {
         return new Answer<Void>() {
+            @Override
             @SuppressWarnings("unchecked")
             public Void answer(InvocationOnMock invocation) throws Throwable {
                 answer.answer(

--- a/src/main/java/org/mockito/internal/stubbing/answers/AnswersWithDelay.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/AnswersWithDelay.java
@@ -4,9 +4,9 @@
  */
 package org.mockito.internal.stubbing.answers;
 
-import java.io.Serializable;
-import java.util.concurrent.TimeUnit;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
+import java.io.Serializable;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.mockito.stubbing.ValidableAnswer;
@@ -33,7 +33,7 @@ public class AnswersWithDelay implements Answer<Object>, ValidableAnswer, Serial
 
     @Override
     public Object answer(final InvocationOnMock invocation) throws Throwable {
-        TimeUnit.MILLISECONDS.sleep(sleepyTime);
+        MILLISECONDS.sleep(sleepyTime);
         return answer.answer(invocation);
     }
 

--- a/src/main/java/org/mockito/internal/stubbing/answers/CallsRealMethods.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/CallsRealMethods.java
@@ -37,6 +37,7 @@ import org.mockito.stubbing.ValidableAnswer;
 public class CallsRealMethods implements Answer<Object>, ValidableAnswer, Serializable {
     private static final long serialVersionUID = 9057165148930624087L;
 
+    @Override
     public Object answer(InvocationOnMock invocation) throws Throwable {
         if (Modifier.isAbstract(invocation.getMethod().getModifiers())) {
             return RETURNS_DEFAULTS.answer(invocation);

--- a/src/main/java/org/mockito/internal/stubbing/answers/ClonesArguments.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/ClonesArguments.java
@@ -16,6 +16,7 @@ import org.mockito.stubbing.Answer;
 // TODO this needs documentation and further analysis - what if someone changes the answer?
 // we might think about implementing it straight on MockSettings
 public class ClonesArguments implements Answer<Object> {
+    @Override
     public Object answer(InvocationOnMock invocation) throws Throwable {
         Object[] arguments = invocation.getArguments();
         for (int i = 0; i < arguments.length; i++) {

--- a/src/main/java/org/mockito/internal/stubbing/answers/Returns.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/Returns.java
@@ -22,6 +22,7 @@ public class Returns implements Answer<Object>, ValidableAnswer, Serializable {
         this.value = value;
     }
 
+    @Override
     public Object answer(InvocationOnMock invocation) throws Throwable {
         return value;
     }

--- a/src/main/java/org/mockito/internal/stubbing/answers/ReturnsArgumentAt.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/ReturnsArgumentAt.java
@@ -73,7 +73,9 @@ public class ReturnsArgumentAt implements Answer<Object>, ValidableAnswer, Seria
     }
 
     private int inferWantedArgumentPosition(InvocationOnMock invocation) {
-        if (wantedArgumentPosition == LAST_ARGUMENT) return invocation.getArguments().length - 1;
+        if (wantedArgumentPosition == LAST_ARGUMENT) {
+            return invocation.getArguments().length - 1;
+        }
 
         return wantedArgumentPosition;
     }

--- a/src/main/java/org/mockito/internal/stubbing/answers/ReturnsElementsOf.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/ReturnsElementsOf.java
@@ -40,11 +40,13 @@ public class ReturnsElementsOf implements Answer<Object> {
                     "ReturnsElementsOf does not accept null as constructor argument.\n"
                             + "Please pass a collection instance");
         }
-        this.elements = new LinkedList<Object>(elements);
+        this.elements = new LinkedList<>(elements);
     }
 
+    @Override
     public Object answer(InvocationOnMock invocation) throws Throwable {
-        if (elements.size() == 1) return elements.get(0);
-        else return elements.poll();
+        if (elements.size() == 1) {
+            return elements.get(0);
+        } else return elements.poll();
     }
 }

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ForwardsInvocations.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ForwardsInvocations.java
@@ -31,6 +31,7 @@ public class ForwardsInvocations implements Answer<Object>, Serializable {
         this.delegatedObject = delegatedObject;
     }
 
+    @Override
     public Object answer(InvocationOnMock invocation) throws Throwable {
         Method mockMethod = invocation.getMethod();
 

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/GloballyConfiguredAnswer.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/GloballyConfiguredAnswer.java
@@ -20,6 +20,7 @@ public class GloballyConfiguredAnswer implements Answer<Object>, Serializable {
 
     private static final long serialVersionUID = 3585893470101750917L;
 
+    @Override
     public Object answer(InvocationOnMock invocation) throws Throwable {
         return new GlobalConfiguration().getDefaultAnswer().answer(invocation);
     }

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/RetrieveGenericsForDefaultAnswers.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/RetrieveGenericsForDefaultAnswers.java
@@ -14,7 +14,7 @@ import org.mockito.internal.util.reflection.GenericMetadataSupport;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.mock.MockCreationSettings;
 
-class RetrieveGenericsForDefaultAnswers {
+final class RetrieveGenericsForDefaultAnswers {
 
     private static final MockitoCore MOCKITO_CORE = new MockitoCore();
 
@@ -139,4 +139,6 @@ class RetrieveGenericsForDefaultAnswers {
     interface AnswerCallback {
         Object apply(Class<?> type);
     }
+
+    private RetrieveGenericsForDefaultAnswers() {}
 }

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsDeepStubs.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsDeepStubs.java
@@ -46,6 +46,7 @@ public class ReturnsDeepStubs implements Answer<Object>, Serializable {
 
     private static final long serialVersionUID = -7105341425736035847L;
 
+    @Override
     public Object answer(InvocationOnMock invocation) throws Throwable {
         GenericMetadataSupport returnTypeGenericMetadata =
                 actualParameterizedType(invocation.getMock())
@@ -192,6 +193,7 @@ public class ReturnsDeepStubs implements Answer<Object>, Serializable {
             this.mock = mock;
         }
 
+        @Override
         public Object answer(InvocationOnMock invocation) throws Throwable {
             return mock;
         }

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValues.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValues.java
@@ -8,8 +8,20 @@ import static org.mockito.internal.util.ObjectMethodsGuru.isCompareToMethod;
 import static org.mockito.internal.util.ObjectMethodsGuru.isToStringMethod;
 
 import java.io.Serializable;
-import java.util.*;
-
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import org.mockito.internal.util.JavaEightUtil;
 import org.mockito.internal.util.MockUtil;
 import org.mockito.internal.util.Primitives;
@@ -56,6 +68,7 @@ public class ReturnsEmptyValues implements Answer<Object>, Serializable {
     /* (non-Javadoc)
      * @see org.mockito.stubbing.Answer#answer(org.mockito.invocation.InvocationOnMock)
      */
+    @Override
     public Object answer(InvocationOnMock invocation) {
         if (isToStringMethod(invocation.getMethod())) {
             Object mock = invocation.getMock();
@@ -87,35 +100,35 @@ public class ReturnsEmptyValues implements Answer<Object>, Serializable {
             // to avoid UnsupportedOperationException if code under test modifies returned
             // collection
         } else if (type == Iterable.class) {
-            return new ArrayList<Object>(0);
+            return new ArrayList<>(0);
         } else if (type == Collection.class) {
-            return new LinkedList<Object>();
+            return new LinkedList<>();
         } else if (type == Set.class) {
-            return new HashSet<Object>();
+            return new HashSet<>();
         } else if (type == HashSet.class) {
-            return new HashSet<Object>();
+            return new HashSet<>();
         } else if (type == SortedSet.class) {
-            return new TreeSet<Object>();
+            return new TreeSet<>();
         } else if (type == TreeSet.class) {
-            return new TreeSet<Object>();
+            return new TreeSet<>();
         } else if (type == LinkedHashSet.class) {
-            return new LinkedHashSet<Object>();
+            return new LinkedHashSet<>();
         } else if (type == List.class) {
-            return new LinkedList<Object>();
+            return new LinkedList<>();
         } else if (type == LinkedList.class) {
-            return new LinkedList<Object>();
+            return new LinkedList<>();
         } else if (type == ArrayList.class) {
-            return new ArrayList<Object>();
+            return new ArrayList<>();
         } else if (type == Map.class) {
-            return new HashMap<Object, Object>();
+            return new HashMap<>();
         } else if (type == HashMap.class) {
-            return new HashMap<Object, Object>();
+            return new HashMap<>();
         } else if (type == SortedMap.class) {
-            return new TreeMap<Object, Object>();
+            return new TreeMap<>();
         } else if (type == TreeMap.class) {
-            return new TreeMap<Object, Object>();
+            return new TreeMap<>();
         } else if (type == LinkedHashMap.class) {
-            return new LinkedHashMap<Object, Object>();
+            return new LinkedHashMap<>();
         } else if ("java.util.Optional".equals(type.getName())) {
             return JavaEightUtil.emptyOptional();
         } else if ("java.util.OptionalDouble".equals(type.getName())) {

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsMoreEmptyValues.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsMoreEmptyValues.java
@@ -52,6 +52,7 @@ public class ReturnsMoreEmptyValues implements Answer<Object>, Serializable {
     /* (non-Javadoc)
      * @see org.mockito.stubbing.Answer#answer(org.mockito.invocation.InvocationOnMock)
      */
+    @Override
     public Object answer(InvocationOnMock invocation) throws Throwable {
         Object ret = delegate.answer(invocation);
         if (ret != null) {

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNulls.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNulls.java
@@ -73,10 +73,11 @@ public class ReturnsSmartNulls implements Answer<Object>, Serializable {
             this.location = location;
         }
 
+        @Override
         public Object answer(InvocationOnMock currentInvocation) throws Throwable {
             if (isToStringMethod(currentInvocation.getMethod())) {
                 return "SmartNull returned by this unstubbed method call on a mock:\n"
-                        + unstubbedInvocation.toString();
+                        + unstubbedInvocation;
             }
 
             throw smartNullPointerException(unstubbedInvocation.toString(), location);

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/TriesToReturnSelf.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/TriesToReturnSelf.java
@@ -14,6 +14,7 @@ public class TriesToReturnSelf implements Answer<Object>, Serializable {
 
     private final ReturnsEmptyValues defaultReturn = new ReturnsEmptyValues();
 
+    @Override
     public Object answer(InvocationOnMock invocation) throws Throwable {
         Class<?> methodReturnType = invocation.getMethod().getReturnType();
         Object mock = invocation.getMock();

--- a/src/main/java/org/mockito/internal/util/Checks.java
+++ b/src/main/java/org/mockito/internal/util/Checks.java
@@ -4,10 +4,8 @@
  */
 package org.mockito.internal.util;
 
-/**
- * Pre-made preconditions
- */
-public class Checks {
+/** Pre-made preconditions */
+public final class Checks {
 
     public static <T> T checkNotNull(T value, String checkedValue) {
         return checkNotNull(value, checkedValue, null);
@@ -31,4 +29,6 @@ public class Checks {
         }
         return iterable;
     }
+
+    private Checks() {}
 }

--- a/src/main/java/org/mockito/internal/util/ConsoleMockitoLogger.java
+++ b/src/main/java/org/mockito/internal/util/ConsoleMockitoLogger.java
@@ -8,7 +8,9 @@ import org.mockito.plugins.MockitoLogger;
 
 public class ConsoleMockitoLogger implements MockitoLogger {
 
-    /* (non-Javadoc)
+    /**
+     * (non-Javadoc)
+     *
      * @see org.mockito.internal.util.Logger#print(java.lang.Object)
      */
     public void log(Object what) {

--- a/src/main/java/org/mockito/internal/util/MockNameImpl.java
+++ b/src/main/java/org/mockito/internal/util/MockNameImpl.java
@@ -47,6 +47,7 @@ public class MockNameImpl implements MockName, Serializable {
         return className + ".class";
     }
 
+    @Override
     public boolean isDefault() {
         return defaultName;
     }

--- a/src/main/java/org/mockito/internal/util/Primitives.java
+++ b/src/main/java/org/mockito/internal/util/Primitives.java
@@ -8,12 +8,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 @SuppressWarnings("unchecked")
-public class Primitives {
+public final class Primitives {
 
-    private static final Map<Class<?>, Class<?>> PRIMITIVE_TYPES =
-            new HashMap<Class<?>, Class<?>>();
+    private static final Map<Class<?>, Class<?>> PRIMITIVE_TYPES = new HashMap<>();
     private static final Map<Class<?>, Object> PRIMITIVE_OR_WRAPPER_DEFAULT_VALUES =
-            new HashMap<Class<?>, Object>();
+            new HashMap<>();
 
     /**
      * Returns the primitive type of the given class.
@@ -92,4 +91,6 @@ public class Primitives {
         PRIMITIVE_OR_WRAPPER_DEFAULT_VALUES.put(float.class, 0F);
         PRIMITIVE_OR_WRAPPER_DEFAULT_VALUES.put(double.class, 0D);
     }
+
+    private Primitives() {}
 }

--- a/src/main/java/org/mockito/internal/util/collections/HashCodeAndEqualsMockWrapper.java
+++ b/src/main/java/org/mockito/internal/util/collections/HashCodeAndEqualsMockWrapper.java
@@ -38,8 +38,12 @@ public class HashCodeAndEqualsMockWrapper {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof HashCodeAndEqualsMockWrapper)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof HashCodeAndEqualsMockWrapper)) {
+            return false;
+        }
 
         HashCodeAndEqualsMockWrapper that = (HashCodeAndEqualsMockWrapper) o;
 

--- a/src/main/java/org/mockito/internal/util/collections/HashCodeAndEqualsSafeSet.java
+++ b/src/main/java/org/mockito/internal/util/collections/HashCodeAndEqualsSafeSet.java
@@ -31,14 +31,15 @@ import org.mockito.internal.util.Checks;
  */
 public class HashCodeAndEqualsSafeSet implements Set<Object> {
 
-    private final HashSet<HashCodeAndEqualsMockWrapper> backingHashSet =
-            new HashSet<HashCodeAndEqualsMockWrapper>();
+    private final HashSet<HashCodeAndEqualsMockWrapper> backingHashSet = new HashSet<>();
 
+    @Override
     public Iterator<Object> iterator() {
         return new Iterator<Object>() {
             private final Iterator<HashCodeAndEqualsMockWrapper> iterator =
                     backingHashSet.iterator();
 
+            @Override
             public boolean hasNext() {
                 return iterator.hasNext();
             }
@@ -53,26 +54,32 @@ public class HashCodeAndEqualsSafeSet implements Set<Object> {
         };
     }
 
+    @Override
     public int size() {
         return backingHashSet.size();
     }
 
+    @Override
     public boolean isEmpty() {
         return backingHashSet.isEmpty();
     }
 
+    @Override
     public boolean contains(Object mock) {
         return backingHashSet.contains(HashCodeAndEqualsMockWrapper.of(mock));
     }
 
+    @Override
     public boolean add(Object mock) {
         return backingHashSet.add(HashCodeAndEqualsMockWrapper.of(mock));
     }
 
+    @Override
     public boolean remove(Object mock) {
         return backingHashSet.remove(HashCodeAndEqualsMockWrapper.of(mock));
     }
 
+    @Override
     public void clear() {
         backingHashSet.clear();
     }
@@ -101,6 +108,15 @@ public class HashCodeAndEqualsSafeSet implements Set<Object> {
     }
 
     @SuppressWarnings("unchecked")
+    public <T> T[] toArray(T[] typedArray) {
+        T[] array =
+                typedArray.length >= size()
+                        ? typedArray
+                        : (T[]) newInstance(typedArray.getClass().getComponentType(), size());
+        return unwrapTo(array);
+    }
+
+    @SuppressWarnings("unchecked")
     private <T> T[] unwrapTo(T[] array) {
         Iterator<Object> iterator = iterator();
         for (int i = 0, objectsLength = array.length; i < objectsLength; i++) {
@@ -111,34 +127,28 @@ public class HashCodeAndEqualsSafeSet implements Set<Object> {
         return array;
     }
 
-    @SuppressWarnings("unchecked")
-    public <T> T[] toArray(T[] typedArray) {
-        T[] array =
-                typedArray.length >= size()
-                        ? typedArray
-                        : (T[]) newInstance(typedArray.getClass().getComponentType(), size());
-        return unwrapTo(array);
-    }
-
     public boolean removeAll(Collection<?> mocks) {
         return backingHashSet.removeAll(asWrappedMocks(mocks));
     }
 
+    @Override
     public boolean containsAll(Collection<?> mocks) {
         return backingHashSet.containsAll(asWrappedMocks(mocks));
     }
 
+    @Override
     public boolean addAll(Collection<?> mocks) {
         return backingHashSet.addAll(asWrappedMocks(mocks));
     }
 
+    @Override
     public boolean retainAll(Collection<?> mocks) {
         return backingHashSet.retainAll(asWrappedMocks(mocks));
     }
 
     private HashSet<HashCodeAndEqualsMockWrapper> asWrappedMocks(Collection<?> mocks) {
         Checks.checkNotNull(mocks, "Passed collection should notify() be null");
-        HashSet<HashCodeAndEqualsMockWrapper> hashSet = new HashSet<HashCodeAndEqualsMockWrapper>();
+        HashSet<HashCodeAndEqualsMockWrapper> hashSet = new HashSet<>();
         for (Object mock : mocks) {
             assert !(mock instanceof HashCodeAndEqualsMockWrapper) : "WRONG";
             hashSet.add(HashCodeAndEqualsMockWrapper.of(mock));

--- a/src/main/java/org/mockito/internal/util/collections/Iterables.java
+++ b/src/main/java/org/mockito/internal/util/collections/Iterables.java
@@ -4,21 +4,19 @@
  */
 package org.mockito.internal.util.collections;
 
+import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 
-/**
- * Utilities for Iterables
- */
-public class Iterables {
+/** Utilities for Iterables */
+public final class Iterables {
 
     /**
      * Converts enumeration into iterable
      */
     public static <T> Iterable<T> toIterable(Enumeration<T> in) {
-        List<T> out = new LinkedList<T>();
+        List<T> out = new ArrayList<T>();
         while (in.hasMoreElements()) {
             out.add(in.nextElement());
         }
@@ -40,4 +38,6 @@ public class Iterables {
         }
         return iterator.next();
     }
+
+    private Iterables() {}
 }

--- a/src/main/java/org/mockito/internal/util/collections/ListUtil.java
+++ b/src/main/java/org/mockito/internal/util/collections/ListUtil.java
@@ -8,12 +8,11 @@ import java.util.Collection;
 import java.util.LinkedList;
 
 /**
- * Basic list/collection operators.
- * We know that there are existing libraries that implement those use cases neatly.
- * However, we want to keep Mockito dependencies minimal.
- * In Java8 we should be able to get rid of this class.
+ * Basic list/collection operators. We know that there are existing libraries that implement those
+ * use cases neatly. However, we want to keep Mockito dependencies minimal. In Java8 we should be
+ * able to get rid of this class.
  */
-public class ListUtil {
+public final class ListUtil {
 
     public static <T> LinkedList<T> filter(Collection<T> collection, Filter<T> filter) {
         LinkedList<T> filtered = new LinkedList<T>();
@@ -25,10 +24,10 @@ public class ListUtil {
         return filtered;
     }
 
-    public static <From, To> LinkedList<To> convert(
-            Collection<From> collection, Converter<From, To> converter) {
+    public static <FromT, To> LinkedList<To> convert(
+            Collection<FromT> collection, Converter<FromT, To> converter) {
         LinkedList<To> converted = new LinkedList<To>();
-        for (From f : collection) {
+        for (FromT f : collection) {
             converted.add(converter.convert(f));
         }
         return converted;
@@ -38,7 +37,9 @@ public class ListUtil {
         boolean isOut(T object);
     }
 
-    public interface Converter<From, To> {
-        To convert(From from);
+    public interface Converter<FromT, To> {
+        To convert(FromT from);
     }
+
+    private ListUtil() {}
 }

--- a/src/main/java/org/mockito/internal/util/concurrent/DetachedThreadLocal.java
+++ b/src/main/java/org/mockito/internal/util/concurrent/DetachedThreadLocal.java
@@ -45,6 +45,14 @@ public class DetachedThreadLocal<T> implements Runnable {
         return map.get(Thread.currentThread());
     }
 
+    /**
+     * @param thread The thread for which to set a thread-local value.
+     * @return The value associated with this thread.
+     */
+    public T get(Thread thread) {
+        return map.get(thread);
+    }
+
     public void set(T value) {
         map.put(Thread.currentThread(), value);
     }
@@ -86,15 +94,7 @@ public class DetachedThreadLocal<T> implements Runnable {
 
     /**
      * @param thread The thread for which to set a thread-local value.
-     * @return The value associated with this thread.
-     */
-    public T get(Thread thread) {
-        return map.get(thread);
-    }
-
-    /**
-     * @param thread The thread for which to set a thread-local value.
-     * @param value  The value to set.
+     * @param value The value to set.
      */
     public void define(Thread thread, T value) {
         map.put(thread, value);

--- a/src/main/java/org/mockito/internal/util/concurrent/WeakConcurrentMap.java
+++ b/src/main/java/org/mockito/internal/util/concurrent/WeakConcurrentMap.java
@@ -35,7 +35,7 @@ public class WeakConcurrentMap<K, V> extends ReferenceQueue<K>
      * @param cleanerThread {@code true} if a thread should be started that removes stale entries.
      */
     public WeakConcurrentMap(boolean cleanerThread) {
-        target = new ConcurrentHashMap<WeakKey<K>, V>();
+        target = new ConcurrentHashMap<>();
         if (cleanerThread) {
             thread = new Thread(this);
             thread.setName("weak-ref-cleaner-" + ID.getAndIncrement());
@@ -53,7 +53,9 @@ public class WeakConcurrentMap<K, V> extends ReferenceQueue<K>
      */
     @SuppressWarnings("CollectionIncompatibleType")
     public V get(K key) {
-        if (key == null) throw new NullPointerException();
+        if (key == null) {
+            throw new NullPointerException();
+        }
         V value = target.get(new LatentKey<K>(key));
         if (value == null) {
             value = defaultValue(key);
@@ -73,7 +75,9 @@ public class WeakConcurrentMap<K, V> extends ReferenceQueue<K>
      */
     @SuppressWarnings("CollectionIncompatibleType")
     public boolean containsKey(K key) {
-        if (key == null) throw new NullPointerException();
+        if (key == null) {
+            throw new NullPointerException();
+        }
         return target.containsKey(new LatentKey<K>(key));
     }
 
@@ -83,7 +87,9 @@ public class WeakConcurrentMap<K, V> extends ReferenceQueue<K>
      * @return The previous entry or {@code null} if it does not exist.
      */
     public V put(K key, V value) {
-        if (key == null || value == null) throw new NullPointerException();
+        if (key == null || value == null) {
+            throw new NullPointerException();
+        }
         return target.put(new WeakKey<K>(key, this), value);
     }
 
@@ -93,7 +99,9 @@ public class WeakConcurrentMap<K, V> extends ReferenceQueue<K>
      */
     @SuppressWarnings("CollectionIncompatibleType")
     public V remove(K key) {
-        if (key == null) throw new NullPointerException();
+        if (key == null) {
+            throw new NullPointerException();
+        }
         return target.remove(new LatentKey<K>(key));
     }
 
@@ -361,7 +369,9 @@ public class WeakConcurrentMap<K, V> extends ReferenceQueue<K>
 
         @Override
         public V setValue(V value) {
-            if (value == null) throw new NullPointerException();
+            if (value == null) {
+                throw new NullPointerException();
+            }
             return entry.setValue(value);
         }
     }

--- a/src/main/java/org/mockito/internal/util/concurrent/WeakConcurrentSet.java
+++ b/src/main/java/org/mockito/internal/util/concurrent/WeakConcurrentSet.java
@@ -21,11 +21,11 @@ public class WeakConcurrentSet<V> implements Runnable, Iterable<V> {
     public WeakConcurrentSet(Cleaner cleaner) {
         switch (cleaner) {
             case INLINE:
-                target = new WeakConcurrentMap.WithInlinedExpunction<V, Boolean>();
+                target = new WeakConcurrentMap.WithInlinedExpunction<>();
                 break;
             case THREAD:
             case MANUAL:
-                target = new WeakConcurrentMap<V, Boolean>(cleaner == Cleaner.THREAD);
+                target = new WeakConcurrentMap<>(cleaner == Cleaner.THREAD);
                 break;
             default:
                 throw new AssertionError();

--- a/src/main/java/org/mockito/internal/util/io/IOUtil.java
+++ b/src/main/java/org/mockito/internal/util/io/IOUtil.java
@@ -4,17 +4,24 @@
  */
 package org.mockito.internal.util.io;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
-
 import org.mockito.exceptions.base.MockitoException;
 
 /**
- * IO utils. A bit of reinventing the wheel but we don't want extra dependencies at this stage and we want to be java.
+ * IO utils. A bit of reinventing the wheel but we don't want extra dependencies at this stage and
+ * we want to be java.
  */
-public class IOUtil {
+public final class IOUtil {
 
     /**
      * Writes text to file
@@ -32,7 +39,7 @@ public class IOUtil {
     }
 
     public static Collection<String> readLines(InputStream is) {
-        List<String> out = new LinkedList<String>();
+        List<String> out = new LinkedList<>();
         BufferedReader r = new BufferedReader(new InputStreamReader(is));
         String line;
         try {
@@ -72,4 +79,6 @@ public class IOUtil {
             }
         }
     }
+
+    private IOUtil() {}
 }

--- a/src/main/java/org/mockito/internal/util/reflection/BeanPropertySetter.java
+++ b/src/main/java/org/mockito/internal/util/reflection/BeanPropertySetter.java
@@ -101,7 +101,7 @@ public class BeanPropertySetter {
     private String setterName(String fieldName) {
         return new StringBuilder(SET_PREFIX)
                 .append(fieldName.substring(0, 1).toUpperCase(Locale.ENGLISH))
-                .append(fieldName.substring(1))
+                .append(fieldName, 1, fieldName.length())
                 .toString();
     }
 

--- a/src/main/java/org/mockito/internal/util/reflection/FieldInitializer.java
+++ b/src/main/java/org/mockito/internal/util/reflection/FieldInitializer.java
@@ -193,6 +193,7 @@ public class FieldInitializer {
             this.field = field;
         }
 
+        @Override
         public FieldInitializationReport instantiate() {
             final MemberAccessor invoker = Plugins.getMemberAccessor();
             try {
@@ -214,16 +215,14 @@ public class FieldInitializer {
                         "the default constructor of type '"
                                 + field.getType().getSimpleName()
                                 + "' has raised an exception (see the stack trace for cause): "
-                                + e.getTargetException().toString(),
+                                + e.getTargetException(),
                         e);
             } catch (InstantiationException e) {
                 throw new MockitoException(
-                        "InstantiationException (see the stack trace for cause): " + e.toString(),
-                        e);
+                        "InstantiationException (see the stack trace for cause): " + e, e);
             } catch (IllegalAccessException e) {
                 throw new MockitoException(
-                        "IllegalAccessException (see the stack trace for cause): " + e.toString(),
-                        e);
+                        "IllegalAccessException (see the stack trace for cause): " + e, e);
             }
         }
     }
@@ -244,6 +243,7 @@ public class FieldInitializer {
         private final ConstructorArgumentResolver argResolver;
         private final Comparator<Constructor<?>> byParameterNumber =
                 new Comparator<Constructor<?>>() {
+                    @Override
                     public int compare(Constructor<?> constructorA, Constructor<?> constructorB) {
                         int argLengths =
                                 constructorB.getParameterTypes().length
@@ -278,6 +278,7 @@ public class FieldInitializer {
             this.argResolver = argumentResolver;
         }
 
+        @Override
         public FieldInitializationReport instantiate() {
             final MemberAccessor accessor = Plugins.getMemberAccessor();
             Constructor<?> constructor = biggestConstructor(field.getType());
@@ -299,16 +300,14 @@ public class FieldInitializer {
                         "the constructor of type '"
                                 + field.getType().getSimpleName()
                                 + "' has raised an exception (see the stack trace for cause): "
-                                + e.getTargetException().toString(),
+                                + e.getTargetException(),
                         e);
             } catch (InstantiationException e) {
                 throw new MockitoException(
-                        "InstantiationException (see the stack trace for cause): " + e.toString(),
-                        e);
+                        "InstantiationException (see the stack trace for cause): " + e, e);
             } catch (IllegalAccessException e) {
                 throw new MockitoException(
-                        "IllegalAccessException (see the stack trace for cause): " + e.toString(),
-                        e);
+                        "IllegalAccessException (see the stack trace for cause): " + e, e);
             }
         }
 

--- a/src/main/java/org/mockito/internal/util/reflection/Fields.java
+++ b/src/main/java/org/mockito/internal/util/reflection/Fields.java
@@ -27,7 +27,7 @@ public abstract class Fields {
      * @return InstanceFields of this object instance.
      */
     public static InstanceFields allDeclaredFieldsOf(Object instance) {
-        List<InstanceField> instanceFields = new ArrayList<InstanceField>();
+        List<InstanceField> instanceFields = new ArrayList<>();
         for (Class<?> clazz = instance.getClass();
                 clazz != Object.class;
                 clazz = clazz.getSuperclass()) {
@@ -43,13 +43,13 @@ public abstract class Fields {
      * @return InstanceFields of this object instance.
      */
     public static InstanceFields declaredFieldsOf(Object instance) {
-        List<InstanceField> instanceFields = new ArrayList<InstanceField>();
+        List<InstanceField> instanceFields = new ArrayList<>();
         instanceFields.addAll(instanceFieldsIn(instance, instance.getClass().getDeclaredFields()));
         return new InstanceFields(instance, instanceFields);
     }
 
     private static List<InstanceField> instanceFieldsIn(Object instance, Field[] fields) {
-        List<InstanceField> instanceDeclaredFields = new ArrayList<InstanceField>();
+        List<InstanceField> instanceDeclaredFields = new ArrayList<>();
         for (Field field : fields) {
             InstanceField instanceField = new InstanceField(field, instance);
             instanceDeclaredFields.add(instanceField);
@@ -67,6 +67,7 @@ public abstract class Fields {
     public static Filter<InstanceField> annotatedBy(
             final Class<? extends Annotation>... annotations) {
         return new Filter<InstanceField>() {
+            @Override
             public boolean isOut(InstanceField instanceField) {
                 Checks.checkNotNull(annotations, "Provide at least one annotation class");
 
@@ -87,6 +88,7 @@ public abstract class Fields {
      */
     private static Filter<InstanceField> nullField() {
         return new Filter<InstanceField>() {
+            @Override
             public boolean isOut(InstanceField instanceField) {
                 return instanceField.isNull();
             }
@@ -100,6 +102,7 @@ public abstract class Fields {
      */
     public static Filter<InstanceField> syntheticField() {
         return new Filter<InstanceField>() {
+            @Override
             public boolean isOut(InstanceField instanceField) {
                 return instanceField.isSynthetic();
             }
@@ -125,11 +128,11 @@ public abstract class Fields {
         }
 
         public List<InstanceField> instanceFields() {
-            return new ArrayList<InstanceField>(instanceFields);
+            return new ArrayList<>(instanceFields);
         }
 
         public List<Object> assignedValues() {
-            List<Object> values = new ArrayList<Object>(instanceFields.size());
+            List<Object> values = new ArrayList<>(instanceFields.size());
             for (InstanceField instanceField : instanceFields) {
                 values.add(instanceField.read());
             }
@@ -137,7 +140,7 @@ public abstract class Fields {
         }
 
         public List<String> names() {
-            List<String> fieldNames = new ArrayList<String>(instanceFields.size());
+            List<String> fieldNames = new ArrayList<>(instanceFields.size());
             for (InstanceField instanceField : instanceFields) {
                 fieldNames.add(instanceField.name());
             }

--- a/src/main/java/org/mockito/internal/util/reflection/GenericMetadataSupport.java
+++ b/src/main/java/org/mockito/internal/util/reflection/GenericMetadataSupport.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
-
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.util.Checks;
 
@@ -70,11 +69,8 @@ public abstract class GenericMetadataSupport {
 
     // public static MockitoLogger logger = new ConsoleMockitoLogger();
 
-    /**
-     * Represents actual type variables resolved for current class.
-     */
-    protected Map<TypeVariable<?>, Type> contextualActualTypeParameters =
-            new HashMap<TypeVariable<?>, Type>();
+    /** Represents actual type variables resolved for current class. */
+    protected Map<TypeVariable<?>, Type> contextualActualTypeParameters = new HashMap<>();
 
     /**
      * Registers the type variables for the given type and all of its superclasses and superinterfaces.
@@ -245,8 +241,7 @@ public abstract class GenericMetadataSupport {
      */
     public Map<TypeVariable<?>, Type> actualTypeArguments() {
         TypeVariable<?>[] typeParameters = rawType().getTypeParameters();
-        LinkedHashMap<TypeVariable<?>, Type> actualTypeArguments =
-                new LinkedHashMap<TypeVariable<?>, Type>();
+        LinkedHashMap<TypeVariable<?>, Type> actualTypeArguments = new LinkedHashMap<>();
 
         for (TypeVariable<?> typeParameter : typeParameters) {
 
@@ -503,9 +498,10 @@ public abstract class GenericMetadataSupport {
          * @return Returns an array with the extracted raw types of {@link #extraInterfaces()}.
          * @see #extractRawTypeOf(java.lang.reflect.Type)
          */
+        @Override
         public Class<?>[] rawExtraInterfaces() {
             List<Type> extraInterfaces = extraInterfaces();
-            List<Class<?>> rawExtraInterfaces = new ArrayList<Class<?>>();
+            List<Class<?>> rawExtraInterfaces = new ArrayList<>();
             for (Type extraInterface : extraInterfaces) {
                 Class<?> rawInterface = extractRawTypeOf(extraInterface);
                 // avoid interface collision with actual raw type (with typevariables, resolution ca
@@ -634,6 +630,7 @@ public abstract class GenericMetadataSupport {
         /**
          * @return either a class or an interface (parameterized or not), if no bounds declared Object is returned.
          */
+        @Override
         public Type firstBound() {
             return typeVariable.getBounds()[0]; //
         }
@@ -645,6 +642,7 @@ public abstract class GenericMetadataSupport {
          * @return other bounds for this type, these bounds can only be only interfaces as the JLS says,
          * empty array if no other bound declared.
          */
+        @Override
         public Type[] interfaceBounds() {
             Type[] interfaceBounds = new Type[typeVariable.getBounds().length - 1];
             System.arraycopy(
@@ -658,8 +656,12 @@ public abstract class GenericMetadataSupport {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             return typeVariable.equals(((TypeVarBoundedType) o).typeVariable);
         }
@@ -698,9 +700,8 @@ public abstract class GenericMetadataSupport {
             this.wildcard = wildcard;
         }
 
-        /**
-         * @return The first bound, either a type or a reference to a TypeVariable
-         */
+        /** @return The first bound, either a type or a reference to a TypeVariable */
+        @Override
         public Type firstBound() {
             Type[] lowerBounds = wildcard.getLowerBounds();
             Type[] upperBounds = wildcard.getUpperBounds();
@@ -708,17 +709,20 @@ public abstract class GenericMetadataSupport {
             return lowerBounds.length != 0 ? lowerBounds[0] : upperBounds[0];
         }
 
-        /**
-         * @return An empty array as, wildcard don't support multiple bounds.
-         */
+        /** @return An empty array as, wildcard don't support multiple bounds. */
+        @Override
         public Type[] interfaceBounds() {
             return new Type[0];
         }
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             return wildcard.equals(((TypeVarBoundedType) o).typeVariable);
         }

--- a/src/main/java/org/mockito/internal/util/reflection/GenericTypeExtractor.java
+++ b/src/main/java/org/mockito/internal/util/reflection/GenericTypeExtractor.java
@@ -7,10 +7,8 @@ package org.mockito.internal.util.reflection;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 
-/**
- * Attempts to extract generic type of given target base class or target interface
- */
-public class GenericTypeExtractor {
+/** Attempts to extract generic type of given target base class or target interface */
+public final class GenericTypeExtractor {
 
     /**
      * Extract generic type of root class either from the target base class or from target base interface.
@@ -86,4 +84,6 @@ public class GenericTypeExtractor {
         }
         return Object.class;
     }
+
+    private GenericTypeExtractor() {}
 }

--- a/src/main/java/org/mockito/internal/util/reflection/InstanceField.java
+++ b/src/main/java/org/mockito/internal/util/reflection/InstanceField.java
@@ -129,8 +129,12 @@ public class InstanceField {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         InstanceField that = (InstanceField) o;
         return field.equals(that.field) && instance.equals(that.instance);

--- a/src/main/java/org/mockito/internal/util/reflection/InstrumentationMemberAccessor.java
+++ b/src/main/java/org/mockito/internal/util/reflection/InstrumentationMemberAccessor.java
@@ -95,8 +95,17 @@ class InstrumentationMemberAccessor implements MemberAccessor {
         INITIALIZATION_ERROR = throwable;
     }
 
-    @SuppressWarnings("unused")
-    private final MethodHandle getModule, isOpen, redefineModule, privateLookupIn;
+    @SuppressWarnings(value = "unused")
+    private final MethodHandle getModule;
+
+    @SuppressWarnings(value = "unused")
+    private final MethodHandle isOpen;
+
+    @SuppressWarnings(value = "unused")
+    private final MethodHandle redefineModule;
+
+    @SuppressWarnings(value = "unused")
+    private final MethodHandle privateLookupIn;
 
     InstrumentationMemberAccessor() {
         if (INITIALIZATION_ERROR != null) {

--- a/src/main/java/org/mockito/internal/util/reflection/ReflectionMemberAccessor.java
+++ b/src/main/java/org/mockito/internal/util/reflection/ReflectionMemberAccessor.java
@@ -4,10 +4,13 @@
  */
 package org.mockito.internal.util.reflection;
 
-import org.mockito.plugins.MemberAccessor;
-
-import java.lang.reflect.*;
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Arrays;
+import org.mockito.plugins.MemberAccessor;
 
 public class ReflectionMemberAccessor implements MemberAccessor {
 
@@ -29,7 +32,7 @@ public class ReflectionMemberAccessor implements MemberAccessor {
                 | InstantiationException
                 | IllegalArgumentException e) {
             throw e;
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             throw new IllegalStateException(
                     "Failed to invoke " + constructor + " with " + Arrays.toString(arguments), e);
         } finally {
@@ -45,7 +48,7 @@ public class ReflectionMemberAccessor implements MemberAccessor {
             return method.invoke(target, arguments);
         } catch (InvocationTargetException | IllegalAccessException | IllegalArgumentException e) {
             throw e;
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             throw new IllegalStateException("Could not invoke " + method + " on " + target, e);
         } finally {
             silentSetAccessible(method, false);
@@ -59,8 +62,8 @@ public class ReflectionMemberAccessor implements MemberAccessor {
             return field.get(target);
         } catch (IllegalAccessException | IllegalArgumentException e) {
             throw e;
-        } catch (Exception e) {
-            throw new IllegalStateException("Could not read " + field + " from " + target);
+        } catch (RuntimeException e) {
+            throw new IllegalStateException("Could not read " + field + " from " + target, e);
         } finally {
             silentSetAccessible(field, false);
         }
@@ -73,7 +76,7 @@ public class ReflectionMemberAccessor implements MemberAccessor {
             field.set(target, value);
         } catch (IllegalAccessException | IllegalArgumentException e) {
             throw e;
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             throw new IllegalStateException("Could not write " + field + " to " + target, e);
         } finally {
             silentSetAccessible(field, false);
@@ -83,7 +86,7 @@ public class ReflectionMemberAccessor implements MemberAccessor {
     private static void silentSetAccessible(AccessibleObject object, boolean value) {
         try {
             object.setAccessible(value);
-        } catch (Exception ignored) {
+        } catch (RuntimeException ignored) {
         }
     }
 }

--- a/src/main/java/org/mockito/internal/util/reflection/SuperTypesLastSorter.java
+++ b/src/main/java/org/mockito/internal/util/reflection/SuperTypesLastSorter.java
@@ -24,7 +24,7 @@ public class SuperTypesLastSorter {
      * then with any fields moved after their supertypes.
      */
     public static List<Field> sortSuperTypesLast(Collection<? extends Field> unsortedFields) {
-        List<Field> fields = new ArrayList<Field>(unsortedFields);
+        List<Field> fields = new ArrayList<>(unsortedFields);
 
         Collections.sort(fields, compareFieldsByName);
 
@@ -54,10 +54,7 @@ public class SuperTypesLastSorter {
     }
 
     private static final Comparator<Field> compareFieldsByName =
-            new Comparator<Field>() {
-                @Override
-                public int compare(Field o1, Field o2) {
-                    return o1.getName().compareTo(o2.getName());
-                }
+            (Field o1, Field o2) -> {
+                return o1.getName().compareTo(o2.getName());
             };
 }

--- a/src/main/java/org/mockito/internal/verification/AtMost.java
+++ b/src/main/java/org/mockito/internal/verification/AtMost.java
@@ -28,6 +28,7 @@ public class AtMost implements VerificationMode {
         this.maxNumberOfInvocations = maxNumberOfInvocations;
     }
 
+    @Override
     public void verify(VerificationData data) {
         List<Invocation> invocations = data.getAllInvocations();
         MatchableInvocation wanted = data.getTarget();

--- a/src/main/java/org/mockito/internal/verification/DefaultRegisteredInvocations.java
+++ b/src/main/java/org/mockito/internal/verification/DefaultRegisteredInvocations.java
@@ -17,14 +17,16 @@ import org.mockito.invocation.Invocation;
 public class DefaultRegisteredInvocations implements RegisteredInvocations, Serializable {
 
     private static final long serialVersionUID = -2674402327380736290L;
-    private final LinkedList<Invocation> invocations = new LinkedList<Invocation>();
+    private final LinkedList<Invocation> invocations = new LinkedList<>();
 
+    @Override
     public void add(Invocation invocation) {
         synchronized (invocations) {
             invocations.add(invocation);
         }
     }
 
+    @Override
     public void removeLast() {
         // TODO: add specific test for synchronization of this block (it is tested by
         // InvocationContainerImplTest at the moment)
@@ -35,21 +37,24 @@ public class DefaultRegisteredInvocations implements RegisteredInvocations, Seri
         }
     }
 
+    @Override
     public List<Invocation> getAll() {
         List<Invocation> copiedList;
         synchronized (invocations) {
-            copiedList = new LinkedList<Invocation>(invocations);
+            copiedList = new LinkedList<>(invocations);
         }
 
         return ListUtil.filter(copiedList, new RemoveToString());
     }
 
+    @Override
     public void clear() {
         synchronized (invocations) {
             invocations.clear();
         }
     }
 
+    @Override
     public boolean isEmpty() {
         synchronized (invocations) {
             return invocations.isEmpty();
@@ -57,6 +62,7 @@ public class DefaultRegisteredInvocations implements RegisteredInvocations, Seri
     }
 
     private static class RemoveToString implements Filter<Invocation> {
+        @Override
         public boolean isOut(Invocation invocation) {
             return isToStringMethod(invocation.getMethod());
         }

--- a/src/main/java/org/mockito/internal/verification/Description.java
+++ b/src/main/java/org/mockito/internal/verification/Description.java
@@ -39,8 +39,6 @@ public class Description implements VerificationMode {
         try {
             verification.verify(data);
 
-        } catch (MockitoAssertionError e) {
-            throw new MockitoAssertionError(e, description);
         } catch (AssertionError e) {
             throw new MockitoAssertionError(e, description);
         }

--- a/src/main/java/org/mockito/internal/verification/InOrderContextImpl.java
+++ b/src/main/java/org/mockito/internal/verification/InOrderContextImpl.java
@@ -12,10 +12,12 @@ public class InOrderContextImpl implements InOrderContext {
 
     final IdentitySet verified = new IdentitySet();
 
+    @Override
     public boolean isVerified(Invocation invocation) {
         return verified.contains(invocation);
     }
 
+    @Override
     public void markVerified(Invocation i) {
         verified.add(i);
     }

--- a/src/main/java/org/mockito/internal/verification/InOrderWrapper.java
+++ b/src/main/java/org/mockito/internal/verification/InOrderWrapper.java
@@ -24,6 +24,7 @@ public class InOrderWrapper implements VerificationMode {
         this.inOrder = inOrder;
     }
 
+    @Override
     public void verify(VerificationData data) {
         List<Invocation> invocations =
                 VerifiableInvocationsFinder.find(inOrder.getMocksToBeVerifiedInOrder());

--- a/src/main/java/org/mockito/internal/verification/MockAwareVerificationMode.java
+++ b/src/main/java/org/mockito/internal/verification/MockAwareVerificationMode.java
@@ -24,14 +24,12 @@ public class MockAwareVerificationMode implements VerificationMode {
         this.listeners = listeners;
     }
 
+    @Override
     public void verify(VerificationData data) {
         try {
             mode.verify(data);
             notifyListeners(new VerificationEventImpl(mock, mode, data, null));
-        } catch (RuntimeException e) {
-            notifyListeners(new VerificationEventImpl(mock, mode, data, e));
-            throw e;
-        } catch (Error e) {
+        } catch (RuntimeException | Error e) {
             notifyListeners(new VerificationEventImpl(mock, mode, data, e));
             throw e;
         }

--- a/src/main/java/org/mockito/internal/verification/NoInteractions.java
+++ b/src/main/java/org/mockito/internal/verification/NoInteractions.java
@@ -14,6 +14,7 @@ import org.mockito.verification.VerificationMode;
 
 public class NoInteractions implements VerificationMode {
 
+    @Override
     @SuppressWarnings("unchecked")
     public void verify(VerificationData data) {
         List<Invocation> invocations = data.getAllInvocations();

--- a/src/main/java/org/mockito/internal/verification/NoMoreInteractions.java
+++ b/src/main/java/org/mockito/internal/verification/NoMoreInteractions.java
@@ -19,6 +19,7 @@ import org.mockito.verification.VerificationMode;
 
 public class NoMoreInteractions implements VerificationMode, VerificationInOrderMode {
 
+    @Override
     @SuppressWarnings("unchecked")
     public void verify(VerificationData data) {
         Invocation unverified = findFirstUnverified(data.getAllInvocations());
@@ -27,6 +28,7 @@ public class NoMoreInteractions implements VerificationMode, VerificationInOrder
         }
     }
 
+    @Override
     public void verifyInOrder(VerificationDataInOrder data) {
         List<Invocation> invocations = data.getAllInvocations();
         Invocation unverified = findFirstUnverifiedInOrder(data.getOrderingContext(), invocations);

--- a/src/main/java/org/mockito/internal/verification/Only.java
+++ b/src/main/java/org/mockito/internal/verification/Only.java
@@ -19,6 +19,7 @@ import org.mockito.verification.VerificationMode;
 
 public class Only implements VerificationMode {
 
+    @Override
     @SuppressWarnings("unchecked")
     public void verify(VerificationData data) {
         MatchableInvocation target = data.getTarget();

--- a/src/main/java/org/mockito/internal/verification/SingleRegisteredInvocation.java
+++ b/src/main/java/org/mockito/internal/verification/SingleRegisteredInvocation.java
@@ -14,22 +14,27 @@ public class SingleRegisteredInvocation implements RegisteredInvocations, Serial
 
     private Invocation invocation;
 
+    @Override
     public void add(Invocation invocation) {
         this.invocation = invocation;
     }
 
+    @Override
     public void removeLast() {
         invocation = null;
     }
 
+    @Override
     public List<Invocation> getAll() {
         return Collections.emptyList();
     }
 
+    @Override
     public void clear() {
         invocation = null;
     }
 
+    @Override
     public boolean isEmpty() {
         return invocation == null;
     }

--- a/src/main/java/org/mockito/internal/verification/VerificationEventImpl.java
+++ b/src/main/java/org/mockito/internal/verification/VerificationEventImpl.java
@@ -22,18 +22,22 @@ public class VerificationEventImpl implements VerificationEvent {
         this.cause = cause;
     }
 
+    @Override
     public Object getMock() {
         return mock;
     }
 
+    @Override
     public VerificationMode getMode() {
         return mode;
     }
 
+    @Override
     public VerificationData getData() {
         return data;
     }
 
+    @Override
     public Throwable getVerificationError() {
         return cause;
     }

--- a/src/main/java/org/mockito/internal/verification/VerificationModeFactory.java
+++ b/src/main/java/org/mockito/internal/verification/VerificationModeFactory.java
@@ -6,7 +6,7 @@ package org.mockito.internal.verification;
 
 import org.mockito.verification.VerificationMode;
 
-public class VerificationModeFactory {
+public final class VerificationModeFactory {
 
     public static VerificationMode atLeastOnce() {
         return atLeast(1);
@@ -54,4 +54,6 @@ public class VerificationModeFactory {
     public static VerificationMode description(VerificationMode mode, String description) {
         return new Description(mode, description);
     }
+
+    private VerificationModeFactory() {}
 }

--- a/src/main/java/org/mockito/internal/verification/VerificationOverTimeImpl.java
+++ b/src/main/java/org/mockito/internal/verification/VerificationOverTimeImpl.java
@@ -77,6 +77,7 @@ public class VerificationOverTimeImpl implements VerificationMode {
      *
      * @throws MockitoAssertionError if the delegate verification mode does not succeed before the timeout
      */
+    @Override
     public void verify(VerificationData data) {
         AssertionError error = null;
 
@@ -90,8 +91,6 @@ public class VerificationOverTimeImpl implements VerificationMode {
                 } else {
                     error = null;
                 }
-            } catch (MockitoAssertionError e) {
-                error = handleVerifyException(e);
             } catch (AssertionError e) {
                 error = handleVerifyException(e);
             }

--- a/src/main/java/org/mockito/internal/verification/VerificationWrapper.java
+++ b/src/main/java/org/mockito/internal/verification/VerificationWrapper.java
@@ -7,15 +7,16 @@ package org.mockito.internal.verification;
 import org.mockito.internal.verification.api.VerificationData;
 import org.mockito.verification.VerificationMode;
 
-public abstract class VerificationWrapper<WrapperType extends VerificationMode>
+public abstract class VerificationWrapper<WrapperT extends VerificationMode>
         implements VerificationMode {
 
-    protected final WrapperType wrappedVerification;
+    protected final WrapperT wrappedVerification;
 
-    public VerificationWrapper(WrapperType wrappedVerification) {
+    public VerificationWrapper(WrapperT wrappedVerification) {
         this.wrappedVerification = wrappedVerification;
     }
 
+    @Override
     public void verify(VerificationData data) {
         wrappedVerification.verify(data);
     }

--- a/src/main/java/org/mockito/internal/verification/api/VerificationDataInOrderImpl.java
+++ b/src/main/java/org/mockito/internal/verification/api/VerificationDataInOrderImpl.java
@@ -22,14 +22,17 @@ public class VerificationDataInOrderImpl implements VerificationDataInOrder {
         this.wanted = wanted;
     }
 
+    @Override
     public List<Invocation> getAllInvocations() {
         return allInvocations;
     }
 
+    @Override
     public InOrderContext getOrderingContext() {
         return inOrder;
     }
 
+    @Override
     public MatchableInvocation getWanted() {
         return wanted;
     }

--- a/src/main/java/org/mockito/internal/verification/argumentmatching/ArgumentMatchingTool.java
+++ b/src/main/java/org/mockito/internal/verification/argumentmatching/ArgumentMatchingTool.java
@@ -23,7 +23,7 @@ public class ArgumentMatchingTool {
             return new Integer[0];
         }
 
-        List<Integer> suspicious = new LinkedList<Integer>();
+        List<Integer> suspicious = new LinkedList<>();
         int i = 0;
         for (ArgumentMatcher m : matchers) {
             if (m instanceof ContainsExtraTypeInfo
@@ -46,6 +46,6 @@ public class ArgumentMatchingTool {
     }
 
     private static boolean toStringEquals(ArgumentMatcher m, Object arg) {
-        return m.toString().equals(arg == null ? "null" : arg.toString());
+        return m.toString().equals(String.valueOf(arg));
     }
 }

--- a/src/main/java/org/mockito/internal/verification/checkers/AtLeastXNumberOfInvocationsChecker.java
+++ b/src/main/java/org/mockito/internal/verification/checkers/AtLeastXNumberOfInvocationsChecker.java
@@ -19,7 +19,7 @@ import org.mockito.invocation.Invocation;
 import org.mockito.invocation.Location;
 import org.mockito.invocation.MatchableInvocation;
 
-public class AtLeastXNumberOfInvocationsChecker {
+public final class AtLeastXNumberOfInvocationsChecker {
 
     public static void checkAtLeastNumberOfInvocations(
             List<Invocation> invocations, MatchableInvocation wanted, int wantedCount) {
@@ -53,4 +53,6 @@ public class AtLeastXNumberOfInvocationsChecker {
 
         markVerifiedInOrder(chunk, wanted, orderingContext);
     }
+
+    private AtLeastXNumberOfInvocationsChecker() {}
 }

--- a/src/main/java/org/mockito/invocation/DescribedInvocation.java
+++ b/src/main/java/org/mockito/invocation/DescribedInvocation.java
@@ -14,6 +14,7 @@ public interface DescribedInvocation {
      *
      * @return the description of this invocation.
      */
+    @Override
     String toString();
 
     /**

--- a/src/main/java/org/mockito/invocation/Invocation.java
+++ b/src/main/java/org/mockito/invocation/Invocation.java
@@ -37,9 +37,8 @@ public interface Invocation extends InvocationOnMock, DescribedInvocation {
      */
     int getSequenceNumber();
 
-    /**
-     * @return the location in code of this invocation.
-     */
+    /** @return the location in code of this invocation. */
+    @Override
     Location getLocation();
 
     /**

--- a/src/main/java/org/mockito/invocation/Location.java
+++ b/src/main/java/org/mockito/invocation/Location.java
@@ -17,6 +17,7 @@ public interface Location {
      *
      * @return location
      */
+    @Override
     String toString();
 
     /**

--- a/src/main/java/org/mockito/junit/MockitoJUnit.java
+++ b/src/main/java/org/mockito/junit/MockitoJUnit.java
@@ -22,7 +22,7 @@ import org.mockito.quality.Strictness;
  *
  * @since 1.10.17
  */
-public class MockitoJUnit {
+public final class MockitoJUnit {
 
     /**
      * Creates rule instance that initiates &#064;Mocks
@@ -60,4 +60,6 @@ public class MockitoJUnit {
     public static VerificationCollector collector() {
         return new VerificationCollectorImpl();
     }
+
+    private MockitoJUnit() {}
 }

--- a/src/main/java/org/mockito/junit/MockitoJUnitRunner.java
+++ b/src/main/java/org/mockito/junit/MockitoJUnitRunner.java
@@ -168,6 +168,7 @@ public class MockitoJUnitRunner extends Runner implements Filterable {
         return runner.getDescription();
     }
 
+    @Override
     public void filter(Filter filter) throws NoTestsRemainException {
         // filter is required because without it UnrootedTests show up in Eclipse
         runner.filter(filter);

--- a/src/main/java/org/mockito/mock/MockName.java
+++ b/src/main/java/org/mockito/mock/MockName.java
@@ -9,9 +9,8 @@ package org.mockito.mock;
  */
 public interface MockName {
 
-    /**
-     * the name
-     */
+    /** the name */
+    @Override
     String toString();
 
     /**

--- a/src/main/java/org/mockito/runners/ConsoleSpammingMockitoJUnitRunner.java
+++ b/src/main/java/org/mockito/runners/ConsoleSpammingMockitoJUnitRunner.java
@@ -68,6 +68,7 @@ public class ConsoleSpammingMockitoJUnitRunner extends Runner implements Filtera
         return runner.getDescription();
     }
 
+    @Override
     public void filter(Filter filter) throws NoTestsRemainException {
         // filter is required because without it UnrootedTests show up in Eclipse
         runner.filter(filter);

--- a/src/main/java/org/mockito/runners/MockitoJUnitRunner.java
+++ b/src/main/java/org/mockito/runners/MockitoJUnitRunner.java
@@ -59,6 +59,7 @@ public class MockitoJUnitRunner extends org.mockito.junit.MockitoJUnitRunner {
         return super.getDescription();
     }
 
+    @Override
     @Deprecated
     public void filter(Filter filter) throws NoTestsRemainException {
         super.filter(filter);

--- a/src/main/java/org/mockito/runners/VerboseMockitoJUnitRunner.java
+++ b/src/main/java/org/mockito/runners/VerboseMockitoJUnitRunner.java
@@ -70,6 +70,7 @@ public class VerboseMockitoJUnitRunner extends Runner implements Filterable {
         return runner.getDescription();
     }
 
+    @Override
     public void filter(Filter filter) throws NoTestsRemainException {
         // filter is required because without it UnrootedTests show up in Eclipse
         runner.filter(filter);

--- a/src/main/java/org/mockito/verification/Timeout.java
+++ b/src/main/java/org/mockito/verification/Timeout.java
@@ -53,10 +53,12 @@ public class Timeout extends VerificationWrapper<VerificationOverTimeImpl>
         return new Timeout(wrappedVerification.copyWithVerificationMode(newVerificationMode));
     }
 
+    @Override
     public VerificationMode atMost(int maxNumberOfInvocations) {
         throw atMostAndNeverShouldNotBeUsedWithTimeout();
     }
 
+    @Override
     public VerificationMode never() {
         throw atMostAndNeverShouldNotBeUsedWithTimeout();
     }


### PR DESCRIPTION
This is the result of running ErrorProne on the codebase. Most notably,
it adds missing override annotations, adds private constructors for
classes that should not be subclassed, removes redundant generic type
specified and fixes handling of casts/instance checks.