### PR TITLE
Remove ASM dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,8 +86,6 @@ dependencies {
     compileOnly libraries.junit4, libraries.hamcrest, libraries.opentest4j
     compile libraries.objenesis
 
-    testCompile libraries.asm
-
     testCompile libraries.assertj
 
     //putting 'provided' dependencies on test compile and runtime classpath

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -28,8 +28,6 @@ libraries.autoservice = "com.google.auto.service:auto-service:1.0"
 
 libraries.objenesis = 'org.objenesis:objenesis:3.2'
 
-libraries.asm = 'org.ow2.asm:asm:7.0'
-
 libraries.osgi = 'org.osgi:osgi.core:8.0.0'
 libraries.equinox = 'org.eclipse.platform:org.eclipse.osgi:3.16.200'
 libraries.bndGradle =  'biz.aQute.bnd:biz.aQute.bnd.gradle:5.2.0'

--- a/src/test/java/org/mockitoutil/SimpleClassGenerator.java
+++ b/src/test/java/org/mockitoutil/SimpleClassGenerator.java
@@ -4,25 +4,11 @@
  */
 package org.mockitoutil;
 
-import static org.objectweb.asm.Opcodes.*;
-
-import org.objectweb.asm.ClassWriter;
+import net.bytebuddy.ByteBuddy;
 
 public class SimpleClassGenerator {
 
     public static byte[] makeMarkerInterface(String qualifiedName) {
-        String relativePath = qualifiedName.replace('.', '/');
-
-        ClassWriter cw = new ClassWriter(0);
-        cw.visit(
-                V1_6,
-                ACC_PUBLIC + ACC_ABSTRACT + ACC_INTERFACE,
-                relativePath,
-                null,
-                "java/lang/Object",
-                null);
-        cw.visitEnd();
-
-        return cw.toByteArray();
+        return new ByteBuddy().makeInterface().name(qualifiedName).make().getBytes();
     }
 }


### PR DESCRIPTION
Mockito depends on byte-buddy to make most of its bytecode fiddling but ASM is still needed for the tests. We can remove this dependency by relying on the already shaded version included on ASM, that we we won't get unaligned between both dependencies and we will remove the need for the explicit ASM library.

R: @raphw

<!-- Hey, 
Thanks for the contribution, this is awesome.
As you may have read, project members have somehow an opinionated view on what and how should be
Mockito, e.g. we don't want mockito to be a feature bloat.
There may be a thorough review, with feedback -> code change loop.
-->
<!--
Which branch : 
- On mockito 3.x, make your pull request target `release/3.x`
- On mockito 2.x, make your pull request target `release/2.x` (2.x is in maintenance mode)
-->
<!--
If you have a suggestion for this template you can fix it in the .github/PULL_REQUEST_TEMPLATE.md file
-->
## Checklist

 - [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/3.x/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [ ] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [ ] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [ ] Mention `Fixes #<issue number>` in the description _if relevant_
 - [ ] At least one commit should mention `Fixes #<issue number>` _if relevant_

