### PR TITLE
Fix stackoverflow in ArgumentsAreDifferent reporting

### DIFF
--- a/src/main/java/org/mockito/exceptions/verification/ArgumentsAreDifferent.java
+++ b/src/main/java/org/mockito/exceptions/verification/ArgumentsAreDifferent.java
@@ -31,6 +31,6 @@ public class ArgumentsAreDifferent extends MockitoAssertionError {
 
     @Override
     public String getMessage() {
-        return removeFirstLine(super.toString());
+        return removeFirstLine(super.getMessage());
     }
 }


### PR DESCRIPTION
When using Mockito without opentest4j, reporting an
ArgumentsAreDifferent exception would throw a StackOverflowError when
attempting to obtain the message from the exception.

The root problem was that super.toString() would call its own
getMessage(). Instead, we should obtain the message from the super, to
avoid the circular call.