### PR TITLE
Renamed main dev branch

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,10 +12,6 @@
 
 # Contributing to Mockito
 
-Which branch :
-* On mockito 3.x (or 2.x), make your pull request target `release/3.x` (or `release/2.x`)
-* On next mockito version make your pull request target `release/3.x`
-
 ## Pull request criteria
 
 * **At least one commit message** in the PR starts with `Fixes #id : ` where `id` is an [issue tracker](https://github.com/mockito/mockito/issues) id. This allows automated release notes generation. Also GitHub will track the issue and [close it](https://github.com/blog/1386-closing-issues-via-commit-messages) when the PR is merged.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,9 @@
 > Hey,
-> 
+>
 > First thanks for reporting, in order to help us to classify issue can you make sure the following check boxes are checked ?
-> 
+>
 > If this is about mockito usage, the better way is to reach out to
-> 
+>
 >  - stackoverflow : https://stackoverflow.com/questions/tagged/mockito
 >  - the mailing-list  : https://groups.google.com/forum/#!forum/mockito / mockito@googlegroups.com
 >    (Note mailing-list is moderated to avoid spam)
@@ -20,6 +20,6 @@ check that
  - [ ] Provide versions (mockito / jdk / os / any other relevant information)
  - [ ] Provide a [Short, Self Contained, Correct (Compilable), Example](http://sscce.org) of the issue
        (same as any question on stackoverflow.com)
- - [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/3.x/.github/CONTRIBUTING.md)
+ - [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,15 @@
-<!-- Hey, 
+<!-- Hey,
 Thanks for the contribution, this is awesome.
 As you may have read, project members have somehow an opinionated view on what and how should be
 Mockito, e.g. we don't want mockito to be a feature bloat.
 There may be a thorough review, with feedback -> code change loop.
 -->
 <!--
-Which branch : 
-- On mockito 3.x, make your pull request target `release/3.x`
-- On mockito 2.x, make your pull request target `release/2.x` (2.x is in maintenance mode)
--->
-<!--
 If you have a suggestion for this template you can fix it in the .github/PULL_REQUEST_TEMPLATE.md file
 -->
 ## Checklist
 
- - [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/release/3.x/.github/CONTRIBUTING.md)
+ - [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
  - [ ] PR should be motivated, i.e. what does it fix, why, and if relevant how
  - [ ] If possible / relevant include an example in the description, that could help all readers
        including project members to get a better picture of the change

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ name: CI
 
 on:
   push:
-    branches: ['release/3.x']
+    branches: ['main']
     tags: [v*]
   pull_request:
     branches: ['**']
@@ -74,7 +74,7 @@ jobs:
     needs: [build] # build job must pass before we can release
 
     if: github.event_name == 'push'
-        && (github.ref == 'refs/heads/release/3.x' || startsWith(github.ref, 'refs/tags/v'))
+        && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
         && github.repository == 'mockito/mockito'
         && !contains(toJSON(github.event.commits.*.message), '[skip release]')
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <a href="https://site.mockito.org">
-<img src="https://raw.githubusercontent.com/mockito/mockito/release/3.x/src/javadoc/org/mockito/logo.png"
-     srcset="https://raw.githubusercontent.com/mockito/mockito/release/3.x/src/javadoc/org/mockito/logo@2x.png 2x"
+<img src="https://raw.githubusercontent.com/mockito/mockito/main/src/javadoc/org/mockito/logo.png"
+     srcset="https://raw.githubusercontent.com/mockito/mockito/main/src/javadoc/org/mockito/logo@2x.png 2x"
      alt="Mockito" />
 </a>
 
@@ -8,7 +8,7 @@ Most popular mocking framework for Java
 
 [![CI](https://github.com/mockito/mockito/workflows/CI/badge.svg)](https://github.com/mockito/mockito/actions?query=workflow%3ACI)
 [![Coverage Status](https://img.shields.io/codecov/c/github/mockito/mockito.svg)](https://codecov.io/github/mockito/mockito)
-[![MIT License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/mockito/mockito/blob/release/3.x/LICENSE)
+[![MIT License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/mockito/mockito/blob/main/LICENSE)
 
 [![Release Notes](https://img.shields.io/badge/release%20notes-3.x-yellow.svg)](https://github.com/mockito/mockito/releases/)
 [![Maven Central](https://img.shields.io/maven-central/v/org.mockito/mockito-core.svg)](https://search.maven.org/artifact/org.mockito/mockito-core/)
@@ -47,7 +47,7 @@ and [javadoc.io](https://javadoc.io/doc/org.mockito/mockito-core/1.10.19/org/moc
 
 All you want to know about Mockito is hosted at [The Mockito Site](https://site.mockito.org) which is [Open Source](https://github.com/mockito/mockito.github.io) and likes [pull requests](https://github.com/mockito/mockito.github.io/pulls), too.
 
-Want to contribute? Take a look at the [Contributing Guide](https://github.com/mockito/mockito/blob/release/3.x/.github/CONTRIBUTING.md).
+Want to contribute? Take a look at the [Contributing Guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md).
 
 Enjoy Mockito!
 

--- a/gradle/java-publication.gradle
+++ b/gradle/java-publication.gradle
@@ -53,7 +53,7 @@ publishing {
                 licenses {
                     license {
                         name = 'The MIT License'
-                        url = 'https://github.com/mockito/mockito/blob/release/3.x/LICENSE'
+                        url = 'https://github.com/mockito/mockito/blob/main/LICENSE'
                         distribution = 'repo'
                     }
                 }


### PR DESCRIPTION
Renamed the main dev branch to a simpler and more intuitive name, GitHub default `main`. Before we merge this, we need to change the main dev branch name in the project settings (happy to do it when this PR is approved).