### PR TITLE
Enabled automated changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,8 @@ reduce risk, and improve code health, while paying the maintainers of the exact 
 
 Mockito publishes every change as a `-SNAPSHOT` version to a public Sonatype repository. Roughly once a month, we
 publish a new minor or patch version to Maven Central. For release automation we use Shipkit
-library (http://shipkit.org), Gradle Nexus [Publish Plugin](https://github.com/gradle-nexus/publish-plugin), and
-Allegro's [Axion Release Plugin](https://github.com/allegro/axion-release-plugin). Fully automated releases are awesome,
-and you should do that for your libraries, too!
+library (http://shipkit.org), Gradle Nexus [Publish Plugin](https://github.com/gradle-nexus/publish-plugin).
+Fully automated releases are awesome, and you should do that for your libraries, too!
 See the [latest release notes](https://github.com/mockito/mockito/releases/)
 and [latest documentation](https://javadoc.io/page/org.mockito/mockito-core/latest/org/mockito/Mockito.html). Docs in
 javadoc.io are available 24h after release. Read also

--- a/build.gradle
+++ b/build.gradle
@@ -10,10 +10,9 @@ buildscript {
 
         classpath "io.github.gradle-nexus:publish-plugin:1.1.0"
         classpath 'org.shipkit:shipkit-changelog:1.1.15'
+        classpath 'org.shipkit:shipkit-auto-version:1.1.11'
 
         classpath 'com.google.googlejavaformat:google-java-format:1.10.0'
-
-        classpath 'pl.allegro.tech.build:axion-release-plugin:1.13.2'
     }
 }
 
@@ -24,21 +23,6 @@ plugins {
     id 'biz.aQute.bnd.builder' version '5.3.0'
     id 'ru.vyarus.animalsniffer' version '1.5.2'
 }
-
-apply plugin: "pl.allegro.tech.build.axion-release"
-
-scmVersion {
-    tag {
-        prefix = 'v'
-        versionSeparator = ''
-    }
-}
-
-allprojects {
-    version = scmVersion.version
-}
-
-println "Building version $version"
 
 description = 'Mockito mock objects library core API and implementation'
 

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -1,10 +1,11 @@
-apply plugin: "org.shipkit.shipkit-changelog"
-apply plugin: "org.shipkit.shipkit-github-release"
+apply plugin: 'org.shipkit.shipkit-auto-version'
+apply plugin: 'org.shipkit.shipkit-changelog'
+apply plugin: 'org.shipkit.shipkit-github-release'
 
-tasks.named("generateChangelog") {
-    previousRevision = 'HEAD' //TODO, this will generate empty release notes
-    githubToken = System.getenv("GITHUB_TOKEN")
-    repository = "mockito/mockito"
+tasks.named('generateChangelog') {
+    previousRevision = project.ext.'shipkit-auto-version.previous-tag'
+    githubToken = System.getenv('GITHUB_TOKEN')
+    repository = 'mockito/mockito'
 }
 
 tasks.named("githubRelease") {


### PR DESCRIPTION
Replaced axion Gradle plugin with Shipkit plugin. The plugin controls the version and provides information about 'previous' version which is needed for correct generation of the backlog.

This change is CI improvement and it does not change the artifacts.
