### PR TITLE
Check package-privacy of method params

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassBytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassBytecodeGenerator.java
@@ -98,7 +98,7 @@ class SubclassBytecodeGenerator implements BytecodeGenerator {
             // package private methods.
             return true;
         }
-        if (hasPackagePrivateParam(features.mockedType)) {
+        if (hasNonPublicTypeReference(features.mockedType)) {
             return true;
         }
 
@@ -106,14 +106,14 @@ class SubclassBytecodeGenerator implements BytecodeGenerator {
             if (!Modifier.isPublic(iface.getModifiers())) {
                 return true;
             }
-            if (hasPackagePrivateParam(iface)) {
+            if (hasNonPublicTypeReference(iface)) {
                 return true;
             }
         }
         return false;
     }
 
-    private static boolean hasPackagePrivateParam(Class<?> iface) {
+    private static boolean hasNonPublicTypeReference(Class<?> iface) {
         for (Method method : iface.getMethods()) {
             if (!Modifier.isPublic(method.getReturnType().getModifiers())) {
                 return true;

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassBytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassBytecodeGenerator.java
@@ -25,6 +25,7 @@ import static org.mockito.internal.util.StringUtil.join;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -97,9 +98,30 @@ class SubclassBytecodeGenerator implements BytecodeGenerator {
             // package private methods.
             return true;
         }
+        if (hasPackagePrivateParam(features.mockedType)) {
+            return true;
+        }
+
         for (Class<?> iface : features.interfaces) {
             if (!Modifier.isPublic(iface.getModifiers())) {
                 return true;
+            }
+            if (hasPackagePrivateParam(iface)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasPackagePrivateParam(Class<?> iface) {
+        for (Method method : iface.getMethods()) {
+            if (!Modifier.isPublic(method.getReturnType().getModifiers())) {
+                return true;
+            }
+            for (Class<?> param : method.getParameterTypes()) {
+                if (!Modifier.isPublic(param.getModifiers())) {
+                    return true;
+                }
             }
         }
         return false;

--- a/src/test/java/org/mockitousage/bugs/creation/PackagePrivateWithContextClassLoaderTest.java
+++ b/src/test/java/org/mockitousage/bugs/creation/PackagePrivateWithContextClassLoaderTest.java
@@ -31,9 +31,23 @@ public class PackagePrivateWithContextClassLoaderTest {
         abstract void packagePrivateAbstractMethod();
     }
 
+    public interface PublicInterfaceWithPackagePrivateMethodParam {
+        void doSomething(PackagePrivateInterface i);
+    }
+
+    public interface PublicInterfaceWithPackagePrivateMethodReturn {
+        PackagePrivateInterface doSomething();
+    }
+
+    public interface PublicInterfaceOverridesPackagePrivateMethodReturn {
+        PublicChildOfPackagePrivate doSomething();
+    }
+
     public interface PublicInterface {}
 
     interface PackagePrivateInterface {}
+
+    public interface PublicChildOfPackagePrivate extends PackagePrivateInterface {}
 
     static class PackagePrivateClass {}
 
@@ -53,6 +67,28 @@ public class PackagePrivateWithContextClassLoaderTest {
         PublicClass publicClass = mock(PublicClass.class);
         when(publicClass.packagePrivateMethod()).thenReturn(3);
         assertThat(publicClass.packagePrivateMethod()).isEqualTo(3);
+    }
+
+    @Test
+    public void should_be_able_to_mock_interface_method_package_private_param() throws Exception {
+        PublicInterfaceWithPackagePrivateMethodParam publicClass =
+                mock(PublicInterfaceWithPackagePrivateMethodParam.class);
+        publicClass.doSomething(null);
+    }
+
+    @Test
+    public void should_be_able_to_mock_interface_method_package_private_return() throws Exception {
+        PublicInterfaceWithPackagePrivateMethodReturn publicClass =
+                mock(PublicInterfaceWithPackagePrivateMethodReturn.class);
+        PackagePrivateInterface packagePrivateInterface = publicClass.doSomething();
+    }
+
+    @Test
+    public void should_be_able_to_mock_interface_method_package_private_return_override()
+            throws Exception {
+        PublicInterfaceOverridesPackagePrivateMethodReturn publicClass =
+                mock(PublicInterfaceOverridesPackagePrivateMethodReturn.class);
+        PackagePrivateInterface packagePrivateInterface = publicClass.doSomething();
     }
 
     @Test


### PR DESCRIPTION
This patch handles methods where an interface uses a package-private type as a param or return value - without it, the generated mock class will produce AbstractMethodError, since its methods do not actually override the methods of the interfaces.

Followup on #2303 