### PR TITLE
Fixes mockito#2311

### DIFF
--- a/src/main/java/org/mockito/internal/matchers/ContainsExtraTypeInfo.java
+++ b/src/main/java/org/mockito/internal/matchers/ContainsExtraTypeInfo.java
@@ -19,8 +19,19 @@ public interface ContainsExtraTypeInfo {
     String toStringWithType();
 
     /**
+     * Returns more verbose description of the object which include type information and fully qualified class name
+     */
+    String toStringWithFullName();
+
+    /**
      * Checks if target target has matching type.
      * If the type matches, there is no point in rendering result from {@link #toStringWithType()}
      */
     boolean typeMatches(Object target);
+
+    /**
+     * Checks if target target's class has same simple name.
+     * If the simple names matches, we need to use {@link #toStringWithFullName()}
+     */
+    boolean sameName(Object target);
 }

--- a/src/main/java/org/mockito/internal/matchers/ContainsExtraTypeInfo.java
+++ b/src/main/java/org/mockito/internal/matchers/ContainsExtraTypeInfo.java
@@ -9,7 +9,7 @@ package org.mockito.internal.matchers;
  * When ArgumentMatcher fails, chance is that the actual object has the same output of toString() than
  * the wanted object. This looks weird when failures are reported.
  * Therefore when matcher fails but toString() yields the same outputs,
- * we will try to use the {@link #toStringWithType(boolean)} method.
+ * we will try to use the {@link #toStringWithType(String)} method.
  */
 public interface ContainsExtraTypeInfo {
 

--- a/src/main/java/org/mockito/internal/matchers/ContainsExtraTypeInfo.java
+++ b/src/main/java/org/mockito/internal/matchers/ContainsExtraTypeInfo.java
@@ -14,20 +14,20 @@ package org.mockito.internal.matchers;
 public interface ContainsExtraTypeInfo {
 
     /**
-     * @param useFullyQualifiedClassName - uses fully qualified class name if true else simple class name
+     * @param className - name of the class to be printed in description
      * Returns more verbose description of the object which include type information
      */
-    String toStringWithType(boolean useFullyQualifiedClassName);
+    String toStringWithType(String className);
 
     /**
      * Checks if target target has matching type.
-     * If the type matches, there is no point in rendering result from {@link #toStringWithType(boolean)}
+     * If the type matches, there is no point in rendering result from {@link #toStringWithType(String)}
      */
     boolean typeMatches(Object target);
 
     /**
      *
-     * @return Returns the Class of the argument
+     * @return Returns the wanted argument
      */
-    Class getWantedClass();
+    Object getWanted();
 }

--- a/src/main/java/org/mockito/internal/matchers/ContainsExtraTypeInfo.java
+++ b/src/main/java/org/mockito/internal/matchers/ContainsExtraTypeInfo.java
@@ -9,29 +9,25 @@ package org.mockito.internal.matchers;
  * When ArgumentMatcher fails, chance is that the actual object has the same output of toString() than
  * the wanted object. This looks weird when failures are reported.
  * Therefore when matcher fails but toString() yields the same outputs,
- * we will try to use the {@link #toStringWithType()} method.
+ * we will try to use the {@link #toStringWithType(boolean)} method.
  */
 public interface ContainsExtraTypeInfo {
 
     /**
+     * @param useFullyQualifiedClassName - uses fully qualified class name if true else simple class name
      * Returns more verbose description of the object which include type information
      */
-    String toStringWithType();
-
-    /**
-     * Returns more verbose description of the object which include type information and fully qualified class name
-     */
-    String toStringWithFullName();
+    String toStringWithType(boolean useFullyQualifiedClassName);
 
     /**
      * Checks if target target has matching type.
-     * If the type matches, there is no point in rendering result from {@link #toStringWithType()}
+     * If the type matches, there is no point in rendering result from {@link #toStringWithType(boolean)}
      */
     boolean typeMatches(Object target);
 
     /**
-     * Checks if target target's class has same simple name.
-     * If the simple names matches, we need to use {@link #toStringWithFullName()}
+     *
+     * @return Returns the Class of the argument
      */
-    boolean sameName(Object target);
+    Class getWantedClass();
 }

--- a/src/main/java/org/mockito/internal/matchers/Equals.java
+++ b/src/main/java/org/mockito/internal/matchers/Equals.java
@@ -56,7 +56,17 @@ public class Equals implements ArgumentMatcher<Object>, ContainsExtraTypeInfo, S
     }
 
     @Override
+    public String toStringWithFullName() {
+        return "(" + wanted.getClass().getCanonicalName() + ") " + describe(wanted);
+    }
+
+    @Override
     public boolean typeMatches(Object target) {
         return wanted != null && target != null && target.getClass() == wanted.getClass();
+    }
+
+    @Override
+    public boolean sameName(Object target) {
+        return wanted != null && target != null && target.getClass().getSimpleName().equals(wanted.getClass().getSimpleName());
     }
 }

--- a/src/main/java/org/mockito/internal/matchers/Equals.java
+++ b/src/main/java/org/mockito/internal/matchers/Equals.java
@@ -31,7 +31,8 @@ public class Equals implements ArgumentMatcher<Object>, ContainsExtraTypeInfo, S
         return ValuePrinter.print(object);
     }
 
-    protected final Object getWanted() {
+    @Override
+    public final Object getWanted() {
         return wanted;
     }
 
@@ -51,18 +52,13 @@ public class Equals implements ArgumentMatcher<Object>, ContainsExtraTypeInfo, S
     }
 
     @Override
-    public String toStringWithType(boolean useFullyQualifiedClassName) {
-        return "(" + (useFullyQualifiedClassName ? wanted.getClass().getCanonicalName() : wanted.getClass().getSimpleName()) + ") " + describe(wanted);
+    public String toStringWithType(String className) {
+        return "(" + className + ") " + describe(wanted);
     }
 
     @Override
     public boolean typeMatches(Object target) {
         return wanted != null && target != null && target.getClass() == wanted.getClass();
-    }
-
-    @Override
-    public Class getWantedClass() {
-        return wanted.getClass();
     }
 
 }

--- a/src/main/java/org/mockito/internal/matchers/Equals.java
+++ b/src/main/java/org/mockito/internal/matchers/Equals.java
@@ -60,5 +60,4 @@ public class Equals implements ArgumentMatcher<Object>, ContainsExtraTypeInfo, S
     public boolean typeMatches(Object target) {
         return wanted != null && target != null && target.getClass() == wanted.getClass();
     }
-
 }

--- a/src/main/java/org/mockito/internal/matchers/Equals.java
+++ b/src/main/java/org/mockito/internal/matchers/Equals.java
@@ -51,13 +51,8 @@ public class Equals implements ArgumentMatcher<Object>, ContainsExtraTypeInfo, S
     }
 
     @Override
-    public String toStringWithType() {
-        return "(" + wanted.getClass().getSimpleName() + ") " + describe(wanted);
-    }
-
-    @Override
-    public String toStringWithFullName() {
-        return "(" + wanted.getClass().getCanonicalName() + ") " + describe(wanted);
+    public String toStringWithType(boolean useFullyQualifiedClassName) {
+        return "(" + (useFullyQualifiedClassName ? wanted.getClass().getCanonicalName() : wanted.getClass().getSimpleName()) + ") " + describe(wanted);
     }
 
     @Override
@@ -66,7 +61,8 @@ public class Equals implements ArgumentMatcher<Object>, ContainsExtraTypeInfo, S
     }
 
     @Override
-    public boolean sameName(Object target) {
-        return wanted != null && target != null && target.getClass().getSimpleName().equals(wanted.getClass().getSimpleName());
+    public Class getWantedClass() {
+        return wanted.getClass();
     }
+
 }

--- a/src/main/java/org/mockito/internal/matchers/text/MatchersPrinter.java
+++ b/src/main/java/org/mockito/internal/matchers/text/MatchersPrinter.java
@@ -31,9 +31,10 @@ public class MatchersPrinter {
         int i = 0;
         for (final ArgumentMatcher matcher : matchers) {
             if (matcher instanceof ContainsExtraTypeInfo && printSettings.extraTypeInfoFor(i)) {
-                out.add(new FormattedText(((ContainsExtraTypeInfo) matcher).toStringWithType()));
-            } else if(matcher instanceof ContainsExtraTypeInfo && printSettings.fullyQualifiedNameFor(i)){
-                out.add(new FormattedText(((ContainsExtraTypeInfo) matcher).toStringWithFullName()));
+                out.add(new FormattedText(((ContainsExtraTypeInfo) matcher).toStringWithType(false)));
+            } else if(matcher instanceof ContainsExtraTypeInfo
+                      && printSettings.fullyQualifiedNameFor(((ContainsExtraTypeInfo) matcher).getWantedClass().getSimpleName())){
+                out.add(new FormattedText(((ContainsExtraTypeInfo) matcher).toStringWithType(true)));
             } else {
                 out.add(new FormattedText(MatcherToString.toString(matcher)));
             }

--- a/src/main/java/org/mockito/internal/matchers/text/MatchersPrinter.java
+++ b/src/main/java/org/mockito/internal/matchers/text/MatchersPrinter.java
@@ -30,11 +30,18 @@ public class MatchersPrinter {
         List<FormattedText> out = new LinkedList<>();
         int i = 0;
         for (final ArgumentMatcher matcher : matchers) {
-            if (matcher instanceof ContainsExtraTypeInfo && printSettings.extraTypeInfoFor(i)) {
-                out.add(new FormattedText(((ContainsExtraTypeInfo) matcher).toStringWithType(false)));
-            } else if(matcher instanceof ContainsExtraTypeInfo
-                      && printSettings.fullyQualifiedNameFor(((ContainsExtraTypeInfo) matcher).getWantedClass().getSimpleName())){
-                out.add(new FormattedText(((ContainsExtraTypeInfo) matcher).toStringWithType(true)));
+            if (matcher instanceof ContainsExtraTypeInfo) {
+                ContainsExtraTypeInfo typeInfoMatcher = (ContainsExtraTypeInfo) matcher;
+                Class<?> wantedClass = typeInfoMatcher.getWanted().getClass();
+                String simpleNameOfArgument = wantedClass.getSimpleName();
+
+                if (printSettings.extraTypeInfoFor(i)) {
+                    out.add(new FormattedText(typeInfoMatcher.toStringWithType(wantedClass.getSimpleName())));
+                } else if (printSettings.fullyQualifiedNameFor(simpleNameOfArgument)) {
+                    out.add(new FormattedText(typeInfoMatcher.toStringWithType(wantedClass.getCanonicalName())));
+                }  else {
+                    out.add(new FormattedText(MatcherToString.toString(matcher)));
+                }
             } else {
                 out.add(new FormattedText(MatcherToString.toString(matcher)));
             }

--- a/src/main/java/org/mockito/internal/matchers/text/MatchersPrinter.java
+++ b/src/main/java/org/mockito/internal/matchers/text/MatchersPrinter.java
@@ -32,6 +32,8 @@ public class MatchersPrinter {
         for (final ArgumentMatcher matcher : matchers) {
             if (matcher instanceof ContainsExtraTypeInfo && printSettings.extraTypeInfoFor(i)) {
                 out.add(new FormattedText(((ContainsExtraTypeInfo) matcher).toStringWithType()));
+            } else if(matcher instanceof ContainsExtraTypeInfo && printSettings.fullyQualifiedNameFor(i)){
+                out.add(new FormattedText(((ContainsExtraTypeInfo) matcher).toStringWithFullName()));
             } else {
                 out.add(new FormattedText(MatcherToString.toString(matcher)));
             }

--- a/src/main/java/org/mockito/internal/matchers/text/MatchersPrinter.java
+++ b/src/main/java/org/mockito/internal/matchers/text/MatchersPrinter.java
@@ -32,14 +32,21 @@ public class MatchersPrinter {
         for (final ArgumentMatcher matcher : matchers) {
             if (matcher instanceof ContainsExtraTypeInfo) {
                 ContainsExtraTypeInfo typeInfoMatcher = (ContainsExtraTypeInfo) matcher;
-                Class<?> wantedClass = typeInfoMatcher.getWanted().getClass();
-                String simpleNameOfArgument = wantedClass.getSimpleName();
+                Object wanted = typeInfoMatcher.getWanted();
+                String simpleNameOfArgument =
+                        wanted != null ? wanted.getClass().getSimpleName() : "";
+                String fullyQualifiedClassName =
+                        wanted != null ? wanted.getClass().getCanonicalName() : "";
 
                 if (printSettings.extraTypeInfoFor(i)) {
-                    out.add(new FormattedText(typeInfoMatcher.toStringWithType(wantedClass.getSimpleName())));
+                    out.add(
+                            new FormattedText(
+                                    typeInfoMatcher.toStringWithType(simpleNameOfArgument)));
                 } else if (printSettings.fullyQualifiedNameFor(simpleNameOfArgument)) {
-                    out.add(new FormattedText(typeInfoMatcher.toStringWithType(wantedClass.getCanonicalName())));
-                }  else {
+                    out.add(
+                            new FormattedText(
+                                    typeInfoMatcher.toStringWithType(fullyQualifiedClassName)));
+                } else {
                     out.add(new FormattedText(MatcherToString.toString(matcher)));
                 }
             } else {

--- a/src/main/java/org/mockito/internal/reporting/PrintSettings.java
+++ b/src/main/java/org/mockito/internal/reporting/PrintSettings.java
@@ -19,6 +19,7 @@ public class PrintSettings {
     public static final int MAX_LINE_LENGTH = 45;
     private boolean multiline;
     private List<Integer> withTypeInfo = new LinkedList<>();
+    private List<Integer> withFullyQualifiedName = new LinkedList<>();
 
     public void setMultiline(boolean multiline) {
         this.multiline = multiline;
@@ -38,8 +39,16 @@ public class PrintSettings {
         return withTypeInfo.contains(argumentIndex);
     }
 
+    public boolean fullyQualifiedNameFor(int argumentIndex) {
+        return withFullyQualifiedName.contains(argumentIndex);
+    }
+
     public void setMatchersToBeDescribedWithExtraTypeInfo(Integer[] indexesOfMatchers) {
         this.withTypeInfo = Arrays.asList(indexesOfMatchers);
+    }
+
+    public void setMatchersToBeDescribedWithFullName(Integer[] indexesOfMatchers) {
+        this.withFullyQualifiedName= Arrays.asList(indexesOfMatchers);
     }
 
     public String print(List<ArgumentMatcher> matchers, Invocation invocation) {

--- a/src/main/java/org/mockito/internal/reporting/PrintSettings.java
+++ b/src/main/java/org/mockito/internal/reporting/PrintSettings.java
@@ -5,8 +5,10 @@
 package org.mockito.internal.reporting;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 import org.mockito.ArgumentMatcher;
 import org.mockito.internal.matchers.text.MatchersPrinter;
@@ -19,7 +21,7 @@ public class PrintSettings {
     public static final int MAX_LINE_LENGTH = 45;
     private boolean multiline;
     private List<Integer> withTypeInfo = new LinkedList<>();
-    private List<Integer> withFullyQualifiedName = new LinkedList<>();
+    private Set<String> withFullyQualifiedName = Collections.emptySet();
 
     public void setMultiline(boolean multiline) {
         this.multiline = multiline;
@@ -39,16 +41,16 @@ public class PrintSettings {
         return withTypeInfo.contains(argumentIndex);
     }
 
-    public boolean fullyQualifiedNameFor(int argumentIndex) {
-        return withFullyQualifiedName.contains(argumentIndex);
+    public boolean fullyQualifiedNameFor(String simpleClassName) {
+        return withFullyQualifiedName.contains(simpleClassName);
     }
 
     public void setMatchersToBeDescribedWithExtraTypeInfo(Integer[] indexesOfMatchers) {
         this.withTypeInfo = Arrays.asList(indexesOfMatchers);
     }
 
-    public void setMatchersToBeDescribedWithFullName(Integer[] indexesOfMatchers) {
-        this.withFullyQualifiedName= Arrays.asList(indexesOfMatchers);
+    public void setMatchersToBeDescribedWithFullName(Set<String> indexesOfMatchers) {
+        this.withFullyQualifiedName= indexesOfMatchers;
     }
 
     public String print(List<ArgumentMatcher> matchers, Invocation invocation) {

--- a/src/main/java/org/mockito/internal/reporting/PrintSettings.java
+++ b/src/main/java/org/mockito/internal/reporting/PrintSettings.java
@@ -50,7 +50,7 @@ public class PrintSettings {
     }
 
     public void setMatchersToBeDescribedWithFullName(Set<String> indexesOfMatchers) {
-        this.withFullyQualifiedName= indexesOfMatchers;
+        this.withFullyQualifiedName = indexesOfMatchers;
     }
 
     public String print(List<ArgumentMatcher> matchers, Invocation invocation) {

--- a/src/main/java/org/mockito/internal/reporting/SmartPrinter.java
+++ b/src/main/java/org/mockito/internal/reporting/SmartPrinter.java
@@ -42,8 +42,7 @@ public class SmartPrinter {
         printSettings.setMultiline(isMultiLine(wanted, allActualInvocations));
         printSettings.setMatchersToBeDescribedWithExtraTypeInfo(
                 indexesOfMatchersToBeDescribedWithExtraTypeInfo);
-        printSettings.setMatchersToBeDescribedWithFullName(
-                classNamesToBeDescribedWithFullName);
+        printSettings.setMatchersToBeDescribedWithFullName(classNamesToBeDescribedWithFullName);
 
         this.wanted = printSettings.print(wanted);
 

--- a/src/main/java/org/mockito/internal/reporting/SmartPrinter.java
+++ b/src/main/java/org/mockito/internal/reporting/SmartPrinter.java
@@ -7,6 +7,7 @@ package org.mockito.internal.reporting;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import org.mockito.invocation.Invocation;
 import org.mockito.invocation.MatchableInvocation;
@@ -29,20 +30,20 @@ public class SmartPrinter {
                 wanted,
                 Collections.singletonList(actual),
                 indexesOfMatchersToBeDescribedWithExtraTypeInfo,
-                new Integer[0]);
+                Collections.emptySet());
     }
 
     public SmartPrinter(
             MatchableInvocation wanted,
             List<Invocation> allActualInvocations,
             Integer[] indexesOfMatchersToBeDescribedWithExtraTypeInfo,
-            Integer[] indexesOfMatchersToBeDescribedWithFullName) {
+            Set<String> classNamesToBeDescribedWithFullName) {
         PrintSettings printSettings = new PrintSettings();
         printSettings.setMultiline(isMultiLine(wanted, allActualInvocations));
         printSettings.setMatchersToBeDescribedWithExtraTypeInfo(
                 indexesOfMatchersToBeDescribedWithExtraTypeInfo);
         printSettings.setMatchersToBeDescribedWithFullName(
-                indexesOfMatchersToBeDescribedWithFullName);
+                classNamesToBeDescribedWithFullName);
 
         this.wanted = printSettings.print(wanted);
 

--- a/src/main/java/org/mockito/internal/reporting/SmartPrinter.java
+++ b/src/main/java/org/mockito/internal/reporting/SmartPrinter.java
@@ -28,17 +28,21 @@ public class SmartPrinter {
         this(
                 wanted,
                 Collections.singletonList(actual),
-                indexesOfMatchersToBeDescribedWithExtraTypeInfo);
+                indexesOfMatchersToBeDescribedWithExtraTypeInfo,
+                new Integer[0]);
     }
 
     public SmartPrinter(
             MatchableInvocation wanted,
             List<Invocation> allActualInvocations,
-            Integer... indexesOfMatchersToBeDescribedWithExtraTypeInfo) {
+            Integer[] indexesOfMatchersToBeDescribedWithExtraTypeInfo,
+            Integer[] indexesOfMatchersToBeDescribedWithFullName) {
         PrintSettings printSettings = new PrintSettings();
         printSettings.setMultiline(isMultiLine(wanted, allActualInvocations));
         printSettings.setMatchersToBeDescribedWithExtraTypeInfo(
                 indexesOfMatchersToBeDescribedWithExtraTypeInfo);
+        printSettings.setMatchersToBeDescribedWithFullName(
+                indexesOfMatchersToBeDescribedWithFullName);
 
         this.wanted = printSettings.print(wanted);
 

--- a/src/main/java/org/mockito/internal/verification/argumentmatching/ArgumentMatchingTool.java
+++ b/src/main/java/org/mockito/internal/verification/argumentmatching/ArgumentMatchingTool.java
@@ -48,4 +48,28 @@ public class ArgumentMatchingTool {
     private static boolean toStringEquals(ArgumentMatcher m, Object arg) {
         return m.toString().equals(String.valueOf(arg));
     }
+
+    /**
+     * Suspiciously not matching arguments are those that don't match, and the classes have same simple name.
+     */
+    public static Integer[] getNotMatchingArgsWithSameNameIndexes(
+        List<ArgumentMatcher> matchers, Object[] arguments) {
+        if (matchers.size() != arguments.length) {
+            return new Integer[0];
+        }
+
+        List<Integer> suspicious = new LinkedList<>();
+        int i = 0;
+        for (ArgumentMatcher m : matchers) {
+            if (m instanceof ContainsExtraTypeInfo
+                && !safelyMatches(m, arguments[i])
+                && !((ContainsExtraTypeInfo) m).typeMatches(arguments[i])
+                && ((ContainsExtraTypeInfo) m).sameName(arguments[i])) {
+                suspicious.add(i);
+            }
+            i++;
+        }
+        return suspicious.toArray(new Integer[0]);
+    }
+
 }

--- a/src/main/java/org/mockito/internal/verification/argumentmatching/ArgumentMatchingTool.java
+++ b/src/main/java/org/mockito/internal/verification/argumentmatching/ArgumentMatchingTool.java
@@ -59,24 +59,31 @@ public class ArgumentMatchingTool {
      */
     public static Set<String> getNotMatchingArgsWithSameName(
             List<ArgumentMatcher> matchers, Object[] arguments) {
-        Set<String> repeatedClassNames = new HashSet<>();
         Map<String, Set<String>> classesHavingSameName = new HashMap<>();
         for (ArgumentMatcher m : matchers) {
             if (m instanceof ContainsExtraTypeInfo) {
-                Class wantedClass = ((ContainsExtraTypeInfo) m).getWanted().getClass();
-                classesHavingSameName.computeIfAbsent(wantedClass.getSimpleName(), className -> new HashSet<>())
-                                     .add(wantedClass.getCanonicalName());
+                Object wanted = ((ContainsExtraTypeInfo) m).getWanted();
+                if (wanted == null) {
+                    continue;
+                }
+                Class wantedClass = wanted.getClass();
+                classesHavingSameName
+                        .computeIfAbsent(wantedClass.getSimpleName(), className -> new HashSet<>())
+                        .add(wantedClass.getCanonicalName());
             }
         }
         for (Object argument : arguments) {
+            if (argument == null) {
+                continue;
+            }
             Class wantedClass = argument.getClass();
-            classesHavingSameName.computeIfAbsent(wantedClass.getSimpleName(), className -> new HashSet<>())
-                                 .add(wantedClass.getCanonicalName());
+            classesHavingSameName
+                    .computeIfAbsent(wantedClass.getSimpleName(), className -> new HashSet<>())
+                    .add(wantedClass.getCanonicalName());
         }
         return classesHavingSameName.entrySet().stream()
-                                    .filter(classEntry -> classEntry.getValue().size() > 1)
-                                    .map(classEntry -> classEntry.getKey())
-                                    .collect(Collectors.toSet());
+                .filter(classEntry -> classEntry.getValue().size() > 1)
+                .map(classEntry -> classEntry.getKey())
+                .collect(Collectors.toSet());
     }
-
 }

--- a/src/main/java/org/mockito/internal/verification/argumentmatching/ArgumentMatchingTool.java
+++ b/src/main/java/org/mockito/internal/verification/argumentmatching/ArgumentMatchingTool.java
@@ -63,7 +63,7 @@ public class ArgumentMatchingTool {
         Map<String, Set<String>> classesHavingSameName = new HashMap<>();
         for (ArgumentMatcher m : matchers) {
             if (m instanceof ContainsExtraTypeInfo) {
-                Class wantedClass = ((ContainsExtraTypeInfo) m).getWantedClass();
+                Class wantedClass = ((ContainsExtraTypeInfo) m).getWanted().getClass();
                 classesHavingSameName.computeIfAbsent(wantedClass.getSimpleName(), className -> new HashSet<>())
                                      .add(wantedClass.getCanonicalName());
             }

--- a/src/main/java/org/mockito/internal/verification/checkers/MissingInvocationChecker.java
+++ b/src/main/java/org/mockito/internal/verification/checkers/MissingInvocationChecker.java
@@ -11,10 +11,11 @@ import static org.mockito.internal.invocation.InvocationsFinder.findAllMatchingU
 import static org.mockito.internal.invocation.InvocationsFinder.findInvocations;
 import static org.mockito.internal.invocation.InvocationsFinder.findPreviousVerifiedInOrder;
 import static org.mockito.internal.invocation.InvocationsFinder.findSimilarInvocation;
-import static org.mockito.internal.verification.argumentmatching.ArgumentMatchingTool.getNotMatchingArgsWithSameNameIndexes;
+import static org.mockito.internal.verification.argumentmatching.ArgumentMatchingTool.getNotMatchingArgsWithSameName;
 import static org.mockito.internal.verification.argumentmatching.ArgumentMatchingTool.getSuspiciouslyNotMatchingArgsIndexes;
 
 import java.util.List;
+import java.util.Set;
 
 import org.mockito.internal.reporting.SmartPrinter;
 import org.mockito.internal.util.collections.ListUtil;
@@ -42,9 +43,9 @@ public class MissingInvocationChecker {
 
         Integer[] indexesOfSuspiciousArgs =
                 getSuspiciouslyNotMatchingArgsIndexes(wanted.getMatchers(), similar.getArguments());
-        Integer[] indexesOfArgsWithSameSimpleName =
-            getNotMatchingArgsWithSameNameIndexes(wanted.getMatchers(), similar.getArguments());
-        SmartPrinter smartPrinter = new SmartPrinter(wanted, invocations, indexesOfSuspiciousArgs,indexesOfArgsWithSameSimpleName);
+        Set<String> classesWithSameSimpleName =
+            getNotMatchingArgsWithSameName(wanted.getMatchers(), similar.getArguments());
+        SmartPrinter smartPrinter = new SmartPrinter(wanted, invocations, indexesOfSuspiciousArgs,classesWithSameSimpleName);
         List<Location> actualLocations =
                 ListUtil.convert(
                         invocations,

--- a/src/main/java/org/mockito/internal/verification/checkers/MissingInvocationChecker.java
+++ b/src/main/java/org/mockito/internal/verification/checkers/MissingInvocationChecker.java
@@ -44,8 +44,10 @@ public class MissingInvocationChecker {
         Integer[] indexesOfSuspiciousArgs =
                 getSuspiciouslyNotMatchingArgsIndexes(wanted.getMatchers(), similar.getArguments());
         Set<String> classesWithSameSimpleName =
-            getNotMatchingArgsWithSameName(wanted.getMatchers(), similar.getArguments());
-        SmartPrinter smartPrinter = new SmartPrinter(wanted, invocations, indexesOfSuspiciousArgs,classesWithSameSimpleName);
+                getNotMatchingArgsWithSameName(wanted.getMatchers(), similar.getArguments());
+        SmartPrinter smartPrinter =
+                new SmartPrinter(
+                        wanted, invocations, indexesOfSuspiciousArgs, classesWithSameSimpleName);
         List<Location> actualLocations =
                 ListUtil.convert(
                         invocations,

--- a/src/main/java/org/mockito/internal/verification/checkers/MissingInvocationChecker.java
+++ b/src/main/java/org/mockito/internal/verification/checkers/MissingInvocationChecker.java
@@ -11,6 +11,7 @@ import static org.mockito.internal.invocation.InvocationsFinder.findAllMatchingU
 import static org.mockito.internal.invocation.InvocationsFinder.findInvocations;
 import static org.mockito.internal.invocation.InvocationsFinder.findPreviousVerifiedInOrder;
 import static org.mockito.internal.invocation.InvocationsFinder.findSimilarInvocation;
+import static org.mockito.internal.verification.argumentmatching.ArgumentMatchingTool.getNotMatchingArgsWithSameNameIndexes;
 import static org.mockito.internal.verification.argumentmatching.ArgumentMatchingTool.getSuspiciouslyNotMatchingArgsIndexes;
 
 import java.util.List;
@@ -41,7 +42,9 @@ public class MissingInvocationChecker {
 
         Integer[] indexesOfSuspiciousArgs =
                 getSuspiciouslyNotMatchingArgsIndexes(wanted.getMatchers(), similar.getArguments());
-        SmartPrinter smartPrinter = new SmartPrinter(wanted, invocations, indexesOfSuspiciousArgs);
+        Integer[] indexesOfArgsWithSameSimpleName =
+            getNotMatchingArgsWithSameNameIndexes(wanted.getMatchers(), similar.getArguments());
+        SmartPrinter smartPrinter = new SmartPrinter(wanted, invocations, indexesOfSuspiciousArgs,indexesOfArgsWithSameSimpleName);
         List<Location> actualLocations =
                 ListUtil.convert(
                         invocations,

--- a/src/test/java/org/mockito/internal/matchers/EqualsTest.java
+++ b/src/test/java/org/mockito/internal/matchers/EqualsTest.java
@@ -28,21 +28,21 @@ public class EqualsTest extends TestBase {
 
     @Test
     public void shouldDescribeWithExtraTypeInfo() throws Exception {
-        String descStr = new Equals(100).toStringWithType(false);
+        String descStr = new Equals(100).toStringWithType(Integer.class.getSimpleName());
 
         assertEquals("(Integer) 100", descStr);
     }
 
     @Test
     public void shouldDescribeWithExtraTypeInfoOfLong() throws Exception {
-        String descStr = new Equals(100L).toStringWithType(false);
+        String descStr = new Equals(100L).toStringWithType(Long.class.getSimpleName());
 
         assertEquals("(Long) 100L", descStr);
     }
 
     @Test
     public void shouldDescribeWithTypeOfString() throws Exception {
-        String descStr = new Equals("x").toStringWithType(false);
+        String descStr = new Equals("x").toStringWithType(String.class.getSimpleName());
 
         assertEquals("(String) \"x\"", descStr);
     }

--- a/src/test/java/org/mockito/internal/matchers/EqualsTest.java
+++ b/src/test/java/org/mockito/internal/matchers/EqualsTest.java
@@ -28,21 +28,21 @@ public class EqualsTest extends TestBase {
 
     @Test
     public void shouldDescribeWithExtraTypeInfo() throws Exception {
-        String descStr = new Equals(100).toStringWithType();
+        String descStr = new Equals(100).toStringWithType(false);
 
         assertEquals("(Integer) 100", descStr);
     }
 
     @Test
     public void shouldDescribeWithExtraTypeInfoOfLong() throws Exception {
-        String descStr = new Equals(100L).toStringWithType();
+        String descStr = new Equals(100L).toStringWithType(false);
 
         assertEquals("(Long) 100L", descStr);
     }
 
     @Test
     public void shouldDescribeWithTypeOfString() throws Exception {
-        String descStr = new Equals("x").toStringWithType();
+        String descStr = new Equals("x").toStringWithType(false);
 
         assertEquals("(String) \"x\"", descStr);
     }

--- a/src/test/java/org/mockito/internal/verification/argumentmatching/ArgumentMatchingToolTest.java
+++ b/src/test/java/org/mockito/internal/verification/argumentmatching/ArgumentMatchingToolTest.java
@@ -124,7 +124,6 @@ public class ArgumentMatchingToolTest extends TestBase {
             public Object getWanted() {
                 return "";
             }
-
         }
 
         // given

--- a/src/test/java/org/mockito/internal/verification/argumentmatching/ArgumentMatchingToolTest.java
+++ b/src/test/java/org/mockito/internal/verification/argumentmatching/ArgumentMatchingToolTest.java
@@ -111,7 +111,7 @@ public class ArgumentMatchingToolTest extends TestBase {
             }
 
             @Override
-            public String toStringWithType(boolean useFullyQualifiedClassName) {
+            public String toStringWithType(String className) {
                 return "";
             }
 
@@ -121,8 +121,8 @@ public class ArgumentMatchingToolTest extends TestBase {
             }
 
             @Override
-            public Class getWantedClass() {
-                return String.class;
+            public Object getWanted() {
+                return "";
             }
 
         }

--- a/src/test/java/org/mockito/internal/verification/argumentmatching/ArgumentMatchingToolTest.java
+++ b/src/test/java/org/mockito/internal/verification/argumentmatching/ArgumentMatchingToolTest.java
@@ -111,12 +111,7 @@ public class ArgumentMatchingToolTest extends TestBase {
             }
 
             @Override
-            public String toStringWithType() {
-                return "";
-            }
-
-            @Override
-            public String toStringWithFullName() {
+            public String toStringWithType(boolean useFullyQualifiedClassName) {
                 return "";
             }
 
@@ -126,8 +121,8 @@ public class ArgumentMatchingToolTest extends TestBase {
             }
 
             @Override
-            public boolean sameName(Object target) {
-                return true;
+            public Class getWantedClass() {
+                return String.class;
             }
 
         }

--- a/src/test/java/org/mockito/internal/verification/argumentmatching/ArgumentMatchingToolTest.java
+++ b/src/test/java/org/mockito/internal/verification/argumentmatching/ArgumentMatchingToolTest.java
@@ -116,9 +116,20 @@ public class ArgumentMatchingToolTest extends TestBase {
             }
 
             @Override
+            public String toStringWithFullName() {
+                return "";
+            }
+
+            @Override
             public boolean typeMatches(Object target) {
                 return true;
             }
+
+            @Override
+            public boolean sameName(Object target) {
+                return true;
+            }
+
         }
 
         // given

--- a/src/test/java/org/mockitousage/IMethods.java
+++ b/src/test/java/org/mockitousage/IMethods.java
@@ -247,9 +247,11 @@ public interface IMethods {
 
     void overloadedMethodWithDifferentClassNameArguments(Integer i, String string);
 
-    void overloadedMethodWithSameClassNameArguments(java.sql.Date javaDate, String string, Date date);
+    void overloadedMethodWithSameClassNameArguments(
+            java.sql.Date javaDate, String string, Date date);
 
-    void overloadedMethodWithSameClassNameArguments(Date date, String string, java.sql.Date javaDate);
+    void overloadedMethodWithSameClassNameArguments(
+            Date date, String string, java.sql.Date javaDate);
 
     /**
      * Using this class to test cases where two classes have same simple name
@@ -269,10 +271,10 @@ public interface IMethods {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o){
+            if (this == o) {
                 return true;
             }
-            if (o == null || getClass() != o.getClass()){
+            if (o == null || getClass() != o.getClass()) {
                 return false;
             }
             Date date = (Date) o;
@@ -283,9 +285,5 @@ public interface IMethods {
         public int hashCode() {
             return Objects.hash(value);
         }
-
     }
-
-
 }
-

--- a/src/test/java/org/mockitousage/IMethods.java
+++ b/src/test/java/org/mockitousage/IMethods.java
@@ -238,4 +238,54 @@ public interface IMethods {
     String forObject(Object object);
 
     <T> String genericToString(T arg);
+
+    void overloadedMethodWithSameClassNameArguments(java.sql.Date javaDate, Date date);
+
+    void overloadedMethodWithSameClassNameArguments(Date date, java.sql.Date javaDate);
+
+    void overloadedMethodWithDifferentClassNameArguments(String String, Integer i);
+
+    void overloadedMethodWithDifferentClassNameArguments(Integer i, String string);
+
+    void overloadedMethodWithSameClassNameArguments(java.sql.Date javaDate, String string, Date date);
+
+    void overloadedMethodWithSameClassNameArguments(Date date, String string, java.sql.Date javaDate);
+
+    /**
+     * Using this class to test cases where two classes have same simple name
+     */
+    public static class Date {
+
+        private int value;
+
+        public Date(int value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o){
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()){
+                return false;
+            }
+            Date date = (Date) o;
+            return value == date.value;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(value);
+        }
+
+    }
+
+
 }
+

--- a/src/test/java/org/mockitousage/MethodsImpl.java
+++ b/src/test/java/org/mockitousage/MethodsImpl.java
@@ -448,4 +448,29 @@ public class MethodsImpl implements IMethods {
     public <T> String genericToString(T arg) {
         return null;
     }
+
+    @Override
+    public void overloadedMethodWithSameClassNameArguments(java.sql.Date javaDate, Date date) {
+    }
+
+    @Override
+    public void overloadedMethodWithSameClassNameArguments(Date date, java.sql.Date javaDate) {
+    }
+
+    @Override
+    public void overloadedMethodWithDifferentClassNameArguments(String string, Integer i) {
+    }
+
+    @Override
+    public void overloadedMethodWithDifferentClassNameArguments(Integer i, String string) {
+    }
+
+    @Override
+    public void overloadedMethodWithSameClassNameArguments(java.sql.Date javaDate, String string, Date date) {
+    }
+
+    @Override
+    public void overloadedMethodWithSameClassNameArguments(Date date, String string, java.sql.Date javaDate) {
+    }
+
 }

--- a/src/test/java/org/mockitousage/MethodsImpl.java
+++ b/src/test/java/org/mockitousage/MethodsImpl.java
@@ -450,27 +450,22 @@ public class MethodsImpl implements IMethods {
     }
 
     @Override
-    public void overloadedMethodWithSameClassNameArguments(java.sql.Date javaDate, Date date) {
-    }
+    public void overloadedMethodWithSameClassNameArguments(java.sql.Date javaDate, Date date) {}
 
     @Override
-    public void overloadedMethodWithSameClassNameArguments(Date date, java.sql.Date javaDate) {
-    }
+    public void overloadedMethodWithSameClassNameArguments(Date date, java.sql.Date javaDate) {}
 
     @Override
-    public void overloadedMethodWithDifferentClassNameArguments(String string, Integer i) {
-    }
+    public void overloadedMethodWithDifferentClassNameArguments(String string, Integer i) {}
 
     @Override
-    public void overloadedMethodWithDifferentClassNameArguments(Integer i, String string) {
-    }
+    public void overloadedMethodWithDifferentClassNameArguments(Integer i, String string) {}
 
     @Override
-    public void overloadedMethodWithSameClassNameArguments(java.sql.Date javaDate, String string, Date date) {
-    }
+    public void overloadedMethodWithSameClassNameArguments(
+            java.sql.Date javaDate, String string, Date date) {}
 
     @Override
-    public void overloadedMethodWithSameClassNameArguments(Date date, String string, java.sql.Date javaDate) {
-    }
-
+    public void overloadedMethodWithSameClassNameArguments(
+            Date date, String string, java.sql.Date javaDate) {}
 }

--- a/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
+++ b/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
@@ -392,110 +392,116 @@ public class DescriptiveMessagesWhenVerificationFailsTest extends TestBase {
     public void should_print_fully_qualified_name_when_arguments_classes_have_same_simple_name() {
         try {
             mock.overloadedMethodWithSameClassNameArguments(new Date(0), new IMethods.Date(0));
-            verify(mock).overloadedMethodWithSameClassNameArguments(new IMethods.Date(0), new Date(0));
+            verify(mock)
+                    .overloadedMethodWithSameClassNameArguments(new IMethods.Date(0), new Date(0));
             fail();
         } catch (Throwable e) {
             String wanted =
-                "\n"
-                    + "Argument(s) are different! Wanted:"
-                    + "\n"
-                    + "iMethods.overloadedMethodWithSameClassNameArguments("
-                    + "\n"
-                    + "    (org.mockitousage.IMethods.Date) 0,"
-                    + "\n"
-                    + "    (java.sql.Date) 1970-01-01"
-                    + "\n"
-                    + ");";
+                    "\n"
+                            + "Argument(s) are different! Wanted:"
+                            + "\n"
+                            + "iMethods.overloadedMethodWithSameClassNameArguments("
+                            + "\n"
+                            + "    (org.mockitousage.IMethods.Date) 0,"
+                            + "\n"
+                            + "    (java.sql.Date) 1970-01-01"
+                            + "\n"
+                            + ");";
 
             assertThat(e).hasMessageContaining(wanted);
 
             String actual =
-                "\n"
-                    + "Actual invocations have different arguments:"
-                    + "\n"
-                    + "iMethods.overloadedMethodWithSameClassNameArguments("
-                    + "\n"
-                    + "    (java.sql.Date) 1970-01-01,"
-                    + "\n"
-                    + "    (org.mockitousage.IMethods.Date) 0"
-                    + "\n"
-                    + ");";
+                    "\n"
+                            + "Actual invocations have different arguments:"
+                            + "\n"
+                            + "iMethods.overloadedMethodWithSameClassNameArguments("
+                            + "\n"
+                            + "    (java.sql.Date) 1970-01-01,"
+                            + "\n"
+                            + "    (org.mockitousage.IMethods.Date) 0"
+                            + "\n"
+                            + ");";
             assertThat(e).hasMessageContaining(actual);
         }
     }
 
     @Test
-    public void should_not_print_fully_qualified_name_when_arguments_classes_have_different_simple_name() {
+    public void
+            should_not_print_fully_qualified_name_when_arguments_classes_have_different_simple_name() {
         try {
             mock.overloadedMethodWithDifferentClassNameArguments("string", 0);
             verify(mock).overloadedMethodWithDifferentClassNameArguments(0, "string");
             fail();
         } catch (Throwable e) {
             String wanted =
-                "\n"
-                    + "Argument(s) are different! Wanted:"
-                    + "\n"
-                    + "iMethods.overloadedMethodWithDifferentClassNameArguments("
-                    + "\n"
-                    + "    0,"
-                    + "\n"
-                    + "    \"string\""
-                    + "\n"
-                    + ");";
+                    "\n"
+                            + "Argument(s) are different! Wanted:"
+                            + "\n"
+                            + "iMethods.overloadedMethodWithDifferentClassNameArguments("
+                            + "\n"
+                            + "    0,"
+                            + "\n"
+                            + "    \"string\""
+                            + "\n"
+                            + ");";
 
             assertThat(e).hasMessageContaining(wanted);
 
             String actual =
-                "\n"
-                    + "Actual invocations have different arguments:"
-                    + "\n"
-                    + "iMethods.overloadedMethodWithDifferentClassNameArguments("
-                    + "\n"
-                    + "    \"string\","
-                    + "\n"
-                    + "    0"
-                    + "\n"
-                    + ");";
+                    "\n"
+                            + "Actual invocations have different arguments:"
+                            + "\n"
+                            + "iMethods.overloadedMethodWithDifferentClassNameArguments("
+                            + "\n"
+                            + "    \"string\","
+                            + "\n"
+                            + "    0"
+                            + "\n"
+                            + ");";
             assertThat(e).hasMessageContaining(actual);
         }
     }
 
     @Test
-    public void should_print_fully_qualified_name_when_some_arguments_classes_have_same_simple_name() {
+    public void
+            should_print_fully_qualified_name_when_some_arguments_classes_have_same_simple_name() {
         try {
-            mock.overloadedMethodWithSameClassNameArguments(new Date(0), "string", new IMethods.Date(0));
-            verify(mock).overloadedMethodWithSameClassNameArguments(new IMethods.Date(0), "string", new Date(0));
+            mock.overloadedMethodWithSameClassNameArguments(
+                    new Date(0), "string", new IMethods.Date(0));
+            verify(mock)
+                    .overloadedMethodWithSameClassNameArguments(
+                            new IMethods.Date(0), "string", new Date(0));
             fail();
         } catch (Throwable e) {
             String wanted =
-                "\n"
-                    + "Argument(s) are different! Wanted:"
-                    + "\n"
-                    + "iMethods.overloadedMethodWithSameClassNameArguments("
-                    + "\n"
-                    + "    (org.mockitousage.IMethods.Date) 0,"
-                    + "\n"
-                    + "    \"string\","
-                    + "\n"
-                    + "    (java.sql.Date) 1970-01-01"
-                    + "\n"
-                    + ");";
+                    "\n"
+                            + "Argument(s) are different! Wanted:"
+                            + "\n"
+                            + "iMethods.overloadedMethodWithSameClassNameArguments("
+                            + "\n"
+                            + "    (org.mockitousage.IMethods.Date) 0,"
+                            + "\n"
+                            + "    \"string\","
+                            + "\n"
+                            + "    (java.sql.Date) 1970-01-01"
+                            + "\n"
+                            + ");";
 
             assertThat(e).hasMessageContaining(wanted);
 
             String actual =
-                "\n"
-                    + "Actual invocations have different arguments:"
-                    + "\n"
-                    + "iMethods.overloadedMethodWithSameClassNameArguments("
-                    + "\n"
-                    + "    (java.sql.Date) 1970-01-01,"
-                    + "\n"
-                    + "    \"string\","
-                    + "\n"
-                    + "    (org.mockitousage.IMethods.Date) 0"
-                    + "\n"
-                    + ");";
+                    "\n"
+                            + "Actual invocations have different arguments:"
+                            + "\n"
+                            + "iMethods.overloadedMethodWithSameClassNameArguments("
+                            + "\n"
+                            + "    (java.sql.Date) 1970-01-01,"
+                            + "\n"
+                            + "    \"string\","
+                            + "\n"
+                            + "    (org.mockitousage.IMethods.Date) 0"
+                            + "\n"
+                            + ");";
             assertThat(e).hasMessageContaining(actual);
         }
     }

--- a/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
+++ b/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
@@ -9,6 +9,8 @@ import static org.junit.Assert.fail;
 import static org.mockito.AdditionalMatchers.aryEq;
 import static org.mockito.Mockito.*;
 
+import java.sql.Date;
+
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -383,6 +385,118 @@ public class DescriptiveMessagesWhenVerificationFailsTest extends TestBase {
                     .hasMessageContaining("iMethods.threeArgumentMethod(12, foo, \"xx\")")
                     .hasMessageContaining("iMethods.arrayMethod([\"a\", \"b\", \"c\"])")
                     .hasMessageContaining("iMethods.forByte((byte) 0x19)");
+        }
+    }
+
+    @Test
+    public void should_print_fully_qualified_name_when_arguments_classes_have_same_simple_name() {
+        try {
+            mock.overloadedMethodWithSameClassNameArguments(new Date(0), new IMethods.Date(0));
+            verify(mock).overloadedMethodWithSameClassNameArguments(new IMethods.Date(0), new Date(0));
+            fail();
+        } catch (Throwable e) {
+            String wanted =
+                "\n"
+                    + "Argument(s) are different! Wanted:"
+                    + "\n"
+                    + "iMethods.overloadedMethodWithSameClassNameArguments("
+                    + "\n"
+                    + "    (org.mockitousage.IMethods.Date) 0,"
+                    + "\n"
+                    + "    (java.sql.Date) 1970-01-01"
+                    + "\n"
+                    + ");";
+
+            assertThat(e).hasMessageContaining(wanted);
+
+            String actual =
+                "\n"
+                    + "Actual invocations have different arguments:"
+                    + "\n"
+                    + "iMethods.overloadedMethodWithSameClassNameArguments("
+                    + "\n"
+                    + "    (java.sql.Date) 1970-01-01,"
+                    + "\n"
+                    + "    (org.mockitousage.IMethods.Date) 0"
+                    + "\n"
+                    + ");";
+            assertThat(e).hasMessageContaining(actual);
+        }
+    }
+
+    @Test
+    public void should_not_print_fully_qualified_name_when_arguments_classes_have_different_simple_name() {
+        try {
+            mock.overloadedMethodWithDifferentClassNameArguments("string", 0);
+            verify(mock).overloadedMethodWithDifferentClassNameArguments(0, "string");
+            fail();
+        } catch (Throwable e) {
+            String wanted =
+                "\n"
+                    + "Argument(s) are different! Wanted:"
+                    + "\n"
+                    + "iMethods.overloadedMethodWithDifferentClassNameArguments("
+                    + "\n"
+                    + "    0,"
+                    + "\n"
+                    + "    \"string\""
+                    + "\n"
+                    + ");";
+
+            assertThat(e).hasMessageContaining(wanted);
+
+            String actual =
+                "\n"
+                    + "Actual invocations have different arguments:"
+                    + "\n"
+                    + "iMethods.overloadedMethodWithDifferentClassNameArguments("
+                    + "\n"
+                    + "    \"string\","
+                    + "\n"
+                    + "    0"
+                    + "\n"
+                    + ");";
+            assertThat(e).hasMessageContaining(actual);
+        }
+    }
+
+    @Test
+    public void should_print_fully_qualified_name_when_some_arguments_classes_have_same_simple_name() {
+        try {
+            mock.overloadedMethodWithSameClassNameArguments(new Date(0), "string", new IMethods.Date(0));
+            verify(mock).overloadedMethodWithSameClassNameArguments(new IMethods.Date(0), "string", new Date(0));
+            fail();
+        } catch (Throwable e) {
+            String wanted =
+                "\n"
+                    + "Argument(s) are different! Wanted:"
+                    + "\n"
+                    + "iMethods.overloadedMethodWithSameClassNameArguments("
+                    + "\n"
+                    + "    (org.mockitousage.IMethods.Date) 0,"
+                    + "\n"
+                    + "    \"string\","
+                    + "\n"
+                    + "    (java.sql.Date) 1970-01-01"
+                    + "\n"
+                    + ");";
+
+            assertThat(e).hasMessageContaining(wanted);
+
+            String actual =
+                "\n"
+                    + "Actual invocations have different arguments:"
+                    + "\n"
+                    + "iMethods.overloadedMethodWithSameClassNameArguments("
+                    + "\n"
+                    + "    (java.sql.Date) 1970-01-01,"
+                    + "\n"
+                    + "    \"string\","
+                    + "\n"
+                    + "    (org.mockitousage.IMethods.Date) 0"
+                    + "\n"
+                    + ");";
+            assertThat(e).hasMessageContaining(actual);
         }
     }
 


### PR DESCRIPTION
Prints fully qualified class name when the simple names of arguments match.

<!-- Hey,
Thanks for the contribution, this is awesome.
As you may have read, project members have somehow an opinionated view on what and how should be
Mockito, e.g. we don't want mockito to be a feature bloat.
There may be a thorough review, with feedback -> code change loop.
-->
<!--
If you have a suggestion for this template you can fix it in the .github/PULL_REQUEST_TEMPLATE.md file
-->
## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

