### PR TITLE
Downgrade Android gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         classpath 'org.shipkit:shipkit-auto-version:1.1.19'
 
         classpath 'com.google.googlejavaformat:google-java-format:1.10.0'
-        classpath 'com.android.tools.build:gradle:4.2.1'
+        classpath 'com.android.tools.build:gradle:4.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
     }
 }


### PR DESCRIPTION
The newer version is only compatible with new versions of
IntelliJ/Android Studio. To ensure that older versions of IntelliJ can
still open this project, we should downgrade our version for now.

This Gradle plugin version supports IntelliJ 2020.3 and newer.

Fixes #2378