### PR TITLE
Reorder InjectMock Javadoc to fit the order of injection

### DIFF
--- a/src/main/java/org/mockito/InjectMocks.java
+++ b/src/main/java/org/mockito/InjectMocks.java
@@ -22,7 +22,7 @@ import org.mockito.junit.MockitoJUnitRunner;
  * </ul>
  * <p>
  * Mockito will try to inject mocks only either by constructor injection,
- * setter injection, or property injection in order and as described below.
+ * property injection or setter injection in order and as described below.
  * If any of the following strategy fail, then Mockito <strong>won't report failure</strong>;
  * i.e. you will have to provide dependencies yourself.
  * <ol>


### PR DESCRIPTION
InjectMock performs inject in the order of Construction, parameter and setter and it would be consistent to use this order in the initial explanation of the Javadoc.

<!-- Hey,
Thanks for the contribution, this is awesome.
As you may have read, project members have somehow an opinionated view on what and how should be
Mockito, e.g. we don't want mockito to be a feature bloat.
There may be a thorough review, with feedback -> code change loop.
-->
<!--
If you have a suggestion for this template you can fix it in the .github/PULL_REQUEST_TEMPLATE.md file
-->
## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

