### PR TITLE
Add checks for sealed types

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
@@ -344,7 +344,9 @@ public class InlineBytecodeGenerator implements BytecodeGenerator, ClassFileTran
         if (subclassingRequired
                 && !features.mockedType.isArray()
                 && !features.mockedType.isPrimitive()
-                && Modifier.isFinal(features.mockedType.getModifiers())) {
+                && (Modifier.isFinal(features.mockedType.getModifiers())
+                        || TypeSupport.INSTANCE.isSealed(features.mockedType)
+                        || features.interfaces.stream().anyMatch(TypeSupport.INSTANCE::isSealed))) {
             throw new MockitoException(
                     "Unsupported settings with this type '" + features.mockedType.getName() + "'");
         }

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassByteBuddyMockMaker.java
@@ -162,7 +162,9 @@ public class SubclassByteBuddyMockMaker implements ClassCreatingMockMaker {
         return new TypeMockability() {
             @Override
             public boolean mockable() {
-                return !type.isPrimitive() && !Modifier.isFinal(type.getModifiers());
+                return !type.isPrimitive()
+                        && !Modifier.isFinal(type.getModifiers())
+                        && !TypeSupport.INSTANCE.isSealed(type);
             }
 
             @Override
@@ -175,6 +177,9 @@ public class SubclassByteBuddyMockMaker implements ClassCreatingMockMaker {
                 }
                 if (Modifier.isFinal(type.getModifiers())) {
                     return "final class";
+                }
+                if (TypeSupport.INSTANCE.isSealed(type)) {
+                    return "sealed class";
                 }
                 return join("not handled type");
             }

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/TypeSupport.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/TypeSupport.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.creation.bytebuddy;
+
+import org.mockito.exceptions.base.MockitoException;
+
+import java.lang.reflect.Method;
+
+class TypeSupport {
+
+    static final TypeSupport INSTANCE;
+
+    static {
+        Method isSealed;
+        try {
+            isSealed = Class.class.getMethod("isSealed");
+        } catch (NoSuchMethodException ignored) {
+            isSealed = null;
+        }
+        INSTANCE = new TypeSupport(isSealed);
+    }
+
+    private final Method isSealed;
+
+    private TypeSupport(Method isSealed) {
+        this.isSealed = isSealed;
+    }
+
+    boolean isSealed(Class<?> type) {
+        if (isSealed == null) {
+            return false;
+        }
+        try {
+            return (boolean) isSealed.invoke(type);
+        } catch (Throwable t) {
+            throw new MockitoException(
+                    "Failed to check if type is sealed using handle " + isSealed, t);
+        }
+    }
+}


### PR DESCRIPTION
Sealed types do not allow for mocks as the sealing property is unmodifiable even by retransformation. This means sealed classes can only be mocked if they are real inline mocks. We should produce proper error messages for this to avoid user confusion.