### PR TITLE
Fixes #2399 : Adds defaultAnswer to the MockitoMockKey to distinguish the mock types, i.e. to separate mocks from spies otherwise spy type is reused for a mock or vice versa.

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/TypeCachingBytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/TypeCachingBytecodeGenerator.java
@@ -89,11 +89,11 @@ class TypeCachingBytecodeGenerator extends ReferenceQueue<ClassLoader>
         private final Answer defaultAnswer;
 
         private MockitoMockKey(
-            Class<?> type,
-            Set<Class<?>> additionalType,
-            SerializableMode serializableMode,
-            boolean stripAnnotations,
-            Answer defaultAnswer) {
+                Class<?> type,
+                Set<Class<?>> additionalType,
+                SerializableMode serializableMode,
+                boolean stripAnnotations,
+                Answer defaultAnswer) {
             super(type, additionalType);
             this.serializableMode = serializableMode;
             this.stripAnnotations = stripAnnotations;

--- a/src/test/java/org/mockito/internal/creation/bytebuddy/TypeCachingMockBytecodeGeneratorTest.java
+++ b/src/test/java/org/mockito/internal/creation/bytebuddy/TypeCachingMockBytecodeGeneratorTest.java
@@ -14,6 +14,8 @@ import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
 import java.util.WeakHashMap;
 
 import org.junit.Before;
@@ -140,6 +142,40 @@ public class TypeCachingMockBytecodeGeneratorTest {
                                 Answers.RETURNS_DEFAULTS));
 
         assertThat(other_mock_type).isNotSameAs(the_mock_type);
+    }
+
+    @Test
+    public void ensure_cache_returns_different_instance_defaultAnswer() throws Exception {
+        // given
+        ClassLoader classloader_with_life_shorter_than_cache =
+                inMemoryClassLoader()
+                        .withClassDefinition("foo.Bar", makeMarkerInterface("foo.Bar"))
+                        .build();
+
+        TypeCachingBytecodeGenerator cachingMockBytecodeGenerator =
+                new TypeCachingBytecodeGenerator(new SubclassBytecodeGenerator(), true);
+
+        Answers[] answers = Answers.values();
+        Set<Class<?>> classes = Collections.newSetFromMap(new IdentityHashMap<>());
+        classes.add(cachingMockBytecodeGenerator.mockClass(
+            withMockFeatures(
+                classloader_with_life_shorter_than_cache.loadClass("foo.Bar"),
+                Collections.<Class<?>>emptySet(),
+                SerializableMode.NONE,
+                false,
+                null)));
+        for (Answers answer : answers) {
+            Class<?> klass = cachingMockBytecodeGenerator.mockClass(
+                withMockFeatures(
+                    classloader_with_life_shorter_than_cache.loadClass("foo.Bar"),
+                    Collections.<Class<?>>emptySet(),
+                    SerializableMode.NONE,
+                    false,
+                    answer));
+            assertThat(classes.add(klass)).isTrue();
+        }
+
+        assertThat(classes).hasSize(answers.length + 1);
     }
 
     @Test

--- a/src/test/java/org/mockito/internal/creation/bytebuddy/TypeCachingMockBytecodeGeneratorTest.java
+++ b/src/test/java/org/mockito/internal/creation/bytebuddy/TypeCachingMockBytecodeGeneratorTest.java
@@ -157,21 +157,23 @@ public class TypeCachingMockBytecodeGeneratorTest {
 
         Answers[] answers = Answers.values();
         Set<Class<?>> classes = Collections.newSetFromMap(new IdentityHashMap<>());
-        classes.add(cachingMockBytecodeGenerator.mockClass(
-            withMockFeatures(
-                classloader_with_life_shorter_than_cache.loadClass("foo.Bar"),
-                Collections.<Class<?>>emptySet(),
-                SerializableMode.NONE,
-                false,
-                null)));
+        classes.add(
+                cachingMockBytecodeGenerator.mockClass(
+                        withMockFeatures(
+                                classloader_with_life_shorter_than_cache.loadClass("foo.Bar"),
+                                Collections.<Class<?>>emptySet(),
+                                SerializableMode.NONE,
+                                false,
+                                null)));
         for (Answers answer : answers) {
-            Class<?> klass = cachingMockBytecodeGenerator.mockClass(
-                withMockFeatures(
-                    classloader_with_life_shorter_than_cache.loadClass("foo.Bar"),
-                    Collections.<Class<?>>emptySet(),
-                    SerializableMode.NONE,
-                    false,
-                    answer));
+            Class<?> klass =
+                    cachingMockBytecodeGenerator.mockClass(
+                            withMockFeatures(
+                                    classloader_with_life_shorter_than_cache.loadClass("foo.Bar"),
+                                    Collections.<Class<?>>emptySet(),
+                                    SerializableMode.NONE,
+                                    false,
+                                    answer));
             assertThat(classes.add(klass)).isTrue();
         }
 

--- a/src/test/java/org/mockitousage/spies/MockCreationShouldNotAffectSpyTest.java
+++ b/src/test/java/org/mockitousage/spies/MockCreationShouldNotAffectSpyTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage.spies;
+
+import org.junit.Test;
+import org.mockitoutil.TestBase;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+public class MockCreationShouldNotAffectSpyTest extends TestBase {
+
+    @Test
+    public void test() {
+        TestClass instance = new TestClass(42);
+
+        TestClass mock = mock(TestClass.class);
+        assertEquals(mock.hashCode(), mock.hashCode());
+        assertEquals(mock, mock);
+
+        TestClass spy = spy(instance);
+        assertEquals(instance.hashCode(), spy.hashCode());
+        assertEquals(spy, instance);
+        assertEquals(instance, spy);
+    }
+
+    static class TestClass {
+        private final long value;
+
+        TestClass(final long value)
+        {
+            this.value = value;
+        }
+
+        public boolean equals(final Object o)
+        {
+            if (!(o instanceof TestClass)) {
+                return false;
+            }
+            return value == ((TestClass)o).value;
+        }
+
+        public int hashCode()
+        {
+            return Long.hashCode(value);
+        }
+    }
+}

--- a/src/test/java/org/mockitousage/spies/MockCreationShouldNotAffectSpyTest.java
+++ b/src/test/java/org/mockitousage/spies/MockCreationShouldNotAffectSpyTest.java
@@ -30,21 +30,18 @@ public class MockCreationShouldNotAffectSpyTest extends TestBase {
     static class TestClass {
         private final long value;
 
-        TestClass(final long value)
-        {
+        TestClass(final long value) {
             this.value = value;
         }
 
-        public boolean equals(final Object o)
-        {
+        public boolean equals(final Object o) {
             if (!(o instanceof TestClass)) {
                 return false;
             }
-            return value == ((TestClass)o).value;
+            return value == ((TestClass) o).value;
         }
 
-        public int hashCode()
-        {
+        public int hashCode() {
             return Long.hashCode(value);
         }
     }

--- a/src/test/java/org/mockitousage/spies/SpyCreationShouldNotAffectMockTest.java
+++ b/src/test/java/org/mockitousage/spies/SpyCreationShouldNotAffectMockTest.java
@@ -35,11 +35,10 @@ public class SpyCreationShouldNotAffectMockTest extends TestBase {
         }
 
         public boolean equals(final Object o) {
-            if (!(o instanceof TestClass))
-            {
+            if (!(o instanceof TestClass)) {
                 return false;
             }
-            return value == ((TestClass)o).value;
+            return value == ((TestClass) o).value;
         }
 
         public int hashCode() {

--- a/src/test/java/org/mockitousage/spies/SpyCreationShouldNotAffectMockTest.java
+++ b/src/test/java/org/mockitousage/spies/SpyCreationShouldNotAffectMockTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage.spies;
+
+import org.junit.Test;
+import org.mockitoutil.TestBase;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+public class SpyCreationShouldNotAffectMockTest extends TestBase {
+
+    @Test
+    public void test() {
+        TestClass instance = new TestClass(Long.MIN_VALUE);
+
+        TestClass spy = spy(instance);
+        assertEquals(instance.hashCode(), spy.hashCode());
+        assertEquals(spy, instance);
+        assertEquals(instance, spy);
+
+        TestClass mock = mock(TestClass.class);
+        assertEquals(mock.hashCode(), mock.hashCode());
+        assertEquals(mock, mock);
+    }
+
+    static class TestClass {
+        private final long value;
+
+        TestClass(final long value) {
+            this.value = value;
+        }
+
+        public boolean equals(final Object o) {
+            if (!(o instanceof TestClass))
+            {
+                return false;
+            }
+            return value == ((TestClass)o).value;
+        }
+
+        public int hashCode() {
+            return Long.hashCode(value);
+        }
+    }
+}


### PR DESCRIPTION
## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

