### PR TITLE
Fix implementation of proxy mock maker for toString and add additional unit tests.

### DIFF
--- a/src/main/java/org/mockito/internal/creation/proxy/ProxyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/proxy/ProxyMockMaker.java
@@ -107,7 +107,7 @@ public class ProxyMockMaker implements MockMaker {
                     case "equals":
                         return proxy == args[0];
                     case "toString":
-                        return "";
+                        break;
                     default:
                         throw new MockitoException(
                                 join(

--- a/subprojects/kotlinTest/src/test/kotlin/org/mockito/kotlin/SuspendTest.kt
+++ b/subprojects/kotlinTest/src/test/kotlin/org/mockito/kotlin/SuspendTest.kt
@@ -5,8 +5,8 @@
 package org.mockito.kotlin
 
 import kotlinx.coroutines.runBlocking
+import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.IsEqual
-import org.junit.Assert.assertThat
 import org.junit.Test
 import org.mockito.Mockito.*
 


### PR DESCRIPTION
Improves on the newly introduced `ProxyMockMaker`.