### PR TITLE
Properly resolve ProxyMockMaker by alias and handle null value as argument for the invocation handler

### DIFF
--- a/src/main/java/org/mockito/internal/configuration/plugins/PluginInitializer.java
+++ b/src/main/java/org/mockito/internal/configuration/plugins/PluginInitializer.java
@@ -9,6 +9,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Set;
 
 import org.mockito.internal.util.collections.Iterables;
 import org.mockito.plugins.PluginSwitch;
@@ -16,10 +17,10 @@ import org.mockito.plugins.PluginSwitch;
 class PluginInitializer {
 
     private final PluginSwitch pluginSwitch;
-    private final String alias;
+    private final Set<String> alias;
     private final DefaultMockitoPlugins plugins;
 
-    PluginInitializer(PluginSwitch pluginSwitch, String alias, DefaultMockitoPlugins plugins) {
+    PluginInitializer(PluginSwitch pluginSwitch, Set<String> alias, DefaultMockitoPlugins plugins) {
         this.pluginSwitch = pluginSwitch;
         this.alias = alias;
         this.plugins = plugins;
@@ -45,8 +46,8 @@ class PluginInitializer {
             String classOrAlias =
                     new PluginFinder(pluginSwitch).findPluginClass(Iterables.toIterable(resources));
             if (classOrAlias != null) {
-                if (classOrAlias.equals(alias)) {
-                    classOrAlias = plugins.getDefaultPluginClass(alias);
+                if (alias.contains(classOrAlias)) {
+                    classOrAlias = plugins.getDefaultPluginClass(classOrAlias);
                 }
                 Class<?> pluginClass = loader.loadClass(classOrAlias);
                 Object plugin = pluginClass.getDeclaredConstructor().newInstance();
@@ -77,8 +78,8 @@ class PluginInitializer {
                             .findPluginClasses(Iterables.toIterable(resources));
             List<T> impls = new ArrayList<>();
             for (String classOrAlias : classesOrAliases) {
-                if (classOrAlias.equals(alias)) {
-                    classOrAlias = plugins.getDefaultPluginClass(alias);
+                if (alias.contains(classOrAlias)) {
+                    classOrAlias = plugins.getDefaultPluginClass(classOrAlias);
                 }
                 Class<?> pluginClass = loader.loadClass(classOrAlias);
                 Object plugin = pluginClass.getDeclaredConstructor().newInstance();

--- a/src/main/java/org/mockito/internal/configuration/plugins/PluginLoader.java
+++ b/src/main/java/org/mockito/internal/configuration/plugins/PluginLoader.java
@@ -7,7 +7,9 @@ package org.mockito.internal.configuration.plugins;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 
 import org.mockito.plugins.PluginSwitch;
@@ -25,21 +27,23 @@ class PluginLoader {
     PluginLoader(PluginSwitch pluginSwitch) {
         this(
                 new DefaultMockitoPlugins(),
-                new PluginInitializer(pluginSwitch, null, new DefaultMockitoPlugins()));
+                new PluginInitializer(
+                        pluginSwitch, Collections.emptySet(), new DefaultMockitoPlugins()));
     }
 
     /**
-     * @deprecated Let's avoid adding more aliases. It complicates the API.
-     * Instead of an alias, we can use fully qualified class name of the alternative implementation.
-     * <p>
      * Adds an alias for a class name to this plugin loader. Instead of the fully qualified type name,
-     * the alias can be used as a convenience name for a known plugin.
+     * the alias can be used as a convenience name for a known plugin. This avoids exposing API that is
+     * explicitly marked as <i>internal</i> through the package name. Without such aliases, we would need
+     * to make internal packages part of the API, not by code but by configuration file.
      */
-    @Deprecated
-    PluginLoader(PluginSwitch pluginSwitch, String alias) {
+    PluginLoader(PluginSwitch pluginSwitch, String... alias) {
         this(
                 new DefaultMockitoPlugins(),
-                new PluginInitializer(pluginSwitch, alias, new DefaultMockitoPlugins()));
+                new PluginInitializer(
+                        pluginSwitch,
+                        new HashSet<>(Arrays.asList(alias)),
+                        new DefaultMockitoPlugins()));
     }
 
     /**

--- a/src/main/java/org/mockito/internal/configuration/plugins/PluginRegistry.java
+++ b/src/main/java/org/mockito/internal/configuration/plugins/PluginRegistry.java
@@ -22,7 +22,10 @@ class PluginRegistry {
             new PluginLoader(new DefaultPluginSwitch()).loadPlugin(PluginSwitch.class);
 
     private final MockMaker mockMaker =
-            new PluginLoader(pluginSwitch, DefaultMockitoPlugins.INLINE_ALIAS)
+            new PluginLoader(
+                            pluginSwitch,
+                            DefaultMockitoPlugins.INLINE_ALIAS,
+                            DefaultMockitoPlugins.PROXY_ALIAS)
                     .loadPlugin(MockMaker.class);
 
     private final MemberAccessor memberAccessor =

--- a/src/main/java/org/mockito/internal/creation/proxy/ProxyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/proxy/ProxyMockMaker.java
@@ -25,6 +25,8 @@ import static org.mockito.internal.util.StringUtil.join;
  */
 public class ProxyMockMaker implements MockMaker {
 
+    private static final Object[] EMPTY = new Object[0];
+
     private final Method invokeDefault;
 
     public ProxyMockMaker() {
@@ -100,6 +102,9 @@ public class ProxyMockMaker implements MockMaker {
 
         @Override
         public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            if (args == null) {
+                args = EMPTY;
+            }
             if (method.getDeclaringClass() == Object.class) {
                 switch (method.getName()) {
                     case "hashCode":

--- a/src/test/java/org/mockito/internal/configuration/plugins/DefaultMockitoPluginsTest.java
+++ b/src/test/java/org/mockito/internal/configuration/plugins/DefaultMockitoPluginsTest.java
@@ -6,6 +6,7 @@ package org.mockito.internal.configuration.plugins;
 
 import static org.junit.Assert.*;
 import static org.mockito.internal.configuration.plugins.DefaultMockitoPlugins.INLINE_ALIAS;
+import static org.mockito.internal.configuration.plugins.DefaultMockitoPlugins.PROXY_ALIAS;
 
 import org.junit.Test;
 import org.mockito.internal.creation.bytebuddy.ByteBuddyMockMaker;
@@ -22,11 +23,15 @@ public class DefaultMockitoPluginsTest extends TestBase {
     private DefaultMockitoPlugins plugins = new DefaultMockitoPlugins();
 
     @Test
+    @SuppressWarnings("deprecation")
     public void provides_plugins() throws Exception {
         assertEquals(
                 "org.mockito.internal.creation.bytebuddy.InlineByteBuddyMockMaker",
                 plugins.getDefaultPluginClass(INLINE_ALIAS));
         assertEquals(InlineByteBuddyMockMaker.class, plugins.getInlineMockMaker().getClass());
+        assertEquals(
+                "org.mockito.internal.creation.proxy.ProxyMockMaker",
+                plugins.getDefaultPluginClass(PROXY_ALIAS));
         assertEquals(
                 ByteBuddyMockMaker.class, plugins.getDefaultPlugin(MockMaker.class).getClass());
         assertNotNull(plugins.getDefaultPlugin(InstantiatorProvider.class));

--- a/src/test/java/org/mockito/internal/creation/proxy/ProxyMockMakerTest.java
+++ b/src/test/java/org/mockito/internal/creation/proxy/ProxyMockMakerTest.java
@@ -55,7 +55,7 @@ public class ProxyMockMakerTest
 
         InvocationHandler handler = Proxy.getInvocationHandler(proxy);
 
-        assertThat(handler.invoke(proxy, Object.class.getMethod("hashCode"), new Object[0]))
+        assertThat(handler.invoke(proxy, Object.class.getMethod("hashCode"), null))
                 .isEqualTo(System.identityHashCode(proxy));
     }
 
@@ -93,8 +93,7 @@ public class ProxyMockMakerTest
 
         InvocationHandler handler = Proxy.getInvocationHandler(proxy);
 
-        assertThat(handler.invoke(proxy, Object.class.getMethod("toString"), new Object[0]))
-                .isNull();
+        assertThat(handler.invoke(proxy, Object.class.getMethod("toString"), null)).isNull();
     }
 
     interface SomeInterface {}


### PR DESCRIPTION
The `InvocationHandler` API allows for a null value for the argument if a method does not declare any parameters what causes a null pointer exception if not replaced by an empty array what fixes #2406. Also, the mock-maker-proxy alias needs an additional registration what fixes #2407.