### PR TITLE
Fixes #2412 : Add toString to AtMost, Only, After and Timeout.

### DIFF
--- a/src/main/java/org/mockito/internal/verification/AtMost.java
+++ b/src/main/java/org/mockito/internal/verification/AtMost.java
@@ -51,4 +51,9 @@ public class AtMost implements VerificationMode {
             }
         }
     }
+
+    @Override
+    public String toString() {
+        return "Wanted invocations count: at most " + maxNumberOfInvocations;
+    }
 }

--- a/src/main/java/org/mockito/internal/verification/Only.java
+++ b/src/main/java/org/mockito/internal/verification/Only.java
@@ -34,4 +34,9 @@ public class Only implements VerificationMode {
         }
         markVerified(chunk.get(0), target);
     }
+
+    @Override
+    public String toString() {
+        return "Wanted invocations count: 1 and no other method invoked";
+    }
 }

--- a/src/main/java/org/mockito/verification/After.java
+++ b/src/main/java/org/mockito/verification/After.java
@@ -38,4 +38,13 @@ public class After extends VerificationWrapper<VerificationOverTimeImpl>
     protected VerificationMode copySelfWithNewVerificationMode(VerificationMode verificationMode) {
         return new After(wrappedVerification.copyWithVerificationMode(verificationMode));
     }
+
+    @Override
+    public String toString() {
+        return "Wanted after "
+                + wrappedVerification.getTimer().duration()
+                + " ms: ["
+                + wrappedVerification.getDelegate()
+                + "]";
+    }
 }

--- a/src/main/java/org/mockito/verification/Timeout.java
+++ b/src/main/java/org/mockito/verification/Timeout.java
@@ -62,4 +62,13 @@ public class Timeout extends VerificationWrapper<VerificationOverTimeImpl>
     public VerificationMode never() {
         throw atMostAndNeverShouldNotBeUsedWithTimeout();
     }
+
+    @Override
+    public String toString() {
+        return "Wanted after at most "
+                + wrappedVerification.getTimer().duration()
+                + " ms: ["
+                + wrappedVerification.getDelegate()
+                + "]";
+    }
 }

--- a/src/test/java/org/mockito/internal/verification/DummyVerificationMode.java
+++ b/src/test/java/org/mockito/internal/verification/DummyVerificationMode.java
@@ -13,4 +13,9 @@ public class DummyVerificationMode implements VerificationMode {
     public VerificationMode description(String description) {
         return new DummyVerificationMode();
     }
+
+    @Override
+    public String toString() {
+        return "Dummy verification mode";
+    }
 }

--- a/src/test/java/org/mockitousage/verification/AtMostXVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/AtMostXVerificationTest.java
@@ -22,6 +22,7 @@ import org.mockito.Mock;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.exceptions.verification.MoreThanAllowedActualInvocations;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
+import org.mockito.verification.VerificationMode;
 import org.mockitoutil.TestBase;
 
 public class AtMostXVerificationTest extends TestBase {
@@ -113,6 +114,13 @@ public class AtMostXVerificationTest extends TestBase {
         } catch (NoInteractionsWanted e) {
             assertThat(e).hasMessageContaining("undesiredInteraction(");
         }
+    }
+
+    @Test
+    public void should_return_formatted_output_from_toString_method() {
+        VerificationMode atMost = atMost(3);
+
+        assertThat(atMost).hasToString("Wanted invocations count: at most 3");
     }
 
     private void undesiredInteraction() {

--- a/src/test/java/org/mockitousage/verification/OnlyVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/OnlyVerificationTest.java
@@ -4,6 +4,7 @@
  */
 package org.mockitousage.verification;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.only;
@@ -15,6 +16,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockito.exceptions.verification.WantedButNotInvoked;
+import org.mockito.verification.VerificationMode;
 import org.mockitoutil.TestBase;
 
 public class OnlyVerificationTest extends TestBase {
@@ -84,5 +86,12 @@ public class OnlyVerificationTest extends TestBase {
         mock2.get(0);
         verify(mock, only()).clear();
         verify(mock2, only()).get(0);
+    }
+
+    @Test
+    public void should_return_formatted_output_from_toString_method() {
+        VerificationMode only = only();
+
+        assertThat(only).hasToString("Wanted invocations count: 1 and no other method invoked");
     }
 }

--- a/src/test/java/org/mockitousage/verification/VerificationWithAfterTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationWithAfterTest.java
@@ -6,6 +6,7 @@ package org.mockitousage.verification;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.verify;
@@ -22,7 +23,9 @@ import org.mockito.Mock;
 import org.mockito.exceptions.verification.MoreThanAllowedActualInvocations;
 import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockito.exceptions.verification.TooManyActualInvocations;
+import org.mockito.internal.verification.DummyVerificationMode;
 import org.mockito.junit.MockitoRule;
+import org.mockito.verification.VerificationMode;
 import org.mockitousage.IMethods;
 import org.mockitoutil.Stopwatch;
 import org.mockitoutil.async.AsyncTesting;
@@ -300,5 +303,30 @@ public class VerificationWithAfterTest {
 
         // using generous number to avoid timing issues
         watch.assertElapsedTimeIsLessThan(2000, MILLISECONDS);
+    }
+
+    @Test
+    public void should_return_formatted_output_from_toString_when_created_with_factory_method() {
+        VerificationMode after = after(3);
+
+        assertThat(after).hasToString("Wanted after 3 ms: [Wanted invocations count: 1]");
+    }
+
+    @Test
+    public void should_return_formatted_output_from_toString_using_wrapped_verification_mode() {
+        org.mockito.verification.After after =
+                new org.mockito.verification.After(10, new DummyVerificationMode());
+
+        assertThat(after).hasToString("Wanted after 10 ms: [Dummy verification mode]");
+    }
+
+    @Test
+    public void
+            should_return_formatted_output_from_toString_when_chaining_other_verification_mode() {
+        VerificationMode afterAndOnly = after(5).only();
+
+        assertThat(afterAndOnly)
+                .hasToString(
+                        "Wanted after 5 ms: [Wanted invocations count: 1 and no other method invoked]");
     }
 }

--- a/src/test/java/org/mockitousage/verification/VerificationWithTimeoutTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationWithTimeoutTest.java
@@ -4,6 +4,7 @@
  */
 package org.mockitousage.verification;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
@@ -21,7 +22,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.exceptions.verification.TooFewActualInvocations;
+import org.mockito.internal.verification.DummyVerificationMode;
 import org.mockito.junit.MockitoRule;
+import org.mockito.verification.Timeout;
+import org.mockito.verification.VerificationMode;
 import org.mockitousage.IMethods;
 import org.mockitoutil.Stopwatch;
 import org.mockitoutil.async.AsyncTesting;
@@ -170,6 +174,31 @@ public class VerificationWithTimeoutTest {
 
         // then
         verify(mock, timeout(100).only()).oneArg('c');
+    }
+
+    @Test
+    public void should_return_formatted_output_from_toString_when_created_with_factory_method() {
+        VerificationMode timeout = timeout(7);
+
+        assertThat(timeout).hasToString("Wanted after at most 7 ms: [Wanted invocations count: 1]");
+    }
+
+    @Test
+    public void should_return_formatted_output_from_toString_using_wrapped_verification_mode() {
+        VerificationMode timeoutAndAtLeastOnce = new Timeout(9, new DummyVerificationMode());
+
+        assertThat(timeoutAndAtLeastOnce)
+                .hasToString("Wanted after at most 9 ms: [Dummy verification mode]");
+    }
+
+    @Test
+    public void
+            should_return_formatted_output_from_toString_when_chaining_other_verification_mode() {
+        VerificationMode timeoutAndOnly = timeout(7).only();
+
+        assertThat(timeoutAndOnly)
+                .hasToString(
+                        "Wanted after at most 7 ms: [Wanted invocations count: 1 and no other method invoked]");
     }
 
     @Test


### PR DESCRIPTION
This PR fixes [#2412](https://github.com/mockito/mockito/issues/2412) ` Some VerificationModes don't have a toString implementation` by adding an overridden `toString()` method to the following `VerificationMode`s:

- `AtMost`
- `Only`
- `Timeout`
- `After`

Below is an example adapted from the one in the linked issue:
```
@RunWith(OleasterRunner.class)
public class DemoTest {

    private MyClass myClass;

    {
        describe("demo", () -> {

            beforeEach(() -> {
                myClass = Mockito.mock(MyClass.class);
                myClass.myMethod();
            });

            verifyMyMethodCalled(atLeast(1));
            verifyMyMethodCalled(atMost(1));
            verifyMyMethodCalled(only());
            verifyMyMethodCalled(after(1).atMost(1));
            verifyMyMethodCalled(after(12).atLeastOnce());
            verifyMyMethodCalled(timeout(31).times(1));
            verifyMyMethodCalled(timeout(1));

        });
    }

    private void verifyMyMethodCalled(VerificationMode verificationMode) {
        it(String.format("should call myMethod. %s", verificationMode), () -> {
            verify(myClass, verificationMode).myMethod();
        });
    }
}
```
And the result of running the tests:
![image](https://user-images.githubusercontent.com/22927506/131259146-4d79b1c6-f5ec-4240-a123-2bb9b4e280dc.png)
