### PR TITLE
Adds additional strategies for invoking super methods

### DIFF
--- a/src/main/java/org/mockito/internal/creation/proxy/InvokeDefaultProxy.java
+++ b/src/main/java/org/mockito/internal/creation/proxy/InvokeDefaultProxy.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.creation.proxy;
+
+import org.mockito.exceptions.base.MockitoException;
+import org.mockito.internal.invocation.RealMethod;
+import org.mockito.internal.invocation.SerializableMethod;
+import org.mockito.internal.util.Platform;
+
+import java.io.Serializable;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.mockito.internal.util.StringUtil.join;
+
+class InvokeDefaultProxy implements ProxyRealMethod {
+
+    private final Method invokeDefault;
+
+    InvokeDefaultProxy() throws Throwable {
+        invokeDefault =
+                InvocationHandler.class.getMethod(
+                        "invokeDefault", Object.class, Method.class, Object[].class);
+    }
+
+    @Override
+    public RealMethod resolve(Object proxy, Method method, Object[] args) {
+        return new InvokeDefaultRealMethod(proxy, method, args);
+    }
+
+    private class InvokeDefaultRealMethod implements RealMethod, Serializable {
+
+        private static final long serialVersionUID = -1;
+
+        private final Object proxy;
+        private final SerializableMethod serializableMethod;
+        private final Object[] args;
+
+        private InvokeDefaultRealMethod(Object proxy, Method method, Object[] args) {
+            this.proxy = proxy;
+            this.serializableMethod = new SerializableMethod(method);
+            this.args = args;
+        }
+
+        @Override
+        public boolean isInvokable() {
+            return true;
+        }
+
+        @Override
+        public Object invoke() throws Throwable {
+            try {
+                return invokeDefault.invoke(null, proxy, serializableMethod.getJavaMethod(), args);
+            } catch (InvocationTargetException e) {
+                throw e.getTargetException();
+            } catch (IllegalAccessException | IllegalArgumentException e) {
+                throw new MockitoException(
+                        join(
+                                "Failed to access default method or invoked method with illegal arguments",
+                                "",
+                                "Method "
+                                        + serializableMethod.getJavaMethod()
+                                        + " could not be delegated, this is not supposed to happen",
+                                Platform.describe()),
+                        e);
+            }
+        }
+    }
+}

--- a/src/main/java/org/mockito/internal/creation/proxy/MethodHandleProxy.java
+++ b/src/main/java/org/mockito/internal/creation/proxy/MethodHandleProxy.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2021 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.creation.proxy;
+
+import org.mockito.internal.SuppressSignatureCheck;
+import org.mockito.internal.invocation.RealMethod;
+
+import java.io.Serializable;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+@SuppressSignatureCheck
+class MethodHandleProxy implements ProxyRealMethod {
+
+    private final MethodHandles.Lookup lookup;
+
+    MethodHandleProxy() throws Throwable {
+        lookup = MethodHandles.lookup();
+    }
+
+    @Override
+    public RealMethod resolve(Object proxy, Method method, Object[] args) {
+        try {
+            return new MethodHandleRealMethod(
+                    lookup.findSpecial(
+                                    method.getDeclaringClass(),
+                                    method.getName(),
+                                    MethodType.methodType(
+                                            method.getReturnType(), method.getParameterTypes()),
+                                    method.getDeclaringClass())
+                            .bindTo(proxy),
+                    args);
+        } catch (Throwable ignored) {
+            return RealMethod.IsIllegal.INSTANCE;
+        }
+    }
+
+    @SuppressSignatureCheck
+    static class LegacyVersion implements ProxyRealMethod {
+
+        private final Constructor<MethodHandles.Lookup> constructor;
+
+        LegacyVersion() throws Throwable {
+            try {
+                Class.forName("java.lang.Module");
+                throw new RuntimeException("Must not be used when modules are available");
+            } catch (ClassNotFoundException ignored) {
+            }
+            constructor = MethodHandles.Lookup.class.getDeclaredConstructor(Class.class);
+            constructor.setAccessible(true);
+        }
+
+        @Override
+        public RealMethod resolve(Object proxy, Method method, Object[] args) {
+            try {
+                return new MethodHandleRealMethod(
+                        constructor
+                                .newInstance(method.getDeclaringClass())
+                                .in(method.getDeclaringClass())
+                                .unreflectSpecial(method, method.getDeclaringClass())
+                                .bindTo(proxy),
+                        args);
+            } catch (Throwable ignored) {
+                return RealMethod.IsIllegal.INSTANCE;
+            }
+        }
+    }
+
+    @SuppressSignatureCheck
+    private static class MethodHandleRealMethod implements RealMethod, Serializable {
+
+        private static final long serialVersionUID = -1;
+
+        private final MethodHandle handle;
+        private final Object[] args;
+
+        private MethodHandleRealMethod(MethodHandle handle, Object[] args) {
+            this.handle = handle;
+            this.args = args;
+        }
+
+        @Override
+        public boolean isInvokable() {
+            return true;
+        }
+
+        @Override
+        public Object invoke() throws Throwable {
+            return handle.invokeWithArguments(args);
+        }
+    }
+}

--- a/src/main/java/org/mockito/internal/creation/proxy/ProxyRealMethod.java
+++ b/src/main/java/org/mockito/internal/creation/proxy/ProxyRealMethod.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.creation.proxy;
+
+import org.mockito.internal.invocation.RealMethod;
+
+import java.lang.reflect.Method;
+
+interface ProxyRealMethod {
+
+    RealMethod resolve(Object proxy, Method method, Object[] args);
+
+    static ProxyRealMethod make() {
+        // From Java 16 on, there is a standard API for invoking a default method from an invocation
+        // handler.
+        try {
+            return new InvokeDefaultProxy();
+        } catch (Throwable ignored) {
+        }
+        // Java 8 does not yet allow special method invocation via proxies. Therefore, we need to
+        // deep reflect what is no longer allowed after Java 8.
+        try {
+            return new MethodHandleProxy.LegacyVersion();
+        } catch (Throwable ignored) {
+        }
+        // Between Java 9 and 15, a default method can be invoked via regular method handle
+        // invocation.
+        try {
+            return new MethodHandleProxy();
+        } catch (Throwable ignored) {
+        }
+        // Nothing works, this might happen on Android where method handles are not supported on old
+        // versions. Default methods cannot be invoked.
+        return (proxy, method, args) -> RealMethod.IsIllegal.INSTANCE;
+    }
+}

--- a/subprojects/proxy/src/test/java/org/mockitoproxy/MocksTest.java
+++ b/subprojects/proxy/src/test/java/org/mockitoproxy/MocksTest.java
@@ -4,7 +4,7 @@
  */
 package org.mockitoproxy;
 
-import net.bytebuddy.ClassFileVersion;
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.exceptions.base.MockitoException;
@@ -17,6 +17,7 @@ import java.lang.reflect.Proxy;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -45,19 +46,28 @@ public class MocksTest {
     }
 
     @Test
-    public void can_call_default_method_java_16() {
-        if (ClassFileVersion.ofThisVm().isLessThan(ClassFileVersion.JAVA_V16)) {
-            return; // Not supported prior to Java 16.
-        }
-
+    public void can_call_default_method_if_available() {
         SomeInterface mock = Mockito.mock(SomeInterface.class);
         assertThat(mock, instanceOf(Proxy.class));
 
-        when(mock.m()).thenCallRealMethod();
+        when(mock.d()).thenCallRealMethod();
 
         assertThat(mock.d(), is("default"));
 
         verify(mock).d();
+    }
+
+    @Test
+    public void cannot_call_default_method_if_not_available() {
+        SomeInterface mock = Mockito.mock(SomeInterface.class);
+        assertThat(mock, instanceOf(Proxy.class));
+
+        try {
+            when(mock.m()).thenCallRealMethod();
+            fail("Expected failure when requesting real method for non-default method");
+        } catch (MockitoException e) {
+            assertThat(e.getMessage(), CoreMatchers.containsString("real method"));
+        }
     }
 
     @Test


### PR DESCRIPTION
When using the proxy mock maker different approaches are available when using older JVMs that do not yet offer a standard API. This should cover all use cases but older Android versions that do not offer this functionality until method handles are introduced.