### PR TITLE
Remove all Incubating annotations

### DIFF
--- a/src/main/java/org/mockito/AdditionalAnswers.java
+++ b/src/main/java/org/mockito/AdditionalAnswers.java
@@ -330,7 +330,6 @@ public final class AdditionalAnswers {
      *
      * @since 2.8.44
      */
-    @Incubating
     public static <T> Answer<T> answersWithDelay(long sleepyTime, Answer<T> answer) {
         return (Answer<T>) new AnswersWithDelay(sleepyTime, (Answer<Object>) answer);
     }
@@ -344,7 +343,6 @@ public final class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.1.0
      */
-    @Incubating
     public static <T, A> Answer<T> answer(Answer1<T, A> answer) {
         return toAnswer(answer);
     }
@@ -357,7 +355,6 @@ public final class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.1.0
      */
-    @Incubating
     public static <A> Answer<Void> answerVoid(VoidAnswer1<A> answer) {
         return toAnswer(answer);
     }
@@ -372,7 +369,6 @@ public final class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.1.0
      */
-    @Incubating
     public static <T, A, B> Answer<T> answer(Answer2<T, A, B> answer) {
         return toAnswer(answer);
     }
@@ -386,7 +382,6 @@ public final class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.1.0
      */
-    @Incubating
     public static <A, B> Answer<Void> answerVoid(VoidAnswer2<A, B> answer) {
         return toAnswer(answer);
     }
@@ -402,7 +397,6 @@ public final class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.1.0
      */
-    @Incubating
     public static <T, A, B, C> Answer<T> answer(Answer3<T, A, B, C> answer) {
         return toAnswer(answer);
     }
@@ -417,7 +411,6 @@ public final class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.1.0
      */
-    @Incubating
     public static <A, B, C> Answer<Void> answerVoid(VoidAnswer3<A, B, C> answer) {
         return toAnswer(answer);
     }
@@ -434,7 +427,6 @@ public final class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.1.0
      */
-    @Incubating
     public static <T, A, B, C, D> Answer<T> answer(Answer4<T, A, B, C, D> answer) {
         return toAnswer(answer);
     }
@@ -450,7 +442,6 @@ public final class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.1.0
      */
-    @Incubating
     public static <A, B, C, D> Answer<Void> answerVoid(VoidAnswer4<A, B, C, D> answer) {
         return toAnswer(answer);
     }
@@ -468,7 +459,6 @@ public final class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.1.0
      */
-    @Incubating
     public static <T, A, B, C, D, E> Answer<T> answer(Answer5<T, A, B, C, D, E> answer) {
         return toAnswer(answer);
     }
@@ -486,7 +476,6 @@ public final class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.1.0
      */
-    @Incubating
     public static <A, B, C, D, E> Answer<Void> answerVoid(VoidAnswer5<A, B, C, D, E> answer) {
         return toAnswer(answer);
     }
@@ -506,7 +495,6 @@ public final class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.26.0
      */
-    @Incubating
     public static <T, A, B, C, D, E, F> Answer<T> answer(Answer6<T, A, B, C, D, E, F> answer) {
         return toAnswer(answer);
     }
@@ -525,7 +513,6 @@ public final class AdditionalAnswers {
      * @return the answer object to use
      * @since 2.26.0
      */
-    @Incubating
     public static <A, B, C, D, E, F> Answer<Void> answerVoid(VoidAnswer6<A, B, C, D, E, F> answer) {
         return toAnswer(answer);
     }

--- a/src/main/java/org/mockito/MockSettings.java
+++ b/src/main/java/org/mockito/MockSettings.java
@@ -255,7 +255,6 @@ public interface MockSettings extends Serializable {
      * @return settings instance so that you can fluently specify other settings
      * @since 2.11.0
      */
-    @Incubating
     MockSettings verificationStartedListeners(VerificationStartedListener... listeners);
 
     /**
@@ -296,7 +295,6 @@ public interface MockSettings extends Serializable {
      * @return settings instance so that you can fluently specify other settings
      * @since 2.7.14 (useConstructor with no arguments was supported since 1.10.12)
      */
-    @Incubating
     MockSettings useConstructor(Object... args);
 
     /**
@@ -311,7 +309,6 @@ public interface MockSettings extends Serializable {
      * @return settings instance so that you can fluently specify other settings
      * @since 1.10.12
      */
-    @Incubating
     MockSettings outerInstance(Object outerClassInstance);
 
     /**
@@ -322,7 +319,6 @@ public interface MockSettings extends Serializable {
      * @return settings instance so that you can fluently specify other settings
      * @since 1.10.13
      */
-    @Incubating
     MockSettings withoutAnnotations();
 
     /**
@@ -337,7 +333,6 @@ public interface MockSettings extends Serializable {
      * @return immutable view of mock settings
      * @since 2.10.0
      */
-    @Incubating
     <T> MockCreationSettings<T> build(Class<T> typeToMock);
 
     /**
@@ -352,7 +347,6 @@ public interface MockSettings extends Serializable {
      * @return immutable view of mock settings
      * @since 2.10.0
      */
-    @Incubating
     <T> MockCreationSettings<T> buildStatic(Class<T> classToMock);
 
     /**
@@ -366,6 +360,5 @@ public interface MockSettings extends Serializable {
      *
      * For more information and an elaborate example, see {@link Mockito#lenient()}.
      */
-    @Incubating
     MockSettings lenient();
 }

--- a/src/main/java/org/mockito/MockedConstruction.java
+++ b/src/main/java/org/mockito/MockedConstruction.java
@@ -19,7 +19,6 @@ import java.util.List;
  *
  * @param <T> The type for which the construction is being mocked.
  */
-@Incubating
 public interface MockedConstruction<T> extends ScopedMock {
 
     List<T> constructed();

--- a/src/main/java/org/mockito/MockedStatic.java
+++ b/src/main/java/org/mockito/MockedStatic.java
@@ -23,7 +23,6 @@ import org.mockito.verification.VerificationMode;
  *
  * @param <T> The type being mocked.
  */
-@Incubating
 public interface MockedStatic<T> extends ScopedMock {
 
     /**

--- a/src/main/java/org/mockito/MockingDetails.java
+++ b/src/main/java/org/mockito/MockingDetails.java
@@ -117,7 +117,6 @@ public interface MockingDetails {
      * @return mock handler instance of this mock
      * @since 2.10.0
      */
-    @Incubating
     MockHandler getMockHandler();
 
     /**

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -2068,7 +2068,6 @@ public class Mockito extends ArgumentMatchers {
      * @return a spy of the provided class
      * @since 1.10.12
      */
-    @Incubating
     public static <T> T spy(Class<T> classToSpy) {
         return MOCKITO_CORE.mock(
                 classToSpy, withSettings().useConstructor().defaultAnswer(CALLS_REAL_METHODS));
@@ -2090,7 +2089,6 @@ public class Mockito extends ArgumentMatchers {
      * @param classToMock class or interface of which static mocks should be mocked.
      * @return mock controller
      */
-    @Incubating
     public static <T> MockedStatic<T> mockStatic(Class<T> classToMock) {
         return mockStatic(classToMock, withSettings());
     }
@@ -2112,7 +2110,6 @@ public class Mockito extends ArgumentMatchers {
      * @param defaultAnswer the default answer when invoking static methods.
      * @return mock controller
      */
-    @Incubating
     public static <T> MockedStatic<T> mockStatic(Class<T> classToMock, Answer defaultAnswer) {
         return mockStatic(classToMock, withSettings().defaultAnswer(defaultAnswer));
     }
@@ -2134,7 +2131,6 @@ public class Mockito extends ArgumentMatchers {
      * @param name the name of the mock to use in error messages.
      * @return mock controller
      */
-    @Incubating
     public static <T> MockedStatic<T> mockStatic(Class<T> classToMock, String name) {
         return mockStatic(classToMock, withSettings().name(name));
     }
@@ -2156,7 +2152,6 @@ public class Mockito extends ArgumentMatchers {
      * @param mockSettings the settings to use where only name and default answer are considered.
      * @return mock controller
      */
-    @Incubating
     public static <T> MockedStatic<T> mockStatic(Class<T> classToMock, MockSettings mockSettings) {
         return MOCKITO_CORE.mockStatic(classToMock, mockSettings);
     }
@@ -2174,7 +2169,6 @@ public class Mockito extends ArgumentMatchers {
      *                         last answer is used. If this array is empty, the {@code defaultAnswer} is used.
      * @return mock controller
      */
-    @Incubating
     public static <T> MockedConstruction<T> mockConstructionWithAnswer(
             Class<T> classToMock, Answer defaultAnswer, Answer... additionalAnswers) {
         return mockConstruction(
@@ -2203,7 +2197,6 @@ public class Mockito extends ArgumentMatchers {
      * @param classToMock non-abstract class of which constructions should be mocked.
      * @return mock controller
      */
-    @Incubating
     public static <T> MockedConstruction<T> mockConstruction(Class<T> classToMock) {
         return mockConstruction(classToMock, index -> withSettings(), (mock, context) -> {});
     }
@@ -2219,7 +2212,6 @@ public class Mockito extends ArgumentMatchers {
      * @param mockInitializer a callback to prepare a mock's methods after its instantiation.
      * @return mock controller
      */
-    @Incubating
     public static <T> MockedConstruction<T> mockConstruction(
             Class<T> classToMock, MockedConstruction.MockInitializer<T> mockInitializer) {
         return mockConstruction(classToMock, withSettings(), mockInitializer);
@@ -2236,7 +2228,6 @@ public class Mockito extends ArgumentMatchers {
      * @param mockSettings the mock settings to use.
      * @return mock controller
      */
-    @Incubating
     public static <T> MockedConstruction<T> mockConstruction(
             Class<T> classToMock, MockSettings mockSettings) {
         return mockConstruction(classToMock, context -> mockSettings);
@@ -2253,7 +2244,6 @@ public class Mockito extends ArgumentMatchers {
      * @param mockSettingsFactory the mock settings to use.
      * @return mock controller
      */
-    @Incubating
     public static <T> MockedConstruction<T> mockConstruction(
             Class<T> classToMock,
             Function<MockedConstruction.Context, MockSettings> mockSettingsFactory) {
@@ -2272,7 +2262,6 @@ public class Mockito extends ArgumentMatchers {
      * @param mockInitializer a callback to prepare a mock's methods after its instantiation.
      * @return mock controller
      */
-    @Incubating
     public static <T> MockedConstruction<T> mockConstruction(
             Class<T> classToMock,
             MockSettings mockSettings,
@@ -2292,7 +2281,6 @@ public class Mockito extends ArgumentMatchers {
      * @param mockInitializer a callback to prepare a mock's methods after its instantiation.
      * @return mock controller
      */
-    @Incubating
     public static <T> MockedConstruction<T> mockConstruction(
             Class<T> classToMock,
             Function<MockedConstruction.Context, MockSettings> mockSettingsFactory,
@@ -3257,7 +3245,6 @@ public class Mockito extends ArgumentMatchers {
      *
      * @since 2.1.0
      */
-    @Incubating
     public static MockitoFramework framework() {
         return new DefaultMockitoFramework();
     }
@@ -3270,7 +3257,6 @@ public class Mockito extends ArgumentMatchers {
      *
      * @since 2.7.0
      */
-    @Incubating
     public static MockitoSessionBuilder mockitoSession() {
         return new DefaultMockitoSessionBuilder();
     }
@@ -3338,7 +3324,6 @@ public class Mockito extends ArgumentMatchers {
      *
      * @since 2.20.0
      */
-    @Incubating
     public static LenientStubber lenient() {
         return MOCKITO_CORE.lenient();
     }

--- a/src/main/java/org/mockito/MockitoFramework.java
+++ b/src/main/java/org/mockito/MockitoFramework.java
@@ -19,7 +19,6 @@ import org.mockito.plugins.MockitoPlugins;
  *
  * @since 2.1.0
  */
-@Incubating
 @NotExtensible
 public interface MockitoFramework {
 
@@ -53,7 +52,6 @@ public interface MockitoFramework {
      * @return this instance of mockito framework (fluent builder pattern)
      * @since 2.1.0
      */
-    @Incubating
     MockitoFramework addListener(MockitoListener listener) throws RedundantListenerException;
 
     /**
@@ -70,7 +68,6 @@ public interface MockitoFramework {
      * @return this instance of mockito framework (fluent builder pattern)
      * @since 2.1.0
      */
-    @Incubating
     MockitoFramework removeListener(MockitoListener listener);
 
     /**
@@ -81,7 +78,6 @@ public interface MockitoFramework {
      * @return object that gives access to mockito plugins
      * @since 2.10.0
      */
-    @Incubating
     MockitoPlugins getPlugins();
 
     /**
@@ -91,7 +87,6 @@ public interface MockitoFramework {
      * @return object that can construct invocations
      * @since 2.10.0
      */
-    @Incubating
     InvocationFactory getInvocationFactory();
 
     /**
@@ -130,7 +125,6 @@ public interface MockitoFramework {
      * @since 2.25.0
      * @see #clearInlineMock(Object)
      */
-    @Incubating
     void clearInlineMocks();
 
     /**
@@ -142,6 +136,5 @@ public interface MockitoFramework {
      * @since 2.25.0
      * @see #clearInlineMocks()
      */
-    @Incubating
     void clearInlineMock(Object mock);
 }

--- a/src/main/java/org/mockito/MockitoSession.java
+++ b/src/main/java/org/mockito/MockitoSession.java
@@ -86,7 +86,6 @@ import org.mockito.session.MockitoSessionBuilder;
  *
  * @since 2.7.0
  */
-@Incubating
 @NotExtensible
 public interface MockitoSession {
 
@@ -101,7 +100,6 @@ public interface MockitoSession {
      * @param strictness new strictness for this session.
      * @since 2.15.0
      */
-    @Incubating
     void setStrictness(Strictness strictness);
 
     /**
@@ -123,7 +121,6 @@ public interface MockitoSession {
      * @see #finishMocking(Throwable)
      * @since 2.7.0
      */
-    @Incubating
     void finishMocking();
 
     /**
@@ -140,6 +137,5 @@ public interface MockitoSession {
      * @see #finishMocking()
      * @since 2.15.0
      */
-    @Incubating
     void finishMocking(Throwable failure);
 }

--- a/src/main/java/org/mockito/ScopedMock.java
+++ b/src/main/java/org/mockito/ScopedMock.java
@@ -8,7 +8,6 @@ package org.mockito;
  * Represents a mock with a thread-local explicit scope. Scoped mocks must be closed by the entity
  * that activates the scoped mock.
  */
-@Incubating
 public interface ScopedMock extends AutoCloseable {
 
     /**

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyCrossClassLoaderSerializationSupport.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyCrossClassLoaderSerializationSupport.java
@@ -21,7 +21,6 @@ import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import org.mockito.Incubating;
 import org.mockito.exceptions.base.MockitoSerializationIssue;
 import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.internal.creation.settings.CreationSettings;
@@ -58,7 +57,6 @@ import org.mockito.plugins.MemberAccessor;
  * @author Brice Dutheil
  * @since 1.10.0
  */
-@Incubating
 class ByteBuddyCrossClassLoaderSerializationSupport implements Serializable {
     private static final long serialVersionUID = 7411152578314420778L;
     private static final String MOCKITO_PROXY_MARKER = "ByteBuddyMockitoProxyMarker";

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMaker.java
@@ -4,7 +4,6 @@
  */
 package org.mockito.internal.creation.bytebuddy;
 
-import org.mockito.Incubating;
 import org.mockito.MockedConstruction;
 import org.mockito.internal.exceptions.Reporter;
 import org.mockito.invocation.MockHandler;
@@ -65,7 +64,6 @@ public class ByteBuddyMockMaker implements ClassCreatingMockMaker {
     }
 
     @Override
-    @Incubating
     public TypeMockability isTypeMockable(Class<?> type) {
         return subclassByteBuddyMockMaker.isTypeMockable(type);
     }

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
@@ -4,7 +4,6 @@
  */
 package org.mockito.internal.creation.bytebuddy;
 
-import org.mockito.Incubating;
 import org.mockito.MockedConstruction;
 import org.mockito.creation.instance.Instantiator;
 import org.mockito.internal.exceptions.Reporter;
@@ -15,7 +14,6 @@ import org.mockito.plugins.InlineMockMaker;
 import java.util.Optional;
 import java.util.function.Function;
 
-@Incubating
 public class InlineByteBuddyMockMaker
         implements ClassCreatingMockMaker, InlineMockMaker, Instantiator {
     private final InlineDelegateByteBuddyMockMaker inlineDelegateByteBuddyMockMaker;

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
@@ -5,7 +5,6 @@
 package org.mockito.internal.creation.bytebuddy;
 
 import net.bytebuddy.agent.ByteBuddyAgent;
-import org.mockito.Incubating;
 import org.mockito.MockedConstruction;
 import org.mockito.creation.instance.InstantiationException;
 import org.mockito.creation.instance.Instantiator;
@@ -100,7 +99,6 @@ import static org.mockito.internal.util.StringUtil.join;
  * (also known as HotSwap). All major VM distributions such as HotSpot (OpenJDK), J9 (IBM/Websphere) or Zing (Azul)
  * support this feature.
  */
-@Incubating
 @SuppressSignatureCheck
 class InlineDelegateByteBuddyMockMaker
         implements ClassCreatingMockMaker, InlineMockMaker, Instantiator {

--- a/src/main/java/org/mockito/invocation/InvocationContainer.java
+++ b/src/main/java/org/mockito/invocation/InvocationContainer.java
@@ -4,7 +4,6 @@
  */
 package org.mockito.invocation;
 
-import org.mockito.Incubating;
 import org.mockito.NotExtensible;
 
 /**
@@ -17,5 +16,4 @@ import org.mockito.NotExtensible;
  * @since 2.10.0
  */
 @NotExtensible
-@Incubating
 public interface InvocationContainer {}

--- a/src/main/java/org/mockito/invocation/InvocationFactory.java
+++ b/src/main/java/org/mockito/invocation/InvocationFactory.java
@@ -7,7 +7,6 @@ package org.mockito.invocation;
 import java.io.Serializable;
 import java.lang.reflect.Method;
 
-import org.mockito.Incubating;
 import org.mockito.MockitoFramework;
 import org.mockito.mock.MockCreationSettings;
 
@@ -23,7 +22,6 @@ import org.mockito.mock.MockCreationSettings;
  *
  * @since 2.10.0
  */
-@Incubating
 public interface InvocationFactory {
 
     /**
@@ -49,7 +47,6 @@ public interface InvocationFactory {
      * @return invocation instance
      * @since 2.14.0
      */
-    @Incubating
     Invocation createInvocation(
             Object target,
             MockCreationSettings settings,

--- a/src/main/java/org/mockito/invocation/MockHandler.java
+++ b/src/main/java/org/mockito/invocation/MockHandler.java
@@ -6,7 +6,6 @@ package org.mockito.invocation;
 
 import java.io.Serializable;
 
-import org.mockito.Incubating;
 import org.mockito.MockSettings;
 import org.mockito.mock.MockCreationSettings;
 
@@ -44,7 +43,6 @@ public interface MockHandler<T> extends Serializable {
      * @return read-only settings of the mock
      * @since 2.10.0
      */
-    @Incubating
     MockCreationSettings<T> getMockSettings();
 
     /**
@@ -60,6 +58,5 @@ public interface MockHandler<T> extends Serializable {
      *          The container is not part of the public API, please do not cast it or provide custom implementations.
      * @since 2.10.0
      */
-    @Incubating
     InvocationContainer getInvocationContainer();
 }

--- a/src/main/java/org/mockito/junit/MockitoJUnit.java
+++ b/src/main/java/org/mockito/junit/MockitoJUnit.java
@@ -5,7 +5,6 @@
 package org.mockito.junit;
 
 import org.junit.rules.TestRule;
-import org.mockito.Incubating;
 import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.internal.junit.JUnitRule;
 import org.mockito.internal.junit.JUnitTestRule;
@@ -56,7 +55,6 @@ public final class MockitoJUnit {
      * @return the rule instance
      * @since 2.1.0
      */
-    @Incubating
     public static VerificationCollector collector() {
         return new VerificationCollectorImpl();
     }

--- a/src/main/java/org/mockito/junit/MockitoRule.java
+++ b/src/main/java/org/mockito/junit/MockitoRule.java
@@ -5,7 +5,6 @@
 package org.mockito.junit;
 
 import org.junit.rules.MethodRule;
-import org.mockito.Incubating;
 import org.mockito.MockSettings;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -146,6 +145,5 @@ public interface MockitoRule extends MethodRule {
      *
      * @since 2.3.0
      */
-    @Incubating
     MockitoRule strictness(Strictness strictness);
 }

--- a/src/main/java/org/mockito/junit/MockitoTestRule.java
+++ b/src/main/java/org/mockito/junit/MockitoTestRule.java
@@ -5,7 +5,6 @@
 package org.mockito.junit;
 
 import org.junit.rules.TestRule;
-import org.mockito.Incubating;
 import org.mockito.quality.Strictness;
 
 /**
@@ -28,6 +27,5 @@ public interface MockitoTestRule extends TestRule {
      *
      * @since 3.3.0
      */
-    @Incubating
     MockitoTestRule strictness(Strictness strictness);
 }

--- a/src/main/java/org/mockito/junit/VerificationCollector.java
+++ b/src/main/java/org/mockito/junit/VerificationCollector.java
@@ -5,7 +5,6 @@
 package org.mockito.junit;
 
 import org.junit.rules.TestRule;
-import org.mockito.Incubating;
 import org.mockito.exceptions.base.MockitoAssertionError;
 
 /**
@@ -37,7 +36,6 @@ import org.mockito.exceptions.base.MockitoAssertionError;
  * @see org.mockito.Mockito#verify(Object, org.mockito.verification.VerificationMode)
  * @since 2.1.0
  */
-@Incubating
 public interface VerificationCollector extends TestRule {
 
     /**
@@ -70,7 +68,6 @@ public interface VerificationCollector extends TestRule {
      * @throws MockitoAssertionError If there were failed verifications
      * @since 2.1.0
      */
-    @Incubating
     void collectAndReport() throws MockitoAssertionError;
 
     /**
@@ -96,6 +93,5 @@ public interface VerificationCollector extends TestRule {
      * @return this
      * @since 2.1.0
      */
-    @Incubating
     VerificationCollector assertLazily();
 }

--- a/src/main/java/org/mockito/listeners/VerificationListener.java
+++ b/src/main/java/org/mockito/listeners/VerificationListener.java
@@ -4,7 +4,6 @@
  */
 package org.mockito.listeners;
 
-import org.mockito.Incubating;
 import org.mockito.verification.VerificationEvent;
 
 /**
@@ -12,7 +11,6 @@ import org.mockito.verification.VerificationEvent;
  * <p>
  * For this to happen, it must be registered using {@link org.mockito.internal.progress.MockingProgress#addListener(MockitoListener)}.
  */
-@Incubating
 public interface VerificationListener extends MockitoListener {
     /**
      * Called after a verification happened.

--- a/src/main/java/org/mockito/listeners/VerificationStartedEvent.java
+++ b/src/main/java/org/mockito/listeners/VerificationStartedEvent.java
@@ -4,15 +4,12 @@
  */
 package org.mockito.listeners;
 
-import org.mockito.Incubating;
-
 /**
  * The instance of this class is passed to {@link VerificationStartedListener}.
  * For all the details, including how and why to use this API, see {@link VerificationStartedListener}.
  *
  * @since 2.11.0
  */
-@Incubating
 public interface VerificationStartedEvent {
 
     /**
@@ -27,7 +24,6 @@ public interface VerificationStartedEvent {
      * @param mock to be used for verification.
      * @since 2.11.0
      */
-    @Incubating
     void setMock(Object mock);
 
     /**
@@ -37,6 +33,5 @@ public interface VerificationStartedEvent {
      *
      * @since 2.11.0
      */
-    @Incubating
     Object getMock();
 }

--- a/src/main/java/org/mockito/listeners/VerificationStartedListener.java
+++ b/src/main/java/org/mockito/listeners/VerificationStartedListener.java
@@ -4,8 +4,6 @@
  */
 package org.mockito.listeners;
 
-import org.mockito.Incubating;
-
 /**
  * This listener gets notified when the user starts verification.
  * It allows to replace the mock object for verification.
@@ -54,7 +52,6 @@ import org.mockito.Incubating;
  *
  * @since 2.11.0
  */
-@Incubating
 public interface VerificationStartedListener {
 
     /**
@@ -64,6 +61,5 @@ public interface VerificationStartedListener {
      * @param event object that allows to identify and replace mock for verification.
      * @since 2.11.0
      */
-    @Incubating
     void onVerificationStarted(VerificationStartedEvent event);
 }

--- a/src/main/java/org/mockito/mock/MockCreationSettings.java
+++ b/src/main/java/org/mockito/mock/MockCreationSettings.java
@@ -7,7 +7,6 @@ package org.mockito.mock;
 import java.util.List;
 import java.util.Set;
 
-import org.mockito.Incubating;
 import org.mockito.MockSettings;
 import org.mockito.NotExtensible;
 import org.mockito.listeners.InvocationListener;
@@ -90,7 +89,6 @@ public interface MockCreationSettings<T> {
      *
      * @since 2.11.0
      */
-    @Incubating
     List<VerificationStartedListener> getVerificationStartedListeners();
 
     /**
@@ -98,7 +96,6 @@ public interface MockCreationSettings<T> {
      *
      * @since 1.10.12
      */
-    @Incubating
     boolean isUsingConstructor();
 
     /**
@@ -110,7 +107,6 @@ public interface MockCreationSettings<T> {
      *
      * @since 2.7.14
      */
-    @Incubating
     Object[] getConstructorArgs();
 
     /**
@@ -119,7 +115,6 @@ public interface MockCreationSettings<T> {
      * @return the outer class instance used for creation of the mock object via the constructor.
      * @since 1.10.12
      */
-    @Incubating
     Object getOuterClassInstance();
 
     /**
@@ -128,6 +123,5 @@ public interface MockCreationSettings<T> {
      *
      * @since 2.20.0
      */
-    @Incubating
     boolean isLenient();
 }

--- a/src/main/java/org/mockito/mock/SerializableMode.java
+++ b/src/main/java/org/mockito/mock/SerializableMode.java
@@ -4,12 +4,9 @@
  */
 package org.mockito.mock;
 
-import org.mockito.Incubating;
-
 /**
  * Mock serializable style.
  */
-@Incubating
 public enum SerializableMode {
 
     /**
@@ -25,6 +22,5 @@ public enum SerializableMode {
     /**
      * Useful if the mock is deserialized in a different classloader / vm.
      */
-    @Incubating
     ACROSS_CLASSLOADERS
 }

--- a/src/main/java/org/mockito/plugins/InlineMockMaker.java
+++ b/src/main/java/org/mockito/plugins/InlineMockMaker.java
@@ -4,7 +4,6 @@
  */
 package org.mockito.plugins;
 
-import org.mockito.Incubating;
 import org.mockito.MockitoFramework;
 
 /**
@@ -26,7 +25,6 @@ import org.mockito.MockitoFramework;
  *
  * @since 2.25.0
  */
-@Incubating
 public interface InlineMockMaker extends MockMaker {
 
     /**
@@ -36,7 +34,6 @@ public interface InlineMockMaker extends MockMaker {
      * @param mock the mock instance whose internal state is to be cleaned.
      * @since 2.25.0
      */
-    @Incubating
     void clearMock(Object mock);
 
     /**
@@ -45,6 +42,5 @@ public interface InlineMockMaker extends MockMaker {
      *
      * @since 2.25.0
      */
-    @Incubating
     void clearAllMocks();
 }

--- a/src/main/java/org/mockito/plugins/MemberAccessor.java
+++ b/src/main/java/org/mockito/plugins/MemberAccessor.java
@@ -4,8 +4,6 @@
  */
 package org.mockito.plugins;
 
-import org.mockito.Incubating;
-
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -15,7 +13,6 @@ import java.lang.reflect.Method;
  * A member accessor is responsible for invoking methods, constructors and for setting
  * and reading field values.
  */
-@Incubating
 public interface MemberAccessor {
 
     Object newInstance(Constructor<?> constructor, Object... arguments)

--- a/src/main/java/org/mockito/plugins/MockMaker.java
+++ b/src/main/java/org/mockito/plugins/MockMaker.java
@@ -4,7 +4,6 @@
  */
 package org.mockito.plugins;
 
-import org.mockito.Incubating;
 import org.mockito.MockedConstruction;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.invocation.MockHandler;
@@ -132,7 +131,6 @@ public interface MockMaker {
      * @return object that carries the information about mockability of given type.
      * @since 2.1.0
      */
-    @Incubating
     TypeMockability isTypeMockable(Class<?> type);
 
     /**
@@ -151,7 +149,6 @@ public interface MockMaker {
      * @return A control for the static mock.
      * @since 3.4.0
      */
-    @Incubating
     default <T> StaticMockControl<T> createStaticMock(
             Class<T> type, MockCreationSettings<T> settings, MockHandler handler) {
         throw new MockitoException(
@@ -181,7 +178,6 @@ public interface MockMaker {
      * @return A control for the mocked construction.
      * @since 3.5.0
      */
-    @Incubating
     default <T> ConstructionMockControl<T> createConstructionMock(
             Class<T> type,
             Function<MockedConstruction.Context, MockCreationSettings<T>> settingsFactory,
@@ -201,7 +197,6 @@ public interface MockMaker {
     /**
      * Clears all cashes for mocked types and removes all byte code alterations, if possible.
      */
-    @Incubating
     default void clearAllCaches() {}
 
     /**
@@ -209,7 +204,6 @@ public interface MockMaker {
      *
      * @since 2.1.0
      */
-    @Incubating
     interface TypeMockability {
         /**
          * informs if type is mockable
@@ -222,7 +216,6 @@ public interface MockMaker {
         String nonMockableReason();
     }
 
-    @Incubating
     interface StaticMockControl<T> {
 
         Class<T> getType();
@@ -232,7 +225,6 @@ public interface MockMaker {
         void disable();
     }
 
-    @Incubating
     interface ConstructionMockControl<T> {
 
         Class<T> getType();

--- a/src/main/java/org/mockito/plugins/MockitoLogger.java
+++ b/src/main/java/org/mockito/plugins/MockitoLogger.java
@@ -4,8 +4,6 @@
  */
 package org.mockito.plugins;
 
-import org.mockito.Incubating;
-
 /**
  * Mockito logger.
  *
@@ -35,13 +33,11 @@ import org.mockito.Incubating;
  *
  * @since 2.23.19
  */
-@Incubating
 public interface MockitoLogger {
     /**
      * Log specified object.
      *
      * @param what to be logged
      */
-    @Incubating
     void log(Object what);
 }

--- a/src/main/java/org/mockito/plugins/PluginSwitch.java
+++ b/src/main/java/org/mockito/plugins/PluginSwitch.java
@@ -4,8 +4,6 @@
  */
 package org.mockito.plugins;
 
-import org.mockito.Incubating;
-
 /**
  * Allows switching off the plugins that are discovered on classpath.
  *
@@ -42,7 +40,6 @@ import org.mockito.Incubating;
  *
  * @since 1.10.15
  */
-@Incubating
 public interface PluginSwitch {
 
     /**

--- a/src/main/java/org/mockito/quality/Strictness.java
+++ b/src/main/java/org/mockito/quality/Strictness.java
@@ -4,7 +4,6 @@
  */
 package org.mockito.quality;
 
-import org.mockito.Incubating;
 import org.mockito.MockitoSession;
 import org.mockito.exceptions.misusing.PotentialStubbingProblem;
 import org.mockito.exceptions.misusing.UnnecessaryStubbingException;
@@ -38,7 +37,6 @@ import org.mockito.junit.MockitoRule;
  *
  * @since 2.3.0
  */
-@Incubating
 public enum Strictness {
 
     /**
@@ -49,7 +47,6 @@ public enum Strictness {
      *
      * @since 2.3.0
      */
-    @Incubating
     LENIENT,
 
     /**
@@ -62,7 +59,6 @@ public enum Strictness {
      *
      * @since 2.3.0
      */
-    @Incubating
     WARN,
 
     /**
@@ -88,6 +84,5 @@ public enum Strictness {
      *
      * @since 2.3.0
      */
-    @Incubating
     STRICT_STUBS;
 }

--- a/src/main/java/org/mockito/session/MockitoSessionBuilder.java
+++ b/src/main/java/org/mockito/session/MockitoSessionBuilder.java
@@ -4,7 +4,6 @@
  */
 package org.mockito.session;
 
-import org.mockito.Incubating;
 import org.mockito.MockitoAnnotations;
 import org.mockito.MockitoSession;
 import org.mockito.NotExtensible;
@@ -17,7 +16,6 @@ import org.mockito.quality.Strictness;
  *
  * @since 2.7.0
  */
-@Incubating
 @NotExtensible
 public interface MockitoSessionBuilder {
 
@@ -41,7 +39,6 @@ public interface MockitoSessionBuilder {
      * @return the same builder instance for fluent configuration of {@code MockitoSession}.
      * @since 2.7.0
      */
-    @Incubating
     MockitoSessionBuilder initMocks(Object testClassInstance);
 
     /**
@@ -59,7 +56,6 @@ public interface MockitoSessionBuilder {
      * @see #initMocks(Object)
      * @since 2.15.0
      */
-    @Incubating
     MockitoSessionBuilder initMocks(Object... testClassInstances);
 
     /**
@@ -81,7 +77,6 @@ public interface MockitoSessionBuilder {
      * @see org.mockito.quality.MockitoHint
      * @since 2.15.0
      */
-    @Incubating
     MockitoSessionBuilder name(String name);
 
     /**
@@ -95,7 +90,6 @@ public interface MockitoSessionBuilder {
      * @return the same builder instance for fluent configuration of {@code MockitoSession}.
      * @since 2.7.0
      */
-    @Incubating
     MockitoSessionBuilder strictness(Strictness strictness);
 
     /**
@@ -114,7 +108,6 @@ public interface MockitoSessionBuilder {
      * @see org.mockito.quality.MockitoHint
      * @since 2.15.0
      */
-    @Incubating
     MockitoSessionBuilder logger(MockitoSessionLogger logger);
 
     /**
@@ -136,6 +129,5 @@ public interface MockitoSessionBuilder {
      * @throws UnfinishedMockingSessionException
      *  when previous session was not concluded with {@link MockitoSession#finishMocking()}
      */
-    @Incubating
     MockitoSession startMocking() throws UnfinishedMockingSessionException;
 }

--- a/src/main/java/org/mockito/session/MockitoSessionLogger.java
+++ b/src/main/java/org/mockito/session/MockitoSessionLogger.java
@@ -4,7 +4,6 @@
  */
 package org.mockito.session;
 
-import org.mockito.Incubating;
 import org.mockito.MockitoSession;
 import org.mockito.NotExtensible;
 
@@ -17,7 +16,6 @@ import org.mockito.NotExtensible;
  *
  * @since 2.15.0
  */
-@Incubating
 @NotExtensible
 public interface MockitoSessionLogger {
 
@@ -26,6 +24,5 @@ public interface MockitoSessionLogger {
      *
      * @param hint to log; never {@code null}
      */
-    @Incubating
     void log(String hint);
 }

--- a/src/main/java/org/mockito/stubbing/Answer1.java
+++ b/src/main/java/org/mockito/stubbing/Answer1.java
@@ -4,8 +4,6 @@
  */
 package org.mockito.stubbing;
 
-import org.mockito.Incubating;
-
 /**
  * Generic interface to be used for configuring mock's answer for a single argument invocation.
  *
@@ -31,7 +29,6 @@ import org.mockito.Incubating;
  * @param <A0> type of the single argument
  * @see Answer
  */
-@Incubating
 public interface Answer1<T, A0> {
     /**
      * @param argument0 the single argument.

--- a/src/main/java/org/mockito/stubbing/Answer2.java
+++ b/src/main/java/org/mockito/stubbing/Answer2.java
@@ -4,8 +4,6 @@
  */
 package org.mockito.stubbing;
 
-import org.mockito.Incubating;
-
 /**
  * Generic interface to be used for configuring mock's answer for a two argument invocation.
  *
@@ -32,7 +30,6 @@ import org.mockito.Incubating;
  * @param <A1> type of the second argument
  * @see Answer
  */
-@Incubating
 public interface Answer2<T, A0, A1> {
     /**
      * @param argument0 the first argument.

--- a/src/main/java/org/mockito/stubbing/Answer3.java
+++ b/src/main/java/org/mockito/stubbing/Answer3.java
@@ -4,8 +4,6 @@
  */
 package org.mockito.stubbing;
 
-import org.mockito.Incubating;
-
 /**
  * Generic interface to be used for configuring mock's answer for a three argument invocation.
  *
@@ -33,7 +31,6 @@ import org.mockito.Incubating;
  * @param <A2> type of the third argument
  * @see Answer
  */
-@Incubating
 public interface Answer3<T, A0, A1, A2> {
     /**
      * @param argument0 the first argument.

--- a/src/main/java/org/mockito/stubbing/Answer4.java
+++ b/src/main/java/org/mockito/stubbing/Answer4.java
@@ -4,8 +4,6 @@
  */
 package org.mockito.stubbing;
 
-import org.mockito.Incubating;
-
 /**
  * Generic interface to be used for configuring mock's answer for a four argument invocation.
  *
@@ -34,7 +32,6 @@ import org.mockito.Incubating;
  * @param <A3> type of the fourth argument
  * @see Answer
  */
-@Incubating
 public interface Answer4<T, A0, A1, A2, A3> {
     /**
      * @param argument0 the first argument.

--- a/src/main/java/org/mockito/stubbing/Answer5.java
+++ b/src/main/java/org/mockito/stubbing/Answer5.java
@@ -4,8 +4,6 @@
  */
 package org.mockito.stubbing;
 
-import org.mockito.Incubating;
-
 /**
  * Generic interface to be used for configuring mock's answer for a five argument invocation.
  *
@@ -34,7 +32,6 @@ import org.mockito.Incubating;
  * @param <A3> type of the fourth argument
  * @see Answer
  */
-@Incubating
 public interface Answer5<T, A0, A1, A2, A3, A4> {
     /**
      * @param argument0 the first argument.

--- a/src/main/java/org/mockito/stubbing/Answer6.java
+++ b/src/main/java/org/mockito/stubbing/Answer6.java
@@ -4,8 +4,6 @@
  */
 package org.mockito.stubbing;
 
-import org.mockito.Incubating;
-
 /**
  * Generic interface to be used for configuring mock's answer for a six argument invocation.
  *
@@ -36,7 +34,6 @@ import org.mockito.Incubating;
  * @param <A5> type of the sixth argument
  * @see Answer
  */
-@Incubating
 public interface Answer6<T, A0, A1, A2, A3, A4, A5> {
     /**
      * @param argument0 the first argument.

--- a/src/main/java/org/mockito/stubbing/Stubbing.java
+++ b/src/main/java/org/mockito/stubbing/Stubbing.java
@@ -4,7 +4,6 @@
  */
 package org.mockito.stubbing;
 
-import org.mockito.Incubating;
 import org.mockito.MockingDetails;
 import org.mockito.Mockito;
 import org.mockito.NotExtensible;
@@ -60,6 +59,5 @@ public interface Stubbing extends Answer {
      *
      * @since 2.20.0
      */
-    @Incubating
     Strictness getStrictness();
 }

--- a/src/main/java/org/mockito/stubbing/ValidableAnswer.java
+++ b/src/main/java/org/mockito/stubbing/ValidableAnswer.java
@@ -4,7 +4,6 @@
  */
 package org.mockito.stubbing;
 
-import org.mockito.Incubating;
 import org.mockito.invocation.InvocationOnMock;
 
 /**
@@ -68,7 +67,6 @@ import org.mockito.invocation.InvocationOnMock;
  *
  * @since 2.3.8
  */
-@Incubating
 public interface ValidableAnswer {
 
     /**

--- a/src/main/java/org/mockito/stubbing/VoidAnswer1.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer1.java
@@ -4,8 +4,6 @@
  */
 package org.mockito.stubbing;
 
-import org.mockito.Incubating;
-
 /**
  * Generic interface to be used for configuring mock's answer for a single argument invocation that returns nothing.
  *
@@ -30,7 +28,6 @@ import org.mockito.Incubating;
  * @param <A0> type of the single argument
  * @see Answer
  */
-@Incubating
 public interface VoidAnswer1<A0> {
     /**
      * @param argument0 the single argument.

--- a/src/main/java/org/mockito/stubbing/VoidAnswer2.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer2.java
@@ -4,8 +4,6 @@
  */
 package org.mockito.stubbing;
 
-import org.mockito.Incubating;
-
 /**
  * Generic interface to be used for configuring mock's answer for a two argument invocation that returns nothing.
  *
@@ -31,7 +29,6 @@ import org.mockito.Incubating;
  * @param <A1> type of the second argument
  * @see Answer
  */
-@Incubating
 public interface VoidAnswer2<A0, A1> {
     /**
      * @param argument0 the first argument.

--- a/src/main/java/org/mockito/stubbing/VoidAnswer3.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer3.java
@@ -4,8 +4,6 @@
  */
 package org.mockito.stubbing;
 
-import org.mockito.Incubating;
-
 /**
  * Generic interface to be used for configuring mock's answer for a three argument invocation that returns nothing.
  *
@@ -32,7 +30,6 @@ import org.mockito.Incubating;
  * @param <A2> type of the third argument
  * @see Answer
  */
-@Incubating
 public interface VoidAnswer3<A0, A1, A2> {
     /**
      * @param argument0 the first argument.

--- a/src/main/java/org/mockito/stubbing/VoidAnswer4.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer4.java
@@ -4,8 +4,6 @@
  */
 package org.mockito.stubbing;
 
-import org.mockito.Incubating;
-
 /**
  * Generic interface to be used for configuring mock's answer for a four argument invocation that returns nothing.
  *
@@ -33,7 +31,6 @@ import org.mockito.Incubating;
  * @param <A3> type of the fourth argument
  * @see Answer
  */
-@Incubating
 public interface VoidAnswer4<A0, A1, A2, A3> {
     /**
      * @param argument0 the first argument.

--- a/src/main/java/org/mockito/stubbing/VoidAnswer5.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer5.java
@@ -4,8 +4,6 @@
  */
 package org.mockito.stubbing;
 
-import org.mockito.Incubating;
-
 /**
  * Generic interface to be used for configuring mock's answer for a five argument invocation that returns nothing.
  *
@@ -34,7 +32,6 @@ import org.mockito.Incubating;
  * @param <A4> type of the fifth argument
  * @see Answer
  */
-@Incubating
 public interface VoidAnswer5<A0, A1, A2, A3, A4> {
     /**
      * @param argument0 the first argument.

--- a/src/main/java/org/mockito/stubbing/VoidAnswer6.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer6.java
@@ -4,8 +4,6 @@
  */
 package org.mockito.stubbing;
 
-import org.mockito.Incubating;
-
 /**
  * Generic interface to be used for configuring mock's answer for a six argument invocation that returns nothing.
  *
@@ -35,7 +33,6 @@ import org.mockito.Incubating;
  * @param <A5> type of the sixth argument
  * @see Answer
  */
-@Incubating
 public interface VoidAnswer6<A0, A1, A2, A3, A4, A5> {
     /**
      * @param argument0 the first argument.

--- a/src/main/java/org/mockito/verification/VerificationEvent.java
+++ b/src/main/java/org/mockito/verification/VerificationEvent.java
@@ -4,13 +4,11 @@
  */
 package org.mockito.verification;
 
-import org.mockito.Incubating;
 import org.mockito.internal.verification.api.VerificationData;
 
 /**
  * Contains all information about a verification that has happened.
  */
-@Incubating
 public interface VerificationEvent {
     /**
      * @return The mock that a verification happened on.


### PR DESCRIPTION
For all of these APIs, we have been shipping them for at least 1 major
release. We consider all of these APIs part of the public API contract
now and therefore we should mark them as such.

This PR removes all usages of the annotation. If we were to later remove
an API, it will first have to be deprecated and then removed in a
subsequent major release. However, we have no plans to do so with any of
these APIs.

Closes #2433