### PR TITLE
Fixes #2389 : Parallel use of mocks with deep stubbing may lead to ConcurrentModificationException

### DIFF
--- a/src/main/java/org/mockito/internal/stubbing/InvocationContainerImpl.java
+++ b/src/main/java/org/mockito/internal/stubbing/InvocationContainerImpl.java
@@ -163,13 +163,20 @@ public class InvocationContainerImpl implements InvocationContainer, Serializabl
         return invocationForStubbing.getInvocation().getMock();
     }
 
-    public MatchableInvocation getInvocationForStubbing() {
-        return invocationForStubbing;
-    }
-
     private RegisteredInvocations createRegisteredInvocations(MockCreationSettings mockSettings) {
         return mockSettings.isStubOnly()
                 ? new SingleRegisteredInvocation()
                 : new DefaultRegisteredInvocations();
+    }
+
+    public Answer findStubbedAnswer() {
+        synchronized (stubbed) {
+            for (StubbedInvocationMatcher s : stubbed) {
+                if (invocationForStubbing.matches(s.getInvocation())) {
+                    return s;
+                }
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsDeepStubs.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsDeepStubs.java
@@ -20,7 +20,6 @@ import org.mockito.internal.util.reflection.GenericMetadataSupport;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.stubbing.Answer;
-import org.mockito.stubbing.Stubbing;
 
 /**
  * Returning deep stub implementation.
@@ -80,12 +79,9 @@ public class ReturnsDeepStubs implements Answer<Object>, Serializable {
             throws Throwable {
         InvocationContainerImpl container = MockUtil.getInvocationContainer(invocation.getMock());
 
-        // matches invocation for verification
-        // TODO why don't we do container.findAnswer here?
-        for (Stubbing stubbing : container.getStubbingsDescending()) {
-            if (container.getInvocationForStubbing().matches(stubbing.getInvocation())) {
-                return stubbing.answer(invocation);
-            }
+        Answer existingAnswer = container.findStubbedAnswer();
+        if (existingAnswer != null) {
+            return existingAnswer.answer(invocation);
         }
 
         // record deep stub answer

--- a/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsDeepStubsConcurrentTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsDeepStubsConcurrentTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.stubbing.defaultanswers;
+
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.junit.Test;
+import org.mockito.Answers;
+
+public class ReturnsDeepStubsConcurrentTest {
+
+    @Test
+    public void
+            given_mock_with_returns_deep_stubs__when_called_concurrently__then_does_not_throw_concurrent_modification_exception() {
+        for (int i = 0; i < 1000; i++) {
+            Service mock = mock(Service.class, Answers.RETURNS_DEEP_STUBS);
+            IntStream.range(1, 100).parallel().forEach(index -> mock.doSomething());
+        }
+    }
+
+    interface Service {
+        List<String> doSomething();
+    }
+}


### PR DESCRIPTION
Fixes #2389 "Parallel use of mocks with deep stubbing may lead to ConcurrentModificationException"

The issue was that ReturnsDeepStubs (line 82) retrieved the existings stubbings via `InvocationContainerImpl::getStubbingsDescending`, and iterating on it to find existing stubbings resulted in a `ConcurrentModificationException` because other threads were adding their own `Answer` to the stubbings list (`InvocationContainerImpl::addAnswer` called at `ReturnsDeepStubs` line 150).

All of the methods in `InvocationContainerImpl` that mutate the `LinkedList<StubbedInvocationMatcher> stubbed` field are synchronized on `stubbed`, but the getters aren't (`getStubbingsAscending` and `getStubbingsDescending`). I added a `InvocationMatcherImpl::findStubbedAnswer` that does basically what `ReturnsDeepStubs` used to do, but synchronizing on `stubbed`.

Somebody had been there before and had noticed there was something weird, because there was a TODO in the code:

```
// TODO why don't we do container.findAnswer here?
```
However, I tried that in my original solution (using `findAnswerFor()`), but it didn't work because it used the `matches()` method from the elements of `stubbed`, which don't have the matchers from `verify()` (see test and debugger screenshots below).
![image](https://user-images.githubusercontent.com/22927506/137038686-658da098-14a6-4967-978e-1291fa7a6392.png)
![image](https://user-images.githubusercontent.com/22927506/137038640-c43df08f-7388-411e-a381-f64332fd9b69.png)


I also added a test for regressions.

**EDIT**: described new solution