### PR TITLE
Use new CodeCov uploader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,18 @@ jobs:
     - name: 7. Upload coverage report
       run: |
         ./gradlew coverageReport -s --scan && cp build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml jacoco.xml
-        bash <(curl -s https://codecov.io/bash)
+        curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
+
+        curl -Os https://uploader.codecov.io/latest/linux/codecov
+        curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+        curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+
+        gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+        shasum -a 256 -c codecov.SHA256SUM
+
+        chmod +x codecov
+        ./codecov
+
 
   #
   # Release job, only for pushes to the main development branch


### PR DESCRIPTION
Per https://about.codecov.io/blog/introducing-codecovs-new-uploader/ the Bash uploader has been deprecated.
The Bash uploader will randomly stop working, meaning we won't be able to inspect our code coverage reports.

Instead, we should be using the new uploader.
We should also check its integrity to avoid a repeat of the security vulnerability in the Bash uploader.
