### PR TITLE
Revert "Bump appcompat from 1.3.1 to 1.4.0"

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -44,7 +44,7 @@ libraries.kotlin = [
 ]
 libraries.android = [
     ktx: 'androidx.core:core-ktx:1.7.0',
-    compat: 'androidx.appcompat:appcompat:1.4.0',
+    compat: 'androidx.appcompat:appcompat:1.3.1',
     material: 'com.google.android.material:material:1.4.0',
     junit: 'androidx.test.ext:junit:1.1.3',
     espresso: 'androidx.test.espresso:espresso-core:3.4.0',


### PR DESCRIPTION
Reverts mockito/mockito#2477

Trying to figure out if this is causing https://github.com/mockito/mockito/issues/2478