### PR TITLE
Remove the recommendation to import ArgumentMatchers methods using Mockito

### DIFF
--- a/src/main/java/org/mockito/ArgumentMatchers.java
+++ b/src/main/java/org/mockito/ArgumentMatchers.java
@@ -32,9 +32,6 @@ import org.mockito.internal.util.Primitives;
 /**
  * Allow flexible verification or stubbing. See also {@link AdditionalMatchers}.
  *
- * <p>
- * {@link Mockito} extends ArgumentMatchers so to get access to all matchers just import Mockito class statically.
- *
  * <pre class="code"><code class="java">
  * //stubbing using anyInt() argument matcher
  * when(mockedList.get(anyInt())).thenReturn("element");


### PR DESCRIPTION
The change removes the recommendation in javadoc to import methods in ArgumentMatchers by their non-canonical name, e.g. using `import static org.mockito.ArgumentMatchers.any;` to import `org.mockito.ArgumentMatchers.any` may be clearer than `import org.mockito.Mockito.any;`.

There's some related discussion in http://errorprone.info/bugpattern/NonCanonicalStaticImport