### PR TITLE
Make sure interface types are initialized before inline mocking to avoid blocking code of static initializers.

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
@@ -252,8 +252,8 @@ public class InlineBytecodeGenerator implements BytecodeGenerator, ClassFileTran
                 } else {
                     do {
                         if (mocked.add(type)) {
-                            assureInitialization(type);
                             if (!flatMocked.remove(type)) {
+                                assureInitialization(type);
                                 targets.add(type);
                             }
                             addInterfaces(targets, type.getInterfaces());
@@ -356,6 +356,7 @@ public class InlineBytecodeGenerator implements BytecodeGenerator, ClassFileTran
         for (Class<?> type : interfaces) {
             if (mocked.add(type)) {
                 if (!flatMocked.remove(type)) {
+                    assureInitialization(type);
                     types.add(type);
                 }
                 addInterfaces(types, type.getInterfaces());

--- a/subprojects/inline/src/test/java/org/mockitoinline/HierarchyPreInitializationTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/HierarchyPreInitializationTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitoinline;
+
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class HierarchyPreInitializationTest {
+
+    @Test
+    @SuppressWarnings("CheckReturnValue")
+    public void testOrder() {
+        mock(MyClass.class);
+        mock(TestSubInterface.class);
+    }
+
+    public interface TestInterface {
+
+        @SuppressWarnings("unused")
+        MyClass INSTANCE = new MyClass().probe();
+    }
+
+    public interface TestSubInterface extends TestInterface {
+    }
+
+    public static class MyClass {
+
+        private final Object obj;
+
+        public MyClass() {
+            obj = new Object();
+        }
+
+        public MyClass probe() {
+            if (obj == null) {
+                throw new RuntimeException();
+            }
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/mockito/mockito/issues/2499

There was no explicit initialization of subinterfaces which can of course also declare initializers. Those were not executed at the right time and broke the mocking.