### PR TITLE
Fixes #2497: Throw exception on invalid matchers for `mockStatic`

### DIFF
--- a/src/main/java/org/mockito/internal/MockedStaticImpl.java
+++ b/src/main/java/org/mockito/internal/MockedStaticImpl.java
@@ -47,6 +47,8 @@ public final class MockedStaticImpl<T> implements MockedStatic<T> {
 
         try {
             verification.apply();
+        } catch (MockitoException exception) {
+            throw exception;
         } catch (Throwable ignored) {
         }
 

--- a/subprojects/inline/inline.gradle
+++ b/subprojects/inline/inline.gradle
@@ -5,6 +5,7 @@ apply from: "$rootDir/gradle/java-library.gradle"
 dependencies {
     api project.rootProject
     testImplementation libraries.junit4
+    testImplementation libraries.assertj
 }
 
 tasks.javadoc.enabled = false

--- a/subprojects/inline/src/test/java/org/mockitoinline/StaticMockTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/StaticMockTest.java
@@ -7,11 +7,14 @@ package org.mockitoinline;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNull;
 import static junit.framework.TestCase.fail;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.exceptions.base.MockitoException;
@@ -19,6 +22,9 @@ import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockito.exceptions.verification.WantedButNotInvoked;
 
 public final class StaticMockTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
 
     @Test
     public void testStaticMockSimple() {
@@ -177,6 +183,20 @@ public final class StaticMockTest {
         assertEquals("bar", Dummy.var1);
     }
 
+    @Test
+    public void testStaticMockMustUseValidMatchers() {
+        exception.expect(MockitoException.class);
+        exception.expectMessage("Invalid use of argument matchers!\n" +
+            "2 matchers expected, 1 recorded:\n" +
+            "-> at org.mockitoinline.StaticMockTest");
+
+        try (MockedStatic<Dummy> mockedClass = Mockito.mockStatic(Dummy.class)) {
+            mockedClass.when(() -> Dummy.fooVoid("foo", any())).thenReturn(null);
+
+            Dummy.fooVoid("foo", "bar");
+        }
+    }
+
     static class Dummy {
 
         static String var1 = null;
@@ -186,6 +206,10 @@ public final class StaticMockTest {
         }
 
         static void fooVoid(String var2) {
+            var1 = var2;
+        }
+
+        static void fooVoid(String var2, String var3) {
             var1 = var2;
         }
     }

--- a/subprojects/inline/src/test/java/org/mockitoinline/StaticMockTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/StaticMockTest.java
@@ -7,14 +7,14 @@ package org.mockitoinline;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNull;
 import static junit.framework.TestCase.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Rule;
+import org.assertj.core.api.ThrowableAssert;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.exceptions.base.MockitoException;
@@ -22,9 +22,6 @@ import org.mockito.exceptions.verification.NoInteractionsWanted;
 import org.mockito.exceptions.verification.WantedButNotInvoked;
 
 public final class StaticMockTest {
-
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
 
     @Test
     public void testStaticMockSimple() {
@@ -177,7 +174,7 @@ public final class StaticMockTest {
         try (MockedStatic<Dummy> dummy = Mockito.mockStatic(Dummy.class)) {
             Dummy.fooVoid("bar");
             assertNull(Dummy.var1);
-            dummy.verify(()->Dummy.fooVoid("bar"));
+            dummy.verify(() -> Dummy.fooVoid("bar"));
         }
         Dummy.fooVoid("bar");
         assertEquals("bar", Dummy.var1);
@@ -185,13 +182,14 @@ public final class StaticMockTest {
 
     @Test
     public void testStaticMockMustUseValidMatchers() {
-        exception.expect(MockitoException.class);
-        exception.expectMessage("Invalid use of argument matchers!\n" +
-            "2 matchers expected, 1 recorded:\n" +
-            "-> at org.mockitoinline.StaticMockTest");
-
         try (MockedStatic<Dummy> mockedClass = Mockito.mockStatic(Dummy.class)) {
-            mockedClass.when(() -> Dummy.fooVoid("foo", any())).thenReturn(null);
+            assertThatThrownBy(
+                new ThrowableAssert.ThrowingCallable() {
+                    public void call() {
+                        mockedClass.when(() -> Dummy.fooVoid("foo", any())).thenReturn(null);
+                    }
+                })
+                .hasMessageContaining("Invalid use of argument matchers!");
 
             Dummy.fooVoid("foo", "bar");
         }

--- a/subprojects/inline/src/test/java/org/mockitoinline/StaticMockTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/StaticMockTest.java
@@ -46,7 +46,7 @@ public final class StaticMockTest {
     }
 
     @Test
-    public void testStaticMockWithMoInteractions() {
+    public void testStaticMockWithNoInteractions() {
         try (MockedStatic<Dummy> dummy = Mockito.mockStatic(Dummy.class)) {
             dummy.when(Dummy::foo).thenReturn("bar");
             dummy.verifyNoInteractions();
@@ -54,7 +54,7 @@ public final class StaticMockTest {
     }
 
     @Test(expected = NoInteractionsWanted.class)
-    public void testStaticMockWithMoInteractionsFailed() {
+    public void testStaticMockWithNoInteractionsFailed() {
         try (MockedStatic<Dummy> dummy = Mockito.mockStatic(Dummy.class)) {
             dummy.when(Dummy::foo).thenReturn("bar");
             assertEquals("bar", Dummy.foo());
@@ -63,7 +63,7 @@ public final class StaticMockTest {
     }
 
     @Test
-    public void testStaticMockWithMoMoreInteractions() {
+    public void testStaticMockWithNoMoreInteractions() {
         try (MockedStatic<Dummy> dummy = Mockito.mockStatic(Dummy.class)) {
             dummy.when(Dummy::foo).thenReturn("bar");
             assertEquals("bar", Dummy.foo());
@@ -73,7 +73,7 @@ public final class StaticMockTest {
     }
 
     @Test(expected = NoInteractionsWanted.class)
-    public void testStaticMockWithMoMoreInteractionsFailed() {
+    public void testStaticMockWithNoMoreInteractionsFailed() {
         try (MockedStatic<Dummy> dummy = Mockito.mockStatic(Dummy.class)) {
             dummy.when(Dummy::foo).thenReturn("bar");
             assertEquals("bar", Dummy.foo());


### PR DESCRIPTION
I'm not sure if the `Throwable` catch block can be removed so I decided to keep it for now. Feel free to mention if it can be deleted.

I didn't follow the "snake case convention" for the test method to be consistent with the other test methods of the file, but I'm fine changing it.

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

