### PR TITLE
Fix JavaDoc warnings and enforce zero errors in Gradle

### DIFF
--- a/gradle/mockito-core/javadoc.gradle
+++ b/gradle/mockito-core/javadoc.gradle
@@ -22,8 +22,6 @@ javadoc {
     // While there's errors the javadoc is still generated without those symbols or links ;
     // for this reason the javadoc output is suppressed and can be reactivated with --info option.
     exclude 'org/mockito/internal'
-    logging.captureStandardError LogLevel.INFO
-    logging.captureStandardOutput LogLevel.INFO // suppress "## warnings" message
 
     options.docTitle = """<h1><a href="org/mockito/Mockito.html">Click to see examples</a>. Mockito ${project.version} API.</h1>"""
     options.windowTitle = "Mockito ${project.version} API"
@@ -53,16 +51,8 @@ javadoc {
         <script type="text/javascript" src="{@docRoot}/js/index.js" async defer></script>
     """.replaceAll(/\r|\n|[ ]{8}/, ""))
     options.stylesheetFile rootProject.file("src/javadoc/stylesheet.css")
-    options.addStringOption('Xdoclint:none', '-quiet')
-
-    def minorVersion = System.getProperty("java.version") =~ /1.8.0_(\d*)/
-
-    // Since JDK 8 version 121 scripts are not allowed in comments. However,
-    // earlier version throw an error if an unknown option is passed.
-    // Therefore only add this option if the JDK is actually correct.
-    if (minorVersion.size() > 0 && Integer.valueOf(minorVersion[0][1]) >= 121 || JavaVersion.current().isJava9Compatible()) {
-        options.addBooleanOption('-allow-script-in-comments', true)
-    }
+    options.addStringOption('Xwerror', '-quiet')
+    options.addBooleanOption('-allow-script-in-comments', true)
 
     doLast {
         copy {

--- a/gradle/mockito-core/javadoc.gradle
+++ b/gradle/mockito-core/javadoc.gradle
@@ -40,12 +40,6 @@ javadoc {
     options.noTree = false
     options.links = ['https://docs.oracle.com/javase/6/docs/api/',
                      'https://junit.org/junit4/javadoc/4.12/']
-    options.header("""<em id="mockito-version-header-javadoc7-header"><strong>Mockito ${project.version} API</strong></em>""")
-    // The footer option has no function past JDK 16:
-    // https://github.com/leohacker/jdk16/commit/d47336bf1cef06762cc0c769d93769edf9f05a47
-    if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
-        options.footer("""<em id="mockito-version-header-javadoc7-footer"><strong>Mockito ${project.version} API</strong></em>""")
-    }
     options.bottom("""
         <script type="text/javascript" src="{@docRoot}/js/jdk6-project-version-insert.min.js"></script>
         <script type="text/javascript" src="{@docRoot}/js/jquery-1.7.min.js"></script>

--- a/gradle/mockito-core/javadoc.gradle
+++ b/gradle/mockito-core/javadoc.gradle
@@ -39,7 +39,7 @@ javadoc {
     options.noNavBar = false
     options.noTree = false
     options.links = ['https://docs.oracle.com/javase/6/docs/api/',
-                     'http://junit.org/junit4/javadoc/4.12/']
+                     'https://junit.org/junit4/javadoc/4.12/']
     options.header("""<em id="mockito-version-header-javadoc7-header"><strong>Mockito ${project.version} API</strong></em>""")
     options.footer("""<em id="mockito-version-header-javadoc7-footer"><strong>Mockito ${project.version} API</strong></em>""")
     options.bottom("""

--- a/gradle/mockito-core/javadoc.gradle
+++ b/gradle/mockito-core/javadoc.gradle
@@ -41,7 +41,11 @@ javadoc {
     options.links = ['https://docs.oracle.com/javase/6/docs/api/',
                      'https://junit.org/junit4/javadoc/4.12/']
     options.header("""<em id="mockito-version-header-javadoc7-header"><strong>Mockito ${project.version} API</strong></em>""")
-    options.footer("""<em id="mockito-version-header-javadoc7-footer"><strong>Mockito ${project.version} API</strong></em>""")
+    // The footer option has no function past JDK 16:
+    // https://github.com/leohacker/jdk16/commit/d47336bf1cef06762cc0c769d93769edf9f05a47
+    if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
+        options.footer("""<em id="mockito-version-header-javadoc7-footer"><strong>Mockito ${project.version} API</strong></em>""")
+    }
     options.bottom("""
         <script type="text/javascript" src="{@docRoot}/js/jdk6-project-version-insert.min.js"></script>
         <script type="text/javascript" src="{@docRoot}/js/jquery-1.7.min.js"></script>

--- a/src/main/java/org/mockito/AdditionalAnswers.java
+++ b/src/main/java/org/mockito/AdditionalAnswers.java
@@ -31,7 +31,7 @@ import org.mockito.stubbing.VoidAnswer6;
  *
  * <p>Currently offer answers that can return the parameter of an invocation at a certain position,
  * along with answers that draw on a strongly typed interface to provide a neater way to write custom answers
- * that either return a value or are void (see answer interfaces in {@link org.mockito.stubbing}).
+ * that either return a value or are void (see answer interfaces in org.mockito.stubbing).
  *
  * <p>See factory methods for more information : {@link #returnsFirstArg}, {@link #returnsSecondArg},
  * {@link #returnsLastArg}, {@link #returnsArgAt}, {@link #answer} and {@link #answerVoid}

--- a/src/main/java/org/mockito/ArgumentCaptor.java
+++ b/src/main/java/org/mockito/ArgumentCaptor.java
@@ -15,7 +15,7 @@ import org.mockito.internal.matchers.CapturingMatcher;
  *
  * <p>
  * Mockito verifies argument values in natural java style: by using an equals() method.
- * This is also the recommended way of matching arguments because it makes tests clean & simple.
+ * This is also the recommended way of matching arguments because it makes tests clean and simple.
  * In some situations though, it is helpful to assert on certain arguments after the actual verification.
  * For example:
  * <pre class="code"><code class="java">

--- a/src/main/java/org/mockito/ArgumentMatcher.java
+++ b/src/main/java/org/mockito/ArgumentMatcher.java
@@ -80,7 +80,7 @@ package org.mockito;
  * and use a lambda, e.g.:
  *
  * <pre class="code"><code class="java">
- *   verify(mock).addAll(<b>argThat(list -> list.size() == 2)</b>);
+ *   verify(mock).addAll(<b>argThat(list -&gt; list.size() == 2)</b>);
  * </code></pre>
  *
  * <p>

--- a/src/main/java/org/mockito/MockSettings.java
+++ b/src/main/java/org/mockito/MockSettings.java
@@ -23,12 +23,12 @@ import org.mockito.stubbing.Answer;
  * <p/>
  * Don't use it too often.
  * Consider writing simple tests that use simple mocks.
- * Repeat after me: simple tests push simple, KISSy, readable & maintainable code.
+ * Repeat after me: simple tests push simple, KISSy, readable and maintainable code.
  * If you cannot write a test in a simple way - refactor the code under test.
  * <p/>
  * Examples of mock settings:
  * <pre class="code"><code class="java">
- *   //Creates mock with different default answer & name
+ *   //Creates mock with different default answer and name
  *   Foo mock = mock(Foo.class, withSettings()
  *                                .defaultAnswer(RETURNS_SMART_NULLS)
  *                                .name("cool mockie")
@@ -51,8 +51,8 @@ public interface MockSettings extends Serializable {
      * Specifies extra interfaces the mock should implement. Might be useful for legacy code or some corner cases.
      * <p>
      * This mysterious feature should be used very occasionally.
-     * The object under test should know exactly its collaborators & dependencies.
-     * If you happen to use it often than please make sure you are really producing simple, clean & readable code.
+     * The object under test should know exactly its collaborators and dependencies.
+     * If you happen to use it often than please make sure you are really producing simple, clean and readable code.
      * <p>
      * Examples:
      * <pre class="code"><code class="java">
@@ -101,7 +101,7 @@ public interface MockSettings extends Serializable {
      * <p>
      * However, there are rare cases when partial mocks come handy:
      * dealing with code you cannot change easily (3rd party interfaces, interim refactoring of legacy code etc.)
-     * However, I wouldn't use partial mocks for new, test-driven & well-designed code.
+     * However, I wouldn't use partial mocks for new, test-driven and well-designed code.
      * <p>
      * Enough warnings about partial mocks, see an example how spiedInstance() works:
      * <pre class="code"><code class="java">

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -51,8 +51,8 @@ import java.util.function.Function;
  *
  * <b>
  *      <a href="#0">0. Migrating to Mockito 2</a><br/>
- *      <a href="#0.1">0.1 Mockito Android support</a></br/>
- *      <a href="#0.2">0.2 Configuration-free inline mock making</a></br/>
+ *      <a href="#0.1">0.1 Mockito Android support</a><br/>
+ *      <a href="#0.2">0.2 Configuration-free inline mock making</a><br/>
  *      <a href="#1">1. Let's verify some behaviour! </a><br/>
  *      <a href="#2">2. How about some stubbing? </a><br/>
  *      <a href="#3">3. Argument matchers </a><br/>
@@ -70,7 +70,7 @@ import java.util.function.Function;
  *      <a href="#15">15. Capturing arguments for further assertions (Since 1.8.0) </a><br/>
  *      <a href="#16">16. Real partial mocks (Since 1.8.0) </a><br/>
  *      <a href="#17">17. Resetting mocks (Since 1.8.0) </a><br/>
- *      <a href="#18">18. Troubleshooting & validating framework usage (Since 1.8.0) </a><br/>
+ *      <a href="#18">18. Troubleshooting and validating framework usage (Since 1.8.0) </a><br/>
  *      <a href="#19">19. Aliases for behavior driven development (Since 1.8.0) </a><br/>
  *      <a href="#20">20. Serializable mocks (Since 1.8.1) </a><br/>
  *      <a href="#21">21. New annotations: <code>&#064;Captor</code>, <code>&#064;Spy</code>, <code>&#064;InjectMocks</code> (Since 1.8.3) </a><br/>
@@ -251,7 +251,7 @@ import java.util.function.Function;
  * verify(mockedList).get(anyInt());
  *
  * //<b>argument matchers can also be written as Java 8 Lambdas</b>
- * verify(mockedList).add(argThat(someString -> someString.length() > 5));
+ * verify(mockedList).add(argThat(someString -&gt; someString.length() &gt; 5));
  *
  * </code></pre>
  *
@@ -263,7 +263,7 @@ import java.util.function.Function;
  * For information solely on <b>custom argument matchers</b> check out javadoc for {@link ArgumentMatcher} class.
  * <p>
  * Be reasonable with using complicated argument matching.
- * The natural matching style using <code>equals()</code> with occasional <code>anyX()</code> matchers tend to give clean & simple tests.
+ * The natural matching style using <code>equals()</code> with occasional <code>anyX()</code> matchers tend to give clean and simple tests.
  * Sometimes it's just better to refactor the code to allow <code>equals()</code> matching or even implement <code>equals()</code> method to help out with testing.
  * <p>
  * Also, read <a href="#15">section 15</a> or javadoc for {@link ArgumentCaptor} class.
@@ -524,7 +524,7 @@ import java.util.function.Function;
  * Yet another controversial feature which was not included in Mockito
  * originally. We recommend simply stubbing with <code>thenReturn()</code> or
  * <code>thenThrow()</code>, which should be enough to test/test-drive
- * any clean & simple code. However, if you do have a need to stub with the generic Answer interface, here is an example:
+ * any clean and simple code. However, if you do have a need to stub with the generic Answer interface, here is an example:
  *
  * <pre class="code"><code class="java">
  * when(mock.someMethod(anyString())).thenAnswer(
@@ -679,7 +679,7 @@ import java.util.function.Function;
  * <h3 id="15">15. <a class="meaningful_link" href="#captors" name="captors">Capturing arguments</a> for further assertions (Since 1.8.0)</h3>
  *
  * Mockito verifies argument values in natural java style: by using an <code>equals()</code> method.
- * This is also the recommended way of matching arguments because it makes tests clean & simple.
+ * This is also the recommended way of matching arguments because it makes tests clean and simple.
  * In some situations though, it is helpful to assert on certain arguments after the actual verification.
  * For example:
  * <pre class="code"><code class="java">
@@ -706,7 +706,7 @@ import java.util.function.Function;
  *
  * <h3 id="16">16. <a class="meaningful_link" href="#partial_mocks" name="partial_mocks">Real partial mocks</a> (Since 1.8.0)</h3>
  *
- *  Finally, after many internal debates & discussions on the mailing list, partial mock support was added to Mockito.
+ *  Finally, after many internal debates and discussions on the mailing list, partial mock support was added to Mockito.
  *  Previously we considered partial mocks as code smells. However, we found a legitimate use case for partial mocks.
  *  <p>
  *  <b>Before release 1.8</b> <code>spy()</code> was not producing real partial mocks and it was confusing for some users.
@@ -731,7 +731,7 @@ import java.util.function.Function;
  * <p>
  * However, there are rare cases when partial mocks come handy:
  * dealing with code you cannot change easily (3rd party interfaces, interim refactoring of legacy code etc.)
- * However, I wouldn't use partial mocks for new, test-driven & well-designed code.
+ * However, I wouldn't use partial mocks for new, test-driven and well-designed code.
  *
  *
  *
@@ -743,7 +743,7 @@ import java.util.function.Function;
  * <p>
  * Instead of <code>reset()</code> please consider writing simple, small and focused test methods over lengthy, over-specified tests.
  * <b>First potential code smell is <code>reset()</code> in the middle of the test method.</b> This probably means you're testing too much.
- * Follow the whisper of your test methods: "Please keep us small & focused on single behavior".
+ * Follow the whisper of your test methods: "Please keep us small and focused on single behavior".
  * There are several threads about it on mockito mailing list.
  * <p>
  * The only reason we added <code>reset()</code> method is to
@@ -757,13 +757,13 @@ import java.util.function.Function;
  *   mock.add(1);
  *
  *   reset(mock);
- *   //at this point the mock forgot any interactions & stubbing
+ *   //at this point the mock forgot any interactions and stubbing
  * </code></pre>
  *
  *
  *
  *
- * <h3 id="18">18. <a class="meaningful_link" href="#framework_validation" name="framework_validation">Troubleshooting & validating framework usage</a> (Since 1.8.0)</h3>
+ * <h3 id="18">18. <a class="meaningful_link" href="#framework_validation" name="framework_validation">Troubleshooting and validating framework usage</a> (Since 1.8.0)</h3>
  *
  * First of all, in case of any trouble, I encourage you to read the Mockito FAQ:
  * <a href="https://github.com/mockito/mockito/wiki/FAQ">https://github.com/mockito/mockito/wiki/FAQ</a>
@@ -928,7 +928,7 @@ import java.util.function.Function;
  * Mockito will now allow you to create mocks when stubbing.
  * Basically, it allows to create a stub in one line of code.
  * This can be helpful to keep test code clean.
- * For example, some boring stub can be created & stubbed at field initialization in a test:
+ * For example, some boring stub can be created and stubbed at field initialization in a test:
  * <pre class="code"><code class="java">
  * public class CarTest {
  *   Car boringStubbedCar = when(mock(Car.class).shiftGear()).thenThrow(EngineNotStarted.class).getMock();
@@ -1075,7 +1075,7 @@ import java.util.function.Function;
  * SomeAbstract spy = spy(SomeAbstract.class);
  *
  * //Mocking abstract methods, spying default methods of an interface (only available since 2.7.13)
- * Function<Foo, Bar> function = spy(Function.class);
+ * Function&lt;Foo, Bar&gt; function = spy(Function.class);
  *
  * //Robust API, via settings builder:
  * OtherAbstract spy = mock(OtherAbstract.class, withSettings()
@@ -1199,21 +1199,21 @@ import java.util.function.Function;
  *
  * // verify a list only had strings of a certain length added to it
  * // note - this will only compile under Java 8
- * verify(list, times(2)).add(argThat(string -> string.length() < 5));
+ * verify(list, times(2)).add(argThat(string -&gt; string.length() &lt; 5));
  *
  * // Java 7 equivalent - not as neat
- * verify(list, times(2)).add(argThat(new ArgumentMatcher<String>(){
+ * verify(list, times(2)).add(argThat(new ArgumentMatcher&lt;String&gt;(){
  *     public boolean matches(String arg) {
- *         return arg.length() < 5;
+ *         return arg.length() &lt; 5;
  *     }
  * }));
  *
  * // more complex Java 8 example - where you can specify complex verification behaviour functionally
- * verify(target, times(1)).receiveComplexObject(argThat(obj -> obj.getSubObject().get(0).equals("expected")));
+ * verify(target, times(1)).receiveComplexObject(argThat(obj -&gt; obj.getSubObject().get(0).equals("expected")));
  *
  * // this can also be used when defining the behaviour of a mock under different inputs
  * // in this case if the input list was fewer than 3 items the mock returns null
- * when(mock.someMethod(argThat(list -> list.size()<3))).thenReturn(null);
+ * when(mock.someMethod(argThat(list -&gt; list.size()&lt;3))).thenReturn(null);
  * </code></pre>
  *
  * <h3 id="37">37. <a class="meaningful_link" href="#Java_8_Custom_Answers" name="Java_8_Custom_Answers">Java 8 Custom Answer Support</a> (Since 2.1.0)</h3>
@@ -1227,12 +1227,12 @@ import java.util.function.Function;
  * <p>
  * <pre class="code"><code class="java">
  * // answer by returning 12 every time
- * doAnswer(invocation -> 12).when(mock).doSomething();
+ * doAnswer(invocation -&gt; 12).when(mock).doSomething();
  *
  * // answer by using one of the parameters - converting into the right
  * // type as your go - in this case, returning the length of the second string parameter
  * // as the answer. This gets long-winded quickly, with casting of parameters.
- * doAnswer(invocation -> ((String)invocation.getArgument(1)).length())
+ * doAnswer(invocation -&gt; ((String)invocation.getArgument(1)).length())
  *     .when(mock).doSomething(anyString(), anyString(), anyString());
  * </code></pre>
  *
@@ -1257,11 +1257,11 @@ import java.util.function.Function;
  * void receive(String item);
  *
  * // Java 8 - style 1
- * doAnswer(AdditionalAnswers.<String,Callback>answerVoid((operand, callback) -> callback.receive("dummy"))
+ * doAnswer(AdditionalAnswers.&lt;String,Callback&gt;answerVoid((operand, callback) -&gt; callback.receive("dummy"))
  *     .when(mock).execute(anyString(), any(Callback.class));
  *
  * // Java 8 - style 2 - assuming static import of AdditionalAnswers
- * doAnswer(answerVoid((String operand, Callback callback) -> callback.receive("dummy"))
+ * doAnswer(answerVoid((String operand, Callback callback) -&gt; callback.receive("dummy"))
  *     .when(mock).execute(anyString(), any(Callback.class));
  *
  * // Java 8 - style 3 - where mocking function to is a static member of test class
@@ -1273,7 +1273,7 @@ import java.util.function.Function;
  *     .when(mock).execute(anyString(), any(Callback.class));
  *
  * // Java 7
- * doAnswer(answerVoid(new VoidAnswer2<String, Callback>() {
+ * doAnswer(answerVoid(new VoidAnswer2&lt;String, Callback&gt;() {
  *     public void answer(String operation, Callback callback) {
  *         callback.receive("dummy");
  *     }})).when(mock).execute(anyString(), any(Callback.class));
@@ -1285,11 +1285,11 @@ import java.util.function.Function;
  *
  * // this could be mocked
  * // Java 8
- * doAnswer(AdditionalAnswers.<Boolean,String,String>answer((input1, input2) -> input1.equals(input2))))
+ * doAnswer(AdditionalAnswers.&lt;Boolean,String,String&gt;answer((input1, input2) -&gt; input1.equals(input2))))
  *     .when(mock).execute(anyString(), anyString());
  *
  * // Java 7
- * doAnswer(answer(new Answer2<String, String, String>() {
+ * doAnswer(answer(new Answer2&lt;String, String, String&gt;() {
  *     public String answer(String input1, String input2) {
  *         return input1 + input2;
  *     }})).when(mock).execute(anyString(), anyString());
@@ -1772,7 +1772,7 @@ public class Mockito extends ArgumentMatchers {
      * <p>
      * However, there are rare cases when partial mocks come handy:
      * dealing with code you cannot change easily (3rd party interfaces, interim refactoring of legacy code etc.)
-     * However, I wouldn't use partial mocks for new, test-driven & well-designed code.
+     * However, I wouldn't use partial mocks for new, test-driven and well-designed code.
      * <p>
      * Example:
      * <pre class="code"><code class="java">
@@ -1977,7 +1977,7 @@ public class Mockito extends ArgumentMatchers {
      * <p>
      * However, there are rare cases when partial mocks come handy:
      * dealing with code you cannot change easily (3rd party interfaces, interim refactoring of legacy code etc.)
-     * However, I wouldn't use partial mocks for new, test-driven & well-designed code.
+     * However, I wouldn't use partial mocks for new, test-driven and well-designed code.
      * <p>
      * Example:
      *
@@ -2422,7 +2422,7 @@ public class Mockito extends ArgumentMatchers {
      * <p>
      * Instead of <code>#reset()</code> please consider writing simple, small and focused test methods over lengthy, over-specified tests.
      * <b>First potential code smell is <code>reset()</code> in the middle of the test method.</b> This probably means you're testing too much.
-     * Follow the whisper of your test methods: "Please keep us small & focused on single behavior".
+     * Follow the whisper of your test methods: "Please keep us small and focused on single behavior".
      * There are several threads about it on mockito mailing list.
      * <p>
      * The only reason we added <code>reset()</code> method is to
@@ -2436,7 +2436,7 @@ public class Mockito extends ArgumentMatchers {
      *   mock.add(1);
      *
      *   reset(mock);
-     *   //at this point the mock forgot any interactions & stubbing
+     *   //at this point the mock forgot any interactions and stubbing
      * </code></pre>
      *
      * @param <T> The Type of the mocks
@@ -2619,7 +2619,7 @@ public class Mockito extends ArgumentMatchers {
      * <p>
      * However, there are rare cases when partial mocks come handy:
      * dealing with code you cannot change easily (3rd party interfaces, interim refactoring of legacy code etc.)
-     * However, I wouldn't use partial mocks for new, test-driven & well-designed code.
+     * However, I wouldn't use partial mocks for new, test-driven and well-designed code.
      * <p>
      * See also javadoc {@link Mockito#spy(Object)} to find out more about partial mocks.
      * <b>Mockito.spy() is a recommended way of creating partial mocks.</b>
@@ -3206,12 +3206,12 @@ public class Mockito extends ArgumentMatchers {
      * <p>
      * Don't use it too often.
      * Consider writing simple tests that use simple mocks.
-     * Repeat after me: simple tests push simple, KISSy, readable & maintainable code.
+     * Repeat after me: simple tests push simple, KISSy, readable and maintainable code.
      * If you cannot write a test in a simple way - refactor the code under test.
      * <p>
      * Examples of mock settings:
      * <pre class="code"><code class="java">
-     *   //Creates mock with different default answer & name
+     *   //Creates mock with different default answer and name
      *   Foo mock = mock(Foo.class, withSettings()
      *       .defaultAnswer(RETURNS_SMART_NULLS)
      *       .name("cool mockie"));

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -7,6 +7,7 @@ package org.mockito;
 import org.mockito.exceptions.misusing.PotentialStubbingProblem;
 import org.mockito.exceptions.misusing.UnnecessaryStubbingException;
 import org.mockito.internal.MockitoCore;
+import org.mockito.internal.creation.proxy.ProxyMockMaker;
 import org.mockito.internal.creation.MockSettingsImpl;
 import org.mockito.internal.framework.DefaultMockitoFramework;
 import org.mockito.internal.session.DefaultMockitoSessionBuilder;
@@ -16,6 +17,7 @@ import org.mockito.invocation.InvocationFactory;
 import org.mockito.invocation.MockHandler;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner.Strict;
 import org.mockito.junit.MockitoRule;
 import org.mockito.listeners.VerificationStartedEvent;
 import org.mockito.listeners.VerificationStartedListener;
@@ -1241,7 +1243,7 @@ import java.util.function.Function;
  * In particular, this approach will make it easier to test functions which use callbacks.
  *
  * The methods {@link AdditionalAnswers#answer(Answer1)}} and {@link AdditionalAnswers#answerVoid(VoidAnswer1)}
- * can be used to create the answer. They rely on the related answer interfaces in {@link org.mockito.stubbing} that
+ * can be used to create the answer. They rely on the related answer interfaces in org.mockito.stubbing that
  * support answers up to 5 parameters.
  *
  * <p>
@@ -1374,7 +1376,7 @@ import java.util.function.Function;
  * To quickly find out how "stricter" Mockito can make you more productive and get your tests cleaner, see:
  * <ul>
  *     <li>Strict stubbing with JUnit4 Rules - {@link MockitoRule#strictness(Strictness)} with {@link Strictness#STRICT_STUBS}</li>
- *     <li>Strict stubbing with JUnit4 Runner - {@link MockitoJUnitRunner.Strict}</li>
+ *     <li>Strict stubbing with JUnit4 Runner - {@link Strict MockitoJUnitRunner.Strict}</li>
  *     <li>Strict stubbing with JUnit5 Extension - <code>org.mockito.junit.jupiter.MockitoExtension</code></li>
  *     <li>Strict stubbing with TestNG Listener <a href="https://github.com/mockito/mockito-testng">MockitoTestNGListener</a></li>
  *     <li>Strict stubbing if you cannot use runner/rule - {@link MockitoSession}</li>
@@ -1589,7 +1591,7 @@ import java.util.function.Function;
  * The JVM offers the {@link java.lang.reflect.Proxy} facility for creating dynamic proxies of interface types. For most applications, Mockito
  * must be capable of mocking classes as supported by the default mock maker, or even final classes, as supported by the inline mock maker. To
  * create such mocks, Mockito requires to setup diverse JVM facilities and must apply code generation. If only interfaces are supposed to be
- * mocked, one can however choose to use a {@link org.mockito.internal.creation.proxy.ProxyMockMaker} that is based on the {@link java.lang.reflect.Proxy}
+ * mocked, one can however choose to use a {@link ProxyMockMaker} that is based on the {@link java.lang.reflect.Proxy}
  * API which avoids diverse overhead of the other mock makers but also limits mocking to interfaces.
  *
  * This mock maker can be activated explicitly by the mockito extension mechanism, just create in the classpath a file

--- a/src/main/java/org/mockito/MockitoFramework.java
+++ b/src/main/java/org/mockito/MockitoFramework.java
@@ -32,7 +32,7 @@ public interface MockitoFramework {
      * Make sure you remove the listener when the job is complete, see {@link #removeListener(MockitoListener)}.
      * Currently the listeners list is thread local so you need to remove listener from the same thread otherwise
      * remove is ineffectual.
-     * In typical scenarios, it is not a problem, because adding & removing listeners typically happens in the same thread.
+     * In typical scenarios, it is not a problem, because adding and removing listeners typically happens in the same thread.
      * <p>
      * If you are trying to add the listener but a listener of the same type was already added (and not removed)
      * this method will throw {@link RedundantListenerException}.
@@ -58,7 +58,7 @@ public interface MockitoFramework {
      * When you add listener using {@link #addListener(MockitoListener)} make sure to remove it.
      * Currently the listeners list is thread local so you need to remove listener from the same thread otherwise
      * remove is ineffectual.
-     * In typical scenarios, it is not a problem, because adding & removing listeners typically happens in the same thread.
+     * In typical scenarios, it is not a problem, because adding and removing listeners typically happens in the same thread.
      * <p>
      * For usage examples, see Mockito codebase.
      * If you have ideas and feature requests about Mockito listeners API

--- a/src/main/java/org/mockito/MockitoSession.java
+++ b/src/main/java/org/mockito/MockitoSession.java
@@ -8,6 +8,7 @@ import org.mockito.exceptions.misusing.PotentialStubbingProblem;
 import org.mockito.exceptions.misusing.UnfinishedMockingSessionException;
 import org.mockito.exceptions.misusing.UnnecessaryStubbingException;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner.StrictStubs;
 import org.mockito.junit.MockitoRule;
 import org.mockito.listeners.MockitoListener;
 import org.mockito.quality.MockitoHint;
@@ -72,7 +73,7 @@ import org.mockito.session.MockitoSessionBuilder;
  * There is no need to use {@code MockitoSession} if you already use {@link MockitoJUnitRunner} or {@link MockitoRule}.
  * If you are JUnit user who does not leverage Mockito rule or runner we strongly recommend to do so.
  * Both the runner and the rule support strict stubbing which can really help driving cleaner tests.
- * See {@link MockitoJUnitRunner.StrictStubs} and {@link MockitoRule#strictness(Strictness)}.
+ * See {@link StrictStubs MockitoJUnitRunner.StrictStubs} and {@link MockitoRule#strictness(Strictness)}.
  * If you cannot use Mockito's JUnit support {@code MockitoSession} exactly is for you!
  * You can automatically take advantage of strict stubbing ({@link Strictness}),
  * automatic initialization of annotated mocks ({@link MockitoAnnotations}),

--- a/src/main/java/org/mockito/exceptions/misusing/PotentialStubbingProblem.java
+++ b/src/main/java/org/mockito/exceptions/misusing/PotentialStubbingProblem.java
@@ -26,7 +26,7 @@ import org.mockito.quality.Strictness;
  * given(mock.getSomething(100)).willReturn(something);
  *
  * //code under test:
- * Something something = mock.getSomething(50); // <-- stubbing argument mismatch
+ * Something something = mock.getSomething(50); // &lt;-- stubbing argument mismatch
  * </code></pre>
  * The stubbing argument mismatch typically indicates:
  * <ol>

--- a/src/main/java/org/mockito/exceptions/misusing/UnnecessaryStubbingException.java
+++ b/src/main/java/org/mockito/exceptions/misusing/UnnecessaryStubbingException.java
@@ -30,8 +30,8 @@ import org.mockito.exceptions.base.MockitoException;
  *
  * //test:
  * ...
- * when(translator.translate("one")).thenReturn("jeden"); // <- stubbing realized during code execution
- * when(translator.translate("two")).thenReturn("dwa"); // <- stubbing never realized
+ * when(translator.translate("one")).thenReturn("jeden"); // &lt;- stubbing realized during code execution
+ * when(translator.translate("two")).thenReturn("dwa"); // &lt;- stubbing never realized
  * ...
  * </code>
  * </pre>
@@ -39,7 +39,7 @@ import org.mockito.exceptions.base.MockitoException;
  * The stray stubbing might be an oversight of the developer, the artifact of copy-paste
  * or the effect of not understanding the test/code.
  * Either way, the developer ends up with unnecessary test code.
- * In order to keep the codebase clean & maintainable it is necessary to remove unnecessary code.
+ * In order to keep the codebase clean and maintainable it is necessary to remove unnecessary code.
  * Otherwise tests are harder to read and reason about.
  * <p>
  * Mockito JUnit Runner triggers <code>UnnecessaryStubbingException</code> only when none of the test methods use the stubbings.

--- a/src/main/java/org/mockito/exceptions/verification/junit/package-info.java
+++ b/src/main/java/org/mockito/exceptions/verification/junit/package-info.java
@@ -7,6 +7,6 @@
  * JUnit integration to provide better support for JUnit 4 and
  * earlier in IDEs.
  *
- * @see org.mockito.exceptions.verification.opentest4j
+ * See also org.mockito.exceptions.verification.opentest4j
  */
 package org.mockito.exceptions.verification.junit;

--- a/src/main/java/org/mockito/exceptions/verification/opentest4j/package-info.java
+++ b/src/main/java/org/mockito/exceptions/verification/opentest4j/package-info.java
@@ -6,7 +6,6 @@
 /**
  * Integration to provide better support for IDEs that support OpenTest4J.
  *
- * @see org.mocktio.exceptions.verification.junit
- * @see org.mocktio.exceptions.verification.junit4
+ * @see org.mockito.exceptions.verification.junit
  */
 package org.mockito.exceptions.verification.opentest4j;

--- a/src/main/java/org/mockito/exceptions/verification/opentest4j/package-info.java
+++ b/src/main/java/org/mockito/exceptions/verification/opentest4j/package-info.java
@@ -6,6 +6,6 @@
 /**
  * Integration to provide better support for IDEs that support OpenTest4J.
  *
- * @see org.mockito.exceptions.verification.junit
+ * See also org.mockito.exceptions.verification.junit
  */
 package org.mockito.exceptions.verification.opentest4j;

--- a/src/main/java/org/mockito/internal/stubbing/answers/CallsRealMethods.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/CallsRealMethods.java
@@ -31,7 +31,7 @@ import org.mockito.stubbing.ValidableAnswer;
  * <p>
  * However, there are rare cases when partial mocks come handy:
  * dealing with code you cannot change easily (3rd party interfaces, interim refactoring of legacy code etc.)
- * However, I wouldn't use partial mocks for new, test-driven & well-designed code.
+ * However, I wouldn't use partial mocks for new, test-driven and well-designed code.
  * <p>
  */
 public class CallsRealMethods implements Answer<Object>, ValidableAnswer, Serializable {

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/RetrieveGenericsForDefaultAnswers.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/RetrieveGenericsForDefaultAnswers.java
@@ -51,7 +51,7 @@ final class RetrieveGenericsForDefaultAnswers {
     /**
      * Try to resolve the result value using {@link ReturnsEmptyValues} and {@link ReturnsMoreEmptyValues}.
      *
-     * This will try to use all parent class (superclass & interfaces) to retrieve the value..
+     * This will try to use all parent class (superclass and interfaces) to retrieve the value..
      *
      * @param type the return type of the method
      * @return a non-null instance if the type has been resolve. Null otherwise.

--- a/src/main/java/org/mockito/internal/verification/api/VerificationData.java
+++ b/src/main/java/org/mockito/internal/verification/api/VerificationData.java
@@ -26,10 +26,10 @@ public interface VerificationData {
      * The target or wanted invocation.
      * Below example illustrates what is the 'target' invocation:
      * <pre class="code"><code class="java">
-     *   mock.foo();   // <- invocation 1
-     *   mock.bar();   // <- invocation 2
+     *   mock.foo();   // &lt;- invocation 1
+     *   mock.bar();   // &lt;- invocation 2
      *
-     *   verify(mock).bar();  // <- target invocation
+     *   verify(mock).bar();  // &lt;- target invocation
      * </code></pre>
      *
      * Target invocation can contain argument matchers therefore the returned type is {@link MatchableInvocation}

--- a/src/main/java/org/mockito/invocation/MatchableInvocation.java
+++ b/src/main/java/org/mockito/invocation/MatchableInvocation.java
@@ -14,8 +14,8 @@ import org.mockito.ArgumentMatcher;
  * It is used during verification process:
  *
  * <pre class="code"><code class="java">
- *   mock.foo();   // <- invocation
- *   verify(mock).bar();  // <- matchable invocation
+ *   mock.foo();   // &lt;- invocation
+ *   verify(mock).bar();  // &lt;- matchable invocation
  * </code></pre>
  *
  * @since 2.2.12

--- a/src/main/java/org/mockito/stubbing/OngoingStubbing.java
+++ b/src/main/java/org/mockito/stubbing/OngoingStubbing.java
@@ -164,7 +164,7 @@ public interface OngoingStubbing<T> {
      * <p>
      * However, there are rare cases when partial mocks come handy:
      * dealing with code you cannot change easily (3rd party interfaces, interim refactoring of legacy code etc.)
-     * However, I wouldn't use partial mocks for new, test-driven & well-designed code.
+     * However, I wouldn't use partial mocks for new, test-driven and well-designed code.
      * <pre class="code"><code class="java">
      *   // someMethod() must be safe (e.g. doesn't throw, doesn't have dependencies to the object state, etc.)
      *   // if it isn't safe then you will have trouble stubbing it using this api. Use Mockito.doCallRealMethod() instead.
@@ -226,7 +226,7 @@ public interface OngoingStubbing<T> {
      * <p>
      * It allows to create a stub in one line of code.
      * This can be helpful to keep test code clean.
-     * For example, some boring stub can be created & stubbed at field initialization in a test:
+     * For example, some boring stub can be created and stubbed at field initialization in a test:
      * <pre class="code"><code class="java">
      * public class CarTest {
      *   Car boringStubbedCar = when(mock(Car.class).shiftGear()).thenThrow(EngineNotStarted.class).getMock();

--- a/src/main/java/org/mockito/stubbing/VoidAnswer4.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer4.java
@@ -21,7 +21,7 @@ package org.mockito.stubbing;
  *         }
  * })).when(mock).someMethod(anyString(), anyInt(), anyString(), anyChar());
  *
- * //Following will raise an exception with the message "ka-boom <3"
+ * //Following will raise an exception with the message "ka-boom &lt;3"
  * mock.someMethod("%s-boom %c%d", 3, "ka", '&lt;');
  * </code></pre>
  *

--- a/src/main/java/org/mockito/stubbing/VoidAnswer5.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer5.java
@@ -21,7 +21,7 @@ package org.mockito.stubbing;
  *         }
  * })).when(mock).someMethod(anyString(), anyInt(), anyString(), anyChar(), anyString());
  *
- * //Following will raise an exception with the message "ka-boom <3 mockito"
+ * //Following will raise an exception with the message "ka-boom &lt;3 mockito"
  * mock.someMethod("%s-boom %c%d %s", 3, "ka", '&lt;', "mockito");
  * </code></pre>
  *

--- a/src/main/java/org/mockito/stubbing/VoidAnswer6.java
+++ b/src/main/java/org/mockito/stubbing/VoidAnswer6.java
@@ -21,7 +21,7 @@ package org.mockito.stubbing;
  *         }
  * })).when(mock).someMethod(anyString(), anyInt(), anyString(), anyChar(), any(), anyString());
  *
- * // The following will raise an exception with the message "ka-boom <3 mockito"
+ * // The following will raise an exception with the message "ka-boom &lt;3 mockito"
  * mock.someMethod("%s-boom %c%d %s", 3, "ka", '&lt;', new Object(), "mockito");
  * </code></pre>
  *

--- a/src/test/java/org/mockitoutil/JUnitResultAssert.java
+++ b/src/test/java/org/mockitoutil/JUnitResultAssert.java
@@ -14,7 +14,7 @@ import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
 
 /**
- * Assertion utility for cleaner & easier to debug tests that inspect on JUnit's Result object
+ * Assertion utility for cleaner and easier to debug tests that inspect on JUnit's Result object
  */
 public class JUnitResultAssert {
     private Result result;


### PR DESCRIPTION
Now, we ensure that our JavaDoc doesn't produce any warnings. The most
common problems were using < instead of &lt; and & instead of the word
"and".