### PR TITLE
Remove an `@link`

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -7,7 +7,6 @@ package org.mockito;
 import org.mockito.exceptions.misusing.PotentialStubbingProblem;
 import org.mockito.exceptions.misusing.UnnecessaryStubbingException;
 import org.mockito.internal.MockitoCore;
-import org.mockito.internal.creation.proxy.ProxyMockMaker;
 import org.mockito.internal.creation.MockSettingsImpl;
 import org.mockito.internal.framework.DefaultMockitoFramework;
 import org.mockito.internal.session.DefaultMockitoSessionBuilder;
@@ -1591,7 +1590,7 @@ import java.util.function.Function;
  * The JVM offers the {@link java.lang.reflect.Proxy} facility for creating dynamic proxies of interface types. For most applications, Mockito
  * must be capable of mocking classes as supported by the default mock maker, or even final classes, as supported by the inline mock maker. To
  * create such mocks, Mockito requires to setup diverse JVM facilities and must apply code generation. If only interfaces are supposed to be
- * mocked, one can however choose to use a {@link ProxyMockMaker} that is based on the {@link java.lang.reflect.Proxy}
+ * mocked, one can however choose to use a org.mockito.internal.creation.proxy.ProxyMockMaker that is based on the {@link java.lang.reflect.Proxy}
  * API which avoids diverse overhead of the other mock makers but also limits mocking to interfaces.
  *
  * This mock maker can be activated explicitly by the mockito extension mechanism, just create in the classpath a file


### PR DESCRIPTION
Remove an `@link` to make it easier to build mockito with the `ProxyMockMaker` disabled

Follow-up to 80e1cc91d66e7cf6e188b2dee26deba81f4b885f