### PR TITLE
Issue 2544

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -2185,7 +2185,7 @@ public class Mockito extends ArgumentMatchers {
                 context -> {
                     if (context.getCount() == 1 || additionalAnswers.length == 0) {
                         return withSettings().defaultAnswer(defaultAnswer);
-                    } else if (context.getCount() >= additionalAnswers.length) {
+                    } else if (context.getCount() > additionalAnswers.length) {
                         return withSettings()
                                 .defaultAnswer(additionalAnswers[additionalAnswers.length - 1]);
                     } else {

--- a/subprojects/inline/src/test/java/org/mockitoinline/ConstructionMockTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/ConstructionMockTest.java
@@ -50,10 +50,11 @@ public final class ConstructionMockTest {
 
     @Test
     public void testConstructionMockDefaultAnswerMultiple() {
-        try (MockedConstruction<Dummy> ignored = Mockito.mockConstructionWithAnswer(Dummy.class, invocation -> "bar", invocation -> "qux")) {
+        try (MockedConstruction<Dummy> ignored = Mockito.mockConstructionWithAnswer(Dummy.class, invocation -> "bar", invocation -> "qux", invocation -> "baz")) {
             assertEquals("bar", new Dummy().foo());
             assertEquals("qux", new Dummy().foo());
-            assertEquals("qux", new Dummy().foo());
+            assertEquals("baz", new Dummy().foo());
+            assertEquals("baz", new Dummy().foo());
         }
     }
 

--- a/subprojects/inline/src/test/java/org/mockitoinline/ConstructionMockTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/ConstructionMockTest.java
@@ -50,6 +50,18 @@ public final class ConstructionMockTest {
 
     @Test
     public void testConstructionMockDefaultAnswerMultiple() {
+        try (MockedConstruction<Dummy> ignored = Mockito.mockConstructionWithAnswer(Dummy.class, invocation -> "bar", invocation -> "qux")) {
+            assertEquals("bar", new Dummy().foo());
+            assertEquals("qux", new Dummy().foo());
+            assertEquals("qux", new Dummy().foo());
+        }
+    }
+
+    /**
+     * Tests issue #2544
+     */
+    @Test
+    public void testConstructionMockDefaultAnswerMultipleMoreThanTwo() {
         try (MockedConstruction<Dummy> ignored = Mockito.mockConstructionWithAnswer(Dummy.class, invocation -> "bar", invocation -> "qux", invocation -> "baz")) {
             assertEquals("bar", new Dummy().foo());
             assertEquals("qux", new Dummy().foo());


### PR DESCRIPTION
Fixed issue 2544.

Mockito.mockConstructionWithAnswer() has a bug when there are more than 2 invocations possible.

If you run the ConstructionMockTest.testConstructionMocDefaultAnswerMultiple() as this:
```
    public void testConstructionMockDefaultAnswerMultiple() {
        try (MockedConstruction<Dummy> ignored = Mockito.mockConstructionWithAnswer(Dummy.class, 
              invocation -> "bar", 
              invocation -> "qux")) {
            assertEquals("bar", new Dummy().foo());
            assertEquals("qux", new Dummy().foo());
            assertEquals("qux", new Dummy().foo());
        }
    }
```
It works fine.
But if you change it to this:

```
    public void testConstructionMockDefaultAnswerMultiple() {
        try (MockedConstruction<Dummy> ignored = Mockito.mockConstructionWithAnswer(Dummy.class, 
               invocation -> "bar", 
               invocation -> "qux", 
               invocation -> "baz")) {
            assertEquals("bar", new Dummy().foo());
            assertEquals("qux", new Dummy().foo());
            assertEquals("baz", new Dummy().foo());
            assertEquals("baz", new Dummy().foo());
        }
    }
```
It will fail when trying to assert `qux`. It's because there is an error in the conditional logic in the `else if (context.getCount() >= additionalAnswers.length)`. It should be `>` not `>=`.

