### PR TITLE
Fixes #2489 : Fixed issue related to exceptions thrown from the nested spies

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
@@ -315,7 +315,8 @@ public class MockMethodAdvice extends MockMethodDispatcher {
             return accessor.invoke(origin, instance, arguments);
         } catch (InvocationTargetException exception) {
             Throwable cause = exception.getCause();
-            new ConditionalStackTraceFilter().filter(removeRecursiveCalls(cause, origin.getDeclaringClass()));
+            new ConditionalStackTraceFilter()
+                    .filter(removeRecursiveCalls(cause, origin.getDeclaringClass()));
             throw cause;
         }
     }
@@ -332,12 +333,13 @@ public class MockMethodAdvice extends MockMethodDispatcher {
                 indexesToBeRemoved.add(elementIndex);
             }
         }
-        final List<StackTraceElement> adjustedList = new ArrayList<>(Arrays.asList(cause.getStackTrace()));
+        final List<StackTraceElement> adjustedList =
+                new ArrayList<>(Arrays.asList(cause.getStackTrace()));
         indexesToBeRemoved.stream()
-            .sorted(Comparator.reverseOrder())
-            .mapToInt(Integer::intValue)
-            .forEach(adjustedList::remove);
-        cause.setStackTrace(adjustedList.toArray(new StackTraceElement[]{}));
+                .sorted(Comparator.reverseOrder())
+                .mapToInt(Integer::intValue)
+                .forEach(adjustedList::remove);
+        cause.setStackTrace(adjustedList.toArray(new StackTraceElement[] {}));
         return cause;
     }
 

--- a/src/test/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMakerTest.java
+++ b/src/test/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMakerTest.java
@@ -249,13 +249,17 @@ public class InlineDelegateByteBuddyMockMakerTest
                         settings, new MockHandlerImpl<>(settings), new ExceptionThrowingClass());
 
         StackTraceElement[] returnedStack =
-            assertThrows(IOException.class, () -> proxy.get().throwException()).getStackTrace();
+                assertThrows(IOException.class, () -> proxy.get().throwException()).getStackTrace();
 
         assertNotNull("Stack trace from mockito expected", returnedStack);
 
-        List<StackTraceElement> exceptionClassElements = Arrays.stream(returnedStack)
-            .filter(element -> element.getClassName().equals(ExceptionThrowingClass.class.getName()))
-            .collect(Collectors.toList());
+        List<StackTraceElement> exceptionClassElements =
+                Arrays.stream(returnedStack)
+                        .filter(
+                                element ->
+                                        element.getClassName()
+                                                .equals(ExceptionThrowingClass.class.getName()))
+                        .collect(Collectors.toList());
         assertEquals(3, exceptionClassElements.size());
         assertEquals("internalThrowException", exceptionClassElements.get(0).getMethodName());
         assertEquals("internalThrowException", exceptionClassElements.get(1).getMethodName());
@@ -264,26 +268,34 @@ public class InlineDelegateByteBuddyMockMakerTest
 
     @Test
     public void should_leave_causing_stack_with_two_spies() throws Exception {
-        //given
+        // given
         MockSettingsImpl<ExceptionThrowingClass> settingsEx = new MockSettingsImpl<>();
         settingsEx.setTypeToMock(ExceptionThrowingClass.class);
         settingsEx.defaultAnswer(Answers.CALLS_REAL_METHODS);
         Optional<ExceptionThrowingClass> proxyEx =
-            mockMaker.createSpy(settingsEx, new MockHandlerImpl<>(settingsEx), new ExceptionThrowingClass());
+                mockMaker.createSpy(
+                        settingsEx,
+                        new MockHandlerImpl<>(settingsEx),
+                        new ExceptionThrowingClass());
 
         MockSettingsImpl<WrapperClass> settingsWr = new MockSettingsImpl<>();
         settingsWr.setTypeToMock(WrapperClass.class);
         settingsWr.defaultAnswer(Answers.CALLS_REAL_METHODS);
         Optional<WrapperClass> proxyWr =
-            mockMaker.createSpy(settingsWr, new MockHandlerImpl<>(settingsWr), new WrapperClass());
+                mockMaker.createSpy(
+                        settingsWr, new MockHandlerImpl<>(settingsWr), new WrapperClass());
 
-        //when
-        IOException ex = assertThrows(IOException.class, () -> proxyWr.get().callWrapped(proxyEx.get()));
-        List<StackTraceElement> wrapperClassElements = Arrays.stream(ex.getStackTrace())
-            .filter(element -> element.getClassName().equals(WrapperClass.class.getName()))
-            .collect(Collectors.toList());
+        // when
+        IOException ex =
+                assertThrows(IOException.class, () -> proxyWr.get().callWrapped(proxyEx.get()));
+        List<StackTraceElement> wrapperClassElements =
+                Arrays.stream(ex.getStackTrace())
+                        .filter(
+                                element ->
+                                        element.getClassName().equals(WrapperClass.class.getName()))
+                        .collect(Collectors.toList());
 
-        //then
+        // then
         assertEquals(1, wrapperClassElements.size());
         assertEquals("callWrapped", wrapperClassElements.get(0).getMethodName());
     }

--- a/src/test/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMakerTest.java
+++ b/src/test/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMakerTest.java
@@ -9,19 +9,14 @@ import static net.bytebuddy.ClassFileVersion.JAVA_V8;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Observable;
-import java.util.Observer;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.ClassFileVersion;
@@ -253,17 +248,44 @@ public class InlineDelegateByteBuddyMockMakerTest
                 mockMaker.createSpy(
                         settings, new MockHandlerImpl<>(settings), new ExceptionThrowingClass());
 
-        StackTraceElement[] returnedStack = null;
-        try {
-            proxy.get().throwException();
-        } catch (IOException ex) {
-            returnedStack = ex.getStackTrace();
-        }
+        StackTraceElement[] returnedStack =
+            assertThrows(IOException.class, () -> proxy.get().throwException()).getStackTrace();
 
         assertNotNull("Stack trace from mockito expected", returnedStack);
 
-        assertEquals(ExceptionThrowingClass.class.getName(), returnedStack[0].getClassName());
-        assertEquals("internalThrowException", returnedStack[0].getMethodName());
+        List<StackTraceElement> exceptionClassElements = Arrays.stream(returnedStack)
+            .filter(element -> element.getClassName().equals(ExceptionThrowingClass.class.getName()))
+            .collect(Collectors.toList());
+        assertEquals(3, exceptionClassElements.size());
+        assertEquals("internalThrowException", exceptionClassElements.get(0).getMethodName());
+        assertEquals("internalThrowException", exceptionClassElements.get(1).getMethodName());
+        assertEquals("throwException", exceptionClassElements.get(2).getMethodName());
+    }
+
+    @Test
+    public void should_leave_causing_stack_with_two_spies() throws Exception {
+        //given
+        MockSettingsImpl<ExceptionThrowingClass> settingsEx = new MockSettingsImpl<>();
+        settingsEx.setTypeToMock(ExceptionThrowingClass.class);
+        settingsEx.defaultAnswer(Answers.CALLS_REAL_METHODS);
+        Optional<ExceptionThrowingClass> proxyEx =
+            mockMaker.createSpy(settingsEx, new MockHandlerImpl<>(settingsEx), new ExceptionThrowingClass());
+
+        MockSettingsImpl<WrapperClass> settingsWr = new MockSettingsImpl<>();
+        settingsWr.setTypeToMock(WrapperClass.class);
+        settingsWr.defaultAnswer(Answers.CALLS_REAL_METHODS);
+        Optional<WrapperClass> proxyWr =
+            mockMaker.createSpy(settingsWr, new MockHandlerImpl<>(settingsWr), new WrapperClass());
+
+        //when
+        IOException ex = assertThrows(IOException.class, () -> proxyWr.get().callWrapped(proxyEx.get()));
+        List<StackTraceElement> wrapperClassElements = Arrays.stream(ex.getStackTrace())
+            .filter(element -> element.getClassName().equals(WrapperClass.class.getName()))
+            .collect(Collectors.toList());
+
+        //then
+        assertEquals(1, wrapperClassElements.size());
+        assertEquals("callWrapped", wrapperClassElements.get(0).getMethodName());
     }
 
     @Test
@@ -271,30 +293,33 @@ public class InlineDelegateByteBuddyMockMakerTest
         StackTraceElement[] stack =
                 new StackTraceElement[] {
                     new StackTraceElement("foo", "", "", -1),
-                    new StackTraceElement(SampleInterface.class.getName(), "", "", -1),
+                    new StackTraceElement(SampleInterface.class.getName(), "", "", 15),
                     new StackTraceElement("qux", "", "", -1),
                     new StackTraceElement("bar", "", "", -1),
+                    new StackTraceElement(SampleInterface.class.getName(), "", "", 15),
                     new StackTraceElement("baz", "", "", -1)
                 };
 
         Throwable throwable = new Throwable();
         throwable.setStackTrace(stack);
-        throwable = MockMethodAdvice.hideRecursiveCall(throwable, 2, SampleInterface.class);
+        throwable = MockMethodAdvice.removeRecursiveCalls(throwable, SampleInterface.class);
 
         assertThat(throwable.getStackTrace())
                 .isEqualTo(
                         new StackTraceElement[] {
                             new StackTraceElement("foo", "", "", -1),
+                            new StackTraceElement("qux", "", "", -1),
                             new StackTraceElement("bar", "", "", -1),
+                            new StackTraceElement(SampleInterface.class.getName(), "", "", 15),
                             new StackTraceElement("baz", "", "", -1)
                         });
     }
 
     @Test
-    public void should_handle_missing_or_inconsistent_stack_trace() throws Exception {
+    public void should_handle_missing_or_inconsistent_stack_trace() {
         Throwable throwable = new Throwable();
         throwable.setStackTrace(new StackTraceElement[0]);
-        assertThat(MockMethodAdvice.hideRecursiveCall(throwable, 0, SampleInterface.class))
+        assertThat(MockMethodAdvice.removeRecursiveCalls(throwable, SampleInterface.class))
                 .isSameAs(throwable);
     }
 
@@ -576,6 +601,12 @@ public class InlineDelegateByteBuddyMockMakerTest
 
         public T value() {
             return null;
+        }
+    }
+
+    public static class WrapperClass {
+        public void callWrapped(ExceptionThrowingClass exceptionThrowingClass) throws IOException {
+            exceptionThrowingClass.throwException();
         }
     }
 


### PR DESCRIPTION
## Description
Fixed issue related to exceptions thrown from the nested spies. 

## What changed
Behavior of the filtering redundant method calls from stacktrace was changed. 
Now it removes only lines that have the same method name and line number.
I've checked the history of this feature, there were two implementations, each one had some minor defects. 

The first one. Let assume that we have the next stacktrace:
- mock1:line1
- internal calls....
- mock1:line1
- mock1:line2
- internal calls....
- mock2:line1
- mock2:line2
- internal calls....
- mock2:line2
This implementation gets difference between current stacktrace and stacktrace from exception, and filters some rows from the beginning. Due to this `mock1:line1` was removed in some cases

The second one worked viceversa, it started filtering from the end of the stacktrace before it find the first iteration of the desired. Let assume that we have the next stacktrace:
- mock1:line1
- internal calls....
- mock1:line1
- mock1:line2
- internal calls....
- mock2:line1
- mock2:line2
- internal calls....
- mock2:line2

This lines will be removed:

-  internal calls....
- mock2:line1
- mock2:line2
- internal calls....
- mock2:line2

In current implementation I'm checking the lines with the same method name  and number and remove them from the list, so
from the stack trace provided above only two items will be removed:

- mock1:line1
- mock2:line2

I don't have many information about this feature since it contains not so many information, so if I made something wrong, please, give me a clue, how could I fix it :)

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

