### PR TITLE
Fixes #2548 : Makes InOrder able to verify static methods

### DIFF
--- a/src/main/java/org/mockito/InOrder.java
+++ b/src/main/java/org/mockito/InOrder.java
@@ -4,6 +4,8 @@
  */
 package org.mockito;
 
+import static org.mockito.Mockito.times;
+
 import org.mockito.verification.VerificationMode;
 
 /**
@@ -61,6 +63,39 @@ public interface InOrder {
      * @return mock object itself
      */
     <T> T verify(T mock, VerificationMode mode);
+
+    /**
+     * Verifies static interaction in order, with exactly one number of invocations.
+     *
+     * @see #verify(MockedStatic, MockedStatic.Verification, VerificationMode)
+     */
+    default void verify(MockedStatic<?> mockedStatic, MockedStatic.Verification verification) {
+        verify(mockedStatic, verification, times(1));
+    }
+
+    /**
+     * Verifies static interaction in order. E.g:
+     *
+     * <pre class="code"><code class="java">
+     * try (MockedStatic<Foo> mocked = mockStatic(Foo.class)) {
+     *   InOrder inOrder = inOrder(Foo.class);
+     *
+     *   mocked.when(Foo::firstMethod).thenReturn("first");
+     *   mocked.when(Foo::secondMethod).thenReturn("second");
+     *
+     *   assertEquals("first", Foo.firstMethod());
+     *   assertEquals("second", Foo.secondMethod());
+     *
+     *   inOrder.verify(mocked, Foo::firstMethod, times(1));
+     *   inOrder.verify(mocked, Foo::secondMethod, atLeastOnce());
+     * }
+     * </code></pre>
+     *
+     * @param mockedStatic static mock to be verified
+     * @param verification verification to be verified
+     * @param mode         for example times(x) or atLeastOnce()
+     */
+    void verify(MockedStatic<?> mockedStatic, MockedStatic.Verification verification, VerificationMode mode);
 
     /**
      * Verifies that no more interactions happened <b>in order</b>.

--- a/src/main/java/org/mockito/InOrder.java
+++ b/src/main/java/org/mockito/InOrder.java
@@ -95,7 +95,10 @@ public interface InOrder {
      * @param verification verification to be verified
      * @param mode         for example times(x) or atLeastOnce()
      */
-    void verify(MockedStatic<?> mockedStatic, MockedStatic.Verification verification, VerificationMode mode);
+    void verify(
+            MockedStatic<?> mockedStatic,
+            MockedStatic.Verification verification,
+            VerificationMode mode);
 
     /**
      * Verifies that no more interactions happened <b>in order</b>.

--- a/src/main/java/org/mockito/internal/InOrderImpl.java
+++ b/src/main/java/org/mockito/internal/InOrderImpl.java
@@ -62,8 +62,7 @@ public class InOrderImpl implements InOrder, InOrderContext {
         }
         if (mode instanceof VerificationWrapper) {
             return mockitoCore.verify(
-                    mock,
-                    new VerificationWrapperInOrderWrapper((VerificationWrapper<?>) mode, this));
+                    mock, new VerificationWrapperInOrderWrapper((VerificationWrapper<?>) mode, this));
         } else if (!(mode instanceof VerificationInOrderMode)) {
             throw new MockitoException(
                     mode.getClass().getSimpleName() + " is not implemented to work with InOrder");

--- a/src/main/java/org/mockito/internal/InOrderImpl.java
+++ b/src/main/java/org/mockito/internal/InOrderImpl.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.mockito.InOrder;
+import org.mockito.MockedStatic;
 import org.mockito.MockingDetails;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.verification.InOrderContextImpl;
@@ -61,12 +62,26 @@ public class InOrderImpl implements InOrder, InOrderContext {
         }
         if (mode instanceof VerificationWrapper) {
             return mockitoCore.verify(
-                    mock, new VerificationWrapperInOrderWrapper((VerificationWrapper) mode, this));
+                    mock,
+                    new VerificationWrapperInOrderWrapper((VerificationWrapper<?>) mode, this));
         } else if (!(mode instanceof VerificationInOrderMode)) {
             throw new MockitoException(
                     mode.getClass().getSimpleName() + " is not implemented to work with InOrder");
         }
         return mockitoCore.verify(mock, new InOrderWrapper((VerificationInOrderMode) mode, this));
+    }
+
+    @Override
+    public void verify(MockedStatic<?> mockedStatic, MockedStatic.Verification verification, VerificationMode mode) {
+        if (mode instanceof VerificationWrapper) {
+            mockedStatic.verify(verification,
+                new VerificationWrapperInOrderWrapper((VerificationWrapper<?>) mode, this));
+        } else if (mode instanceof VerificationInOrderMode) {
+            mockedStatic.verify(verification, new InOrderWrapper((VerificationInOrderMode) mode, this));
+        } else {
+            throw new MockitoException(
+                mode.getClass().getSimpleName() + " is not implemented to work with InOrder");
+        }
     }
 
     // We can't use `this.mocksToBeVerifiedInOrder.contains`, since that in turn calls `.equals` on

--- a/src/main/java/org/mockito/internal/InOrderImpl.java
+++ b/src/main/java/org/mockito/internal/InOrderImpl.java
@@ -62,7 +62,8 @@ public class InOrderImpl implements InOrder, InOrderContext {
         }
         if (mode instanceof VerificationWrapper) {
             return mockitoCore.verify(
-                    mock, new VerificationWrapperInOrderWrapper((VerificationWrapper<?>) mode, this));
+                    mock,
+                    new VerificationWrapperInOrderWrapper((VerificationWrapper<?>) mode, this));
         } else if (!(mode instanceof VerificationInOrderMode)) {
             throw new MockitoException(
                     mode.getClass().getSimpleName() + " is not implemented to work with InOrder");
@@ -71,15 +72,20 @@ public class InOrderImpl implements InOrder, InOrderContext {
     }
 
     @Override
-    public void verify(MockedStatic<?> mockedStatic, MockedStatic.Verification verification, VerificationMode mode) {
+    public void verify(
+            MockedStatic<?> mockedStatic,
+            MockedStatic.Verification verification,
+            VerificationMode mode) {
         if (mode instanceof VerificationWrapper) {
-            mockedStatic.verify(verification,
-                new VerificationWrapperInOrderWrapper((VerificationWrapper<?>) mode, this));
+            mockedStatic.verify(
+                    verification,
+                    new VerificationWrapperInOrderWrapper((VerificationWrapper<?>) mode, this));
         } else if (mode instanceof VerificationInOrderMode) {
-            mockedStatic.verify(verification, new InOrderWrapper((VerificationInOrderMode) mode, this));
+            mockedStatic.verify(
+                    verification, new InOrderWrapper((VerificationInOrderMode) mode, this));
         } else {
             throw new MockitoException(
-                mode.getClass().getSimpleName() + " is not implemented to work with InOrder");
+                    mode.getClass().getSimpleName() + " is not implemented to work with InOrder");
         }
     }
 

--- a/subprojects/inline/src/test/java/org/mockitoinline/InOrderVerificationTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/InOrderVerificationTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2022 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitoinline;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+
+import java.util.function.Consumer;
+
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.MockedStatic;
+import org.mockito.exceptions.base.MockitoException;
+import org.mockito.exceptions.misusing.NotAMockException;
+import org.mockito.exceptions.verification.VerificationInOrderFailure;
+import org.mockito.verification.VerificationMode;
+
+public class InOrderVerificationTest {
+
+    @Test
+    public void shouldVerifyStaticMethods() {
+        mockedStaticTest(mockedStatic -> {
+            // given
+            InOrder inOrder = inOrder(StaticContext.class);
+
+            // when
+            StaticContext.firstMethod();
+            StaticContext.secondMethod(0);
+
+            // then
+            inOrder.verify(mockedStatic, StaticContext::firstMethod);
+            inOrder.verify(mockedStatic, () -> StaticContext.secondMethod(0));
+        });
+    }
+
+    @Test
+    public void shouldVerifyStaticAndInstanceMethods() {
+        mockedStaticTest(mockedStatic -> {
+            // given
+            StaticContext mocked = mock(StaticContext.class);
+            InOrder inOrder = inOrder(mocked, StaticContext.class);
+
+            // when
+            StaticContext.firstMethod();
+            mocked.instanceMethod();
+            StaticContext.secondMethod(10);
+
+            // then
+            inOrder.verify(mockedStatic, StaticContext::firstMethod);
+            inOrder.verify(mocked).instanceMethod();
+            inOrder.verify(mockedStatic, () -> StaticContext.secondMethod(10));
+        });
+    }
+
+    @Test
+    public void shouldVerifyStaticMethodsWithSimpleAndWrapperModes() {
+        mockedStaticTest(mockedStatic -> {
+            // given
+            InOrder inOrder = inOrder(StaticContext.class);
+
+            // when
+            StaticContext.firstMethod();
+            StaticContext.firstMethod();
+            StaticContext.secondMethod(0);
+
+            // then
+            inOrder.verify(mockedStatic, StaticContext::firstMethod, times(2));
+            inOrder.verify(mockedStatic, () -> StaticContext.secondMethod(0), timeout(100).atLeastOnce());
+        });
+    }
+
+    @Test(expected = MockitoException.class)
+    public void shouldThrowExceptionWhenModeIsUnsupported() {
+        mockedStaticTest(mockedStatic -> {
+            // given
+            VerificationMode unsupportedMode = data -> { };
+            InOrder inOrder = inOrder(StaticContext.class);
+
+            // when
+            StaticContext.firstMethod();
+
+            // then
+            inOrder.verify(mockedStatic, StaticContext::firstMethod, unsupportedMode);
+        });
+    }
+
+    @Test(expected = VerificationInOrderFailure.class)
+    public void shouldThrowExceptionWhenOrderIsWrong() {
+        mockedStaticTest(mockedStatic -> {
+            // given
+            InOrder inOrder = inOrder(StaticContext.class);
+
+            // when
+            StaticContext.firstMethod();
+            StaticContext.secondMethod(0);
+
+            // then
+            inOrder.verify(mockedStatic, () -> StaticContext.secondMethod(0));
+            inOrder.verify(mockedStatic, StaticContext::firstMethod);
+        });
+    }
+
+    @Test(expected = VerificationInOrderFailure.class)
+    public void shouldThrowExceptionWhenNoMoreInteractionsInvokedButThereAre() {
+        mockedStaticTest(mockedStatic -> {
+            // given
+            InOrder inOrder = inOrder(StaticContext.class);
+
+            // when
+            StaticContext.firstMethod();
+            StaticContext.secondMethod(0);
+
+            // then
+            inOrder.verify(mockedStatic, StaticContext::firstMethod);
+            inOrder.verifyNoMoreInteractions();
+        });
+    }
+
+    @Test(expected = VerificationInOrderFailure.class)
+    public void shouldThrowExceptionWhenNoMoreInteractionsInvokedWithoutVerifyingStaticMethods() {
+        mockedStaticTest(ignored -> {
+            // given
+            StaticContext mocked = mock(StaticContext.class);
+            InOrder inOrder = inOrder(StaticContext.class, mocked);
+
+            // when
+            mocked.instanceMethod();
+            StaticContext.firstMethod();
+
+            // then
+            inOrder.verify(mocked).instanceMethod();
+            inOrder.verifyNoMoreInteractions();
+        });
+    }
+
+    @Test(expected = NotAMockException.class)
+    public void shouldThrowExceptionWhenClassIsNotMocked() {
+        InOrder ignored = inOrder(StaticContext.class);
+    }
+
+    @Test
+    public void shouldVerifyStaticMethodsWithoutInterferingWithMocking() {
+        mockedStaticTest(mockedStatic -> {
+            // given
+            InOrder inOrder = inOrder(StaticContext.class);
+            Exception expected = new RuntimeException();
+            Exception actual = null;
+            mockedStatic.when(StaticContext::firstMethod).thenThrow(expected);
+
+            // when
+            try {
+                StaticContext.firstMethod();
+            } catch (Exception e) {
+                actual = e;
+            }
+
+            // then
+            if (actual != expected) {
+                fail("Unable to mock static method");
+            }
+            inOrder.verify(mockedStatic, StaticContext::firstMethod);
+            inOrder.verifyNoMoreInteractions();
+        });
+    }
+
+    private void mockedStaticTest(Consumer<MockedStatic<StaticContext>> body) {
+        try (MockedStatic<StaticContext> mockedStatic = mockStatic(StaticContext.class)) {
+            body.accept(mockedStatic);
+        }
+    }
+
+    private static class StaticContext {
+        static void firstMethod() {
+            fail("firstMethod should be mocked");
+        }
+
+        static void secondMethod(int n) {
+            fail("secondMethod should be mocked but was invoked with argument " + n);
+        }
+
+        void instanceMethod() {
+            fail("instanceMethod should be mocked");
+        }
+    }
+}


### PR DESCRIPTION
<!-- Hey,
Thanks for the contribution, this is awesome.
As you may have read, project members have somehow an opinionated view on what and how should be
Mockito, e.g. we don't want mockito to be a feature bloat.
There may be a thorough review, with feedback -> code change loop.
-->
<!--
If you have a suggestion for this template you can fix it in the .github/PULL_REQUEST_TEMPLATE.md file
-->

This PR makes it possible to verify static methods calls in order. Fixes: #2548 

Example of usage:

```
try (MockedStatic<Foo> mocked = mockStatic(Foo.class)) {
  InOrder inOrder = inOrder(Foo.class);
  mocked.when(Foo::firstMethod).thenReturn("first");
  assertEquals("first", Foo.firstMethod());

  inOrder.verify(mocked, Foo::firstMethod);
}
```
You can also pass a specific `VerificationMode` as third argument to the `InOrder#verify` method.

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

