### PR TITLE
Bump versions.errorprone from 2.10.0 to 2.12.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,10 @@ allprojects { proj ->
         mavenCentral()
         google()
     }
-    plugins.withId('java') {
-        proj.apply from: "$rootDir/gradle/errorprone.gradle"
+    if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11)) {
+        plugins.withId('java') {
+            proj.apply from: "$rootDir/gradle/errorprone.gradle"
+        }
     }
     tasks.withType(JavaCompile) {
         //I don't believe those warnings add value given modern IDEs

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -6,7 +6,7 @@ def versions = [:]
 
 versions.bytebuddy = '1.12.7'
 versions.junitJupiter = '5.8.2'
-versions.errorprone = '2.12.0'
+versions.errorprone = '2.12.1'
 
 libraries.junit4 = 'junit:junit:4.13.2'
 libraries.junitJupiterApi = "org.junit.jupiter:junit-jupiter-api:${versions.junitJupiter}"

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -6,7 +6,7 @@ def versions = [:]
 
 versions.bytebuddy = '1.12.7'
 versions.junitJupiter = '5.8.2'
-versions.errorprone = '2.11.0'
+versions.errorprone = '2.12.0'
 
 libraries.junit4 = 'junit:junit:4.13.2'
 libraries.junitJupiterApi = "org.junit.jupiter:junit-jupiter-api:${versions.junitJupiter}"

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -6,7 +6,7 @@ def versions = [:]
 
 versions.bytebuddy = '1.12.7'
 versions.junitJupiter = '5.8.2'
-versions.errorprone = '2.10.0'
+versions.errorprone = '2.11.0'
 
 libraries.junit4 = 'junit:junit:4.13.2'
 libraries.junitJupiterApi = "org.junit.jupiter:junit-jupiter-api:${versions.junitJupiter}"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,10 +14,15 @@ include("inline",
     "junitJupiterInlineMockMakerExtensionTest",
     "module-test",
     "memory-test",
-    "errorprone",
     "junitJupiterParallelTest",
     "osgi-test",
     "bom")
+
+if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11)) {
+    include("errorprone")
+} else {
+    logger.info("Not including errorprone, which requires minimum JDK 11+")
+}
 
 if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17) && (System.getenv("ANDROID_SDK_ROOT") != null || File(".local.properties").exists())) {
     include("androidTest")

--- a/src/main/java/org/mockito/internal/matchers/EqualsWithDelta.java
+++ b/src/main/java/org/mockito/internal/matchers/EqualsWithDelta.java
@@ -6,6 +6,7 @@ package org.mockito.internal.matchers;
 
 import java.io.Serializable;
 
+import java.util.Objects;
 import org.mockito.ArgumentMatcher;
 
 public class EqualsWithDelta implements ArgumentMatcher<Number>, Serializable {
@@ -24,7 +25,7 @@ public class EqualsWithDelta implements ArgumentMatcher<Number>, Serializable {
             return false;
         }
 
-        if (wanted == actual) {
+        if (Objects.equals(wanted, actual)) {
             return true;
         }
 

--- a/src/test/java/org/mockito/internal/matchers/text/ValuePrinterTest.java
+++ b/src/test/java/org/mockito/internal/matchers/text/ValuePrinterTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.internal.matchers.text.ValuePrinter.print;
 
 import java.util.LinkedHashMap;
-
+import java.util.Map;
 import org.junit.Test;
 
 public class ValuePrinterTest {
@@ -24,29 +24,23 @@ public class ValuePrinterTest {
         assertThat(print(3.14d)).isEqualTo("3.14d");
         assertThat(print(3.14f)).isEqualTo("3.14f");
         assertThat(print(new int[] {1, 2})).isEqualTo("[1, 2]");
-        assertThat(
-                        print(
-                                new LinkedHashMap<String, Object>() {
-                                    {
-                                        put("foo", 2L);
-                                    }
-                                }))
-                .isEqualTo("{\"foo\" = 2L}");
-        assertThat(
-                        print(
-                                new LinkedHashMap<String, Object>() {
-                                    {
-                                        put("int passed as hex", 0x01);
-                                        put("byte", (byte) 0x01);
-                                        put("short", (short) 2);
-                                        put("int", 3);
-                                        put("long", 4L);
-                                        put("float", 2.71f);
-                                        put("double", 3.14d);
-                                    }
-                                }))
+
+        Map<String, Object> map1 = new LinkedHashMap<>();
+        map1.put("foo", 2L);
+        assertThat(print(map1)).isEqualTo("{\"foo\" = 2L}");
+
+        Map<String, Object> map2 = new LinkedHashMap<>();
+        map2.put("int passed as hex", 0x01);
+        map2.put("byte", (byte) 0x01);
+        map2.put("short", (short) 2);
+        map2.put("int", 3);
+        map2.put("long", 4L);
+        map2.put("float", 2.71f);
+        map2.put("double", 3.14d);
+        assertThat(print(map2))
                 .isEqualTo(
                         "{\"int passed as hex\" = 1, \"byte\" = (byte) 0x01, \"short\" = (short) 2, \"int\" = 3, \"long\" = 4L, \"float\" = 2.71f, \"double\" = 3.14d}");
+
         assertTrue(print(new UnsafeToString()).contains("UnsafeToString"));
         assertThat(print(new ToString())).isEqualTo("ToString");
         assertThat(print(new FormattedText("formatted"))).isEqualTo("formatted");

--- a/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNullsTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNullsTest.java
@@ -16,7 +16,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ThrowableAssert;
 import org.junit.Test;
@@ -307,20 +306,14 @@ public class ReturnsSmartNullsTest extends TestBase {
             should_return_a_empty_map_that_has_been_defined_with_method_generic_and_provided_in_var_args()
                     throws Throwable {
 
-        final Map<String, String> map1 =
-                new HashMap<String, String>() {
-                    {
-                        put("key-1", "value-1");
-                        put("key-2", "value-2");
-                    }
-                };
-        final Map<String, String> map2 =
-                new HashMap<String, String>() {
-                    {
-                        put("key-3", "value-1");
-                        put("key-4", "value-2");
-                    }
-                };
+        final Map<String, String> map1 = new HashMap<>();
+        map1.put("key-1", "value-1");
+        map1.put("key-2", "value-2");
+
+        final Map<String, String> map2 = new HashMap<>();
+        map2.put("key-3", "value-1");
+        map2.put("key-4", "value-2");
+
         Answer<Object> answer = new ReturnsSmartNulls();
 
         Object smartNull = answer.answer(invocationMethodWithVarArgs(new Map[] {map1, map2}));

--- a/src/test/java/org/mockito/internal/util/PlatformTest.java
+++ b/src/test/java/org/mockito/internal/util/PlatformTest.java
@@ -8,7 +8,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import java.util.Map;
-
 import org.junit.Test;
 
 // Possible description on a IBM J9 VM (see #801)
@@ -75,23 +74,19 @@ public class PlatformTest {
         // https://stackoverflow.com/questions/35844985/how-do-we-get-sr-and-fp-of-ibm-jre-using-java
         //  -
         // https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.80.doc/user/build_number.html
-        Map<String, Boolean> versions =
-                new HashMap<String, Boolean>() {
-                    {
-                        put("1.8.0_92-b14", false);
-                        put("1.8.0-b24", true);
-                        put("1.8.0_5", true);
-                        put("1.8.0b5_u44", true);
-                        put("1.8.0b5_u92", false);
-                        put("1.7.0_4", false);
-                        put("1.4.0_03-b04", false);
-                        put("1.4.0_03-ea-b01", false);
-                        put("pxi3270_27sr4-20160303_03 (SR4)", false);
-                        put("pwi3260sr11-20120412_01 (SR11)", false);
-                        put("pwa6480sr1fp10-20150711_01 (SR1 FP10)", false);
-                        put("null", false);
-                    }
-                };
+        Map<String, Boolean> versions = new HashMap<>();
+        versions.put("1.8.0_92-b14", false);
+        versions.put("1.8.0-b24", true);
+        versions.put("1.8.0_5", true);
+        versions.put("1.8.0b5_u44", true);
+        versions.put("1.8.0b5_u92", false);
+        versions.put("1.7.0_4", false);
+        versions.put("1.4.0_03-b04", false);
+        versions.put("1.4.0_03-ea-b01", false);
+        versions.put("pxi3270_27sr4-20160303_03 (SR4)", false);
+        versions.put("pwi3260sr11-20120412_01 (SR11)", false);
+        versions.put("pwa6480sr1fp10-20150711_01 (SR1 FP10)", false);
+        versions.put("null", false);
 
         assertPlatformParsesCorrectlyVariousVersionScheme(versions);
     }
@@ -134,15 +129,11 @@ public class PlatformTest {
         // java.specification.version      1.9           9
         // java.vm.specification.version   1.9           9
         //
-        Map<String, Boolean> versions =
-                new HashMap<String, Boolean>() {
-                    {
-                        put("9-ea+73", false);
-                        put("9+100", false);
-                        put("9.1.2+62", false);
-                        put("9.0.1+20", false);
-                    }
-                };
+        Map<String, Boolean> versions = new HashMap<>();
+        versions.put("9-ea+73", false);
+        versions.put("9+100", false);
+        versions.put("9.1.2+62", false);
+        versions.put("9.0.1+20", false);
 
         assertPlatformParsesCorrectlyVariousVersionScheme(versions);
     }

--- a/src/test/java/org/mockitousage/stubbing/StubbingWithThrowablesTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingWithThrowablesTest.java
@@ -24,6 +24,7 @@ import java.util.LinkedList;
 import java.util.Map;
 
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.exceptions.base.MockitoException;
@@ -248,34 +249,34 @@ public class StubbingWithThrowablesTest extends TestBase {
                 .hasMessageContaining("Cannot stub with null throwable");
     }
 
-    @Test
-    public void shouldNotAllowSettingNullThrowableClass() {
-        assertThatThrownBy(
-                        () -> {
-                            when(mock.isEmpty()).thenThrow((Class) null);
-                        })
+    private void assertExceptionTypeCanNotBeNull(ThrowingCallable throwingCallable) {
+        assertThatThrownBy(throwingCallable)
                 .isInstanceOf(MockitoException.class)
                 .hasMessageContaining("Exception type cannot be null");
+    }
+
+    @Test
+    public void shouldNotAllowSettingNullThrowableClass() {
+        assertExceptionTypeCanNotBeNull(
+                () -> {
+                    when(mock.isEmpty()).thenThrow((Class) null);
+                });
     }
 
     @Test
     public void shouldNotAllowSettingNullThrowableClasses() {
-        assertThatThrownBy(
-                        () -> {
-                            when(mock.isEmpty()).thenThrow(RuntimeException.class, (Class[]) null);
-                        })
-                .isInstanceOf(MockitoException.class)
-                .hasMessageContaining("Exception type cannot be null");
+        assertExceptionTypeCanNotBeNull(
+                () -> {
+                    when(mock.isEmpty()).thenThrow(RuntimeException.class, (Class[]) null);
+                });
     }
 
     @Test
     public void shouldNotAllowSettingNullVarArgThrowableClass() {
-        assertThatThrownBy(
-                        () -> {
-                            when(mock.isEmpty()).thenThrow(RuntimeException.class, (Class) null);
-                        })
-                .isInstanceOf(MockitoException.class)
-                .hasMessageContaining("Exception type cannot be null");
+        assertExceptionTypeCanNotBeNull(
+                () -> {
+                    when(mock.isEmpty()).thenThrow(RuntimeException.class, (Class) null);
+                });
     }
 
     @Test

--- a/subprojects/errorprone/src/main/java/org/mockito/errorprone/bugpatterns/MockitoAnyIncorrectPrimitiveType.java
+++ b/subprojects/errorprone/src/main/java/org/mockito/errorprone/bugpatterns/MockitoAnyIncorrectPrimitiveType.java
@@ -49,7 +49,7 @@ public class MockitoAnyIncorrectPrimitiveType extends AbstractMockitoAnyForPrimi
   };
 
   private static final Matcher<ExpressionTree> METHOD_MATCHER =
-      staticMethod().onClassAny(CLASS_NAMES).withNameMatching(METHOD_NAME_PATTERN).withParameters();
+      staticMethod().onClassAny(CLASS_NAMES).withNameMatching(METHOD_NAME_PATTERN).withNoParameters();
 
   @Override
   protected Matcher<? super MethodInvocationTree> matcher() {


### PR DESCRIPTION
Fixes #2554. 

Today ErrorProne [2.12.0](https://github.com/google/error-prone/releases/tag/v2.12.0) has been released. It contains https://github.com/google/error-prone/issues/2926, which fixes the incompatibility issue for Mockito. 
We are blocked internally on the new Mockito release and therefore decided to help out and open this PR.

I'm open to other ideas on how to improve the code.  

---
Bumps `versions.errorprone` from 2.10.0 to 2.12.1.

Updates `error_prone_core` from 2.10.0 to 2.12.1
- [Release notes](https://github.com/google/error-prone/releases)
- [Commits](https://github.com/google/error-prone/compare/v2.10.0...v2.12.1)

Updates `error_prone_test_helpers` from 2.10.0 to 2.12.1
- [Release notes](https://github.com/google/error-prone/releases)
- [Commits](https://github.com/google/error-prone/compare/v2.10.0...v2.12.1)

---
updated-dependencies:
- dependency-name: com.google.errorprone:error_prone_core
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: com.google.errorprone:error_prone_test_helpers
  dependency-type: direct:production
  update-type: version-update:semver-minor
...
