### PR TITLE
Support subclass mocks on Graal VM.

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
@@ -33,6 +33,7 @@ import net.bytebuddy.description.field.FieldList;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.method.MethodList;
 import net.bytebuddy.description.method.ParameterDescription;
+import net.bytebuddy.description.type.TypeDefinition;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.scaffold.MethodGraph;
 import net.bytebuddy.implementation.Implementation;
@@ -188,7 +189,9 @@ public class MockMethodAdvice extends MockMethodDispatcher {
         SoftReference<MethodGraph> reference = graphs.get(instance.getClass());
         MethodGraph methodGraph = reference == null ? null : reference.get();
         if (methodGraph == null) {
-            methodGraph = compiler.compile(new TypeDescription.ForLoadedType(instance.getClass()));
+            methodGraph =
+                    compiler.compile(
+                            (TypeDefinition) TypeDescription.ForLoadedType.of(instance.getClass()));
             graphs.put(instance.getClass(), new SoftReference<>(methodGraph));
         }
         MethodGraph.Node node =

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/ModuleHandler.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/ModuleHandler.java
@@ -4,13 +4,6 @@
  */
 package org.mockito.internal.creation.bytebuddy;
 
-import static net.bytebuddy.matcher.ElementMatchers.isTypeInitializer;
-import static org.mockito.internal.util.StringUtil.join;
-
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.Random;
-
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.description.modifier.Ownership;
 import net.bytebuddy.description.modifier.Visibility;
@@ -18,8 +11,17 @@ import net.bytebuddy.dynamic.scaffold.subclass.ConstructorStrategy;
 import net.bytebuddy.implementation.Implementation;
 import net.bytebuddy.implementation.MethodCall;
 import net.bytebuddy.implementation.StubMethod;
+import net.bytebuddy.utility.GraalImageCode;
+import net.bytebuddy.utility.RandomString;
+import org.mockito.Mockito;
 import org.mockito.codegen.InjectionBase;
 import org.mockito.exceptions.base.MockitoException;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import static net.bytebuddy.matcher.ElementMatchers.isTypeInitializer;
+import static org.mockito.internal.util.StringUtil.join;
 
 abstract class ModuleHandler {
 
@@ -35,9 +37,9 @@ abstract class ModuleHandler {
 
     abstract void adjustModuleGraph(Class<?> source, Class<?> target, boolean export, boolean read);
 
-    static ModuleHandler make(ByteBuddy byteBuddy, SubclassLoader loader, Random random) {
+    static ModuleHandler make(ByteBuddy byteBuddy, SubclassLoader loader) {
         try {
-            return new ModuleSystemFound(byteBuddy, loader, random);
+            return new ModuleSystemFound(byteBuddy, loader);
         } catch (Exception ignored) {
             return new NoModuleSystemFound();
         }
@@ -47,7 +49,6 @@ abstract class ModuleHandler {
 
         private final ByteBuddy byteBuddy;
         private final SubclassLoader loader;
-        private final Random random;
 
         private final int injectonBaseSuffix;
 
@@ -58,15 +59,15 @@ abstract class ModuleHandler {
                 canRead,
                 addExports,
                 addReads,
-                addOpens,
                 forName;
 
-        private ModuleSystemFound(ByteBuddy byteBuddy, SubclassLoader loader, Random random)
-                throws Exception {
+        private ModuleSystemFound(ByteBuddy byteBuddy, SubclassLoader loader) throws Exception {
             this.byteBuddy = byteBuddy;
             this.loader = loader;
-            this.random = random;
-            injectonBaseSuffix = Math.abs(random.nextInt());
+            injectonBaseSuffix =
+                    GraalImageCode.getCurrent().isDefined()
+                            ? 0
+                            : Math.abs(Mockito.class.hashCode());
             Class<?> moduleType = Class.forName("java.lang.Module");
             getModule = Class.class.getMethod("getModule");
             isOpen = moduleType.getMethod("isOpen", String.class, moduleType);
@@ -75,7 +76,6 @@ abstract class ModuleHandler {
             canRead = moduleType.getMethod("canRead", moduleType);
             addExports = moduleType.getMethod("addExports", String.class, moduleType);
             addReads = moduleType.getMethod("addReads", moduleType);
-            addOpens = moduleType.getMethod("addOpens", String.class, moduleType);
             forName = Class.class.getMethod("forName", String.class);
         }
 
@@ -207,9 +207,12 @@ abstract class ModuleHandler {
                                             ConstructorStrategy.Default.NO_CONSTRUCTORS)
                                     .name(
                                             String.format(
-                                                    "%s$%d",
+                                                    "%s$%s%s",
                                                     "org.mockito.codegen.MockitoTypeCarrier",
-                                                    Math.abs(random.nextInt())))
+                                                    RandomString.hashOf(
+                                                            source.getName().hashCode()),
+                                                    RandomString.hashOf(
+                                                            target.getName().hashCode())))
                                     .defineField(
                                             "mockitoType",
                                             Class.class,
@@ -262,10 +265,11 @@ abstract class ModuleHandler {
                                 .subclass(Object.class)
                                 .name(
                                         String.format(
-                                                "%s$%s$%d",
+                                                "%s$%s$%s%s",
                                                 source.getName(),
                                                 "MockitoModuleProbe",
-                                                Math.abs(random.nextInt())))
+                                                RandomString.hashOf(source.getName().hashCode()),
+                                                RandomString.hashOf(target.getName().hashCode())))
                                 .invokable(isTypeInitializer())
                                 .intercept(implementation)
                                 .make()

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassInjectionLoader.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassInjectionLoader.java
@@ -11,6 +11,7 @@ import java.lang.reflect.Method;
 
 import net.bytebuddy.dynamic.loading.ClassInjector;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+import net.bytebuddy.utility.GraalImageCode;
 import org.mockito.codegen.InjectionBase;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.util.Platform;
@@ -27,9 +28,14 @@ class SubclassInjectionLoader implements SubclassLoader {
     private final SubclassLoader loader;
 
     SubclassInjectionLoader() {
-        if (!Boolean.getBoolean("org.mockito.internal.noUnsafeInjection")
+        if (!Boolean.parseBoolean(
+                        System.getProperty(
+                                "org.mockito.internal.noUnsafeInjection",
+                                Boolean.toString(GraalImageCode.getCurrent().isDefined())))
                 && ClassInjector.UsingReflection.isAvailable()) {
             this.loader = new WithReflection();
+        } else if (GraalImageCode.getCurrent().isDefined()) {
+            this.loader = new WithIsolatedLoader();
         } else if (ClassInjector.UsingLookup.isAvailable()) {
             this.loader = tryLookup();
         } else {
@@ -67,6 +73,20 @@ class SubclassInjectionLoader implements SubclassLoader {
                     localMock
                             ? mockedType.getProtectionDomain()
                             : InjectionBase.class.getProtectionDomain());
+        }
+    }
+
+    private static class WithIsolatedLoader implements SubclassLoader {
+
+        @Override
+        public boolean isDisrespectingOpenness() {
+            return false;
+        }
+
+        @Override
+        public ClassLoadingStrategy<ClassLoader> resolveStrategy(
+                Class<?> mockedType, ClassLoader classLoader, boolean localMock) {
+            return ClassLoadingStrategy.Default.WRAPPER;
         }
     }
 

--- a/src/main/java/org/mockito/internal/util/Platform.java
+++ b/src/main/java/org/mockito/internal/util/Platform.java
@@ -69,7 +69,11 @@ public abstract class Platform {
     }
 
     public static boolean isJava8BelowUpdate45() {
-        return isJava8BelowUpdate45(JVM_VERSION);
+        if (JVM_VERSION == null) {
+            return false;
+        } else {
+            return isJava8BelowUpdate45(JVM_VERSION);
+        }
     }
 
     static boolean isJava8BelowUpdate45(String jvmVersion) {

--- a/src/test/java/org/mockitointegration/NoByteCodeDependenciesTest.java
+++ b/src/test/java/org/mockitointegration/NoByteCodeDependenciesTest.java
@@ -15,8 +15,6 @@ import org.mockitoutil.ClassLoaders;
 
 public class NoByteCodeDependenciesTest {
 
-    private ClassLoader contextClassLoader;
-
     @Test
     public void pure_mockito_should_not_depend_bytecode_libraries() throws Exception {
 


### PR DESCRIPTION
Adds support for running Mockito on Graal native image using the (still experimental) experimental-class-define-support. Byte Buddy now picks up the Graal image code and creates more predicatable class files such that hashes during the JIT runtime and the image runtime match.

This leads to some minor restrictions, but generally this should not be a big issue. With future improvements in Graal, these restrictions might fade in the future. 

As an example, with the mockto.jar that is produced in this PR:

```bash
#!/bin/bash
set -x
set -e
if [[ -z $1 ]]; then
  echo "Specify location of Graal VM as first argument"
  exit 1
fi
$1/bin/gu install native-image
rm -rf META-INF sample.build_artifacts.txt Sample.class Sample.java
echo "public class Sample {
  public static void main(String[] args) {
    Sample sample = org.mockito.Mockito.mock(Sample.class);
    org.mockito.Mockito.when(sample.m()).thenReturn(\"Hello Graal!\");
    System.out.println(sample.getClass());
    System.out.println(sample.m());
  }
  public String m() { return null; }
}" > Sample.java
wget -O bytebuddy.jar https://search.maven.org/remotecontent?filepath=net/bytebuddy/byte-buddy/1.12.9/byte-buddy-1.12.9.jar
#wget -O mockito.jar https://search.maven.org/remotecontent?filepath=org/mockito/mockito-core/XXX/mockito-core-XXXX.jar
wget -O objenesis.jar https://search.maven.org/remotecontent?filepath=org/objenesis/objenesis/3.2/objenesis-3.2.jar
export dependencies=bytebuddy.jar:mockito.jar:objenesis.jar:.
$1/bin/javac -cp $dependencies Sample.java
$1/bin/java -agentlib:native-image-agent=config-output-dir=META-INF/native-image,experimental-class-define-support -Dorg.graalvm.nativeimage.imagecode=agent -cp $dependencies Sample
$1/bin/native-image --no-fallback -cp $dependencies \
--rerun-class-initialization-at-runtime=\
net.bytebuddy.ClassFileVersion,\
net.bytebuddy.utility.dispatcher.JavaDispatcher,\
net.bytebuddy.utility.Invoker\$Dispatcher \
--initialize-at-build-time=\
net.bytebuddy.description.method.MethodDescription\$InDefinedShape\$AbstractBase\$ForLoadedExecutable,\
net.bytebuddy.description.type.TypeDescription\$AbstractBase,\
net.bytebuddy.description.type.TypeDescription\$ForLoadedType,\
net.bytebuddy.description.method.MethodDescription\$ForLoadedMethod,\
net.bytebuddy.implementation.bind.annotation.Argument\$BindingMechanic,\
net.bytebuddy.implementation.bind.annotation.Argument\$BindingMechanic\$1,\
net.bytebuddy.implementation.bind.annotation.Argument\$BindingMechanic\$2,\
net.bytebuddy.implementation.bind.annotation.Super\$Instantiation\$2 \
Sample
./sample
```

The setup is still a bit cluncky but Oracle is working on improving the process. There will likely be plugins for the tools in question to improve this.