### PR TITLE
Fixes #2623: Use zulu distribution and java 11 for release GHA job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,11 +96,11 @@ jobs:
         with:
           fetch-depth: '0' # https://github.com/shipkit/shipkit-changelog#fetch-depth-on-ci
 
-      - name: Set up Java 8
+      - name: Set up Java 11
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
-          java-version: 8
+          distribution: 'zulu'
+          java-version: 11
 
       - name: Build and release
         run: ./gradlew githubRelease publishToSonatype closeAndReleaseStagingRepository releaseSummary


### PR DESCRIPTION
Error prone module set to release only with jdk 11.  Release GHA was still set to use only jdk 8.  This resolves #2623 by moving the GHA for release to java 11.

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [X ] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [ X] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [ X] Avoid other runtime dependencies
 - [ X] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [ X] The pull request follows coding style
 - [ X] Mention `Fixes #<issue number>` in the description _if relevant_
 - [ X] At least one commit should mention `Fixes #<issue number>` _if relevant_

