### PR TITLE
fix Reproducible Build issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,8 @@ allprojects { proj ->
     tasks.withType(AbstractArchiveTask) {
         preserveFileTimestamps = false
         reproducibleFileOrder = true
+        dirMode = Integer.parseInt("0755", 8)
+        fileMode = Integer.parseInt("0644", 8)
     }
 
     apply plugin: 'checkstyle'


### PR DESCRIPTION
see https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/mockito/mockito-core/README.md

release 4.5.1 has only 1 cause of non-reproducible bits: unix group permission on files

with that little change, next release should be 100% reproducible as reproduced by independant people