### PR TITLE
Fixes #2648 : Add support for customising strictness via @Mock annotation and MockSettings

### DIFF
--- a/src/main/java/org/mockito/Mock.java
+++ b/src/main/java/org/mockito/Mock.java
@@ -13,6 +13,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.quality.Strictness;
 import org.mockito.stubbing.Answer;
 
 /**
@@ -111,4 +112,12 @@ public @interface Mock {
      * @since 2.23.3
      */
     boolean lenient() default false;
+
+    /**
+     * Mock will have custom strictness, see {@link MockSettings#strictness(Strictness)}.
+     * For examples how to use 'Mock' annotation and parameters see {@link Mock}.
+     *
+     * @since 4.5.2
+     */
+    Strictness strictness() default Strictness.STRICT_STUBS;
 }

--- a/src/main/java/org/mockito/MockSettings.java
+++ b/src/main/java/org/mockito/MockSettings.java
@@ -361,4 +361,20 @@ public interface MockSettings extends Serializable {
      * For more information and an elaborate example, see {@link Mockito#lenient()}.
      */
     MockSettings lenient();
+
+    /**
+     * Specifies strictness level for the mock.
+     * The default strictness level is STRICT_STUBS
+     *
+     * <pre class="code"><code class="java">
+     *   Foo defaultStrictMock = mock(Foo.class);
+     *   Foo explicitStrictMock = mock(Foo.class, withSettings().strictness(Strictness.STRICT_STUBS));
+     *   Foo lenientMock = mock(Foo.class, withSettings().strictness(Strictness.LENIENT));
+     * </code></pre>
+     *
+     * @param strictness the strictness level to set on mock
+     * @return settings instance so that you can fluently specify other settings
+     * @since 4.5.2
+     */
+    MockSettings strictness(Strictness strictness);
 }

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -105,6 +105,7 @@ import java.util.function.Function;
  *      <a href="#49">49. New API for mocking object construction (Since 3.5.0)</a><br/>
  *      <a href="#50">50. Avoiding code generation when restricting mocks to interfaces (Since 3.12.2)</a><br/>
  *      <a href="#51">51. New API for marking classes as unmockable (Since 4.1.0)</a><br/>
+ *      <a href="#51">52. New strictness attribute for @Mock annotation and <code>MockSettings.strictness()</code> methods (Since 4.5.2)</a><br/>
  * </b>
  *
  * <h3 id="0">0. <a class="meaningful_link" href="#mockito2" name="mockito2">Migrating to Mockito 2</a></h3>
@@ -1606,6 +1607,20 @@ import java.util.function.Function;
  * For any class/interface you own that is problematic to mock, you can now mark the class with {@link org.mockito.DoNotMock @DoNotMock}. For usage
  * of the annotation and how to ship your own (to avoid a compile time dependency on a test artifact), please see its JavaDoc.
  * <p>
+ *
+ * <h3 id="52">52. <a class="meaningful_link" href="#mockito_strictness" name="mockito_strictness">
+ *  New strictness attribute for @Mock annotation and <code>MockSettings.strictness()</code> methods (Since 4.5.2)</a></h3>
+ *
+ * By default Mocks use Strict stubbing and now you can customize the strictness level
+ * either using @Mock annotation strictness attribute or using MockSettings.strictness().
+ *
+ * <pre class="code"><code class="java">
+ *   @Mock(strictness = Strictness.LENIENT)
+ *   Foo mock;
+ *   // using MockSettings.withSettings()
+ *   Foo mock = Mockito.mock(Foo.class, withSettings().strictness(Strictness.WARN));
+ * </code></pre>
+ *
  */
 @CheckReturnValue
 @SuppressWarnings("unchecked")

--- a/src/main/java/org/mockito/internal/configuration/MockAnnotationProcessor.java
+++ b/src/main/java/org/mockito/internal/configuration/MockAnnotationProcessor.java
@@ -45,6 +45,7 @@ public class MockAnnotationProcessor implements FieldAnnotationProcessor<Mock> {
         if (annotation.stubOnly()) {
             mockSettings.stubOnly();
         }
+        mockSettings.strictness(annotation.strictness());
         if (annotation.lenient()) {
             mockSettings.lenient();
         }

--- a/src/main/java/org/mockito/internal/creation/MockSettingsImpl.java
+++ b/src/main/java/org/mockito/internal/creation/MockSettingsImpl.java
@@ -12,6 +12,7 @@ import static org.mockito.internal.exceptions.Reporter.extraInterfacesDoesNotAcc
 import static org.mockito.internal.exceptions.Reporter.extraInterfacesRequiresAtLeastOneInterface;
 import static org.mockito.internal.exceptions.Reporter.methodDoesNotAcceptParameter;
 import static org.mockito.internal.exceptions.Reporter.requiresAtLeastOneListener;
+import static org.mockito.internal.exceptions.Reporter.strictnessDoesNotAcceptNullParameter;
 import static org.mockito.internal.util.collections.Sets.newSet;
 
 import java.io.Serializable;
@@ -33,6 +34,7 @@ import org.mockito.listeners.VerificationStartedListener;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.mock.MockName;
 import org.mockito.mock.SerializableMode;
+import org.mockito.quality.Strictness;
 import org.mockito.stubbing.Answer;
 
 @SuppressWarnings("unchecked")
@@ -239,7 +241,16 @@ public class MockSettingsImpl<T> extends CreationSettings<T>
 
     @Override
     public MockSettings lenient() {
-        this.lenient = true;
+        this.strictness = Strictness.LENIENT;
+        return this;
+    }
+
+    @Override
+    public MockSettings strictness(Strictness strictness) {
+        this.strictness = strictness;
+        if (strictness == null) {
+            throw strictnessDoesNotAcceptNullParameter();
+        }
         return this;
     }
 

--- a/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
+++ b/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
@@ -18,6 +18,7 @@ import org.mockito.listeners.VerificationStartedListener;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.mock.MockName;
 import org.mockito.mock.SerializableMode;
+import org.mockito.quality.Strictness;
 import org.mockito.stubbing.Answer;
 
 public class CreationSettings<T> implements MockCreationSettings<T>, Serializable {
@@ -44,7 +45,7 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
     private boolean useConstructor;
     private Object outerClassInstance;
     private Object[] constructorArgs;
-    protected boolean lenient;
+    protected Strictness strictness = Strictness.STRICT_STUBS;
 
     public CreationSettings() {}
 
@@ -65,7 +66,7 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
         this.useConstructor = copy.isUsingConstructor();
         this.outerClassInstance = copy.getOuterClassInstance();
         this.constructorArgs = copy.getConstructorArgs();
-        this.lenient = copy.lenient;
+        this.strictness = copy.strictness;
         this.stripAnnotations = copy.stripAnnotations;
     }
 
@@ -170,6 +171,11 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
 
     @Override
     public boolean isLenient() {
-        return lenient;
+        return strictness == Strictness.LENIENT;
+    }
+
+    @Override
+    public Strictness getStrictness() {
+        return strictness;
     }
 }

--- a/src/main/java/org/mockito/internal/exceptions/Reporter.java
+++ b/src/main/java/org/mockito/internal/exceptions/Reporter.java
@@ -964,6 +964,10 @@ public class Reporter {
         return new MockitoException("defaultAnswer() does not accept null parameter");
     }
 
+    public static MockitoException strictnessDoesNotAcceptNullParameter() {
+        return new MockitoException("strictness() does not accept null parameter");
+    }
+
     public static MockitoException serializableWontWorkForObjectsThatDontImplementSerializable(
             Class<?> classToMock) {
         return new MockitoException(

--- a/src/main/java/org/mockito/internal/stubbing/InvocationContainerImpl.java
+++ b/src/main/java/org/mockito/internal/stubbing/InvocationContainerImpl.java
@@ -38,7 +38,7 @@ public class InvocationContainerImpl implements InvocationContainer, Serializabl
 
     public InvocationContainerImpl(MockCreationSettings mockSettings) {
         this.registeredInvocations = createRegisteredInvocations(mockSettings);
-        this.mockStrictness = mockSettings.isLenient() ? Strictness.LENIENT : null;
+        this.mockStrictness = mockSettings.getStrictness();
         this.doAnswerStyleStubbing = new DoAnswerStyleStubbing();
     }
 

--- a/src/main/java/org/mockito/mock/MockCreationSettings.java
+++ b/src/main/java/org/mockito/mock/MockCreationSettings.java
@@ -124,4 +124,12 @@ public interface MockCreationSettings<T> {
      * @since 2.20.0
      */
     boolean isLenient();
+
+    /**
+     * Sets strictness level for the mock, e.g. having {@link Strictness#STRICT_STUBS} characteristic.
+     * For more information about using mocks with custom strictness, see {@link MockSettings#strictness(Strictness)}.
+     *
+     * @since 4.5.2
+     */
+    Strictness getStrictness();
 }

--- a/src/test/java/org/mockitousage/strictness/StrictnessMockAnnotationTest.java
+++ b/src/test/java/org/mockitousage/strictness/StrictnessMockAnnotationTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage.strictness;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.exceptions.misusing.PotentialStubbingProblem;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
+import org.mockitousage.IMethods;
+
+import static org.mockito.Mockito.when;
+
+public class StrictnessMockAnnotationTest {
+
+    public @Rule MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+
+    @Mock(strictness = Strictness.LENIENT)
+    IMethods lenientMock;
+
+    @Mock IMethods regularMock;
+
+    @Test
+    public void mock_is_lenient() {
+        when(lenientMock.simpleMethod("1")).thenReturn("1");
+        when(regularMock.simpleMethod("2")).thenReturn("2");
+
+        // then lenient mock does not throw:
+        ProductionCode.simpleMethod(lenientMock, "3");
+
+        // but regular mock throws:
+        Assertions.assertThatThrownBy(
+                        new ThrowableAssert.ThrowingCallable() {
+                            public void call() {
+                                ProductionCode.simpleMethod(regularMock, "4");
+                            }
+                        })
+                .isInstanceOf(PotentialStubbingProblem.class);
+    }
+}

--- a/src/test/java/org/mockitousage/strictness/StrictnessWithSettingsTest.java
+++ b/src/test/java/org/mockitousage/strictness/StrictnessWithSettingsTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage.strictness;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.exceptions.misusing.PotentialStubbingProblem;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
+import org.mockitousage.IMethods;
+
+import static org.mockito.Mockito.*;
+
+public class StrictnessWithSettingsTest {
+
+    public @Rule MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+
+    IMethods lenientMock;
+    IMethods regularMock;
+    IMethods strictMock;
+
+    @Before
+    public void before() {
+        lenientMock = mock(IMethods.class, withSettings().strictness(Strictness.LENIENT));
+        regularMock = mock(IMethods.class);
+        strictMock = mock(IMethods.class, withSettings().strictness(Strictness.STRICT_STUBS));
+    }
+
+    @Test
+    public void mock_is_lenient() {
+        when(lenientMock.simpleMethod("1")).thenReturn("1");
+        when(regularMock.simpleMethod("3")).thenReturn("3");
+        when(strictMock.simpleMethod("2")).thenReturn("2");
+
+        // then lenient mock does not throw:
+        ProductionCode.simpleMethod(lenientMock, "3");
+
+        // but regular mock throws:
+        Assertions.assertThatThrownBy(
+                        new ThrowableAssert.ThrowingCallable() {
+                            public void call() {
+                                ProductionCode.simpleMethod(regularMock, "4");
+                            }
+                        })
+                .isInstanceOf(PotentialStubbingProblem.class);
+
+        // also strict mock throws:
+        Assertions.assertThatThrownBy(
+                        new ThrowableAssert.ThrowingCallable() {
+                            public void call() {
+                                ProductionCode.simpleMethod(strictMock, "5");
+                            }
+                        })
+                .isInstanceOf(PotentialStubbingProblem.class);
+    }
+}


### PR DESCRIPTION
This PR fixes the issue https://github.com/mockito/mockito/issues/2648.

This is to add support for customising strictness level for mock using @Mock annotation or MockSettings.

Example 1:

```
class MyTest {
     @Mock(strictness = Strictness.LENIENT)
     Foo foo;
     ....
}
```

Example 2:

```
class MyTest {
     Foo mock = Mockito.mock(Foo.class, withSettings().strictness(Strictness.WARN));
     ....
}
```
