### PR TITLE
Fix for Issue2656

### DIFF
--- a/src/main/java/org/mockito/Mock.java
+++ b/src/main/java/org/mockito/Mock.java
@@ -122,7 +122,7 @@ public @interface Mock {
      *
      * @since 4.6.1
      */
-    Strictness strictness() default Strictness.NOT_SET;
+    Strictness strictness() default Strictness.TEST_LEVEL_DEFAULT;
 
     enum Strictness {
 
@@ -131,7 +131,7 @@ public @interface Mock {
          *
          * @since 4.6.1
          */
-        NOT_SET,
+        TEST_LEVEL_DEFAULT,
 
         /**
          * See {@link org.mockito.quality.Strictness#LENIENT}

--- a/src/main/java/org/mockito/Mock.java
+++ b/src/main/java/org/mockito/Mock.java
@@ -13,7 +13,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import org.mockito.junit.MockitoJUnitRunner;
-import org.mockito.quality.Strictness;
 import org.mockito.stubbing.Answer;
 
 /**
@@ -34,12 +33,13 @@ import org.mockito.stubbing.Answer;
  *       &#064;Mock(name = "database") private ArticleDatabase dbMock;
  *       &#064;Mock(answer = RETURNS_MOCKS) private UserProvider userProvider;
  *       &#064;Mock(extraInterfaces = {Queue.class, Observer.class}) private ArticleMonitor articleMonitor;
+ *       &#064;Mock(strictness = Mock.Strictness.LENIENT) private ArticleConsumer articleConsumer;
  *       &#064;Mock(stubOnly = true) private Logger logger;
  *
  *       private ArticleManager manager;
  *
  *       &#064;Before public void setup() {
- *           manager = new ArticleManager(userProvider, database, calculator, articleMonitor, logger);
+ *           manager = new ArticleManager(userProvider, database, calculator, articleMonitor, articleConsumer, logger);
  *       }
  *   }
  *
@@ -117,10 +117,45 @@ public @interface Mock {
     boolean lenient() default false;
 
     /**
-     * Mock will have custom strictness, see {@link MockSettings#strictness(Strictness)}.
+     * Mock will have custom strictness, see {@link MockSettings#strictness(org.mockito.quality.Strictness)}.
      * For examples how to use 'Mock' annotation and parameters see {@link Mock}.
      *
-     * @since 4.6.0
+     * @since 4.6.1
      */
-    Strictness strictness() default Strictness.STRICT_STUBS;
+    Strictness strictness() default Strictness.NOT_SET;
+
+    enum Strictness {
+
+        /**
+         * Default value used to indicate the mock does not override the test level strictness.
+         *
+         * @since 4.6.1
+         */
+        NOT_SET(null),
+
+        /**
+         * See {@link org.mockito.quality.Strictness#LENIENT}
+         */
+        LENIENT(org.mockito.quality.Strictness.LENIENT),
+
+        /**
+         * See {@link org.mockito.quality.Strictness#WARN}
+         */
+        WARN(org.mockito.quality.Strictness.WARN),
+
+        /**
+         * See {@link org.mockito.quality.Strictness#STRICT_STUBS}
+         */
+        STRICT_STUBS(org.mockito.quality.Strictness.STRICT_STUBS);
+
+        private final org.mockito.quality.Strictness outer;
+
+        Strictness(org.mockito.quality.Strictness outer) {
+            this.outer = outer;
+        }
+
+        public org.mockito.quality.Strictness outer() {
+            return outer;
+        }
+    }
 }

--- a/src/main/java/org/mockito/Mock.java
+++ b/src/main/java/org/mockito/Mock.java
@@ -131,31 +131,21 @@ public @interface Mock {
          *
          * @since 4.6.1
          */
-        NOT_SET(null),
+        NOT_SET,
 
         /**
          * See {@link org.mockito.quality.Strictness#LENIENT}
          */
-        LENIENT(org.mockito.quality.Strictness.LENIENT),
+        LENIENT,
 
         /**
          * See {@link org.mockito.quality.Strictness#WARN}
          */
-        WARN(org.mockito.quality.Strictness.WARN),
+        WARN,
 
         /**
          * See {@link org.mockito.quality.Strictness#STRICT_STUBS}
          */
-        STRICT_STUBS(org.mockito.quality.Strictness.STRICT_STUBS);
-
-        private final org.mockito.quality.Strictness outer;
-
-        Strictness(org.mockito.quality.Strictness outer) {
-            this.outer = outer;
-        }
-
-        public org.mockito.quality.Strictness outer() {
-            return outer;
-        }
+        STRICT_STUBS
     }
 }

--- a/src/main/java/org/mockito/internal/configuration/MockAnnotationProcessor.java
+++ b/src/main/java/org/mockito/internal/configuration/MockAnnotationProcessor.java
@@ -17,6 +17,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.util.Supplier;
+import org.mockito.quality.Strictness;
 
 /**
  * Instantiates a mock on a field annotated by {@link Mock}
@@ -50,7 +51,7 @@ public class MockAnnotationProcessor implements FieldAnnotationProcessor<Mock> {
             mockSettings.lenient();
         }
         if (annotation.strictness() != Mock.Strictness.NOT_SET) {
-            mockSettings.strictness(annotation.strictness().outer());
+            mockSettings.strictness(Strictness.valueOf(annotation.strictness().toString()));
         }
 
         // see @Mock answer default value

--- a/src/main/java/org/mockito/internal/configuration/MockAnnotationProcessor.java
+++ b/src/main/java/org/mockito/internal/configuration/MockAnnotationProcessor.java
@@ -28,6 +28,7 @@ public class MockAnnotationProcessor implements FieldAnnotationProcessor<Mock> {
                 annotation, field.getType(), field::getGenericType, field.getName());
     }
 
+    @SuppressWarnings("deprecation")
     public static Object processAnnotationForMock(
             Mock annotation, Class<?> type, Supplier<Type> genericType, String name) {
         MockSettings mockSettings = Mockito.withSettings();
@@ -45,9 +46,11 @@ public class MockAnnotationProcessor implements FieldAnnotationProcessor<Mock> {
         if (annotation.stubOnly()) {
             mockSettings.stubOnly();
         }
-        mockSettings.strictness(annotation.strictness());
         if (annotation.lenient()) {
             mockSettings.lenient();
+        }
+        if (annotation.strictness() != Mock.Strictness.NOT_SET) {
+            mockSettings.strictness(annotation.strictness().outer());
         }
 
         // see @Mock answer default value

--- a/src/main/java/org/mockito/internal/configuration/MockAnnotationProcessor.java
+++ b/src/main/java/org/mockito/internal/configuration/MockAnnotationProcessor.java
@@ -50,7 +50,7 @@ public class MockAnnotationProcessor implements FieldAnnotationProcessor<Mock> {
         if (annotation.lenient()) {
             mockSettings.lenient();
         }
-        if (annotation.strictness() != Mock.Strictness.NOT_SET) {
+        if (annotation.strictness() != Mock.Strictness.TEST_LEVEL_DEFAULT) {
             mockSettings.strictness(Strictness.valueOf(annotation.strictness().toString()));
         }
 

--- a/src/main/java/org/mockito/internal/creation/MockSettingsImpl.java
+++ b/src/main/java/org/mockito/internal/creation/MockSettingsImpl.java
@@ -247,10 +247,10 @@ public class MockSettingsImpl<T> extends CreationSettings<T>
 
     @Override
     public MockSettings strictness(Strictness strictness) {
-        this.strictness = strictness;
         if (strictness == null) {
             throw strictnessDoesNotAcceptNullParameter();
         }
+        this.strictness = strictness;
         return this;
     }
 

--- a/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
+++ b/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
@@ -45,7 +45,7 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
     private boolean useConstructor;
     private Object outerClassInstance;
     private Object[] constructorArgs;
-    protected Strictness strictness = Strictness.STRICT_STUBS;
+    protected Strictness strictness = null;
 
     public CreationSettings() {}
 

--- a/src/test/java/org/mockito/MockTest.java
+++ b/src/test/java/org/mockito/MockTest.java
@@ -4,29 +4,57 @@
  */
 package org.mockito;
 
+import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assume.assumeThat;
 
-@RunWith(value = Parameterized.class)
+@RunWith(Enclosed.class)
 public class MockTest {
 
-    public org.mockito.quality.Strictness strictness;
+    @RunWith(value = Parameterized.class)
+    public static class StrictnessToMockStrictnessTest {
 
-    public MockTest(org.mockito.quality.Strictness strictness) {
-        this.strictness = strictness;
+        public org.mockito.quality.Strictness strictness;
+
+        public StrictnessToMockStrictnessTest(org.mockito.quality.Strictness strictness) {
+            this.strictness = strictness;
+        }
+
+        @Test
+        public void should_have_matching_enum_in_mock_strictness_enum() {
+            Mock.Strictness.valueOf(strictness.name());
+        }
+
+        @Parameterized.Parameters(name = "{0}")
+        public static org.mockito.quality.Strictness[] data() {
+            return org.mockito.quality.Strictness.values();
+        }
     }
 
-    @Test
-    public void should_have_matching_enum_in_mock_strictness_enum() {
-        final Mock.Strictness mockStrictness = Mock.Strictness.valueOf(this.strictness.name());
-        assertThat(mockStrictness.outer()).isEqualTo(strictness);
-    }
+    @RunWith(value = Parameterized.class)
+    public static class MockStrictnessToStrictnessTest {
 
-    @Parameterized.Parameters
-    public static org.mockito.quality.Strictness[] data() {
-        return org.mockito.quality.Strictness.values();
+        public Mock.Strictness strictness;
+
+        public MockStrictnessToStrictnessTest(Mock.Strictness strictness) {
+            this.strictness = strictness;
+        }
+
+        @Test
+        public void should_have_matching_enum_in_strictness_enum() {
+            assumeThat("Ignore NOT_SET", strictness, not(Mock.Strictness.NOT_SET));
+            org.mockito.quality.Strictness.valueOf(strictness.name());
+        }
+
+        @Parameterized.Parameters(name = "{0}")
+        public static Mock.Strictness[] data() {
+            return Mock.Strictness.values();
+        }
     }
 }

--- a/src/test/java/org/mockito/MockTest.java
+++ b/src/test/java/org/mockito/MockTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(value = Parameterized.class)
+public class MockTest {
+
+    public org.mockito.quality.Strictness strictness;
+
+    public MockTest(org.mockito.quality.Strictness strictness) {
+        this.strictness = strictness;
+    }
+
+    @Test
+    public void should_have_matching_enum_in_mock_strictness_enum() {
+        final Mock.Strictness mockStrictness = Mock.Strictness.valueOf(this.strictness.name());
+        assertThat(mockStrictness.outer()).isEqualTo(strictness);
+    }
+
+    @Parameterized.Parameters
+    public static org.mockito.quality.Strictness[] data() {
+        return org.mockito.quality.Strictness.values();
+    }
+}

--- a/src/test/java/org/mockito/MockTest.java
+++ b/src/test/java/org/mockito/MockTest.java
@@ -4,14 +4,12 @@
  */
 package org.mockito;
 
-import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assume.assumeThat;
 
 @RunWith(Enclosed.class)
@@ -48,7 +46,7 @@ public class MockTest {
 
         @Test
         public void should_have_matching_enum_in_strictness_enum() {
-            assumeThat("Ignore NOT_SET", strictness, not(Mock.Strictness.NOT_SET));
+            assumeThat("Ignore NOT_SET", strictness, not(Mock.Strictness.TEST_LEVEL_DEFAULT));
             org.mockito.quality.Strictness.valueOf(strictness.name());
         }
 

--- a/src/test/java/org/mockitousage/strictness/StrictnessMockAnnotationTest.java
+++ b/src/test/java/org/mockitousage/strictness/StrictnessMockAnnotationTest.java
@@ -7,6 +7,8 @@ package org.mockitousage.strictness;
 import org.assertj.core.api.Assertions;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.exceptions.misusing.PotentialStubbingProblem;
 import org.mockito.junit.MockitoJUnit;
@@ -16,28 +18,56 @@ import org.mockitousage.IMethods;
 
 import static org.mockito.Mockito.when;
 
+@RunWith(Enclosed.class)
 public class StrictnessMockAnnotationTest {
 
-    public @Rule MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+    public static class StrictStubsTest {
+        public @Rule MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
 
-    @Mock(strictness = Strictness.LENIENT)
-    IMethods lenientMock;
+        @Mock(strictness = Mock.Strictness.LENIENT)
+        IMethods lenientMock;
 
-    @Mock IMethods regularMock;
+        @Mock IMethods regularMock;
 
-    @Test
-    public void mock_is_lenient() {
-        when(lenientMock.simpleMethod("1")).thenReturn("1");
+        @Test
+        public void mock_is_lenient() {
+            when(lenientMock.simpleMethod("1")).thenReturn("1");
 
-        // then lenient mock does not throw:
-        ProductionCode.simpleMethod(lenientMock, "3");
+            // then lenient mock does not throw:
+            ProductionCode.simpleMethod(lenientMock, "3");
+        }
+
+        @Test
+        public void mock_is_strict() {
+            when(regularMock.simpleMethod("2")).thenReturn("2");
+
+            Assertions.assertThatThrownBy(() -> ProductionCode.simpleMethod(regularMock, "4"))
+                    .isInstanceOf(PotentialStubbingProblem.class);
+        }
     }
 
-    @Test
-    public void mock_is_strict() {
-        when(regularMock.simpleMethod("2")).thenReturn("2");
+    public static class LenientStubsTest {
+        public @Rule MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.LENIENT);
 
-        Assertions.assertThatThrownBy(() -> ProductionCode.simpleMethod(regularMock, "4"))
-                .isInstanceOf(PotentialStubbingProblem.class);
+        @Mock IMethods lenientMock;
+
+        @Mock(strictness = Mock.Strictness.STRICT_STUBS)
+        IMethods regularMock;
+
+        @Test
+        public void mock_is_lenient() {
+            when(lenientMock.simpleMethod("1")).thenReturn("1");
+
+            // then lenient mock does not throw:
+            ProductionCode.simpleMethod(lenientMock, "3");
+        }
+
+        @Test
+        public void mock_is_strict() {
+            when(regularMock.simpleMethod("2")).thenReturn("2");
+
+            Assertions.assertThatThrownBy(() -> ProductionCode.simpleMethod(regularMock, "4"))
+                    .isInstanceOf(PotentialStubbingProblem.class);
+        }
     }
 }

--- a/subprojects/junit-jupiter/src/test/java/org/mockitousage/ProductionCode.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockitousage/ProductionCode.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2022 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockitousage;
 
 import java.util.function.Predicate;

--- a/subprojects/junit-jupiter/src/test/java/org/mockitousage/ProductionCode.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockitousage/ProductionCode.java
@@ -1,0 +1,11 @@
+package org.mockitousage;
+
+import java.util.function.Predicate;
+
+public class ProductionCode {
+
+    @SuppressWarnings("ReturnValueIgnored")
+    public static void simpleMethod(Predicate<String> mock, String argument) {
+        mock.test(argument);
+    }
+}

--- a/subprojects/junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java
@@ -21,7 +21,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
@@ -159,6 +161,29 @@ class StrictnessTest {
     void inherits_strictness_from_base_class() {
         TestExecutionResult result = invokeTestClassAndRetrieveMethodResult(InheritedWarnStubs.class);
 
+        assertThat(result.getStatus()).isEqualTo(TestExecutionResult.Status.SUCCESSFUL);
+    }
+
+    @ExtendWith(MockitoExtension.class)
+    @MockitoSettings(strictness = Strictness.LENIENT)
+    static class LenientMockitoSettings {
+
+        @Mock
+        private Predicate<String> rootMock;
+
+        @Test
+        void should_not_throw_on_potential_stubbing_issue() {
+            Mockito.doReturn(true).when(rootMock).test("Foo");
+
+            ProductionCode.simpleMethod(rootMock, "Bar");
+        }
+    }
+
+    @Test
+    void use_strictness_from_settings_annotation() {
+        TestExecutionResult result = invokeTestClassAndRetrieveMethodResult(LenientMockitoSettings.class);
+
+        assertThat(result.getThrowable()).isEqualTo(Optional.empty());
         assertThat(result.getStatus()).isEqualTo(TestExecutionResult.Status.SUCCESSFUL);
     }
 


### PR DESCRIPTION
fix: https://github.com/mockito/mockito/issues/2656

Release 4.6.0 introduced a new feature https://github.com/mockito/mockito/pull/2650 to allow strictness to be set via the `@Mock` annotation. Unfortunately, the feature has a bug that results in any test-level strictness setting being ignored, e.g. 

```java
@ExtendWith(MockitorExtension.class)
@MockitoSettings(strictness = Strictness.LENIENT)
class ThingTest {

  @Mock
  private Thing lenientMock;
}
```

In the above code the `lenientMock` would actually be strict, as the `@Mock`'s `strictness` defaults to `STRICT_STUBS`. This default was overriding the test level `LENIENT`.

To fix the issue the default of the `Mock.strictness` method needs to be something meaning `not set`, allowing the mock's strictness to be ignored and the test level strictness to be used.

Unfortunately, no `no set` value exists in the `Strictness` enum and it is illegal to default to `null`. Fixing this in a backwards compatible way would have meant polluting the public API, (e.g. adding a `DEFAULT` value to the existing `Strictness` enum, which doesn't make sense in a lot of other places the enum is used).  As this feature has only just been released, and is essentially broken, a breaking change is being introduced to fix the issue.  

BREAKING CHANGE: This PR changes the return value of `Mock.strictness()` to a local `Strictness` enum value.  This will require users to change any code written against 4.6.0 that sets the `strictness` via the `@Mock` annotation to change their code.

Example code migration:

```java
class ThingTest {

    @Mock(strictness = Strictness.LENIENT)
    private Thing thing;

    ...
}
```

To:

```java
class ThingTest {

    @Mock(strictness = Mock.Strictness.LENIENT)
    private Thing thing;

    ...
}
```

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

