### PR TITLE
Improve Varargs handling in AdditionalAnswers

### DIFF
--- a/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java
@@ -4,8 +4,6 @@
  */
 package org.mockito.internal.stubbing.answers;
 
-import org.mockito.exceptions.base.MockitoException;
-import org.mockito.invocation.Invocation;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.mockito.stubbing.Answer1;
@@ -22,8 +20,6 @@ import org.mockito.stubbing.VoidAnswer5;
 import org.mockito.stubbing.VoidAnswer6;
 
 import java.lang.reflect.Method;
-
-import static org.mockito.internal.util.StringUtil.join;
 
 /**
  * Functional interfaces to make it easy to implement answers in Java 8
@@ -339,8 +335,8 @@ public class AnswerFunctionalInterfaces {
 
     @SuppressWarnings("unchecked")
     private static <A> A lastParameter(
-            InvocationOnMock invocationOnMock, Method answerMethod, int argumentIndex) {
-        final Method invocationMethod = invocationOnMock.getMethod();
+            InvocationOnMock invocation, Method answerMethod, int argumentIndex) {
+        final Method invocationMethod = invocation.getMethod();
 
         if (invocationMethod.isVarArgs()
                 && invocationMethod.getParameterTypes().length == (argumentIndex + 1)) {
@@ -348,11 +344,10 @@ public class AnswerFunctionalInterfaces {
                     invocationMethod.getParameterTypes()[argumentIndex];
             final Class<?> answerRawArgType = answerMethod.getParameterTypes()[argumentIndex];
             if (answerRawArgType.isAssignableFrom(invocationRawArgType)) {
-                Invocation invocation = (Invocation) invocationOnMock;
                 return (A) invocation.getRawArguments()[argumentIndex];
             }
         }
 
-        return invocationOnMock.getArgument(argumentIndex);
+        return invocation.getArgument(argumentIndex);
     }
 }

--- a/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java
@@ -4,6 +4,8 @@
  */
 package org.mockito.internal.stubbing.answers;
 
+import org.mockito.exceptions.base.MockitoException;
+import org.mockito.invocation.Invocation;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.mockito.stubbing.Answer1;
@@ -18,6 +20,10 @@ import org.mockito.stubbing.VoidAnswer3;
 import org.mockito.stubbing.VoidAnswer4;
 import org.mockito.stubbing.VoidAnswer5;
 import org.mockito.stubbing.VoidAnswer6;
+
+import java.lang.reflect.Method;
+
+import static org.mockito.internal.util.StringUtil.join;
 
 /**
  * Functional interfaces to make it easy to implement answers in Java 8
@@ -38,11 +44,11 @@ public class AnswerFunctionalInterfaces {
      * @return a new answer object
      */
     public static <T, A> Answer<T> toAnswer(final Answer1<T, A> answer) {
+        final Method answerMethod = findAnswerMethod(answer.getClass(), 1);
         return new Answer<T>() {
             @Override
-            @SuppressWarnings("unchecked")
             public T answer(InvocationOnMock invocation) throws Throwable {
-                return answer.answer((A) invocation.getArgument(0));
+                return answer.answer(lastParameter(invocation, answerMethod, 0));
             }
         };
     }
@@ -54,11 +60,11 @@ public class AnswerFunctionalInterfaces {
      * @return a new answer object
      */
     public static <A> Answer<Void> toAnswer(final VoidAnswer1<A> answer) {
+        final Method answerMethod = findAnswerMethod(answer.getClass(), 1);
         return new Answer<Void>() {
             @Override
-            @SuppressWarnings("unchecked")
             public Void answer(InvocationOnMock invocation) throws Throwable {
-                answer.answer((A) invocation.getArgument(0));
+                answer.answer(lastParameter(invocation, answerMethod, 0));
                 return null;
             }
         };
@@ -73,11 +79,13 @@ public class AnswerFunctionalInterfaces {
      * @return a new answer object
      */
     public static <T, A, B> Answer<T> toAnswer(final Answer2<T, A, B> answer) {
+        final Method answerMethod = findAnswerMethod(answer.getClass(), 2);
         return new Answer<T>() {
             @Override
             @SuppressWarnings("unchecked")
             public T answer(InvocationOnMock invocation) throws Throwable {
-                return answer.answer((A) invocation.getArgument(0), (B) invocation.getArgument(1));
+                return answer.answer(
+                        (A) invocation.getArgument(0), lastParameter(invocation, answerMethod, 1));
             }
         };
     }
@@ -90,11 +98,13 @@ public class AnswerFunctionalInterfaces {
      * @return a new answer object
      */
     public static <A, B> Answer<Void> toAnswer(final VoidAnswer2<A, B> answer) {
+        final Method answerMethod = findAnswerMethod(answer.getClass(), 2);
         return new Answer<Void>() {
             @Override
             @SuppressWarnings("unchecked")
             public Void answer(InvocationOnMock invocation) throws Throwable {
-                answer.answer((A) invocation.getArgument(0), (B) invocation.getArgument(1));
+                answer.answer(
+                        (A) invocation.getArgument(0), lastParameter(invocation, answerMethod, 1));
                 return null;
             }
         };
@@ -110,6 +120,7 @@ public class AnswerFunctionalInterfaces {
      * @return a new answer object
      */
     public static <T, A, B, C> Answer<T> toAnswer(final Answer3<T, A, B, C> answer) {
+        final Method answerMethod = findAnswerMethod(answer.getClass(), 3);
         return new Answer<T>() {
             @Override
             @SuppressWarnings("unchecked")
@@ -117,7 +128,7 @@ public class AnswerFunctionalInterfaces {
                 return answer.answer(
                         (A) invocation.getArgument(0),
                         (B) invocation.getArgument(1),
-                        (C) invocation.getArgument(2));
+                        lastParameter(invocation, answerMethod, 2));
             }
         };
     }
@@ -131,6 +142,7 @@ public class AnswerFunctionalInterfaces {
      * @return a new answer object
      */
     public static <A, B, C> Answer<Void> toAnswer(final VoidAnswer3<A, B, C> answer) {
+        final Method answerMethod = findAnswerMethod(answer.getClass(), 3);
         return new Answer<Void>() {
             @Override
             @SuppressWarnings("unchecked")
@@ -138,7 +150,7 @@ public class AnswerFunctionalInterfaces {
                 answer.answer(
                         (A) invocation.getArgument(0),
                         (B) invocation.getArgument(1),
-                        (C) invocation.getArgument(2));
+                        lastParameter(invocation, answerMethod, 2));
                 return null;
             }
         };
@@ -155,6 +167,7 @@ public class AnswerFunctionalInterfaces {
      * @return a new answer object
      */
     public static <T, A, B, C, D> Answer<T> toAnswer(final Answer4<T, A, B, C, D> answer) {
+        final Method answerMethod = findAnswerMethod(answer.getClass(), 4);
         return new Answer<T>() {
             @Override
             @SuppressWarnings("unchecked")
@@ -163,7 +176,7 @@ public class AnswerFunctionalInterfaces {
                         (A) invocation.getArgument(0),
                         (B) invocation.getArgument(1),
                         (C) invocation.getArgument(2),
-                        (D) invocation.getArgument(3));
+                        lastParameter(invocation, answerMethod, 3));
             }
         };
     }
@@ -178,6 +191,7 @@ public class AnswerFunctionalInterfaces {
      * @return a new answer object
      */
     public static <A, B, C, D> Answer<Void> toAnswer(final VoidAnswer4<A, B, C, D> answer) {
+        final Method answerMethod = findAnswerMethod(answer.getClass(), 4);
         return new Answer<Void>() {
             @Override
             @SuppressWarnings("unchecked")
@@ -186,7 +200,7 @@ public class AnswerFunctionalInterfaces {
                         (A) invocation.getArgument(0),
                         (B) invocation.getArgument(1),
                         (C) invocation.getArgument(2),
-                        (D) invocation.getArgument(3));
+                        lastParameter(invocation, answerMethod, 3));
                 return null;
             }
         };
@@ -204,6 +218,7 @@ public class AnswerFunctionalInterfaces {
      * @return a new answer object
      */
     public static <T, A, B, C, D, E> Answer<T> toAnswer(final Answer5<T, A, B, C, D, E> answer) {
+        final Method answerMethod = findAnswerMethod(answer.getClass(), 5);
         return new Answer<T>() {
             @Override
             @SuppressWarnings("unchecked")
@@ -213,7 +228,7 @@ public class AnswerFunctionalInterfaces {
                         (B) invocation.getArgument(1),
                         (C) invocation.getArgument(2),
                         (D) invocation.getArgument(3),
-                        (E) invocation.getArgument(4));
+                        lastParameter(invocation, answerMethod, 4));
             }
         };
     }
@@ -229,6 +244,7 @@ public class AnswerFunctionalInterfaces {
      * @return a new answer object
      */
     public static <A, B, C, D, E> Answer<Void> toAnswer(final VoidAnswer5<A, B, C, D, E> answer) {
+        final Method answerMethod = findAnswerMethod(answer.getClass(), 5);
         return new Answer<Void>() {
             @Override
             @SuppressWarnings("unchecked")
@@ -238,7 +254,7 @@ public class AnswerFunctionalInterfaces {
                         (B) invocation.getArgument(1),
                         (C) invocation.getArgument(2),
                         (D) invocation.getArgument(3),
-                        (E) invocation.getArgument(4));
+                        lastParameter(invocation, answerMethod, 4));
                 return null;
             }
         };
@@ -259,6 +275,7 @@ public class AnswerFunctionalInterfaces {
      */
     public static <T, A, B, C, D, E, F> Answer<T> toAnswer(
             final Answer6<T, A, B, C, D, E, F> answer) {
+        final Method answerMethod = findAnswerMethod(answer.getClass(), 6);
         return new Answer<T>() {
             @Override
             @SuppressWarnings("unchecked")
@@ -269,7 +286,7 @@ public class AnswerFunctionalInterfaces {
                         (C) invocation.getArgument(2),
                         (D) invocation.getArgument(3),
                         (E) invocation.getArgument(4),
-                        (F) invocation.getArgument(5));
+                        lastParameter(invocation, answerMethod, 5));
             }
         };
     }
@@ -288,6 +305,7 @@ public class AnswerFunctionalInterfaces {
      */
     public static <A, B, C, D, E, F> Answer<Void> toAnswer(
             final VoidAnswer6<A, B, C, D, E, F> answer) {
+        final Method answerMethod = findAnswerMethod(answer.getClass(), 6);
         return new Answer<Void>() {
             @Override
             @SuppressWarnings("unchecked")
@@ -298,9 +316,43 @@ public class AnswerFunctionalInterfaces {
                         (C) invocation.getArgument(2),
                         (D) invocation.getArgument(3),
                         (E) invocation.getArgument(4),
-                        (F) invocation.getArgument(5));
+                        lastParameter(invocation, answerMethod, 5));
                 return null;
             }
         };
+    }
+
+    private static Method findAnswerMethod(final Class<?> type, final int numberOfParameters) {
+        for (final Method m : type.getDeclaredMethods()) {
+            if (!m.isBridge()
+                    && m.getName().equals("answer")
+                    && m.getParameterTypes().length == numberOfParameters) {
+                return m;
+            }
+        }
+        throw new IllegalStateException(
+                "Failed to find answer() method on the supplied class: "
+                        + type.getName()
+                        + ", with the supplied number of parameters: "
+                        + numberOfParameters);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <A> A lastParameter(
+            InvocationOnMock invocationOnMock, Method answerMethod, int argumentIndex) {
+        final Method invocationMethod = invocationOnMock.getMethod();
+
+        if (invocationMethod.isVarArgs()
+                && invocationMethod.getParameterTypes().length == (argumentIndex + 1)) {
+            final Class<?> invocationRawArgType =
+                    invocationMethod.getParameterTypes()[argumentIndex];
+            final Class<?> answerRawArgType = answerMethod.getParameterTypes()[argumentIndex];
+            if (answerRawArgType.isAssignableFrom(invocationRawArgType)) {
+                Invocation invocation = (Invocation) invocationOnMock;
+                return (A) invocation.getRawArguments()[argumentIndex];
+            }
+        }
+
+        return invocationOnMock.getArgument(argumentIndex);
     }
 }

--- a/src/main/java/org/mockito/internal/stubbing/answers/ReturnsArgumentAt.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/ReturnsArgumentAt.java
@@ -51,9 +51,7 @@ public class ReturnsArgumentAt implements Answer<Object>, ValidableAnswer, Seria
     }
 
     @Override
-    public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
-        Invocation invocation = (Invocation) invocationOnMock;
-
+    public Object answer(InvocationOnMock invocation) throws Throwable {
         if (wantedArgIndexIsVarargAndSameTypeAsReturnType(invocation)) {
             // answer raw vararg array argument
             return invocation.getRawArguments()[invocation.getRawArguments().length - 1];
@@ -82,7 +80,7 @@ public class ReturnsArgumentAt implements Answer<Object>, ValidableAnswer, Seria
         return wantedArgumentPosition;
     }
 
-    private int inferWantedRawArgumentPosition(Invocation invocation) {
+    private int inferWantedRawArgumentPosition(InvocationOnMock invocation) {
         if (wantedArgumentPosition == LAST_ARGUMENT) {
             return invocation.getRawArguments().length - 1;
         }
@@ -121,7 +119,7 @@ public class ReturnsArgumentAt implements Answer<Object>, ValidableAnswer, Seria
         }
     }
 
-    private boolean wantedArgIndexIsVarargAndSameTypeAsReturnType(Invocation invocation) {
+    private boolean wantedArgIndexIsVarargAndSameTypeAsReturnType(InvocationOnMock invocation) {
         int rawArgumentPosition = inferWantedRawArgumentPosition(invocation);
         Method method = invocation.getMethod();
         Class<?>[] parameterTypes = method.getParameterTypes();

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ForwardsInvocations.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ForwardsInvocations.java
@@ -12,7 +12,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 import org.mockito.internal.configuration.plugins.Plugins;
-import org.mockito.invocation.Invocation;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.plugins.MemberAccessor;
 import org.mockito.stubbing.Answer;
@@ -45,7 +44,7 @@ public class ForwardsInvocations implements Answer<Object>, Serializable {
             }
 
             MemberAccessor accessor = Plugins.getMemberAccessor();
-            Object[] rawArguments = ((Invocation) invocation).getRawArguments();
+            Object[] rawArguments = invocation.getRawArguments();
             return accessor.invoke(delegateMethod, delegatedObject, rawArguments);
         } catch (NoSuchMethodException e) {
             throw delegatedMethodDoesNotExistOnDelegate(

--- a/src/main/java/org/mockito/invocation/Invocation.java
+++ b/src/main/java/org/mockito/invocation/Invocation.java
@@ -42,14 +42,6 @@ public interface Invocation extends InvocationOnMock, DescribedInvocation {
     Location getLocation();
 
     /**
-     * Returns unprocessed arguments whereas {@link #getArguments()} returns
-     * arguments already processed (e.g. varargs expended, etc.).
-     *
-     * @return unprocessed arguments, exactly as provided to this invocation.
-     */
-    Object[] getRawArguments();
-
-    /**
      * Wraps each argument using {@link org.mockito.ArgumentMatchers#eq(Object)} or
      * {@link org.mockito.AdditionalMatchers#aryEq(Object[])}
      * Used internally for the purposes of human-readable invocation printing.

--- a/src/main/java/org/mockito/invocation/Invocation.java
+++ b/src/main/java/org/mockito/invocation/Invocation.java
@@ -56,6 +56,7 @@ public interface Invocation extends InvocationOnMock, DescribedInvocation {
      * arguments already processed (e.g. varargs expended, etc.).
      *
      * @return unprocessed arguments, exactly as provided to this invocation.
+     * @since 4.7.0
      */
     Class<?> getRawReturnType();
 

--- a/src/main/java/org/mockito/invocation/InvocationOnMock.java
+++ b/src/main/java/org/mockito/invocation/InvocationOnMock.java
@@ -37,6 +37,7 @@ public interface InvocationOnMock extends Serializable {
      * arguments already processed (e.g. varargs expended, etc.).
      *
      * @return unprocessed arguments, exactly as provided to this invocation.
+     * @since 4.7.0
      */
     Object[] getRawArguments();
 

--- a/src/main/java/org/mockito/invocation/InvocationOnMock.java
+++ b/src/main/java/org/mockito/invocation/InvocationOnMock.java
@@ -33,6 +33,14 @@ public interface InvocationOnMock extends Serializable {
     Method getMethod();
 
     /**
+     * Returns unprocessed arguments whereas {@link #getArguments()} returns
+     * arguments already processed (e.g. varargs expended, etc.).
+     *
+     * @return unprocessed arguments, exactly as provided to this invocation.
+     */
+    Object[] getRawArguments();
+
+    /**
      * Returns arguments passed to the method.
      *
      * Vararg are expanded in this array.

--- a/src/test/java/org/mockitousage/IMethods.java
+++ b/src/test/java/org/mockitousage/IMethods.java
@@ -133,7 +133,25 @@ public interface IMethods {
 
     String threeArgumentMethodWithStrings(int valueOne, String valueTwo, String valueThree);
 
+    String threeArgumentVarArgsMethod(int valueOne, String valueTwo, String... valueThree);
+
     String fourArgumentMethod(int valueOne, String valueTwo, String valueThree, boolean[] array);
+
+    String fourArgumentVarArgsMethod(
+            int valueOne, String valueTwo, int valueThree, String... valueFour);
+
+    String fiveArgumentVarArgsMethod(
+            int valueOne, String valueTwo, int valueThree, String valueFour, String... valueFive);
+
+    String sixArgumentVarArgsMethod(
+            int valueOne,
+            String valueTwo,
+            int valueThree,
+            String valueFour,
+            String valueFive,
+            String... valueSix);
+
+    int arrayVarargsMethod(String[]... arrayVarArgs);
 
     void twoArgumentMethod(int one, int two);
 
@@ -234,6 +252,8 @@ public interface IMethods {
     int toIntPrimitive(Integer i);
 
     Integer toIntWrapper(int i);
+
+    Integer toIntWrapperVarArgs(int i, Object... varargs);
 
     String forObject(Object object);
 

--- a/src/test/java/org/mockitousage/MethodsImpl.java
+++ b/src/test/java/org/mockitousage/MethodsImpl.java
@@ -254,9 +254,46 @@ public class MethodsImpl implements IMethods {
         return null;
     }
 
+    public String threeArgumentVarArgsMethod(
+            final int valueOne, final String valueTwo, final String... valueThree) {
+        return null;
+    }
+
     public String fourArgumentMethod(
             int valueOne, String valueTwo, String valueThree, boolean[] array) {
         return null;
+    }
+
+    public String fourArgumentVarArgsMethod(
+            final int valueOne,
+            final String valueTwo,
+            final int valueThree,
+            final String... valueFour) {
+        return null;
+    }
+
+    public String fiveArgumentVarArgsMethod(
+            final int valueOne,
+            final String valueTwo,
+            final int valueThree,
+            final String valueFour,
+            final String... valueFive) {
+        return null;
+    }
+
+    public String sixArgumentVarArgsMethod(
+            final int valueOne,
+            final String valueTwo,
+            final int valueThree,
+            final String valueFour,
+            final String valueFive,
+            final String... valueSix) {
+        return null;
+    }
+
+    @Override
+    public int arrayVarargsMethod(final String[]... arrayVarArgs) {
+        return 0;
     }
 
     public void twoArgumentMethod(int one, int two) {}
@@ -432,6 +469,11 @@ public class MethodsImpl implements IMethods {
     }
 
     public Integer toIntWrapper(int i) {
+        return null;
+    }
+
+    @Override
+    public Integer toIntWrapperVarArgs(final int i, final Object... varargs) {
         return null;
     }
 

--- a/src/test/java/org/mockitousage/stubbing/StubbingWithAdditionalAnswersTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingWithAdditionalAnswersTest.java
@@ -5,6 +5,7 @@
 package org.mockitousage.stubbing;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.within;
 import static org.mockito.AdditionalAnswers.answer;
 import static org.mockito.AdditionalAnswers.answerVoid;
@@ -22,11 +23,13 @@ import static org.mockito.BDDMockito.mock;
 import static org.mockito.BDDMockito.times;
 import static org.mockito.BDDMockito.verify;
 
+import java.util.Arrays;
 import java.util.Date;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.exceptions.base.MockitoException;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer1;
 import org.mockito.stubbing.Answer2;
@@ -42,6 +45,7 @@ import org.mockito.stubbing.VoidAnswer5;
 import org.mockito.stubbing.VoidAnswer6;
 import org.mockitousage.IMethods;
 
+@SuppressWarnings({"Convert2Lambda", "Anonymous2MethodRef", "RedundantThrows"})
 @RunWith(MockitoJUnitRunner.class)
 public class StubbingWithAdditionalAnswersTest {
 
@@ -52,10 +56,39 @@ public class StubbingWithAdditionalAnswersTest {
         given(iMethods.objectArgMethod(any())).will(returnsFirstArg());
         given(iMethods.threeArgumentMethod(eq(0), any(), anyString())).will(returnsSecondArg());
         given(iMethods.threeArgumentMethod(eq(1), any(), anyString())).will(returnsLastArg());
+        given(iMethods.mixedVarargsReturningString(eq(1), any())).will(returnsArgAt(2));
 
         assertThat(iMethods.objectArgMethod("first")).isEqualTo("first");
         assertThat(iMethods.threeArgumentMethod(0, "second", "whatever")).isEqualTo("second");
         assertThat(iMethods.threeArgumentMethod(1, "whatever", "last")).isEqualTo("last");
+        assertThat(iMethods.mixedVarargsReturningString(1, "a", "b")).isEqualTo("b");
+    }
+
+    @Test
+    public void can_return_var_arguments_of_invocation() throws Exception {
+        given(iMethods.mixedVarargsReturningStringArray(eq(1), any())).will(returnsLastArg());
+        given(iMethods.mixedVarargsReturningObjectArray(eq(1), any())).will(returnsArgAt(1));
+
+        assertThat(iMethods.mixedVarargsReturningStringArray(1, "the", "var", "args"))
+                .containsExactlyInAnyOrder("the", "var", "args");
+        assertThat(iMethods.mixedVarargsReturningObjectArray(1, "the", "var", "args"))
+                .containsExactlyInAnyOrder("the", "var", "args");
+    }
+
+    @Test
+    public void returns_arg_at_throws_on_out_of_range_var_args() throws Exception {
+        given(iMethods.mixedVarargsReturningString(eq(1), any())).will(returnsArgAt(3));
+
+        assertThatThrownBy(() -> iMethods.mixedVarargsReturningString(1, "a", "b"))
+                .isInstanceOf(MockitoException.class)
+                .hasMessageContaining("Invalid argument index");
+
+        assertThatThrownBy(
+                        () ->
+                                given(iMethods.mixedVarargsReturningStringArray(eq(1), any()))
+                                        .will(returnsArgAt(3)))
+                .isInstanceOf(MockitoException.class)
+                .hasMessageContaining("The argument of type 'String' cannot be returned");
     }
 
     @Test
@@ -85,9 +118,11 @@ public class StubbingWithAdditionalAnswersTest {
     public void can_return_primitives_or_wrappers() throws Exception {
         given(iMethods.toIntPrimitive(anyInt())).will(returnsFirstArg());
         given(iMethods.toIntWrapper(anyInt())).will(returnsFirstArg());
+        given(iMethods.toIntWrapperVarArgs(anyInt(), any())).will(returnsFirstArg());
 
         assertThat(iMethods.toIntPrimitive(1)).isEqualTo(1);
         assertThat(iMethods.toIntWrapper(1)).isEqualTo(1);
+        assertThat(iMethods.toIntWrapperVarArgs(1, 10)).isEqualTo(1);
     }
 
     @Test
@@ -346,5 +381,341 @@ public class StubbingWithAdditionalAnswersTest {
 
         // expect the answer to write correctly to "target"
         verify(target, times(1)).simpleMethod("hello", 1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void can_return_based_on_strongly_types_one_parameter_var_args_function()
+            throws Exception {
+        given(iMethods.varargs(any()))
+                .will(
+                        answer(
+                                new Answer1<Integer, String[]>() {
+                                    public Integer answer(String[] strings) {
+                                        return strings.length;
+                                    }
+                                }));
+
+        assertThat(iMethods.varargs("some", "args")).isEqualTo(2);
+    }
+
+    @Test
+    public void will_execute_a_void_based_on_strongly_typed_one_parameter_var_args_function()
+            throws Exception {
+        final IMethods target = mock(IMethods.class);
+
+        given(iMethods.varargs(any()))
+                .will(
+                        answerVoid(
+                                new VoidAnswer1<String[]>() {
+                                    public void answer(String[] s) {
+                                        target.varargs(s);
+                                    }
+                                }));
+
+        // invoke on iMethods
+        iMethods.varargs("some", "args");
+
+        // expect the answer to write correctly to "target"
+        verify(target, times(1)).varargs("some", "args");
+    }
+
+    @Test
+    public void can_return_based_on_strongly_typed_two_parameter_var_args_function()
+            throws Exception {
+        given(iMethods.mixedVarargsReturningString(any(), any()))
+                .will(
+                        answer(
+                                new Answer2<String, Object, String[]>() {
+                                    public String answer(Object o, String[] s) {
+                                        return String.join("-", s);
+                                    }
+                                }));
+
+        assertThat(iMethods.mixedVarargsReturningString(1, "var", "args")).isEqualTo("var-args");
+    }
+
+    @Test
+    public void will_execute_a_void_based_on_strongly_typed_two_parameter_var_args_function()
+            throws Exception {
+        final IMethods target = mock(IMethods.class);
+
+        given(iMethods.mixedVarargsReturningString(any(), any()))
+                .will(
+                        answerVoid(
+                                new VoidAnswer2<Object, String[]>() {
+                                    public void answer(Object o, String[] s) {
+                                        target.mixedVarargsReturningString(o, s);
+                                    }
+                                }));
+
+        // invoke on iMethods
+        iMethods.mixedVarargsReturningString(1, "var", "args");
+
+        // expect the answer to write correctly to "target"
+        verify(target).mixedVarargsReturningString(1, "var", "args");
+    }
+
+    @Test
+    public void can_return_based_on_strongly_typed_three_parameter_var_args_function()
+            throws Exception {
+        final IMethods target = mock(IMethods.class);
+
+        given(iMethods.threeArgumentVarArgsMethod(anyInt(), any(), any()))
+                .will(
+                        answer(
+                                new Answer3<String, Integer, String, String[]>() {
+                                    public String answer(Integer i, String s1, String[] s2) {
+                                        target.threeArgumentVarArgsMethod(i, s1, s2);
+                                        return String.join("-", s2);
+                                    }
+                                }));
+
+        // invoke on iMethods
+        assertThat(iMethods.threeArgumentVarArgsMethod(1, "string1", "var", "args"))
+                .isEqualTo("var-args");
+
+        // expect the answer to write correctly to "target"
+        verify(target).threeArgumentVarArgsMethod(1, "string1", "var", "args");
+    }
+
+    @Test
+    public void will_execute_a_void_based_on_strongly_typed_three_parameter_var_args_function()
+            throws Exception {
+        final IMethods target = mock(IMethods.class);
+
+        given(iMethods.threeArgumentVarArgsMethod(anyInt(), any(), any()))
+                .will(
+                        answerVoid(
+                                new VoidAnswer3<Integer, String, String[]>() {
+                                    public void answer(Integer i, String s1, String[] s2) {
+                                        target.threeArgumentVarArgsMethod(i, s1, s2);
+                                    }
+                                }));
+
+        // invoke on iMethods
+        iMethods.threeArgumentVarArgsMethod(1, "string1", "var", "args");
+
+        // expect the answer to write correctly to "target"
+        verify(target, times(1)).threeArgumentVarArgsMethod(1, "string1", "var", "args");
+    }
+
+    @Test
+    public void can_return_based_on_strongly_typed_four_parameter_var_args_function()
+            throws Exception {
+        final IMethods target = mock(IMethods.class);
+        given(iMethods.fourArgumentVarArgsMethod(anyInt(), any(), anyInt(), any()))
+                .will(
+                        answer(
+                                new Answer4<String, Integer, String, Integer, String[]>() {
+                                    public String answer(
+                                            Integer i1, String s2, Integer i3, String[] s4) {
+                                        target.fourArgumentVarArgsMethod(i1, s2, i3, s4);
+                                        return String.join("-", s4);
+                                    }
+                                }));
+
+        // invoke on iMethods
+        String[] varargs = {"var", "args"};
+        assertThat(iMethods.fourArgumentVarArgsMethod(1, "string1", 3, varargs))
+                .isEqualTo("var-args");
+
+        // expect the answer to write correctly to "target"
+        verify(target, times(1)).fourArgumentVarArgsMethod(1, "string1", 3, varargs);
+    }
+
+    @Test
+    public void will_execute_a_void_based_on_strongly_typed_four_parameter_var_args_function()
+            throws Exception {
+        final IMethods target = mock(IMethods.class);
+
+        given(iMethods.fourArgumentVarArgsMethod(anyInt(), any(), anyInt(), any()))
+                .will(
+                        answerVoid(
+                                new VoidAnswer4<Integer, String, Integer, String[]>() {
+                                    public void answer(
+                                            Integer i, String s2, Integer i3, String[] s4) {
+                                        target.fourArgumentVarArgsMethod(i, s2, i3, s4);
+                                    }
+                                }));
+
+        // invoke on iMethods
+        iMethods.fourArgumentVarArgsMethod(1, "string1", 3, "var", "args");
+
+        // expect the answer to write correctly to "target"
+        verify(target, times(1)).fourArgumentVarArgsMethod(1, "string1", 3, "var", "args");
+    }
+
+    @Test
+    public void can_return_based_on_strongly_typed_five_parameter_var_args_function()
+            throws Exception {
+        final IMethods target = mock(IMethods.class);
+        given(iMethods.fiveArgumentVarArgsMethod(anyInt(), any(), anyInt(), any(), any()))
+                .will(
+                        answer(
+                                new Answer5<String, Integer, String, Integer, String, String[]>() {
+                                    public String answer(
+                                            Integer i1,
+                                            String s2,
+                                            Integer i3,
+                                            String s4,
+                                            String[] s5) {
+                                        target.fiveArgumentVarArgsMethod(i1, s2, i3, s4, s5);
+                                        return String.join("-", s5);
+                                    }
+                                }));
+
+        // invoke on iMethods
+        assertThat(iMethods.fiveArgumentVarArgsMethod(1, "two", 3, "four", "var", "args"))
+                .isEqualTo("var-args");
+
+        // expect the answer to write correctly to "target"
+        verify(target).fiveArgumentVarArgsMethod(1, "two", 3, "four", "var", "args");
+    }
+
+    @Test
+    public void will_execute_a_void_based_on_strongly_typed_five_parameter_var_args_function()
+            throws Exception {
+        final IMethods target = mock(IMethods.class);
+
+        given(iMethods.fiveArgumentVarArgsMethod(anyInt(), any(), anyInt(), any(), any()))
+                .will(
+                        answerVoid(
+                                new VoidAnswer5<Integer, String, Integer, String, String[]>() {
+                                    public void answer(
+                                            Integer i1,
+                                            String s2,
+                                            Integer i3,
+                                            String s4,
+                                            String[] s5) {
+                                        target.fiveArgumentVarArgsMethod(i1, s2, i3, s4, s5);
+                                    }
+                                }));
+
+        // invoke on iMethods
+        iMethods.fiveArgumentVarArgsMethod(1, "two", 3, "four", "var", "args");
+
+        // expect the answer to write correctly to "target"
+        verify(target).fiveArgumentVarArgsMethod(1, "two", 3, "four", "var", "args");
+    }
+
+    @Test
+    public void can_return_based_on_strongly_typed_six_parameter_var_args_function()
+            throws Exception {
+        final IMethods target = mock(IMethods.class);
+        given(iMethods.sixArgumentVarArgsMethod(anyInt(), any(), anyInt(), any(), any(), any()))
+                .will(
+                        answer(
+                                new Answer6<
+                                        String,
+                                        Integer,
+                                        String,
+                                        Integer,
+                                        String,
+                                        String,
+                                        String[]>() {
+                                    public String answer(
+                                            Integer i1,
+                                            String s2,
+                                            Integer i3,
+                                            String s4,
+                                            String s5,
+                                            String[] s6) {
+                                        target.sixArgumentVarArgsMethod(i1, s2, i3, s4, s5, s6);
+                                        return "answered";
+                                    }
+                                }));
+
+        // invoke on iMethods
+        assertThat(iMethods.sixArgumentVarArgsMethod(1, "two", 3, "four", "five", "var", "args"))
+                .isEqualTo("answered");
+
+        // expect the answer to write correctly to "target"
+        verify(target, times(1))
+                .sixArgumentVarArgsMethod(1, "two", 3, "four", "five", "var", "args");
+    }
+
+    @Test
+    public void will_execute_a_void_returning_strongly_typed_six_parameter_var_args_function()
+            throws Exception {
+        final IMethods target = mock(IMethods.class);
+        given(iMethods.sixArgumentVarArgsMethod(anyInt(), any(), anyInt(), any(), any(), any()))
+                .will(
+                        answerVoid(
+                                new VoidAnswer6<
+                                        Integer, String, Integer, String, String, String[]>() {
+                                    public void answer(
+                                            Integer i1,
+                                            String s2,
+                                            Integer i3,
+                                            String s4,
+                                            String s5,
+                                            String[] s6) {
+                                        target.sixArgumentVarArgsMethod(i1, s2, i3, s4, s5, s6);
+                                    }
+                                }));
+
+        // invoke on iMethods
+        iMethods.sixArgumentVarArgsMethod(1, "two", 3, "four", "five", "var", "args");
+
+        // expect the answer to write correctly to "target"
+        verify(target, times(1))
+                .sixArgumentVarArgsMethod(1, "two", 3, "four", "five", "var", "args");
+    }
+
+    @Test
+    public void can_accept_array_supertype_for_strongly_typed_var_args_function() throws Exception {
+        given(iMethods.varargs(any()))
+                .will(
+                        answer(
+                                new Answer1<Integer, Object[]>() {
+                                    public Integer answer(Object[] s) {
+                                        return s.length;
+                                    }
+                                }));
+
+        assertThat(iMethods.varargs("var", "args")).isEqualTo(2);
+    }
+
+    @Test
+    public void can_accept_non_vararg_answer_on_var_args_function() throws Exception {
+        given(iMethods.varargs(any()))
+                .will(
+                        answer(
+                                new Answer2<Integer, String, String>() {
+                                    public Integer answer(String s1, String s2) {
+                                        return s1.length() + s2.length();
+                                    }
+                                }));
+
+        assertThat(iMethods.varargs("var", "args")).isEqualTo(7);
+    }
+
+    @Test
+    public void should_work_with_var_args_with_no_elements() throws Exception {
+        given(iMethods.varargs(any()))
+                .will(
+                        answer(
+                                new Answer1<Integer, String[]>() {
+                                    public Integer answer(String[] s) {
+                                        return s.length;
+                                    }
+                                }));
+
+        assertThat(iMethods.varargs()).isEqualTo(0);
+    }
+
+    @Test
+    public void should_work_with_array_var_args() throws Exception {
+        given(iMethods.arrayVarargsMethod(any()))
+                .will(
+                        answer(
+                                new Answer1<Integer, String[][]>() {
+                                    public Integer answer(String[][] s) {
+                                        return Arrays.stream(s).mapToInt(e -> e.length).sum();
+                                    }
+                                }));
+
+        String[][] varArgs = {{}, {""}, {"", ""}};
+        assertThat(iMethods.arrayVarargsMethod(varArgs)).isEqualTo(3);
     }
 }

--- a/src/test/java/org/mockitousage/stubbing/StubbingWithAdditionalAnswersTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingWithAdditionalAnswersTest.java
@@ -82,7 +82,10 @@ public class StubbingWithAdditionalAnswersTest {
         assertThatThrownBy(() -> iMethods.mixedVarargsReturningString(1, "a", "b"))
                 .isInstanceOf(MockitoException.class)
                 .hasMessageContaining("Invalid argument index");
+    }
 
+    @Test
+    public void returns_arg_at_throws_on_out_of_range_array_var_args() throws Exception {
         assertThatThrownBy(
                         () ->
                                 given(iMethods.mixedVarargsReturningStringArray(eq(1), any()))


### PR DESCRIPTION
Fixes: #2644

Fixes issues around vararg handling for the following methods in `AdditionalAnswers`:
 * `returnsFirstArg`
 * `returnsSecondArg`
 * `returnsLastArg`
 * `returnsArgAt`
 * `answer`
 * `answerVoid`

These methods were not correctly handling varargs. For example,

```java
doAnswer(answerVoid(
      (VoidAnswer2<String, Object[]>) logger::info
   )).when(mock)
      .info(any(), (Object[]) any());

mock.info("Some message with {} {} {}", "three", "parameters", "");
```

Would previously have resulted in a `ClassCastException` being thrown from the `mock.info` call.  This was because the `answerVoid` method was not taking into account that the second parameter was a varargs parameter and was attempting to pass the second actual argument `"three"`, rather than the second _raw_ argument `["three", "parameters", ""]`.

The fix is to add checks for varargs methods and, when encountered, check to see if the required parameter type is the raw varargs type or the its component type.

## Checklist
 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

