### PR TITLE
Fix #2616 wrong stub for nested static

### DIFF
--- a/src/main/java/org/mockito/internal/handler/MockHandlerImpl.java
+++ b/src/main/java/org/mockito/internal/handler/MockHandlerImpl.java
@@ -107,18 +107,25 @@ public class MockHandlerImpl<T> implements MockHandler<T> {
                 mockingProgress().reportOngoingStubbing(ongoingStubbing);
             }
         } else {
-            Object ret = mockSettings.getDefaultAnswer().answer(invocation);
-            DefaultAnswerValidator.validateReturnValueFor(invocation, ret);
+            try {
+                Object ret = mockSettings.getDefaultAnswer().answer(invocation);
+                DefaultAnswerValidator.validateReturnValueFor(invocation, ret);
 
-            // Mockito uses it to redo setting invocation for potential stubbing in case of partial
-            // mocks / spies.
-            // Without it, the real method inside 'when' might have delegated to other self method
-            // and overwrite the intended stubbed method with a different one.
-            // This means we would be stubbing a wrong method.
-            // Typically this would led to runtime exception that validates return type with stubbed
-            // method signature.
-            invocationContainer.resetInvocationForPotentialStubbing(invocationMatcher);
-            return ret;
+                return ret;
+            } finally {
+                // Mockito uses it to redo setting invocation for potential stubbing in case of
+                // partial
+                // mocks / spies.
+                // Without it, the real method inside 'when' might have delegated to other self
+                // method
+                // and overwrite the intended stubbed method with a different one.
+                // This means we would be stubbing a wrong method.
+                // Typically this would led to runtime exception that validates return type with
+                // stubbed
+                // method signature.
+                invocationContainer.resetInvocationForPotentialStubbing(invocationMatcher);
+                mockingProgress().reportOngoingStubbing(ongoingStubbing);
+            }
         }
     }
 

--- a/src/test/java/org/mockitousage/spies/SpyAsDefaultMockUsageTest.java
+++ b/src/test/java/org/mockitousage/spies/SpyAsDefaultMockUsageTest.java
@@ -2,16 +2,14 @@
  * Copyright (c) 2007 Mockito contributors
  * This program is made available under the terms of the MIT License.
  */
-package org.mockitousage.misuse;
+package org.mockitousage.spies;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.*;
 
 import org.junit.Test;
-import org.mockito.exceptions.misusing.WrongTypeOfReturnValue;
 
-public class SpyStubbingMisuseTest {
+public class SpyAsDefaultMockUsageTest {
 
     @Test
     public void nestedWhenTest() {
@@ -19,15 +17,8 @@ public class SpyStubbingMisuseTest {
         Sampler mpoo = mock(Sampler.class);
         Producer out = spy(new Producer(mfoo));
 
-        try {
-            when(out.produce()).thenReturn(mpoo);
-            fail();
-        } catch (WrongTypeOfReturnValue e) {
-            assertThat(e.getMessage())
-                    .contains("spy")
-                    .contains("syntax")
-                    .contains("doReturn|Throw");
-        }
+        when(out.produce()).thenReturn(mpoo);
+        assertSame(mpoo, out.produce());
     }
 
     public class Sample {}

--- a/subprojects/inline/src/test/java/org/mockitoinline/bugs/OngoingStubShiftTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/bugs/OngoingStubShiftTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitoinline.bugs;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mockStatic;
+
+public class OngoingStubShiftTest {
+
+    private static class StaticInt {
+        static int getInt() {
+            return 1;
+        }
+    }
+
+    private static class StaticStr {
+        static String getStr() {
+            return Integer.toString(StaticInt.getInt());
+        }
+    }
+
+    @Test
+    public void keep_ongoing_stub_when_spy() {
+        try (MockedStatic<StaticInt> mockInt = mockStatic(StaticInt.class);
+             MockedStatic<StaticStr> mockStr = mockStatic(StaticStr.class, CALLS_REAL_METHODS)) {
+
+            mockStr.when(StaticStr::getStr).thenReturn("1");
+            assertEquals("1", StaticStr.getStr());
+        }
+    }
+
+    private static class StaticWithException {
+        static String getString() {
+            return Integer.toString(getInt());
+        }
+
+        static int getInt() {
+            throw new NullPointerException();
+        }
+    }
+
+    @Test
+    public void keep_ongoing_stub_when_exception() {
+        try (MockedStatic<StaticWithException> mock = mockStatic(StaticWithException.class, CALLS_REAL_METHODS)) {
+            mock.when(StaticWithException::getString).thenReturn("1");
+            assertEquals("1", StaticWithException.getString());
+        }
+    }
+}


### PR DESCRIPTION
It fixed 2 nested static spy cases (see added unittest for detail)

case1 
```java
    private static class StaticInt {
        static int getInt() { return 1; }
    }

    private static class StaticStr {
        static String getStr() {
            return Integer.toString(StaticInt.getInt());
        }
    }

    @Test
    public void keep_ongoing_stub_when_spy() {
        try (MockedStatic<StaticInt> mockInt = mockStatic(StaticInt.class);
             MockedStatic<StaticStr> mockStr = mockStatic(StaticStr.class, CALLS_REAL_METHODS)) {

            mockStr.when(StaticStr::getStr).thenReturn("1"); // here, StaticInt.getInt() is considered as the stubbing point
            assertEquals("1", StaticStr.getStr());
        }
    }
```

case2
```java

    private static class StaticWithException {
        static String getString() { return Integer.toString(getInt()); }

        static int getInt() { throw new NullPointerException(); }
    }

    @Test
    public void keep_ongoing_stub_when_exception() {
        try (MockedStatic<StaticWithException> mock = mockStatic(StaticWithException.class, CALLS_REAL_METHODS)) {
            mock.when(StaticWithException::getString).thenReturn("1");
            assertEquals("1", StaticWithException.getString());
        }
    }
```

the fix is in org.mockito.internal.handler.MockHandlerImpl#handle branch (stubbing == null) branch only:
- add a mockingProgress().reportOngoingStubbing() call
- add try-finally block to ensure they are invoked.
