### PR TITLE
RETURNS_SELF: Avoids returning mock when mock type is assignable to method return type, but method return type is Object.

### DIFF
--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/TriesToReturnSelf.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/TriesToReturnSelf.java
@@ -20,7 +20,7 @@ public class TriesToReturnSelf implements Answer<Object>, Serializable {
         Object mock = invocation.getMock();
         Class<?> mockType = MockUtil.getMockHandler(mock).getMockSettings().getTypeToMock();
 
-        if (methodReturnType.isAssignableFrom(mockType)) {
+        if (methodReturnType.isAssignableFrom(mockType) && methodReturnType != Object.class) {
             return invocation.getMock();
         }
 

--- a/src/test/java/org/mockitousage/stubbing/StubbingReturnsSelfTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingReturnsSelfTest.java
@@ -74,6 +74,13 @@ public class StubbingReturnsSelfTest {
     }
 
     @Test
+    public void should_not_fail_when_calling_method_with_generic_return_type() {
+        Builder builder = mock(Builder.class, RETURNS_SELF);
+
+        assertThat(builder.returnGeneric("Generic Result")).isEqualTo(null);
+    }
+
+    @Test
     public void use_full_builder_with_terminating_method() {
         HttpBuilder builder = mock(HttpBuilder.class, RETURNS_SELF);
         HttpRequesterWithHeaders requester = new HttpRequesterWithHeaders(builder);
@@ -98,6 +105,10 @@ public class StubbingReturnsSelfTest {
 
         public int returnInt() {
             return 1;
+        }
+
+        public <T> T returnGeneric(T result) {
+            return result;
         }
     }
 


### PR DESCRIPTION
Fixes #2686 
This PR adds a test which is expected to pass.
Without the change to `TriesToReturnSelf` it throws a `java.lang.ClassCastException`.

```Java
org.mockitousage.stubbing.StubbingReturnsSelfTest > should_not_fail_when_calling_method_with_generic_return_type FAILED
    java.lang.ClassCastException: class org.mockitousage.stubbing.StubbingReturnsSelfTest$Builder$MockitoMock$idXgt9U6 cannot be cast to class java.lang.String (org.mockitousage.stubbing.StubbingReturnsSelfTest$Builder$MockitoMock$idXgt9U6 is in unnamed module of loader 'app'; java.lang.String is in module java.base of loader 'bootstrap')
        at org.mockitousage.stubbing.StubbingReturnsSelfTest.should_not_fail_when_calling_method_with_generic_return_type(StubbingReturnsSelfTest.java:80)

```