### PR TITLE
Makes error message less misleading and points to github for help. Issue #2692

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyCrossClassLoaderSerializationSupport.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyCrossClassLoaderSerializationSupport.java
@@ -219,14 +219,14 @@ class ByteBuddyCrossClassLoaderSerializationSupport implements Serializable {
                                         + typeToMock.getCanonicalName()
                                         + "'. The error was :",
                                 "  " + ioe.getMessage(),
-                                "If you are unsure what is the reason of this exception, feel free to contact us on the mailing list."),
+                                "If you are unsure what is the reason of this exception, feel free to open an issue on GitHub."),
                         ioe);
             } catch (ClassNotFoundException cce) {
                 throw new MockitoSerializationIssue(
                         join(
                                 "A class couldn't be found while deserializing a Mockito mock, you should check your classpath. The error was :",
                                 "  " + cce.getMessage(),
-                                "If you are still unsure what is the reason of this exception, feel free to contact us on the mailing list."),
+                                "If you are still unsure what is the reason of this exception, feel free to open an issue on GitHub."),
                         cce);
             }
         }

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
@@ -434,7 +434,7 @@ class InlineDelegateByteBuddyMockMaker
                 join(
                         "Mockito cannot mock this class: " + mockFeatures.getTypeToMock() + ".",
                         "",
-                        "If you're not sure why you're getting this error, please report to the mailing list.",
+                        "If you're not sure why you're getting this error, please open an issue on GitHub.",
                         "",
                         Platform.warnForVM(
                                 "IBM J9 VM",

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassByteBuddyMockMaker.java
@@ -114,7 +114,8 @@ public class SubclassByteBuddyMockMaker implements ClassCreatingMockMaker {
                 join(
                         "Mockito cannot mock this class: " + mockFeatures.getTypeToMock() + ".",
                         "",
-                        "Mockito can only mock non-private & non-final classes.",
+                        "Mockito can only mock non-private & non-final classes, but the root cause of this error might be different.",
+                        "Please check the full stacktrace to understand what the issue is.",
                         "If you're not sure why you're getting this error, please report to the mailing list.",
                         "",
                         Platform.warnForVM(

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassByteBuddyMockMaker.java
@@ -116,7 +116,7 @@ public class SubclassByteBuddyMockMaker implements ClassCreatingMockMaker {
                         "",
                         "Mockito can only mock non-private & non-final classes, but the root cause of this error might be different.",
                         "Please check the full stacktrace to understand what the issue is.",
-                        "If you're not sure why you're getting this error, please report to the mailing list.",
+                        "If you're still not sure why you're getting this error, please open an issue on GitHub.",
                         "",
                         Platform.warnForVM(
                                 "IBM J9 VM",

--- a/src/main/java/org/mockito/internal/runners/RunnerFactory.java
+++ b/src/main/java/org/mockito/internal/runners/RunnerFactory.java
@@ -93,7 +93,7 @@ public class RunnerFactory {
                             + "MockitoRunner can only be used with JUnit 4.5 or higher.\n"
                             + "You can upgrade your JUnit version or write your own Runner (please consider contributing your runner to the Mockito community).\n"
                             + "Bear in mind that you can still enjoy all features of the framework without using runners (they are completely optional).\n"
-                            + "If you get this error despite using JUnit 4.5 or higher then please report this error to the mockito mailing list.\n",
+                            + "If you get this error despite using JUnit 4.5 or higher, then please open an issue on GitHub.\n",
                     t);
         }
     }


### PR DESCRIPTION
Small changes to some error messages, that might help users not to search in the wrong place for the cause of an issue.