### PR TITLE
Allow @InjectMock into static/final fields (fixes #1417)

### DIFF
--- a/src/main/java/org/mockito/InjectUnsafe.java
+++ b/src/main/java/org/mockito/InjectUnsafe.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito;
+
+import java.lang.annotation.*;
+
+/**
+ * Change the behavior of {@link InjectMocks}: allow injection of static/final fields that are normally skipped.
+ *
+ * <p>Typically, injection into instances is done via the constructor
+ * <strong>and in most cases you should refactor your code to support these best practices!</strong></p>
+ *
+ * <p>However, sometimes you don't want to/cannot expose fields via constructor as this might change your api
+ * (even if the constructor is package-private).<br/>
+ * Even worse with static fields: you'd have to make expose the fields via setters.<br/>
+ * And then there's always legacy/library code that cannot be changed easily :(</p>
+ *
+ * <p>
+ * InjectUnsafe to the rescue:<br/>
+ * Modifies the behavior of InjectMocks in a way that allows injection into static and final fields. </p>
+ * <p>
+ * <hr/>
+ *
+ * <strong>
+ * <p>
+ * With great power comes great responsibility: while injecting into final instance variables is safe,
+ * injecting into <i>static</i> or <i>static final</i> fields may have unexpected consequences:
+ * </p>
+ * <p>
+ * if these values do not get reset to their default value (mockito does <i>not</i> do this!),
+ * followup tests in any test class anywhere (!) will use the mock until the ClassLoader running the tests
+ * shuts down (usually at JVM termination).
+ * </p>
+ * <p>
+ * If you forget this, there <i>will</i> be hard-to-debug bugs!
+ * </p>
+ * </strong>
+ * <p>
+ * <hr/>
+ *
+ * <p>
+ * Example:
+ * <pre class="code"><code class="java">
+ * // the object under test:
+ * public class ArticleCalculator {
+ *     private static Computer computer = new Computer();
+ *
+ *     public long calculate(Integer foo) {
+ *         return computer.retrieveOrCalculateExpensiveOperation(foo);
+ *     }
+ * }
+ *
+ * public class Computer {
+ *     private final ConcurrentHashMap<Integer, Long> data = new ConcurrentHashMap<>();
+ *
+ *     public Long retrieveOrCalculateExpensiveOperation(int param) {
+ *         return data.computeIfAbsent(param, (k) -> (long) ((Math.random() * Integer.MAX_VALUE)) * param);
+ *     }
+ * }
+ *
+ * public class CalculatorTest {
+ *
+ *     &#064;Mock
+ *     private Computer computer;
+ *
+ *     &#064;InjectMocks
+ *     &#064;InjectUnsafe(OverrideStaticFields.STATIC)
+ *     private ArticleCalculator calculator;
+ *
+ *     &#064;Before
+ *     public void initMocks() {
+ *         MockitoAnnotations.initMocks(this);
+ *     }
+ *
+ *     &#064;Test
+ *     public void shouldCalculate() {
+ *         Mockito.when(computer.retrieveOrCalculateExpensiveOperation(3)).thenReturn(42L);
+ *
+ *         long result = calculator.calculate(3);
+ *
+ *         // the mocked value is returned
+ *         Assert.assertEquals(42L, result);
+ *     }
+ * }
+ * </code></pre>
+ * <p>
+ * If the &#064;InjectMocks annotation is not given in the example above,
+ * the mock will (silently) not get injected and the test will fail.
+ * </p>
+ *
+ * @since 2.23.9
+ */
+@Incubating
+@Documented
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface InjectUnsafe {
+    enum UnsafeFieldModifier {
+        /**
+         * no injection into static fields. Mainly useful for tooling.
+         */
+        NONE(false, false),
+        /**
+         * Allow mock injection into final instance fields.
+         */
+        FINAL(false, false),
+        /**
+         * Allow injection into static fields - non-final only.
+         */
+        STATIC(true, true),
+        /**
+         * Only use this if you <strong>absolutely know what you're doing!</strong>, see {@link InjectUnsafe} for
+         * details.
+         * <p>
+         * Allow injection into static fields - including static final.
+         */
+        STATIC_FINAL(true, true);
+
+        public final boolean restoreOldValue;
+        public final boolean makeAccessible;
+
+        UnsafeFieldModifier(boolean restoreOldValue, boolean makeAccessible) {
+            this.restoreOldValue = restoreOldValue;
+            this.makeAccessible = makeAccessible;
+        }
+    }
+
+    /**
+     * Allow mock-injection into fields that get skipped during the normal injection cycle.
+     */
+    UnsafeFieldModifier value() default UnsafeFieldModifier.FINAL;
+
+    UnsafeFieldModifier FALLBACK_VALUE = UnsafeFieldModifier.NONE;
+}

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -105,7 +105,8 @@ import java.util.function.Function;
  *      <a href="#49">49. New API for mocking object construction (Since 3.5.0)</a><br/>
  *      <a href="#50">50. Avoiding code generation when restricting mocks to interfaces (Since 3.12.2)</a><br/>
  *      <a href="#51">51. New API for marking classes as unmockable (Since 4.1.0)</a><br/>
- *      <a href="#51">52. New strictness attribute for @Mock annotation and <code>MockSettings.strictness()</code> methods (Since 4.6.0)</a><br/>
+ *      <a href="#52">52. New strictness attribute for @Mock annotation and <code>MockSettings.strictness()</code> methods (Since 4.6.0)</a><br/>
+ *      <a href="#53">53. New <code>InjectUnsafe</code> annotation (FIXME: Since ?.??.?)</a><br/>
  * </b>
  *
  * <h3 id="0">0. <a class="meaningful_link" href="#mockito2" name="mockito2">Migrating to Mockito 2</a></h3>
@@ -1622,6 +1623,17 @@ import java.util.function.Function;
  *   Foo mock = Mockito.mock(Foo.class, withSettings().strictness(Strictness.WARN));
  * </code></pre>
  *
+ * <h3 id="48">48. New annotation:
+ * <a class="meaningful_link" href="#unjectunsafe_annotation" name="unjectunsafe_annotation">
+ *     {@link InjectUnsafe @InjectUnsafe}</a></h3>
+ *
+ * <p>
+ *     The annotation {@link InjectUnsafe} modifies the behavior of {@link InjectMocks}.
+ *     It finally (hehe) enables injecting Mocks into final, static and static-final fields.
+ * </p>
+ * <p>
+ *     <strong>Please note: there are some risks involved! See {@link InjectUnsafe} for more details!</strong>
+ * </p>
  */
 @CheckReturnValue
 @SuppressWarnings("unchecked")

--- a/src/main/java/org/mockito/internal/configuration/injection/InjectUnsafeFallback.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/InjectUnsafeFallback.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2016 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.configuration.injection;
+
+import org.mockito.InjectUnsafe;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * A neutral element implementation of {@link InjectUnsafe} so we don't have to deal with null.
+ */
+@SuppressWarnings("ClassExplicitlyAnnotation")
+class InjectUnsafeFallback implements InjectUnsafe {
+
+    @Override
+    public UnsafeFieldModifier value() {
+        return InjectUnsafe.FALLBACK_VALUE;
+    }
+
+    @Override
+    public Class<? extends Annotation> annotationType() {
+        return InjectUnsafe.class;
+    }
+}

--- a/src/main/java/org/mockito/internal/configuration/injection/InjectUnsafeParser.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/InjectUnsafeParser.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.configuration.injection;
+
+import org.mockito.InjectUnsafe;
+
+import java.lang.reflect.Field;
+
+class InjectUnsafeParser {
+    public InjectUnsafe parse(Field field) {
+        InjectUnsafe injectUnsafe = field.getAnnotation(InjectUnsafe.class);
+        if (injectUnsafe == null) {
+            injectUnsafe = new InjectUnsafeFallback();
+        }
+
+        return injectUnsafe;
+    }
+}

--- a/src/main/java/org/mockito/internal/util/reflection/StaticFinalOverrider.java
+++ b/src/main/java/org/mockito/internal/util/reflection/StaticFinalOverrider.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.util.reflection;
+
+import javax.annotation.Generated;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+/**
+ * To set a value on a static final field, setting the field accessible
+ * by using {@link Field#setAccessible(boolean)} is not enough.
+ * Only if removing the field modifier {@link Modifier#STATIC}, a value can be set via reflection.
+ */
+public abstract class StaticFinalOverrider {
+    public static StaticFinalOverrider forField(Field field) {
+        if (needsOverriding(field)) {
+            return new NopStaticFinalOverrider();
+        } else {
+            return new StaticFinalOverriderImpl(field);
+        }
+    }
+
+    private static boolean needsOverriding(Field field) {
+        boolean canWrite = (field.getModifiers() & (Modifier.FINAL)) == 0;
+        return canWrite;
+    }
+
+    public abstract void enableWrite();
+
+    public abstract void restore();
+
+    private static class StaticFinalOverriderImpl extends StaticFinalOverrider {
+        private final Field injecteeField;
+        private final Field modifiersField;
+
+        private Integer originalModifiers = null;
+
+        private StaticFinalOverriderImpl(Field injecteeField) {
+            this.injecteeField = injecteeField;
+
+            modifiersField = tryFindModifiersField();
+        }
+
+        @Generated(
+                "exclude from coverage report because we cannot test the exception in a meaningful way")
+        private static Field tryFindModifiersField() {
+            try {
+                Field modifiersField = findModifiersField();
+
+                return modifiersField;
+            } catch (NoSuchFieldException e) {
+                throw new IllegalStateException("Field.modifiers not found", e);
+            }
+        }
+
+        private static Field findModifiersField() throws NoSuchFieldException {
+            Field modifiersField = Field.class.getDeclaredField("modifiers");
+
+            return modifiersField;
+        }
+
+        @Override
+        public void enableWrite() {
+            backupFieldSettings();
+            tryRemoveFinalModifier();
+        }
+
+        @Override
+        public void restore() {
+            ensureFieldSettingsBackupValid();
+            tryRestoreFieldSettings();
+        }
+
+        @Generated(
+                "exclude from coverage report because we cannot test the exception in a meaningful way")
+        private void tryRemoveFinalModifier() {
+            try {
+                removeFinalModifier();
+            } catch (IllegalAccessException e) {
+                throw new IllegalStateException(
+                        "Cannot change modifier on field: " + injecteeField, e);
+            }
+        }
+
+        private void removeFinalModifier() throws IllegalAccessException {
+            modifiersField.setAccessible(true);
+            modifiersField.setInt(injecteeField, injecteeField.getModifiers() & ~Modifier.FINAL);
+        }
+
+        private void backupFieldSettings() {
+            originalModifiers = injecteeField.getModifiers();
+        }
+
+        private void ensureFieldSettingsBackupValid() {
+            if (originalModifiers == null) {
+                throw new IllegalStateException(
+                        "The field " + injecteeField + " was never modified");
+            }
+        }
+
+        @Generated(
+                "exclude from coverage report because we cannot test the exception in a meaningful way")
+        private void tryRestoreFieldSettings() {
+            try {
+                restoreFieldSettings();
+            } catch (IllegalAccessException e) {
+                throw new IllegalStateException("Cannot reset field: " + injecteeField, e);
+            }
+        }
+
+        private void restoreFieldSettings() throws IllegalAccessException {
+            modifiersField.setInt(injecteeField, originalModifiers);
+            modifiersField.setAccessible(false);
+        }
+    }
+
+    private static class NopStaticFinalOverrider extends StaticFinalOverrider {
+        @Override
+        public void enableWrite() {
+            // nop
+        }
+
+        @Override
+        public void restore() {
+            // nop
+        }
+    }
+}

--- a/src/test/java/org/mockito/internal/configuration/injection/InjectUnsafeParserTest.java
+++ b/src/test/java/org/mockito/internal/configuration/injection/InjectUnsafeParserTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.configuration.injection;
+
+import org.junit.Test;
+import org.mockito.InjectUnsafe;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.InjectUnsafe.UnsafeFieldModifier.NONE;
+import static org.mockito.InjectUnsafe.UnsafeFieldModifier.STATIC_FINAL;
+
+public class InjectUnsafeParserTest {
+
+    private final InjectUnsafeParser parser = new InjectUnsafeParser();
+
+    static class Fixture {
+        @InjectUnsafe(STATIC_FINAL)
+        public Object foo;
+    }
+
+    static class FieldWithoutAnnotationFixture {
+        public Object noAnnotation;
+    }
+
+    @Test
+    public void parses_value_from_the_annotation() throws NoSuchFieldException {
+        Field field = Fixture.class.getDeclaredField("foo");
+
+        InjectUnsafe annotation = parser.parse(field);
+
+        assertThat(annotation.value()).isEqualTo(STATIC_FINAL);
+    }
+
+    @Test
+    public void fallback_value_is_NONE() {
+        assertThat(InjectUnsafe.FALLBACK_VALUE).isEqualTo(NONE);
+    }
+
+    @Test
+    public void parses_field_without_annotation_to_fallback_value() throws NoSuchFieldException {
+        Field field = FieldWithoutAnnotationFixture.class.getDeclaredField("noAnnotation");
+
+        InjectUnsafe annotation = parser.parse(field);
+
+        assertThat(annotation.value()).isEqualTo(InjectUnsafe.FALLBACK_VALUE);
+    }
+}

--- a/src/test/java/org/mockito/internal/configuration/injection/PropertyAndSetterInjectionTest.java
+++ b/src/test/java/org/mockito/internal/configuration/injection/PropertyAndSetterInjectionTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.configuration.injection;
+
+import org.junit.Test;
+import org.mockito.InjectUnsafe;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.function.Predicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.InjectUnsafe.UnsafeFieldModifier.*;
+
+public class PropertyAndSetterInjectionTest {
+
+    @SuppressWarnings("ClassExplicitlyAnnotation")
+    private static class InjectUnsafeTesting implements InjectUnsafe {
+        private final UnsafeFieldModifier allow;
+
+        private InjectUnsafeTesting(UnsafeFieldModifier allow) {
+            this.allow = allow;
+        }
+
+        @Override
+        public UnsafeFieldModifier value() {
+            return allow;
+        }
+
+        @Override
+        public Class<? extends Annotation> annotationType() {
+            return InjectUnsafe.class;
+        }
+    }
+
+    @SuppressWarnings({"FieldMayBeFinal", "FieldMayBeStatic"})
+    public static class Foo {
+        private int aInstance = 0;
+        private final int aFinal = 0;
+        private static int aStatic = 0;
+        private static final int A_STATIC_FINAL = 0;
+    }
+
+    @SuppressWarnings({"FieldMayBeFinal", "FieldMayBeStatic"})
+    public static class Bar extends Foo {
+        private int zInstance = 0;
+        private final int zFinal = 0;
+        private static int zStatic = 0;
+        private static final int Z_STATIC_FINAL = 0;
+    }
+
+    private static final Field FOO_INSTANCE_FIELD;
+    private static final Field FOO_FINAL_FIELD;
+    private static final Field FOO_STATIC_FIELD;
+    private static final Field FOO_STATIC_FINAL_FIELD;
+    private static final Field BAR_INSTANCE_FIELD;
+    private static final Field BAR_FINAL_FIELD;
+    private static final Field BAR_STATIC_FIELD;
+    private static final Field BAR_STATIC_FINAL_FIELD;
+
+    static {
+        try {
+            FOO_INSTANCE_FIELD = Foo.class.getDeclaredField("aInstance");
+            FOO_FINAL_FIELD = Foo.class.getDeclaredField("aFinal");
+            FOO_STATIC_FIELD = Foo.class.getDeclaredField("aStatic");
+            FOO_STATIC_FINAL_FIELD = Foo.class.getDeclaredField("A_STATIC_FINAL");
+            BAR_INSTANCE_FIELD = Bar.class.getDeclaredField("zInstance");
+            BAR_FINAL_FIELD = Bar.class.getDeclaredField("zFinal");
+            BAR_STATIC_FIELD = Bar.class.getDeclaredField("zStatic");
+            BAR_STATIC_FINAL_FIELD = Bar.class.getDeclaredField("Z_STATIC_FINAL");
+        } catch (NoSuchFieldException e) {
+            throw new IllegalArgumentException("Test setup failure: field does not exist: " + e);
+        }
+    }
+
+    /**
+     * Exclude test-internal fields (JaCoCo test coverage).
+     * <p>
+     * JaCoCo test coverage is implemented by instrumenting <i>any</i> class with a new field named "$jacocoData".
+     * This field contains JaCoCo internal data structures.
+     * It is only instrumented on gradle test runs and thus not present in production classes.
+     * Thus we can simply ignore/remove this field in our tests.
+     */
+    private static void excludeCoverageEngineFields(List<Field> fields) {
+        Predicate<Field> isJaCoCoField = f -> f.getName().startsWith("$jacoco");
+        Predicate<Field> isIntelliJField = f -> f.getName().equals("__$lineHits$__");
+
+        fields.removeIf(isJaCoCoField.or(isIntelliJField));
+    }
+
+    @Test
+    public void shouldBuildFieldList_ForField() {
+        List<Field> fields =
+                new PropertyAndSetterInjection()
+                        .orderedInstanceFieldsFrom(Foo.class, new InjectUnsafeTesting(NONE));
+        excludeCoverageEngineFields(fields);
+
+        assertThat(fields).containsExactly(FOO_INSTANCE_FIELD);
+    }
+
+    @Test
+    public void shouldBuildFieldList_ForField_WithSubclass() {
+        List<Field> fields =
+                new PropertyAndSetterInjection()
+                        .orderedInstanceFieldsFrom(Bar.class, new InjectUnsafeTesting(NONE));
+        excludeCoverageEngineFields(fields);
+
+        assertThat(fields).containsExactly(BAR_INSTANCE_FIELD);
+    }
+
+    @Test
+    public void shouldBuildFieldList_ForFinalField() {
+        List<Field> fields =
+                new PropertyAndSetterInjection()
+                        .orderedInstanceFieldsFrom(Foo.class, new InjectUnsafeTesting(FINAL));
+        excludeCoverageEngineFields(fields);
+
+        assertThat(fields).containsExactly(FOO_FINAL_FIELD, FOO_INSTANCE_FIELD);
+    }
+
+    @Test
+    public void shouldBuildFieldList_ForFinalField_WithSubclass() {
+        List<Field> fields =
+                new PropertyAndSetterInjection()
+                        .orderedInstanceFieldsFrom(Bar.class, new InjectUnsafeTesting(FINAL));
+        excludeCoverageEngineFields(fields);
+
+        assertThat(fields).containsExactly(BAR_FINAL_FIELD, BAR_INSTANCE_FIELD);
+    }
+
+    @Test
+    public void shouldBuildFieldList_ForStaticField() {
+        List<Field> fields =
+                new PropertyAndSetterInjection()
+                        .orderedInstanceFieldsFrom(Foo.class, new InjectUnsafeTesting(STATIC));
+        excludeCoverageEngineFields(fields);
+
+        assertThat(fields).containsExactly(FOO_INSTANCE_FIELD, FOO_STATIC_FIELD);
+    }
+
+    @Test
+    public void shouldBuildFieldList_ForStaticField_WithSubclass() {
+        List<Field> fields =
+                new PropertyAndSetterInjection()
+                        .orderedInstanceFieldsFrom(Bar.class, new InjectUnsafeTesting(STATIC));
+        excludeCoverageEngineFields(fields);
+
+        assertThat(fields).containsExactly(BAR_INSTANCE_FIELD, BAR_STATIC_FIELD);
+    }
+
+    @Test
+    public void shouldBuildFieldList_ForStaticFinalField() {
+        List<Field> fields =
+                new PropertyAndSetterInjection()
+                        .orderedInstanceFieldsFrom(
+                                Foo.class, new InjectUnsafeTesting(STATIC_FINAL));
+        excludeCoverageEngineFields(fields);
+
+        assertThat(fields).containsExactly(FOO_STATIC_FINAL_FIELD, FOO_INSTANCE_FIELD);
+    }
+
+    @Test
+    public void shouldBuildFieldList_ForStaticFinalField_WithSubclass() {
+        List<Field> fields =
+                new PropertyAndSetterInjection()
+                        .orderedInstanceFieldsFrom(
+                                Bar.class, new InjectUnsafeTesting(STATIC_FINAL));
+        excludeCoverageEngineFields(fields);
+
+        assertThat(fields).containsExactly(BAR_STATIC_FINAL_FIELD, BAR_INSTANCE_FIELD);
+    }
+}

--- a/src/test/java/org/mockito/internal/configuration/injection/filter/TerminalMockCandidateFilterTest.java
+++ b/src/test/java/org/mockito/internal/configuration/injection/filter/TerminalMockCandidateFilterTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2022 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.configuration.injection.filter;
+
+import org.junit.Test;
+import org.mockitoutil.ExceptionHider;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockitoutil.ExceptionHider.wrap;
+
+public class TerminalMockCandidateFilterTest {
+
+    private static class Content {
+        public String name;
+
+        public Content(String name) {
+            this.name = name;
+        }
+    }
+
+    private static class TargetClass {
+        @SuppressWarnings("FieldMayBeFinal")
+        private Content content = null;
+    }
+
+    private static class StaticFinalClass {
+        private static final Content content = null;
+    }
+
+    private final TerminalMockCandidateFilter filter = new TerminalMockCandidateFilter();
+    private final TargetClass targetInstance = new TargetClass();
+    private final Field targetField = wrap(() -> TargetClass.class.getDeclaredField("content"));
+    private final Content mock = new Content("candidate");
+
+    @Test
+    public void injects_mock_into_field() {
+        filter.filterCandidate(
+                        Collections.singletonList(mock),
+                        targetField,
+                        Collections.emptyList(),
+                        targetInstance)
+                .thenInject();
+
+        assertThat(targetInstance.content).isSameAs(mock);
+    }
+
+    @Test
+    public void does_nothing_if_no_mocks_present() {
+        filter.filterCandidate(
+                        Collections.emptyList(),
+                        targetField,
+                        Collections.emptyList(),
+                        targetInstance)
+                .thenInject();
+
+        assertThat(targetInstance.content).isNull();
+    }
+
+    @Test
+    public void does_nothing_if_more_than_one_mock() {
+        filter.filterCandidate(
+                        Arrays.asList(mock, new Content("other mock")),
+                        targetField,
+                        Collections.emptyList(),
+                        targetInstance)
+                .thenInject();
+
+        assertThat(targetInstance.content).isNull();
+    }
+
+    @Test
+    public void injects_mock_into_static_final_field() {
+        StaticFinalClass targetInstance = new StaticFinalClass();
+        Field targetField =
+                ExceptionHider.wrap(() -> StaticFinalClass.class.getDeclaredField("content"));
+
+        filter.filterCandidate(
+                        Collections.singletonList(mock),
+                        targetField,
+                        Collections.emptyList(),
+                        targetInstance)
+                .thenInject();
+
+        assertThat(StaticFinalClass.content).isSameAs(mock);
+    }
+}

--- a/src/test/java/org/mockito/internal/util/reflection/StaticFinalOverriderTest.java
+++ b/src/test/java/org/mockito/internal/util/reflection/StaticFinalOverriderTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.util.reflection;
+
+import org.assertj.core.api.AbstractAssert;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.stream.IntStream;
+
+import static java.lang.reflect.Modifier.FINAL;
+import static java.lang.reflect.Modifier.STATIC;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.internal.util.reflection.StaticFinalOverriderTest.FieldAssertions.assertThatField;
+
+public class StaticFinalOverriderTest {
+
+    private static class StaticFinalFixture {
+        private static final Integer STATIC_FINAL = null;
+    }
+
+    private static class StaticFixture {
+        @SuppressWarnings("FieldMayBeFinal")
+        private static Integer STATIC = null;
+    }
+
+    private static class FinalFixture {
+        private final Integer FINAL = null;
+    }
+
+    private static class NormalFixture {
+        @SuppressWarnings("FieldMayBeFinal")
+        private Integer NORMAL = null;
+    }
+
+    @Test
+    public void static_final_field_is_made_writable() throws NoSuchFieldException {
+        Field field = StaticFinalFixture.class.getDeclaredField("STATIC_FINAL");
+        int originalModifiers = field.getModifiers();
+        // sanity check
+        assertThatField(field).includesModifiers(STATIC, FINAL);
+
+        StaticFinalOverrider overrider = StaticFinalOverrider.forField(field);
+
+        overrider.enableWrite();
+
+        assertThatField(field).includesModifiers(STATIC).doesNotIncludeModifiers(FINAL);
+
+        overrider.restore();
+
+        assertThatField(field).hasModifiers(originalModifiers);
+    }
+
+    @Test
+    public void static_field_is_made_writable() throws NoSuchFieldException {
+        Field field = StaticFixture.class.getDeclaredField("STATIC");
+        int originalModifiers = field.getModifiers();
+        // sanity check
+        assertThatField(field).includesModifiers(STATIC).doesNotIncludeModifiers(FINAL);
+
+        StaticFinalOverrider overrider = StaticFinalOverrider.forField(field);
+
+        overrider.enableWrite();
+
+        assertThatField(field).includesModifiers(STATIC).doesNotIncludeModifiers(FINAL);
+
+        overrider.restore();
+
+        assertThatField(field).hasModifiers(originalModifiers);
+    }
+
+    @Test
+    public void final_field_is_made_writable() throws NoSuchFieldException {
+        Field field = FinalFixture.class.getDeclaredField("FINAL");
+        int originalModifiers = field.getModifiers();
+        // sanity check
+        assertThatField(field).doesNotIncludeModifiers(STATIC).includesModifiers(FINAL);
+
+        StaticFinalOverrider overrider = StaticFinalOverrider.forField(field);
+
+        overrider.enableWrite();
+
+        assertThatField(field).doesNotIncludeModifiers(STATIC, FINAL);
+
+        overrider.restore();
+
+        assertThatField(field).hasModifiers(originalModifiers);
+    }
+
+    @Test
+    public void normal_field_needs_no_modification() throws NoSuchFieldException {
+        Field field = NormalFixture.class.getDeclaredField("NORMAL");
+        int originalModifiers = field.getModifiers();
+        // sanity check
+        assertThatField(field).doesNotIncludeModifiers(STATIC, FINAL);
+
+        StaticFinalOverrider overrider = StaticFinalOverrider.forField(field);
+
+        overrider.enableWrite();
+
+        assertThatField(field).doesNotIncludeModifiers(STATIC, FINAL);
+
+        overrider.restore();
+
+        assertThatField(field).hasModifiers(originalModifiers);
+    }
+
+    @Test
+    public void restoring_modifiers_without_enabling_first_throws_exception()
+            throws NoSuchFieldException {
+        Field field = StaticFinalFixture.class.getDeclaredField("STATIC_FINAL");
+        StaticFinalOverrider overrider = StaticFinalOverrider.forField(field);
+
+        assertThatThrownBy(() -> overrider.restore())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining(field.toString());
+    }
+
+    public static class FieldAssertions extends AbstractAssert<FieldAssertions, Field> {
+
+        protected FieldAssertions(Field field) {
+            super(field, FieldAssertions.class);
+        }
+
+        public static FieldAssertions assertThatField(Field field) {
+            return new FieldAssertions(field);
+        }
+
+        /**
+         * Field modifiers must match exactly.
+         */
+        public FieldAssertions hasModifiers(int... expected) {
+            int allExpected = IntStream.of(expected).sum();
+
+            @SuppressWarnings("MagicConstant")
+            boolean modifiersMatch = actual.getModifiers() == allExpected;
+
+            if (!modifiersMatch) {
+                String actualModifiers = Modifier.toString(actual.getModifiers());
+                String expectedModifiers = Modifier.toString(allExpected);
+
+                failWithActualExpectedAndMessage(
+                        actual.getModifiers(),
+                        allExpected,
+                        "Expecting field modifiers to be:\n  '%s'\nbut was:\n  '%s'",
+                        expectedModifiers,
+                        actualModifiers);
+            }
+
+            return this;
+        }
+
+        /**
+         * Field modifiers must include expected modifiers (but may also contain others).
+         */
+        public FieldAssertions includesModifiers(int... expected) {
+            int allExpected = IntStream.of(expected).sum();
+
+            int intersection = actual.getModifiers() & allExpected;
+            boolean modifiersMatch = intersection == allExpected;
+
+            if (!modifiersMatch) {
+                String actualModifiers = Modifier.toString(actual.getModifiers());
+                String expectedModifiers = Modifier.toString(allExpected);
+                int missing = allExpected - intersection;
+                String missingModifiers = Modifier.toString(missing);
+
+                failWithActualExpectedAndMessage(
+                        actual.getModifiers(),
+                        allExpected,
+                        "Expecting field modifiers to include:\n  '%s'\nbut was:\n  '%s'\nMissing:\n  '%s'",
+                        expectedModifiers,
+                        actualModifiers,
+                        missingModifiers);
+            }
+
+            return this;
+        }
+
+        /**
+         * Field modifiers must <strong>not</strong> include the given modifies.
+         */
+        public FieldAssertions doesNotIncludeModifiers(int... unexpected) {
+            int allExcluded = IntStream.of(unexpected).sum();
+
+            int intersection = actual.getModifiers() & allExcluded;
+            boolean foundExcluded = intersection != 0;
+
+            if (foundExcluded) {
+                String actualModifiers = Modifier.toString(actual.getModifiers());
+                String notExpectedModifiers = Modifier.toString(allExcluded);
+                String surplus = Modifier.toString(intersection);
+
+                failWithActualExpectedAndMessage(
+                        actual.getModifiers(),
+                        allExcluded,
+                        "Expecting field modifiers to *not* include:\n  '%s'\nbut were:\n  '%s'\nSurplus:\n  '%s'",
+                        notExpectedModifiers,
+                        actualModifiers,
+                        surplus);
+            }
+
+            return this;
+        }
+    }
+}

--- a/src/test/java/org/mockitousage/annotation/InjectUnsafeTest.java
+++ b/src/test/java/org/mockitousage/annotation/InjectUnsafeTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2022 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage.annotation;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.InjectUnsafe;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.InjectUnsafe.UnsafeFieldModifier.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InjectUnsafeTest {
+
+    public static class Antenna {
+        private final String name;
+
+        public Antenna(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    public static class FinalReceiver {
+        private final Antenna antenna = new Antenna("the-real-one");
+
+        public String getAntennaName() {
+            return antenna.getName();
+        }
+    }
+
+    public static class StaticReceiver {
+        @SuppressWarnings("FieldMayBeFinal")
+        private static Antenna antenna = new Antenna("the-real-one");
+
+        public String getAntennaName() {
+            return antenna.getName();
+        }
+    }
+
+    public static class StaticFinalReceiver {
+        @SuppressWarnings("FieldMayBeFinal")
+        private static final Antenna antenna = new Antenna("the-real-one");
+
+        public String getAntennaName() {
+            return antenna.getName();
+        }
+    }
+
+    @Before
+    public void before() {
+        System.out.println("before");
+    }
+
+    @After
+    public void after() {
+        System.out.println("after");
+    }
+
+    @Mock private Antenna mockAntenna;
+
+    @InjectMocks
+    @InjectUnsafe(FINAL)
+    private FinalReceiver finalReceiver;
+
+    @InjectMocks
+    @InjectUnsafe(STATIC)
+    private StaticReceiver staticReceiver;
+
+    @InjectMocks
+    @InjectUnsafe(STATIC_FINAL)
+    private StaticFinalReceiver staticFinalReceiver;
+
+    @Test
+    public void injectunsafe_injects_into_final_fields() {
+        Mockito.doReturn("final mock").when(mockAntenna).getName();
+
+        String actual = finalReceiver.getAntennaName();
+
+        assertEquals("final mock", actual);
+    }
+
+    @Test
+    public void injectunsafe_injects_into_static_fields() {
+        Mockito.doReturn("static mock").when(mockAntenna).getName();
+
+        String actual = staticReceiver.getAntennaName();
+
+        assertEquals("static mock", actual);
+    }
+
+    @Test
+    public void injectunsafe_injects_into_static_final_fields() {
+        Mockito.doReturn("static final mock").when(mockAntenna).getName();
+
+        String actual = staticFinalReceiver.getAntennaName();
+
+        assertEquals("static final mock", actual);
+    }
+}

--- a/src/test/java/org/mockitoutil/ExceptionHider.java
+++ b/src/test/java/org/mockitoutil/ExceptionHider.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitoutil;
+
+import java.util.concurrent.Callable;
+
+public final class ExceptionHider {
+
+    private ExceptionHider() {
+        // utility class
+    }
+
+    public static <T> T wrap(Callable<T> provider) {
+        try {
+            return provider.call();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Allow @InjectMock into static/final fields (fixes #1417)

This pr is a rebase on current main and partial reimplementation of the old PR: #1418