### PR TITLE
Remove useless thrown exception from constructor

### DIFF
--- a/src/main/java/org/mockito/junit/MockitoJUnitRunner.java
+++ b/src/main/java/org/mockito/junit/MockitoJUnitRunner.java
@@ -68,7 +68,7 @@ import org.mockito.quality.Strictness;
  * }
  * </code></pre>
  *
- * If you would like to take advantage of Mockito JUnit runner features
+ * If you would like to take advantage of Mockito JUnit runner features,
  * but you cannot use the runner there is a solution!
  * {@link MockitoSession} API is intended to offer cleaner tests and improved debuggability
  * to users that cannot use Mockito's built-in JUnit support (runner or the rule).
@@ -154,7 +154,7 @@ public class MockitoJUnitRunner extends Runner implements Filterable {
         this(new StrictRunner(new RunnerFactory().createStrict(klass), klass));
     }
 
-    MockitoJUnitRunner(InternalRunner runner) throws InvocationTargetException {
+    MockitoJUnitRunner(InternalRunner runner) {
         this.runner = runner;
     }
 


### PR DESCRIPTION
<!-- Hey,
Thanks for the contribution, this is awesome.
As you may have read, project members have somehow an opinionated view on what and how should be
Mockito, e.g. we don't want mockito to be a feature bloat.
There may be a thorough review, with feedback -> code change loop.
-->
<!--
If you have a suggestion for this template you can fix it in the .github/PULL_REQUEST_TEMPLATE.md file
-->
This PR removes a thrown Exception from a constructor, since it will never be thrown. Also a minor grammar fix in javadoc.

If a constructor only has variable assignment(s), then an exception will never be thrown, thus the constructor must not include any 'thrown' clauses.

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

