### PR TITLE
Drop varargs collector before invoking a user method.

### DIFF
--- a/src/main/java/org/mockito/internal/util/reflection/InstrumentationMemberAccessor.java
+++ b/src/main/java/org/mockito/internal/util/reflection/InstrumentationMemberAccessor.java
@@ -235,6 +235,9 @@ class InstrumentationMemberAccessor implements MemberAccessor {
             if (!Modifier.isStatic(method.getModifiers())) {
                 handle = handle.bindTo(target);
             }
+            if (handle.isVarargsCollector()) {
+                handle = handle.asFixedArity();
+            }
             try {
                 return DISPATCHER.invokeWithArguments(handle, arguments);
             } catch (Throwable t) {

--- a/subprojects/inline/src/test/java/org/mockitoinline/StaticMockTest.java
+++ b/subprojects/inline/src/test/java/org/mockitoinline/StaticMockTest.java
@@ -212,6 +212,15 @@ public final class StaticMockTest {
         }
     }
 
+    @Test
+    public void testStaticMockVarargs() {
+        assertEquals("foobar", Dummy.fooVarargs("foo", "bar"));
+        try (MockedStatic<Dummy> ignored = Mockito.mockStatic(Dummy.class)) {
+            assertNull(Dummy.fooVarargs("foo", "bar"));
+        }
+        assertEquals("foobar", Dummy.fooVarargs("foo", "bar"));
+    }
+
     static class Dummy {
 
         static String var1 = null;
@@ -226,6 +235,14 @@ public final class StaticMockTest {
 
         static void fooVoid(String var2, String var3) {
             var1 = var2;
+        }
+
+        static String fooVarargs(String... args) {
+            StringBuilder sb = new StringBuilder();
+            for (String arg : args) {
+                sb.append(arg);
+            }
+            return sb.toString();
         }
     }
 }


### PR DESCRIPTION
When invoking a user method that uses a varargs collector, we need to drop this collector before invoking as we do not supply arguments as varargs. Fixes #2703.