### PR TITLE
Update Javadoc deeps link to Java 11

### DIFF
--- a/gradle/mockito-core/javadoc.gradle
+++ b/gradle/mockito-core/javadoc.gradle
@@ -38,7 +38,7 @@ javadoc {
     options.noIndex = false
     options.noNavBar = false
     options.noTree = false
-    options.links = ['https://docs.oracle.com/javase/6/docs/api/',
+    options.links = ['https://docs.oracle.com/javase/11/docs/api/',
                      'https://junit.org/junit4/javadoc/4.12/']
     options.bottom("""
         <script type="text/javascript" src="{@docRoot}/js/jdk6-project-version-insert.min.js"></script>


### PR DESCRIPTION
We currently use Java 6 to deeplink to the JDK and the URL no longer shows the necessary element-list, which is why it currently fails the build: https://github.com/mockito/mockito/actions/runs/3100073977/jobs/5019939573#step:7:229