### PR TITLE
automatically detect class to mock

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -1902,6 +1902,23 @@ public class Mockito extends ArgumentMatchers {
     public static final Answer<Object> RETURNS_SELF = Answers.RETURNS_SELF;
 
     /**
+     * Creates mock object of requested class or interface.
+     * <p>
+     * See examples in javadoc for {@link Mockito} class
+     *
+     * @param reified don't pass any values to it. It's a trick to detect the class/interface you want to mock.
+     * @return mock object
+     */
+    public static <T> T mock(T... reified) {
+        if (reified.length > 0) {
+            throw new IllegalArgumentException(
+                    "Please don't pass any values here. Java will detect class automagically.");
+        }
+        Class<T> classToMock = (Class<T>) reified.getClass().getComponentType();
+        return mock(classToMock, withSettings());
+    }
+
+    /**
      * Creates mock object of given class or interface.
      * <p>
      * See examples in javadoc for {@link Mockito} class

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -1647,10 +1647,6 @@ import java.util.function.Function;
  * <h3 id="54">54. <a class="meaningful_link" href="#mock_without_class" name="mock_without_class">
  *  Mocking/spying without specifying class</a> (Since 4.9.0)</h3>
  *
- * <p>
- * Starting from 4.9.0, there is a shorter form of creating a mock or spy.
- * </p>
- *
  * Instead of calling method {@link Mockito#mock(Class)} or {@link Mockito#spy(Class)} with Class parameter, you can now
  * now call method {@code mock()} or {@code spy()} <strong>without parameters</strong>:
  *

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -1657,8 +1657,9 @@ import java.util.function.Function;
  *
  * Mockito will automatically detect the needed class.
  * <p>
- * P.S. Works only if you assign result of {@code mock()} or {@code spy()} to a variable or field.
- * Only then Java compiler can know the type of that variable.
+ * It works only if you assign result of {@code mock()} or {@code spy()} to a variable or field with an explicit type.
+ * With an implicit type, the Java compiler is unable to automatically determine the type of a mock and you need
+ * to pass in the {@code Class} explicitly.
  * </p>
  */
 @CheckReturnValue

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -33,7 +33,11 @@ import org.mockito.stubbing.LenientStubber;
 import org.mockito.stubbing.OngoingStubbing;
 import org.mockito.stubbing.Stubber;
 import org.mockito.stubbing.VoidAnswer1;
-import org.mockito.verification.*;
+import org.mockito.verification.After;
+import org.mockito.verification.Timeout;
+import org.mockito.verification.VerificationAfterDelay;
+import org.mockito.verification.VerificationMode;
+import org.mockito.verification.VerificationWithTimeout;
 
 import java.util.function.Function;
 
@@ -107,7 +111,7 @@ import java.util.function.Function;
  *      <a href="#51">51. New API for marking classes as unmockable (Since 4.1.0)</a><br/>
  *      <a href="#52">52. New strictness attribute for @Mock annotation and <code>MockSettings.strictness()</code> methods (Since 4.6.0)</a><br/>
  *      <a href="#53">53. Specifying mock maker for individual mocks (Since 4.8.0)</a><br/>
- *      <a href="#54">54. Mocking without specifying class (Since 4.9.0)</a><br/>
+ *      <a href="#54">54. Mocking/spying without specifying class (Since 4.9.0)</a><br/>
  * </b>
  *
  * <h3 id="0">0. <a class="meaningful_link" href="#mockito2" name="mockito2">Migrating to Mockito 2</a></h3>
@@ -1641,23 +1645,24 @@ import java.util.function.Function;
  * </code></pre>
  *
  * <h3 id="54">54. <a class="meaningful_link" href="#mock_without_class" name="mock_without_class">
- *  Mocking without specifying class</a> (Since 4.9.0)</h3>
+ *  Mocking/spying without specifying class</a> (Since 4.9.0)</h3>
  *
  * <p>
- * Starting from 4.9.0, there is a shorter form of creating a mock.
+ * Starting from 4.9.0, there is a shorter form of creating a mock or spy.
  * </p>
  *
- * Instead of calling method {@link Mockito#mock(Class)} with Class parameter, you can now
- * now call method {@code mock()} <strong>without parameters</strong>:
+ * Instead of calling method {@link Mockito#mock(Class)} or {@link Mockito#spy(Class)} with Class parameter, you can now
+ * now call method {@code mock()} or {@code spy()} <strong>without parameters</strong>:
  *
  * <pre class="code"><code class="java">
  *   Foo foo = Mockito.mock();
- *   Bar bar = Mockito.mock();
+ *   Bar bar = Mockito.spy();
  * </code></pre>
  *
  * Mockito will automatically detect the needed class.
  * <p>
- * P.S. Works only if you assign result of {@code mock()} to a variable or field. Only then Java compiler can know the type of that variable.
+ * P.S. Works only if you assign result of {@code mock()} or {@code spy()} to a variable or field.
+ * Only then Java compiler can know the type of that variable.
  * </p>
  */
 @CheckReturnValue
@@ -1935,8 +1940,7 @@ public class Mockito extends ArgumentMatchers {
             throw new IllegalArgumentException(
                     "Please don't pass any values here. Java will detect class automagically.");
         }
-        Class<T> classToMock = (Class<T>) reified.getClass().getComponentType();
-        return mock(classToMock, withSettings());
+        return mock(getClassOf(reified), withSettings());
     }
 
     /**
@@ -2151,6 +2155,25 @@ public class Mockito extends ArgumentMatchers {
     public static <T> T spy(Class<T> classToSpy) {
         return MOCKITO_CORE.mock(
                 classToSpy, withSettings().useConstructor().defaultAnswer(CALLS_REAL_METHODS));
+    }
+
+    /**
+     * Please refer to the documentation of {@link #spy(Class)}.
+     *
+     * @param reified don't pass any values to it. It's a trick to detect the class/interface you want to mock.
+     * @return spy object
+     * @since 4.9.0
+     */
+    public static <T> T spy(T... reified) {
+        if (reified.length > 0) {
+            throw new IllegalArgumentException(
+                    "Please don't pass any values here. Java will detect class automagically.");
+        }
+        return spy(getClassOf(reified));
+    }
+
+    private static <T> Class<T> getClassOf(T[] array) {
+        return (Class<T>) array.getClass().getComponentType();
     }
 
     /**

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -107,6 +107,7 @@ import java.util.function.Function;
  *      <a href="#51">51. New API for marking classes as unmockable (Since 4.1.0)</a><br/>
  *      <a href="#52">52. New strictness attribute for @Mock annotation and <code>MockSettings.strictness()</code> methods (Since 4.6.0)</a><br/>
  *      <a href="#53">53. Specifying mock maker for individual mocks (Since 4.8.0)</a><br/>
+ *      <a href="#54">54. Mocking without specifying class (Since 4.9.0)</a><br/>
  * </b>
  *
  * <h3 id="0">0. <a class="meaningful_link" href="#mockito2" name="mockito2">Migrating to Mockito 2</a></h3>
@@ -1639,6 +1640,25 @@ import java.util.function.Function;
  *   Foo mock = Mockito.mock(Foo.class, withSettings().mockMaker(MockMakers.SUBCLASS));
  * </code></pre>
  *
+ * <h3 id="54">54. <a class="meaningful_link" href="#mock_without_class" name="mock_without_class">
+ *  Mocking without specifying class</a> (Since 4.9.0)</h3>
+ *
+ * <p>
+ * Starting from 4.9.0, there is a shorter form of creating a mock.
+ * </p>
+ *
+ * Instead of calling method {@link Mockito#mock(Class)} with Class parameter, you can now
+ * now call method {@code mock()} <strong>without parameters</strong>:
+ *
+ * <pre class="code"><code class="java">
+ *   Foo foo = Mockito.mock();
+ *   Bar bar = Mockito.mock();
+ * </code></pre>
+ *
+ * Mockito will automatically detect the needed class.
+ * <p>
+ * P.S. Works only if you assign result of {@code mock()} to a variable or field. Only then Java compiler can know the type of that variable.
+ * </p>
  */
 @CheckReturnValue
 @SuppressWarnings("unchecked")
@@ -1908,6 +1928,7 @@ public class Mockito extends ArgumentMatchers {
      *
      * @param reified don't pass any values to it. It's a trick to detect the class/interface you want to mock.
      * @return mock object
+     * @since 4.9.0
      */
     public static <T> T mock(T... reified) {
         if (reified.length > 0) {

--- a/src/test/java/org/mockito/MockitoTest.java
+++ b/src/test/java/org/mockito/MockitoTest.java
@@ -133,4 +133,12 @@ public class MockitoTest {
         // when / then
         assertThat(settings.getDefaultAnswer()).isEqualTo(Mockito.RETURNS_DEFAULTS);
     }
+
+    @Test
+    @SuppressWarnings({"DoNotMock", "DoNotMockAutoValue"})
+    public void automaticallyDetectsClassToMock() {
+        List<String> mock = Mockito.mock();
+        Mockito.when(mock.size()).thenReturn(42);
+        assertThat(mock.size()).isEqualTo(42);
+    }
 }

--- a/src/test/java/org/mockito/MockitoTest.java
+++ b/src/test/java/org/mockito/MockitoTest.java
@@ -4,6 +4,7 @@
  */
 package org.mockito;
 
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.times;
@@ -140,5 +141,16 @@ public class MockitoTest {
         List<String> mock = Mockito.mock();
         Mockito.when(mock.size()).thenReturn(42);
         assertThat(mock.size()).isEqualTo(42);
+    }
+
+    @Test
+    @SuppressWarnings({"DoNotMock", "DoNotMockAutoValue"})
+    public void newMockMethod_shouldNotBeCalledWithParameters() {
+        assertThatThrownBy(
+            () -> {
+                Mockito.mock(asList("1", "2"), asList("3", "4"));
+            })
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageStartingWith("Please don't pass any values here");
     }
 }

--- a/src/test/java/org/mockito/MockitoTest.java
+++ b/src/test/java/org/mockito/MockitoTest.java
@@ -147,10 +147,30 @@ public class MockitoTest {
     @SuppressWarnings({"DoNotMock", "DoNotMockAutoValue"})
     public void newMockMethod_shouldNotBeCalledWithParameters() {
         assertThatThrownBy(
-            () -> {
-                Mockito.mock(asList("1", "2"), asList("3", "4"));
-            })
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageStartingWith("Please don't pass any values here");
+                        () -> {
+                            Mockito.mock(asList("1", "2"), asList("3", "4"));
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageStartingWith("Please don't pass any values here");
+    }
+
+    @Test
+    @SuppressWarnings({"DoNotMock", "DoNotMockAutoValue"})
+    public void automaticallyDetectsClassToSpy() {
+        List<String> mock = Mockito.spy();
+        Mockito.when(mock.size()).thenReturn(42);
+        assertThat(mock.size()).isEqualTo(42);
+        assertThat(mock.get(0)).isNull();
+    }
+
+    @Test
+    @SuppressWarnings({"DoNotMock", "DoNotMockAutoValue"})
+    public void newSpyMethod_shouldNotBeCalledWithParameters() {
+        assertThatThrownBy(
+                        () -> {
+                            Mockito.spy(asList("1", "2"), asList("3", "4"));
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageStartingWith("Please don't pass any values here");
     }
 }

--- a/subprojects/kotlinTest/src/test/kotlin/org/mockito/kotlin/InlineClassTest.kt
+++ b/subprojects/kotlinTest/src/test/kotlin/org/mockito/kotlin/InlineClassTest.kt
@@ -339,4 +339,14 @@ class InlineClassTest {
 
         verify(mock).returnsResult()
     }
+
+    @Test
+    @SuppressWarnings("DoNotMock", "DoNotMockAutoValue")
+    fun automaticallyDetectsClassToMock() {
+        val mock: WithResult = mock()
+
+        `when`(mock.returnsResult()).thenReturn(Result.success("OK"))
+
+        assertEquals("OK", mock.returnsResult().getOrNull())
+    }
 }


### PR DESCRIPTION
this commit adds method `Mockito.mock()` as a shorter alternative for `Mockito.mock(Class)`. When result of this call is assigned to a variable/field, java will detect the needed class automatically.

P.S. I had to ignore errorprone checks "DoNotMock" and "DoNotMockAutoValue" because they fail with IndexOutOfBoundException trying to get the first argument of `Mockito.mock()`. :)
