### PR TITLE
Avoids clearing stale weak entries from critical code segments.

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
@@ -94,8 +94,8 @@ public class InlineBytecodeGenerator implements BytecodeGenerator, ClassFileTran
                         .with(Implementation.Context.Disabled.Factory.INSTANCE)
                         .with(MethodGraph.Compiler.ForDeclaredMethods.INSTANCE)
                         .ignore(isSynthetic().and(not(isConstructor())).or(isDefaultFinalizer()));
-        mocked = new WeakConcurrentSet<>(WeakConcurrentSet.Cleaner.INLINE);
-        flatMocked = new WeakConcurrentSet<>(WeakConcurrentSet.Cleaner.INLINE);
+        mocked = new WeakConcurrentSet<>(WeakConcurrentSet.Cleaner.MANUAL);
+        flatMocked = new WeakConcurrentSet<>(WeakConcurrentSet.Cleaner.MANUAL);
         String identifier = RandomString.make();
         subclassEngine =
                 new TypeCachingBytecodeGenerator(
@@ -299,6 +299,9 @@ public class InlineBytecodeGenerator implements BytecodeGenerator, ClassFileTran
                 lastException = null;
             }
         }
+
+        mocked.expungeStaleEntries();
+        flatMocked.expungeStaleEntries();
     }
 
     private void assureCanReadMockito(Set<Class<?>> types) {


### PR DESCRIPTION
This reduces the probability of checking for mocked from from the mock-checking code what can lead to infinitive loops. Fixes #2767.