### PR TITLE
Include Java 19 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     # Definition of the build matrix
     strategy:
       matrix:
-        java: [11, 17]
+        java: [11, 17, 19]
         entry:
           - { mock-maker: 'mock-maker-default', member-accessor: 'member-accessor-default' }
           - { mock-maker: 'mock-maker-inline', member-accessor: 'member-accessor-module' }
@@ -64,7 +64,7 @@ jobs:
       if: matrix.java == 11 && matrix.entry.mock-maker == 'mock-maker-default' # SINGLE-MATRIX-JOB
       run: ./gradlew spotlessCheck
 
-    - name: 6. Build on Java ${{ matrix.java }} with ${{ matrix.entry.mock-maker }} and ${{ matrix.entry.member-accessor }} 
+    - name: 6. Build on Java ${{ matrix.java }} with ${{ matrix.entry.mock-maker }} and ${{ matrix.entry.member-accessor }}
       run: ./gradlew build idea --scan
       env:
         MOCK_MAKER: ${{ matrix.entry.mock-maker }}


### PR DESCRIPTION
Since Project Loom is a fairly significant internal architecture  change within Java, it is probably worth running CI against it as a baseline.

This is also a useful exercise in detecting potential test failures that may eventually impact the next LTS release for Java (Java 21 in September 2023).

Relates to #2767, and #2780.