### PR TITLE
Upgrade errorprone from 2.14.0 to 2.16

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -6,7 +6,7 @@ def versions = [:]
 
 versions.bytebuddy = '1.12.16'
 versions.junitJupiter = '5.9.1'
-versions.errorprone = '2.14.0'
+versions.errorprone = '2.16'
 
 libraries.junit4 = 'junit:junit:4.13.2'
 libraries.junitJupiterApi = "org.junit.jupiter:junit-jupiter-api:${versions.junitJupiter}"

--- a/src/test/java/org/mockitousage/stubbing/StubbingWithCustomAnswerTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingWithCustomAnswerTest.java
@@ -7,7 +7,6 @@ package org.mockitousage.stubbing;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-import java.lang.reflect.Method;
 import java.util.Set;
 
 import org.junit.Test;
@@ -110,7 +109,8 @@ public class StubbingWithCustomAnswerTest extends TestBase {
                         new Answer<String>() {
                             public String answer(InvocationOnMock invocation) throws Throwable {
                                 assertTrue(invocation.getArguments().getClass().isArray());
-                                assertEquals(Method.class, invocation.getMethod().getClass());
+                                assertEquals(
+                                        IMethods.class, invocation.getMethod().getDeclaringClass());
 
                                 return "assertions passed";
                             }


### PR DESCRIPTION
we need to fix the following violation:

StubbingWithCustomAnswerTest.java:113: error: [DoNotCall] Calling getClass on Method returns the Class object for Method, you probably meant to retrieve the class containing the method represented by this Method using getDeclaringClass

Supersedes and closes https://github.com/mockito/mockito/pull/2771