### PR TITLE
Hack about to fix #2796

### DIFF
--- a/src/main/java/org/mockito/ArgumentCaptor.java
+++ b/src/main/java/org/mockito/ArgumentCaptor.java
@@ -62,11 +62,12 @@ import org.mockito.internal.matchers.CapturingMatcher;
 @CheckReturnValue
 public class ArgumentCaptor<T> {
 
-    private final CapturingMatcher<T> capturingMatcher = new CapturingMatcher<T>();
+    private final CapturingMatcher<T> capturingMatcher;
     private final Class<? extends T> clazz;
 
     private ArgumentCaptor(Class<? extends T> clazz) {
         this.clazz = clazz;
+        this.capturingMatcher = new CapturingMatcher<T>(clazz);
     }
 
     /**

--- a/src/main/java/org/mockito/internal/hamcrest/HamcrestArgumentMatcher.java
+++ b/src/main/java/org/mockito/internal/hamcrest/HamcrestArgumentMatcher.java
@@ -9,6 +9,8 @@ import org.hamcrest.StringDescription;
 import org.mockito.ArgumentMatcher;
 import org.mockito.internal.matchers.VarargMatcher;
 
+import java.util.Optional;
+
 public class HamcrestArgumentMatcher<T> implements ArgumentMatcher<T> {
 
     private final Matcher matcher;
@@ -24,6 +26,10 @@ public class HamcrestArgumentMatcher<T> implements ArgumentMatcher<T> {
 
     public boolean isVarargMatcher() {
         return matcher instanceof VarargMatcher;
+    }
+
+    public Optional<VarargMatcher> varargMatcher() {
+        return isVarargMatcher() ? Optional.of((VarargMatcher) matcher) : Optional.empty();
     }
 
     @Override

--- a/src/main/java/org/mockito/internal/invocation/MatcherApplicationStrategy.java
+++ b/src/main/java/org/mockito/internal/invocation/MatcherApplicationStrategy.java
@@ -20,9 +20,7 @@ public class MatcherApplicationStrategy {
     private final Invocation invocation;
     private final List<ArgumentMatcher<?>> matchers;
 
-    private MatcherApplicationStrategy(
-            Invocation invocation,
-            List<ArgumentMatcher<?>> matchers) {
+    private MatcherApplicationStrategy(Invocation invocation, List<ArgumentMatcher<?>> matchers) {
         this.invocation = invocation;
         this.matchers = matchers;
     }
@@ -62,13 +60,17 @@ public class MatcherApplicationStrategy {
      *         </ul>
      */
     public boolean forEachMatcherAndArgument(ArgumentMatcherAction action) {
-        final boolean isVararg = invocation.getMethod().isVarArgs()
-            && invocation.getRawArguments().length == matchers.size()
-            && getLastVarargMatcher(matchers).isPresent();
+        final boolean isVararg =
+                invocation.getMethod().isVarArgs()
+                        && invocation.getRawArguments().length == matchers.size()
+                        && getLastVarargMatcher(matchers).isPresent();
 
         if (isVararg) {
             final Type type = getLastVarargMatcher(matchers).get().type();
-            final Class<?> varArgType = invocation.getMethod().getParameterTypes()[invocation.getMethod().getParameterTypes().length - 1];
+            final Class<?> varArgType =
+                    invocation.getMethod()
+                            .getParameterTypes()[
+                            invocation.getMethod().getParameterTypes().length - 1];
             if (type.equals(varArgType)) {
                 return argsMatch(invocation.getRawArguments(), matchers, action);
             }
@@ -87,9 +89,10 @@ public class MatcherApplicationStrategy {
         return false;
     }
 
-    private boolean argsMatch(final Object[] arguments,
-                              final List<ArgumentMatcher<?>> matchers,
-                              final ArgumentMatcherAction action) {
+    private boolean argsMatch(
+            final Object[] arguments,
+            final List<ArgumentMatcher<?>> matchers,
+            final ArgumentMatcherAction action) {
 
         for (int i = 0; i < arguments.length; i++) {
             ArgumentMatcher<?> matcher = matchers.get(i);
@@ -102,12 +105,15 @@ public class MatcherApplicationStrategy {
         return true;
     }
 
-    private static Optional<VarargMatcher> getLastVarargMatcher(final List<ArgumentMatcher<?>> matchers) {
+    private static Optional<VarargMatcher> getLastVarargMatcher(
+            final List<ArgumentMatcher<?>> matchers) {
         ArgumentMatcher<?> argumentMatcher = lastMatcher(matchers);
         if (argumentMatcher instanceof HamcrestArgumentMatcher<?>) {
             return ((HamcrestArgumentMatcher<?>) argumentMatcher).varargMatcher();
         }
-        return argumentMatcher instanceof VarargMatcher ? Optional.of((VarargMatcher) argumentMatcher) : Optional.empty();
+        return argumentMatcher instanceof VarargMatcher
+                ? Optional.of((VarargMatcher) argumentMatcher)
+                : Optional.empty();
     }
 
     private static List<ArgumentMatcher<?>> appendLastMatcherNTimes(

--- a/src/main/java/org/mockito/internal/matchers/Any.java
+++ b/src/main/java/org/mockito/internal/matchers/Any.java
@@ -5,6 +5,7 @@
 package org.mockito.internal.matchers;
 
 import java.io.Serializable;
+import java.lang.reflect.Type;
 
 import org.mockito.ArgumentMatcher;
 
@@ -20,5 +21,10 @@ public class Any implements ArgumentMatcher<Object>, VarargMatcher, Serializable
     @Override
     public String toString() {
         return "<any>";
+    }
+
+    @Override
+    public Type type() {
+        return Object.class;
     }
 }

--- a/src/main/java/org/mockito/internal/matchers/CapturingMatcher.java
+++ b/src/main/java/org/mockito/internal/matchers/CapturingMatcher.java
@@ -7,6 +7,7 @@ package org.mockito.internal.matchers;
 import static org.mockito.internal.exceptions.Reporter.noArgumentValueWasCaptured;
 
 import java.io.Serializable;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.locks.Lock;
@@ -19,11 +20,16 @@ import org.mockito.ArgumentMatcher;
 public class CapturingMatcher<T>
         implements ArgumentMatcher<T>, CapturesArguments, VarargMatcher, Serializable {
 
+    private final Class<? extends T> clazz;
     private final List<Object> arguments = new ArrayList<>();
 
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
     private final Lock readLock = lock.readLock();
     private final Lock writeLock = lock.writeLock();
+
+    public CapturingMatcher(final Class<? extends T> clazz) {
+        this.clazz = clazz;
+    }
 
     @Override
     public boolean matches(Object argument) {
@@ -65,5 +71,10 @@ public class CapturingMatcher<T>
         } finally {
             writeLock.unlock();
         }
+    }
+
+    @Override
+    public Type type() {
+        return clazz;
     }
 }

--- a/src/main/java/org/mockito/internal/matchers/InstanceOf.java
+++ b/src/main/java/org/mockito/internal/matchers/InstanceOf.java
@@ -5,13 +5,14 @@
 package org.mockito.internal.matchers;
 
 import java.io.Serializable;
+import java.lang.reflect.Type;
 
 import org.mockito.ArgumentMatcher;
 import org.mockito.internal.util.Primitives;
 
 public class InstanceOf implements ArgumentMatcher<Object>, Serializable {
 
-    private final Class<?> clazz;
+    final Class<?> clazz;
     private final String description;
 
     public InstanceOf(Class<?> clazz) {
@@ -43,6 +44,11 @@ public class InstanceOf implements ArgumentMatcher<Object>, Serializable {
 
         public VarArgAware(Class<?> clazz, String describedAs) {
             super(clazz, describedAs);
+        }
+
+        @Override
+        public Type type() {
+            return clazz;
         }
     }
 }

--- a/src/main/java/org/mockito/internal/matchers/VarargMatcher.java
+++ b/src/main/java/org/mockito/internal/matchers/VarargMatcher.java
@@ -5,9 +5,14 @@
 package org.mockito.internal.matchers;
 
 import java.io.Serializable;
+import java.lang.reflect.Type;
 
 /**
  * Internal interface that informs Mockito that the matcher is intended to capture varargs.
  * This information is needed when mockito collects the arguments.
  */
-public interface VarargMatcher extends Serializable {}
+public interface VarargMatcher extends Serializable {
+
+    // Todo: default impl to avoid compatability issues?
+    Type type();
+}

--- a/src/test/java/org/mockito/internal/invocation/InvocationMatcherTest.java
+++ b/src/test/java/org/mockito/internal/invocation/InvocationMatcherTest.java
@@ -136,7 +136,7 @@ public class InvocationMatcherTest extends TestBase {
     public void should_capture_arguments_from_invocation() throws Exception {
         // given
         Invocation invocation = new InvocationBuilder().args("1", 100).toInvocation();
-        CapturingMatcher capturingMatcher = new CapturingMatcher();
+        CapturingMatcher capturingMatcher = new CapturingMatcher(List.class);
         InvocationMatcher invocationMatcher =
                 new InvocationMatcher(invocation, (List) asList(new Equals("1"), capturingMatcher));
 
@@ -167,7 +167,7 @@ public class InvocationMatcherTest extends TestBase {
         // given
         mock.mixedVarargs(1, "a", "b");
         Invocation invocation = getLastInvocation();
-        CapturingMatcher m = new CapturingMatcher();
+        CapturingMatcher m = new CapturingMatcher(List.class);
         InvocationMatcher invocationMatcher =
                 new InvocationMatcher(invocation, Arrays.<ArgumentMatcher>asList(new Equals(1), m));
 

--- a/src/test/java/org/mockito/internal/invocation/MatcherApplicationStrategyTest.java
+++ b/src/test/java/org/mockito/internal/invocation/MatcherApplicationStrategyTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.internal.invocation.MatcherApplicationStrategy.getMatcherApplicationStrategyFor;
 import static org.mockito.internal.matchers.Any.ANY;
 
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -230,6 +231,11 @@ public class MatcherApplicationStrategyTest extends TestBase {
         }
 
         public void describeTo(Description description) {}
+
+        @Override
+        public Type type() {
+            return Integer.class;
+        }
     }
 
     private Invocation mixedVarargs(Object a, String... s) {

--- a/src/test/java/org/mockito/internal/matchers/CapturingMatcherTest.java
+++ b/src/test/java/org/mockito/internal/matchers/CapturingMatcherTest.java
@@ -19,7 +19,7 @@ public class CapturingMatcherTest extends TestBase {
     @Test
     public void should_capture_arguments() throws Exception {
         // given
-        CapturingMatcher<String> m = new CapturingMatcher<String>();
+        CapturingMatcher<String> m = new CapturingMatcher<String>(String.class);
 
         // when
         m.captureFrom("foo");
@@ -32,7 +32,7 @@ public class CapturingMatcherTest extends TestBase {
     @Test
     public void should_know_last_captured_value() throws Exception {
         // given
-        CapturingMatcher<String> m = new CapturingMatcher<String>();
+        CapturingMatcher<String> m = new CapturingMatcher<String>(String.class);
 
         // when
         m.captureFrom("foo");
@@ -45,7 +45,7 @@ public class CapturingMatcherTest extends TestBase {
     @Test
     public void should_scream_when_nothing_yet_captured() throws Exception {
         // given
-        CapturingMatcher<String> m = new CapturingMatcher<String>();
+        CapturingMatcher<String> m = new CapturingMatcher<String>(String.class);
 
         try {
             // when
@@ -59,7 +59,7 @@ public class CapturingMatcherTest extends TestBase {
     @Test
     public void should_not_fail_when_used_in_concurrent_tests() throws Exception {
         // given
-        final CapturingMatcher<String> m = new CapturingMatcher<String>();
+        final CapturingMatcher<String> m = new CapturingMatcher<String>(String.class);
 
         // when
         m.captureFrom("concurrent access");

--- a/src/test/java/org/mockitousage/stubbing/StubbingWithAdditionalAnswersTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingWithAdditionalAnswersTest.java
@@ -66,50 +66,51 @@ public class StubbingWithAdditionalAnswersTest {
 
     public interface Foo {
         String m1(String arg);
+
         String m1(String... args);
     }
 
     @Mock private Foo foo;
 
     @Test
-    public void shouldWorkWithCasts() throws Exception  {
-        given(foo.m1((String)any())).willReturn("single arg method");
-        given(foo.m1((String[])any())).willReturn("var arg method");
+    public void shouldWorkWithCasts() throws Exception {
+        given(foo.m1((String) any())).willReturn("single arg method");
+        given(foo.m1((String[]) any())).willReturn("var arg method");
 
-        assertThat(foo.m1( "a")).isEqualTo("single arg method");
+        assertThat(foo.m1("a")).isEqualTo("single arg method");
         assertThat(foo.m1()).isEqualTo("var arg method");
-        assertThat(foo.m1( new String[] {"a" })).isEqualTo("var arg method");
+        assertThat(foo.m1(new String[] {"a"})).isEqualTo("var arg method");
         assertThat(foo.m1("a", "b")).isEqualTo("var arg method");
     }
 
     @Test
-    public void shouldWork() throws Exception  {
+    public void shouldWork() throws Exception {
         given(foo.m1(any(String.class))).willReturn("single arg method");
 
-        assertThat(foo.m1( "a")).isEqualTo("single arg method");
-        assertThat(foo.m1( new String[] {"a"})).isNull();
-        assertThat(foo.m1( "a", "b")).isNull();
-        assertThat(foo.m1( "a", "b", "c")).isNull();
+        assertThat(foo.m1("a")).isEqualTo("single arg method");
+        assertThat(foo.m1(new String[] {"a"})).isNull();
+        assertThat(foo.m1("a", "b")).isNull();
+        assertThat(foo.m1("a", "b", "c")).isNull();
     }
 
     @Test
-    public void shouldWork2() throws Exception  {
+    public void shouldWork2() throws Exception {
         given(foo.m1(any(String[].class))).willReturn("var arg method");
 
-        assertThat(foo.m1( "a")).isNull();
-        assertThat(foo.m1( new String[] {"a"})).isEqualTo("var arg method");
-        assertThat(foo.m1( "a", "b")).isEqualTo("var arg method");
-        assertThat(foo.m1( "a", "b", "c")).isEqualTo("var arg method");
+        assertThat(foo.m1("a")).isNull();
+        assertThat(foo.m1(new String[] {"a"})).isEqualTo("var arg method");
+        assertThat(foo.m1("a", "b")).isEqualTo("var arg method");
+        assertThat(foo.m1("a", "b", "c")).isEqualTo("var arg method");
     }
 
     @Test
-    public void shouldWork3() throws Exception  {
+    public void shouldWork3() throws Exception {
         given(foo.m1(any(String.class), any(String.class))).willReturn("var arg method");
 
-        assertThat(foo.m1( "a")).isNull();
-        assertThat(foo.m1( new String[] {"a"})).isNull();
-        assertThat(foo.m1( "a", "b")).isEqualTo("var arg method");
-        assertThat(foo.m1( "a", "b", "c")).isNull();
+        assertThat(foo.m1("a")).isNull();
+        assertThat(foo.m1(new String[] {"a"})).isNull();
+        assertThat(foo.m1("a", "b")).isEqualTo("var arg method");
+        assertThat(foo.m1("a", "b", "c")).isNull();
     }
 
     @Test
@@ -128,7 +129,6 @@ public class StubbingWithAdditionalAnswersTest {
         verify(iMethods).varargs(captor.capture());
     }
 
-
     @Test
     public void shouldVerifyVarArgs_any_nullArrayArg() {
         iMethods.varargs((String[]) null);
@@ -143,12 +143,10 @@ public class StubbingWithAdditionalAnswersTest {
         verify(iMethods).varargs(ArgumentMatchers.eq(null));
     }
 
-
-
     @Test
     public void shouldVerifyVarArgs_eq_nullArrayArg() {
 
-        iMethods.varargs((String)null);
+        iMethods.varargs((String) null);
 
         verify(iMethods).varargs(ArgumentMatchers.eq(null));
     }
@@ -156,7 +154,7 @@ public class StubbingWithAdditionalAnswersTest {
     @Test
     public void shouldVerifyVarArgs_isNull_nullArrayArg() {
 
-        iMethods.varargs((String)null);
+        iMethods.varargs((String) null);
 
         verify(iMethods).varargs(ArgumentMatchers.isNull());
     }
@@ -167,7 +165,7 @@ public class StubbingWithAdditionalAnswersTest {
         iMethods.varargs();
 
         // Todo: still fails. Would require `NotNull` to be `VarargMatcher` I think
-        //verify(iMethods).varargs(ArgumentMatchers.isNotNull());
+        // verify(iMethods).varargs(ArgumentMatchers.isNotNull());
     }
 
     @Test

--- a/src/test/java/org/mockitousage/stubbing/StubbingWithAdditionalAnswersTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingWithAdditionalAnswersTest.java
@@ -58,10 +58,12 @@ public class StubbingWithAdditionalAnswersTest {
         given(iMethods.objectArgMethod(any())).will(returnsFirstArg());
         given(iMethods.threeArgumentMethod(eq(0), any(), anyString())).will(returnsSecondArg());
         given(iMethods.threeArgumentMethod(eq(1), any(), anyString())).will(returnsLastArg());
+        given(iMethods.mixedVarargsReturningString(eq(1), any())).will(returnsArgAt(2));
 
         assertThat(iMethods.objectArgMethod("first")).isEqualTo("first");
         assertThat(iMethods.threeArgumentMethod(0, "second", "whatever")).isEqualTo("second");
         assertThat(iMethods.threeArgumentMethod(1, "whatever", "last")).isEqualTo("last");
+        assertThat(iMethods.mixedVarargsReturningString(1, "a", "b")).isEqualTo("b");
     }
 
     public interface Foo {


### PR DESCRIPTION
This PR contains changes NOT intended to be committed 'as-is', but as a showcase for a potential solution to:

* https://github.com/mockito/mockito/issues/2796
* https://github.com/mockito/mockito/issues/1593

And potentially other vararg related issues.

The crux of the issue is that Mockito needs to handle the last matcher passed to a method, when that matcher aligns with a vararg parameter and has the same type as the vararg parameter.

For example,

```java
public interface Foo {
 String m1(String... args);  // Vararg param at index 0 and type String[]
}

@Test
public void shouldWork2() throws Exception  {
  // Last matcher at index 0, and with type String[]: needs special handling!
  given(foo.m1(any(String[].class))).willReturn("var arg method");
  ...
}
```

In such situations that code needs to match the raw argument, _not_ the current functionality, which is to use the last matcher to match the last _non raw_ argument.

Unfortunately, I'm not aware of a way to get at the type of the matcher without adding a method to `VarargMatcher` to get this information. This is the downside of this approach.

The PR includes the tests suggested in https://github.com/mockito/mockito/pull/1236, though one still fails (and is commented out with explanation).

Crux of the change is in `MatcherApplicationStrategy`. Obviously, it needs some refactoring. Not sure if you'd want the refactor as a separate PR or as the first commit of the main PR????

Alternatively, I could resurrect https://github.com/mockito/mockito/pull/1224 and take it through to merging.

