### PR TITLE
Improve vararg handling

### DIFF
--- a/src/main/java/org/mockito/ArgumentCaptor.java
+++ b/src/main/java/org/mockito/ArgumentCaptor.java
@@ -62,11 +62,12 @@ import org.mockito.internal.matchers.CapturingMatcher;
 @CheckReturnValue
 public class ArgumentCaptor<T> {
 
-    private final CapturingMatcher<T> capturingMatcher = new CapturingMatcher<T>();
+    private final CapturingMatcher<T> capturingMatcher;
     private final Class<? extends T> clazz;
 
     private ArgumentCaptor(Class<? extends T> clazz) {
         this.clazz = clazz;
+        this.capturingMatcher = new CapturingMatcher<T>(clazz);
     }
 
     /**

--- a/src/main/java/org/mockito/internal/hamcrest/HamcrestArgumentMatcher.java
+++ b/src/main/java/org/mockito/internal/hamcrest/HamcrestArgumentMatcher.java
@@ -9,6 +9,8 @@ import org.hamcrest.StringDescription;
 import org.mockito.ArgumentMatcher;
 import org.mockito.internal.matchers.VarargMatcher;
 
+import java.util.Optional;
+
 public class HamcrestArgumentMatcher<T> implements ArgumentMatcher<T> {
 
     private final Matcher matcher;
@@ -24,6 +26,10 @@ public class HamcrestArgumentMatcher<T> implements ArgumentMatcher<T> {
 
     public boolean isVarargMatcher() {
         return matcher instanceof VarargMatcher;
+    }
+
+    public Optional<VarargMatcher> varargMatcher() {
+        return isVarargMatcher() ? Optional.of((VarargMatcher) matcher) : Optional.empty();
     }
 
     @Override

--- a/src/main/java/org/mockito/internal/invocation/MatcherApplicationStrategy.java
+++ b/src/main/java/org/mockito/internal/invocation/MatcherApplicationStrategy.java
@@ -4,7 +4,6 @@
  */
 package org.mockito.internal.invocation;
 
-import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/org/mockito/internal/matchers/Any.java
+++ b/src/main/java/org/mockito/internal/matchers/Any.java
@@ -21,4 +21,9 @@ public class Any implements ArgumentMatcher<Object>, VarargMatcher, Serializable
     public String toString() {
         return "<any>";
     }
+
+    @Override
+    public Class<?> type() {
+        return Object.class;
+    }
 }

--- a/src/main/java/org/mockito/internal/matchers/CapturingMatcher.java
+++ b/src/main/java/org/mockito/internal/matchers/CapturingMatcher.java
@@ -19,11 +19,16 @@ import org.mockito.ArgumentMatcher;
 public class CapturingMatcher<T>
         implements ArgumentMatcher<T>, CapturesArguments, VarargMatcher, Serializable {
 
+    private final Class<? extends T> clazz;
     private final List<Object> arguments = new ArrayList<>();
 
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
     private final Lock readLock = lock.readLock();
     private final Lock writeLock = lock.writeLock();
+
+    public CapturingMatcher(final Class<? extends T> clazz) {
+        this.clazz = clazz;
+    }
 
     @Override
     public boolean matches(Object argument) {
@@ -65,5 +70,10 @@ public class CapturingMatcher<T>
         } finally {
             writeLock.unlock();
         }
+    }
+
+    @Override
+    public Class<?> type() {
+        return clazz;
     }
 }

--- a/src/main/java/org/mockito/internal/matchers/InstanceOf.java
+++ b/src/main/java/org/mockito/internal/matchers/InstanceOf.java
@@ -11,7 +11,7 @@ import org.mockito.internal.util.Primitives;
 
 public class InstanceOf implements ArgumentMatcher<Object>, Serializable {
 
-    private final Class<?> clazz;
+    final Class<?> clazz;
     private final String description;
 
     public InstanceOf(Class<?> clazz) {
@@ -43,6 +43,11 @@ public class InstanceOf implements ArgumentMatcher<Object>, Serializable {
 
         public VarArgAware(Class<?> clazz, String describedAs) {
             super(clazz, describedAs);
+        }
+
+        @Override
+        public Class<?> type() {
+            return clazz;
         }
     }
 }

--- a/src/main/java/org/mockito/internal/matchers/VarargMatcher.java
+++ b/src/main/java/org/mockito/internal/matchers/VarargMatcher.java
@@ -10,4 +10,44 @@ import java.io.Serializable;
  * Internal interface that informs Mockito that the matcher is intended to capture varargs.
  * This information is needed when mockito collects the arguments.
  */
-public interface VarargMatcher extends Serializable {}
+public interface VarargMatcher extends Serializable {
+
+    /**
+     * The type of the argument the matcher matches.
+     *
+     * <p>If a vararg aware matcher:
+     * <ul>
+     *     <li>is at the parameter index of a vararg parameter</li>
+     *     <li>is the last matcher passed</li>
+     *     <li>matchers the raw type of the vararg parameter</li>
+     * </ul>
+     *
+     * Then the matcher is matched against the vararg raw parameter.
+     * Otherwise, the matcher will be matched against each element in the vararg raw parameters.
+     *
+     * <p>For example:
+     *
+     * <pre class="code"><code class="java">
+     *  // Given vararg method with signature:
+     *  int someVarargMethod(int x, String... args);
+     *
+     *  // The following will match the last matcher against the contents of the `args` array:
+     *  (as the above criteria are met)
+     *  mock.someVarargMethod(eq(1), any(String[].class));
+     *
+     *  // The following will match the last matcher against each element of the `args` array:
+     *  // (as the type of the last matcher does not match the raw type of the vararg parameter)
+     *  mock.someVarargMethod(eq(1), any(String.class));
+     *
+     *  // The following will match only invocations with two strings in the 'args' array:
+     *  // (as there are more matchers than raw arguments)
+     *  mock.someVarargMethod(eq(1), any(), any());
+     * </code></pre>
+     *
+     * @return the type this matcher handles.
+     * @since 4.10.0
+     */
+    default Class<?> type() {
+        return Void.class;
+    }
+}

--- a/src/test/java/org/mockito/internal/invocation/InvocationMatcherTest.java
+++ b/src/test/java/org/mockito/internal/invocation/InvocationMatcherTest.java
@@ -136,7 +136,7 @@ public class InvocationMatcherTest extends TestBase {
     public void should_capture_arguments_from_invocation() throws Exception {
         // given
         Invocation invocation = new InvocationBuilder().args("1", 100).toInvocation();
-        CapturingMatcher capturingMatcher = new CapturingMatcher();
+        CapturingMatcher capturingMatcher = new CapturingMatcher(List.class);
         InvocationMatcher invocationMatcher =
                 new InvocationMatcher(invocation, (List) asList(new Equals("1"), capturingMatcher));
 
@@ -167,7 +167,7 @@ public class InvocationMatcherTest extends TestBase {
         // given
         mock.mixedVarargs(1, "a", "b");
         Invocation invocation = getLastInvocation();
-        CapturingMatcher m = new CapturingMatcher();
+        CapturingMatcher m = new CapturingMatcher(List.class);
         InvocationMatcher invocationMatcher =
                 new InvocationMatcher(invocation, Arrays.<ArgumentMatcher>asList(new Equals(1), m));
 

--- a/src/test/java/org/mockito/internal/invocation/MatcherApplicationStrategyTest.java
+++ b/src/test/java/org/mockito/internal/invocation/MatcherApplicationStrategyTest.java
@@ -9,6 +9,7 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.internal.invocation.MatcherApplicationStrategy.getMatcherApplicationStrategyFor;
 import static org.mockito.internal.matchers.Any.ANY;
 
@@ -225,12 +226,32 @@ public class MatcherApplicationStrategyTest extends TestBase {
         recordAction.assertContainsExactly(argumentMatcher, argumentMatcher);
     }
 
+    @Test
+    public void shouldMatchAnyThatMatchesRawVarArgType() {
+        // given
+        invocation = varargs("1", "2");
+        InstanceOf.VarArgAware any = new InstanceOf.VarArgAware(String[].class, "<any String[]>");
+        matchers = asList(any);
+
+        // when
+        getMatcherApplicationStrategyFor(invocation, matchers)
+                .forEachMatcherAndArgument(recordAction);
+
+        // then
+        recordAction.assertContainsExactly(any);
+    }
+
     private static class IntMatcher extends BaseMatcher<Integer> implements VarargMatcher {
         public boolean matches(Object o) {
             return true;
         }
 
         public void describeTo(Description description) {}
+
+        @Override
+        public Class<?> type() {
+            return Integer.class;
+        }
     }
 
     private Invocation mixedVarargs(Object a, String... s) {

--- a/src/test/java/org/mockito/internal/matchers/CapturingMatcherTest.java
+++ b/src/test/java/org/mockito/internal/matchers/CapturingMatcherTest.java
@@ -19,7 +19,7 @@ public class CapturingMatcherTest extends TestBase {
     @Test
     public void should_capture_arguments() throws Exception {
         // given
-        CapturingMatcher<String> m = new CapturingMatcher<String>();
+        CapturingMatcher<String> m = new CapturingMatcher<String>(String.class);
 
         // when
         m.captureFrom("foo");
@@ -32,7 +32,7 @@ public class CapturingMatcherTest extends TestBase {
     @Test
     public void should_know_last_captured_value() throws Exception {
         // given
-        CapturingMatcher<String> m = new CapturingMatcher<String>();
+        CapturingMatcher<String> m = new CapturingMatcher<String>(String.class);
 
         // when
         m.captureFrom("foo");
@@ -45,7 +45,7 @@ public class CapturingMatcherTest extends TestBase {
     @Test
     public void should_scream_when_nothing_yet_captured() throws Exception {
         // given
-        CapturingMatcher<String> m = new CapturingMatcher<String>();
+        CapturingMatcher<String> m = new CapturingMatcher<String>(String.class);
 
         try {
             // when
@@ -59,7 +59,7 @@ public class CapturingMatcherTest extends TestBase {
     @Test
     public void should_not_fail_when_used_in_concurrent_tests() throws Exception {
         // given
-        final CapturingMatcher<String> m = new CapturingMatcher<String>();
+        final CapturingMatcher<String> m = new CapturingMatcher<String>(String.class);
 
         // when
         m.captureFrom("concurrent access");

--- a/src/test/java/org/mockitousage/IMethods.java
+++ b/src/test/java/org/mockitousage/IMethods.java
@@ -199,6 +199,10 @@ public interface IMethods {
 
     Object[] mixedVarargsReturningObjectArray(Object i, String... string);
 
+    String methodWithVarargAndNonVarargVariants(String string);
+
+    String methodWithVarargAndNonVarargVariants(String... string);
+
     List<String> listReturningMethod(Object... objects);
 
     LinkedList<String> linkedListReturningMethod();

--- a/src/test/java/org/mockitousage/MethodsImpl.java
+++ b/src/test/java/org/mockitousage/MethodsImpl.java
@@ -376,6 +376,16 @@ public class MethodsImpl implements IMethods {
         return null;
     }
 
+    @Override
+    public String methodWithVarargAndNonVarargVariants(String string) {
+        return "plain";
+    }
+
+    @Override
+    public String methodWithVarargAndNonVarargVariants(String... string) {
+        return "varargs";
+    }
+
     public void varargsbyte(byte... bytes) {}
 
     public List<String> listReturningMethod(Object... objects) {

--- a/src/test/java/org/mockitousage/matchers/VarargsTest.java
+++ b/src/test/java/org/mockitousage/matchers/VarargsTest.java
@@ -403,7 +403,7 @@ public class VarargsTest {
     public void shouldHandleArrayVarargsMethods() {
         given(mock.arrayVarargsMethod(any(String[][].class))).willReturn(1);
 
-        assertThat(mock.arrayVarargsMethod(new String[]{})).isEqualTo(1);
+        assertThat(mock.arrayVarargsMethod(new String[] {})).isEqualTo(1);
     }
 
     @Test

--- a/src/test/java/org/mockitousage/matchers/VarargsTest.java
+++ b/src/test/java/org/mockitousage/matchers/VarargsTest.java
@@ -9,9 +9,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.ArgumentMatchers.isNotNull;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -53,29 +55,24 @@ public class VarargsTest {
         verify(mock).varargs();
     }
 
+    /* todo
+    To support this, `NotNull` would need to implement `VarargsMatcher`.
     @Test
-    @Ignore("This test must succeed but is fails currently, see github issue #616")
     public void shouldMatchEmptyVarArgs_noArgsIsNotNull() {
         mock.varargs();
 
-        verify(mock).varargs(isNotNull());
+        verify(mock).varargs(isNotNull(String[].class));
     }
 
+    To support this, `Null` would need to implement `VarargsMatcher`.
     @Test
-    @Ignore("This test must succeed but is fails currently, see github issue #616")
     public void shouldMatchEmptyVarArgs_noArgsIsNull() {
-        mock.varargs();
+        mock.varargs((String[]) null);
 
-        verify(mock).varargs(isNull());
+        verify(mock).varargs(isNull(String[].class));
     }
 
-    @Test
-    @Ignore("This test must succeed but is fails currently, see github issue #616")
-    public void shouldMatchEmptyVarArgs_noArgsIsNotNullArray() {
-        mock.varargs();
-
-        verify(mock).varargs((String[]) isNotNull());
-    }
+     */
 
     @Test
     public void shouldMatchVarArgs_oneNullArg_eqNull() {
@@ -179,13 +176,15 @@ public class VarargsTest {
         verify(mock).varargsbyte();
     }
 
+    /* todo
+    To support this, `NotNull` would need to implement `VarargsMatcher`.
     @Test
-    @Ignore
     public void shouldMatchEmptyVarArgs_emptyArrayIsNotNull() {
         mock.varargsbyte();
 
-        verify(mock).varargsbyte((byte[]) isNotNull());
+        verify(mock).varargsbyte(isNotNull(byte[].class));
     }
+    */
 
     @Test
     public void shouldMatchVarArgs_oneArgIsNotNull() {
@@ -306,16 +305,7 @@ public class VarargsTest {
                 .isInstanceOf(ArgumentsAreDifferent.class);
     }
 
-    /**
-     * As of v2.0.0-beta.118 this test fails. Once the github issues:
-     * <ul>
-     * <li>'#584 ArgumentCaptor can't capture varargs-arrays
-     * <li>#565 ArgumentCaptor should be type aware' are fixed this test must
-     * succeed
-     * </ul>
-     */
     @Test
-    @Ignore("Blocked by github issue: #584 & #565")
     public void shouldCaptureVarArgsAsArray() {
         mock.varargs("1", "2");
 
@@ -430,42 +420,90 @@ public class VarargsTest {
     public void shouldVerifyVarArgs_any_NullArrayArg1() {
         mock.varargs((String[]) null);
 
-        verify(mock).varargs(ArgumentMatchers.any());
+        verify(mock).varargs(any());
     }
 
     @Test
     public void shouldVerifyVarArgs_any_NullArrayArg2() {
         mock.varargs((String) null);
 
-        verify(mock).varargs(ArgumentMatchers.any());
+        verify(mock).varargs(any());
     }
 
     @Test
     public void shouldVerifyVarArgs_eq_NullArrayArg1() {
         mock.varargs((String[]) null);
 
-        verify(mock).varargs(ArgumentMatchers.eq(null));
+        verify(mock).varargs(eq(null));
     }
 
     @Test
     public void shouldVerifyVarArgs_eq_NullArrayArg2() {
         mock.varargs((String) null);
 
-        verify(mock).varargs(ArgumentMatchers.eq(null));
+        verify(mock).varargs(eq(null));
     }
 
+    /*
+    To support this, `Null` would need to implement `VarargsMatcher`.
     @Test
-    public void shouldVerifyVarArgs_isNull_NullArrayArg1() {
-        mock.varargs((String[]) null);
+    public void shouldVerifyVarArgs_isNull_NullArrayArg() {
+        mock.varargs((String) null);
 
-        verify(mock).varargs(ArgumentMatchers.isNull());
+        verify(mock).varargs(isNull(String.class));
     }
+    */
 
     @Test
     public void shouldVerifyVarArgs_isNull_NullArrayArg2() {
         mock.varargs((String) null);
 
-        verify(mock).varargs(ArgumentMatchers.isNull());
+        verify(mock).varargs(isNull());
+    }
+
+    @Test
+    public void shouldVerifyExactlyOneVarArg_isA() {
+        mock.varargs("one param");
+
+        verify(mock).varargs(isA(String.class));
+    }
+
+    @Test
+    public void shouldNotVerifyExactlyOneVarArg_isA() {
+        mock.varargs("two", "params");
+
+        verify(mock, never()).varargs(isA(String.class));
+    }
+
+    @Test
+    @Ignore("Fails. Fixing this would require isA to use `InstanceOf.VarArgAware")
+    public void shouldVerifyVarArgArray_isA() {
+        mock.varargs("one param");
+
+        verify(mock).varargs(isA(String[].class));
+    }
+
+    @Test
+    @Ignore("Fails. Fixing this would require isA to use `InstanceOf.VarArgAware")
+    public void shouldVerifyVarArgArray_isA2() {
+        mock.varargs("two", "params");
+
+        verify(mock).varargs(isA(String[].class));
+    }
+
+    @Test
+    public void shouldVerifyExactlyOneVarArg_any() {
+        mock.varargs("one param");
+
+        verify(mock).varargs(any(String.class));
+    }
+
+    @Test
+    @Ignore("Fails due to https://github.com/mockito/mockito/issues/1593")
+    public void shouldNotVerifyExactlyOneVarArg_any() {
+        mock.varargs("two", "params");
+
+        verify(mock, never()).varargs(any(String.class));
     }
 
     private static <T> AbstractListAssert<?, ?, T, ObjectAssert<T>> assertThatCaptor(


### PR DESCRIPTION
Fixes: https://github.com/mockito/mockito/issues/2796

An alternative approach is available in https://github.com/mockito/mockito/pull/2807.

Add an optional method to `VarargMatcher`, which implementations can choose to override to return the type of object the matcher is matching.

This is used by `MatcherApplicationStrategy` to determine if the type of matcher used to match a vararg parameter is of a type compatible with the vararg parameter.

Where a vararg compatible matcher is found, the matcher is used to match the _raw_ parameters.

## Known limitations

The main limitation I'm aware of, is not a new limitation. It is that it is not possible to assert only a single parameter is passed to the vararg parameter, when using a `VarargMatcher`. (ref: https://github.com/mockito/mockito/issues/1593). For example:

```java
// Given method:
int vararg(String... args);

// I want to mock this invocation:
mock.vararag("one param");

// ...but not these:
mock.vararg();
mock.vararg("more than", "one param");
```

There is no current way to do this.  This is because in the following intuitive mocking:

```java
given(mock.vararg(any(String.class))).willReturn(1);
```

... matches zero or more vararg parameters, as the `any()` method is using `VarargMatcher`.

It seems to me that `VarargMatcher` is... a little broken.  This PR leverages `VarargMatcher`... which, if its broken, might not be something we want to do.

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

