### PR TITLE
Fix incorrect Javadoc inline tag for MockitoJUnitRunner

### DIFF
--- a/src/main/java/org/mockito/junit/MockitoJUnitRunner.java
+++ b/src/main/java/org/mockito/junit/MockitoJUnitRunner.java
@@ -34,7 +34,7 @@ import org.mockito.quality.Strictness;
  *       See {@link UnnecessaryStubbingException}.
  *       Similar to JUnit rules, the runner also reports stubbing argument mismatches as console warnings
  *       (see {@link MockitoHint}).
- *       To opt-out from this feature, use {@code}&#064;RunWith(MockitoJUnitRunner.Silent.class){@code}
+ *       To opt-out from this feature, use {@code @RunWith(MockitoJUnitRunner.Silent.class)}
  *   <li>
  *      Initializes mocks annotated with {@link Mock},
  *      so that explicit usage of {@link MockitoAnnotations#openMocks(Object)} is not necessary.


### PR DESCRIPTION
Fixes incorrect usage of the `{@code ...}` Javadoc inline tag. As part of that the `&#064;` had to be replaced with `@` because `{@code ...}` treats its content literally.

<!-- Hey,
Thanks for the contribution, this is awesome.
As you may have read, project members have somehow an opinionated view on what and how should be
Mockito, e.g. we don't want mockito to be a feature bloat.
There may be a thorough review, with feedback -> code change loop.
-->
<!--
If you have a suggestion for this template you can fix it in the .github/PULL_REQUEST_TEMPLATE.md file
-->
## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [ ] Mention `Fixes #<issue number>` in the description _if relevant_
 - [ ] At least one commit should mention `Fixes #<issue number>` _if relevant_

