### PR TITLE
Fixes #2786: Add unequal arguments positions in failed verification message

### DIFF
--- a/src/main/java/org/mockito/internal/verification/argumentmatching/ArgumentMatchingTool.java
+++ b/src/main/java/org/mockito/internal/verification/argumentmatching/ArgumentMatchingTool.java
@@ -4,6 +4,8 @@
  */
 package org.mockito.internal.verification.argumentmatching;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -15,7 +17,7 @@ import java.util.stream.Collectors;
 import org.mockito.ArgumentMatcher;
 import org.mockito.internal.matchers.ContainsExtraTypeInfo;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings("rawtypes")
 public class ArgumentMatchingTool {
 
     private ArgumentMatchingTool() {}
@@ -40,6 +42,28 @@ public class ArgumentMatchingTool {
             i++;
         }
         return suspicious.toArray(new Integer[0]);
+    }
+
+    /**
+     * Returns indexes of arguments not matching the provided matchers.
+     */
+    public static List<Integer> getNotMatchingArgsIndexes(
+            List<ArgumentMatcher> matchers, Object[] arguments) {
+        if (matchers.size() != arguments.length) {
+            return Collections.emptyList();
+        }
+
+        List<Integer> nonMatching = new ArrayList<>();
+        int i = 0;
+        for (ArgumentMatcher m : matchers) {
+            if (!safelyMatches(m, arguments[i])) {
+                nonMatching.add(i);
+            }
+
+            i++;
+        }
+
+        return nonMatching;
     }
 
     private static boolean safelyMatches(ArgumentMatcher m, Object arg) {

--- a/src/main/java/org/mockito/internal/verification/checkers/MissingInvocationChecker.java
+++ b/src/main/java/org/mockito/internal/verification/checkers/MissingInvocationChecker.java
@@ -52,7 +52,11 @@ public class MissingInvocationChecker {
                 invocations.stream().map(Invocation::getLocation).collect(Collectors.toList());
 
         throw argumentsAreDifferent(
-                smartPrinter.getWanted(), smartPrinter.getActuals(), actualLocations);
+                similar,
+                wanted,
+                smartPrinter.getWanted(),
+                smartPrinter.getActuals(),
+                actualLocations);
     }
 
     public static void checkMissingInvocation(

--- a/src/test/java/org/mockito/internal/verification/argumentmatching/ArgumentMatchingToolTest.java
+++ b/src/test/java/org/mockito/internal/verification/argumentmatching/ArgumentMatchingToolTest.java
@@ -17,7 +17,7 @@ import org.mockito.internal.matchers.ContainsExtraTypeInfo;
 import org.mockito.internal.matchers.Equals;
 import org.mockitoutil.TestBase;
 
-@SuppressWarnings({"unchecked", "serial"})
+@SuppressWarnings({"rawtypes", "unchecked", "serial"})
 public class ArgumentMatchingToolTest extends TestBase {
 
     @Test
@@ -97,7 +97,6 @@ public class ArgumentMatchingToolTest extends TestBase {
     }
 
     @Test
-    @SuppressWarnings("rawtypes")
     public void shouldUseMatchersSafely() {
         // This matcher is evil cause typeMatches(Object) returns true for every passed type but
         // matches(T)
@@ -136,5 +135,50 @@ public class ArgumentMatchingToolTest extends TestBase {
 
         // then
         assertEquals(0, suspicious.length);
+    }
+
+    @Test
+    public void shouldNotFindNonMatchingIndexesWhenEveryArgsMatch() {
+        String arg1Value = "arg1";
+        Integer arg2Value = 2222;
+
+        Equals arg1 = new Equals(arg1Value);
+        Equals arg2 = new Equals(arg2Value);
+
+        List<Integer> indexes =
+                ArgumentMatchingTool.getNotMatchingArgsIndexes(
+                        Arrays.asList(arg1, arg2), new Object[] {arg1Value, arg2Value});
+
+        assertEquals(Arrays.asList(), indexes);
+    }
+
+    @Test
+    public void shouldFindNonMatchingIndexesWhenSingleArgDoesNotMatch() {
+        String arg1Value = "arg1";
+        Integer arg2Value = 2222;
+
+        Equals arg1 = new Equals(arg1Value);
+        Equals arg2 = new Equals(1111);
+
+        List<Integer> indexes =
+                ArgumentMatchingTool.getNotMatchingArgsIndexes(
+                        Arrays.asList(arg1, arg2), new Object[] {arg1Value, arg2Value});
+
+        assertEquals(Arrays.asList(1), indexes);
+    }
+
+    @Test
+    public void shouldFindNonMatchingIndexesWhenMultiArgsDoNotMatch() {
+        String arg1Value = "arg1";
+        Integer arg2Value = 2222;
+
+        Equals arg1 = new Equals("differs");
+        Equals arg2 = new Equals(1111);
+
+        List<Integer> indexes =
+                ArgumentMatchingTool.getNotMatchingArgsIndexes(
+                        Arrays.asList(arg1, arg2), new Object[] {arg1Value, arg2Value});
+
+        assertEquals(Arrays.asList(0, 1), indexes);
     }
 }

--- a/src/test/java/org/mockito/internal/verification/checkers/MissingInvocationCheckerTest.java
+++ b/src/test/java/org/mockito/internal/verification/checkers/MissingInvocationCheckerTest.java
@@ -95,6 +95,76 @@ public class MissingInvocationCheckerTest extends TestBase {
                         "mock.intArgumentMethod(MyCoolPrint(1111));");
     }
 
+    @Test
+    public void shouldSpecifyPosition0WhenWantedInvocationDiffersFromActual() {
+        wanted = buildMultiArgsMethod().args("arg1", 2222).toInvocationMatcher();
+        invocations = singletonList(buildMultiArgsMethod().args("differs", 2222).toInvocation());
+
+        assertThatThrownBy(
+                        () -> {
+                            MissingInvocationChecker.checkMissingInvocation(invocations, wanted);
+                        })
+                .isInstanceOf(ArgumentsAreDifferent.class)
+                .hasMessageContainingAll(
+                        "Argument(s) are different! Wanted:",
+                        "mock.simpleMethod(\"arg1\", 2222);",
+                        "Actual invocations have different arguments at position [0]:",
+                        "mock.simpleMethod(\"differs\", 2222);");
+    }
+
+    @Test
+    public void shouldSpecifyPosition1WhenWantedInvocationDiffersFromActual() {
+        wanted = buildMultiArgsMethod().args("arg1", 2222).toInvocationMatcher();
+        invocations = singletonList(buildMultiArgsMethod().args("arg1", 1111).toInvocation());
+
+        assertThatThrownBy(
+                        () -> {
+                            MissingInvocationChecker.checkMissingInvocation(invocations, wanted);
+                        })
+                .isInstanceOf(ArgumentsAreDifferent.class)
+                .hasMessageContainingAll(
+                        "Argument(s) are different! Wanted:",
+                        "mock.simpleMethod(\"arg1\", 2222);",
+                        "Actual invocations have different arguments at position [1]:",
+                        "mock.simpleMethod(\"arg1\", 1111);");
+    }
+
+    @Test
+    public void shouldSpecifyPosition0And1WhenWantedInvocationDiffersFromActual() {
+        wanted = buildMultiArgsMethod().args("arg1", 2222).toInvocationMatcher();
+        invocations = singletonList(buildMultiArgsMethod().args("differs", 1111).toInvocation());
+
+        assertThatThrownBy(
+                        () -> {
+                            MissingInvocationChecker.checkMissingInvocation(invocations, wanted);
+                        })
+                .isInstanceOf(ArgumentsAreDifferent.class)
+                .hasMessageContainingAll(
+                        "Argument(s) are different! Wanted:",
+                        "mock.simpleMethod(\"arg1\", 2222);",
+                        "Actual invocations have different arguments at positions [0, 1]:",
+                        "mock.simpleMethod(\"differs\", 1111);");
+    }
+
+    @Test
+    public void shouldNotSpecifyPositionWhenWantedSingleArgInvocationSiffersFromActual() {
+        wanted = buildIntArgMethod(new CustomInvocationBuilder()).arg(2222).toInvocationMatcher();
+        invocations =
+                singletonList(
+                        buildIntArgMethod(new CustomInvocationBuilder()).arg(1111).toInvocation());
+
+        assertThatThrownBy(
+                        () -> {
+                            MissingInvocationChecker.checkMissingInvocation(invocations, wanted);
+                        })
+                .isInstanceOf(ArgumentsAreDifferent.class)
+                .hasMessageContainingAll(
+                        "Argument(s) are different! Wanted:",
+                        "mock.intArgumentMethod(MyCoolPrint(2222));",
+                        "Actual invocations have different arguments:",
+                        "mock.intArgumentMethod(MyCoolPrint(1111));");
+    }
+
     private InvocationBuilder buildIntArgMethod(InvocationBuilder invocationBuilder) {
         return invocationBuilder.mock(mock).method("intArgumentMethod").argTypes(int.class);
     }
@@ -105,6 +175,13 @@ public class MissingInvocationCheckerTest extends TestBase {
 
     private InvocationBuilder buildDifferentMethod() {
         return new InvocationBuilder().mock(mock).differentMethod();
+    }
+
+    private InvocationBuilder buildMultiArgsMethod() {
+        return new InvocationBuilder()
+                .mock(mock)
+                .method("simpleMethod")
+                .argTypes(String.class, Integer.class);
     }
 
     static class CustomInvocationBuilder extends InvocationBuilder {

--- a/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
+++ b/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
@@ -83,7 +83,7 @@ public class DescriptiveMessagesWhenVerificationFailsTest extends TestBase {
 
             String actual =
                     "\n"
-                            + "Actual invocations have different arguments:"
+                            + "Actual invocations have different arguments at position [1]:"
                             + "\n"
                             + "iMethods.varargs(1, 2);";
 
@@ -392,7 +392,7 @@ public class DescriptiveMessagesWhenVerificationFailsTest extends TestBase {
 
             String actual =
                     "\n"
-                            + "Actual invocations have different arguments:"
+                            + "Actual invocations have different arguments at positions [0, 1]:"
                             + "\n"
                             + "iMethods.overloadedMethodWithSameClassNameArguments("
                             + "\n"
@@ -429,7 +429,7 @@ public class DescriptiveMessagesWhenVerificationFailsTest extends TestBase {
 
             String actual =
                     "\n"
-                            + "Actual invocations have different arguments:"
+                            + "Actual invocations have different arguments at positions [0, 1]:"
                             + "\n"
                             + "iMethods.overloadedMethodWithDifferentClassNameArguments("
                             + "\n"
@@ -471,7 +471,7 @@ public class DescriptiveMessagesWhenVerificationFailsTest extends TestBase {
 
             String actual =
                     "\n"
-                            + "Actual invocations have different arguments:"
+                            + "Actual invocations have different arguments at positions [0, 2]:"
                             + "\n"
                             + "iMethods.overloadedMethodWithSameClassNameArguments("
                             + "\n"


### PR DESCRIPTION
I found this one useful (and an opportunity to dive into the code) since it also occurred to me in the past to be confused on which argument was unequal.

Tried to make it not too intrusive. Essentially it gives a hint on which argument positions are considered not matching. There are a few possible cases:
1. Single arg method: same as before as the culprit is pretty clear
2. Single arg not matching: `Actual invocations have different arguments at position [0]:`
3. Multiple args not matching: `Actual invocations have different arguments at positions [0, 1]:`

The example from the issue would become (notice the _at position [0]_ added):
```
Argument(s) are different! Wanted:
testObject.doStuff(
    "asdknasodinsafERFgldfD334D",
    <Capturing argument>
);
-> at com.qumea.mobilitysense.apiservice.messaging.consumers.ExampleTest$TestObject.doStuff(ExampleTest.java:35)
Actual invocations have different arguments at position [0]:
testObject.doStuff(
    "asdknasodinsafERFgIdfD334D",
    com.qumea.mobilitysense.apiservice.messaging.consumers.ExampleTest$$Lambda$5127/0x00000008028baf08@71ebb0f1
);
```

Let me know if this is an adequate solution, or if you dont intend to add something like this.

## Checklist

 - [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [ ] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [ ] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [ ] Avoid other runtime dependencies
 - [ ] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [ ] The pull request follows coding style
 - [ ] Mention `Fixes #<issue number>` in the description _if relevant_
 - [ ] At least one commit should mention `Fixes #<issue number>` _if relevant_

