### PR TITLE
Fixed tests relying on timezone to succeed

### DIFF
--- a/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
+++ b/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
@@ -370,37 +370,43 @@ public class DescriptiveMessagesWhenVerificationFailsTest extends TestBase {
 
     @Test
     public void should_print_fully_qualified_name_when_arguments_classes_have_same_simple_name() {
+        Date dateArg = new Date(0);
+        String stringifiedDateArg = dateArg.toString();
+
         try {
-            mock.overloadedMethodWithSameClassNameArguments(new Date(0), new IMethods.Date(0));
-            verify(mock)
-                    .overloadedMethodWithSameClassNameArguments(new IMethods.Date(0), new Date(0));
+            mock.overloadedMethodWithSameClassNameArguments(dateArg, new IMethods.Date(0));
+            verify(mock).overloadedMethodWithSameClassNameArguments(new IMethods.Date(0), dateArg);
             fail();
         } catch (Throwable e) {
             String wanted =
-                    "\n"
-                            + "Argument(s) are different! Wanted:"
-                            + "\n"
-                            + "iMethods.overloadedMethodWithSameClassNameArguments("
-                            + "\n"
-                            + "    (org.mockitousage.IMethods.Date) 0,"
-                            + "\n"
-                            + "    (java.sql.Date) 1970-01-01"
-                            + "\n"
-                            + ");";
+                    String.format(
+                            "\n"
+                                    + "Argument(s) are different! Wanted:"
+                                    + "\n"
+                                    + "iMethods.overloadedMethodWithSameClassNameArguments("
+                                    + "\n"
+                                    + "    (org.mockitousage.IMethods.Date) 0,"
+                                    + "\n"
+                                    + "    (java.sql.Date) %s"
+                                    + "\n"
+                                    + ");",
+                            stringifiedDateArg);
 
             assertThat(e).hasMessageContaining(wanted);
 
             String actual =
-                    "\n"
-                            + "Actual invocations have different arguments:"
-                            + "\n"
-                            + "iMethods.overloadedMethodWithSameClassNameArguments("
-                            + "\n"
-                            + "    (java.sql.Date) 1970-01-01,"
-                            + "\n"
-                            + "    (org.mockitousage.IMethods.Date) 0"
-                            + "\n"
-                            + ");";
+                    String.format(
+                            "\n"
+                                    + "Actual invocations have different arguments:"
+                                    + "\n"
+                                    + "iMethods.overloadedMethodWithSameClassNameArguments("
+                                    + "\n"
+                                    + "    (java.sql.Date) %s,"
+                                    + "\n"
+                                    + "    (org.mockitousage.IMethods.Date) 0"
+                                    + "\n"
+                                    + ");",
+                            stringifiedDateArg);
             assertThat(e).hasMessageContaining(actual);
         }
     }
@@ -445,43 +451,50 @@ public class DescriptiveMessagesWhenVerificationFailsTest extends TestBase {
     @Test
     public void
             should_print_fully_qualified_name_when_some_arguments_classes_have_same_simple_name() {
+        Date dateArg = new Date(0);
+        String stringifiedDateArg = dateArg.toString();
+
         try {
             mock.overloadedMethodWithSameClassNameArguments(
-                    new Date(0), "string", new IMethods.Date(0));
+                dateArg, "string", new IMethods.Date(0));
             verify(mock)
                     .overloadedMethodWithSameClassNameArguments(
-                            new IMethods.Date(0), "string", new Date(0));
+                            new IMethods.Date(0), "string", dateArg);
             fail();
         } catch (Throwable e) {
             String wanted =
-                    "\n"
-                            + "Argument(s) are different! Wanted:"
-                            + "\n"
-                            + "iMethods.overloadedMethodWithSameClassNameArguments("
-                            + "\n"
-                            + "    (org.mockitousage.IMethods.Date) 0,"
-                            + "\n"
-                            + "    \"string\","
-                            + "\n"
-                            + "    (java.sql.Date) 1970-01-01"
-                            + "\n"
-                            + ");";
+                    String.format(
+                            "\n"
+                                    + "Argument(s) are different! Wanted:"
+                                    + "\n"
+                                    + "iMethods.overloadedMethodWithSameClassNameArguments("
+                                    + "\n"
+                                    + "    (org.mockitousage.IMethods.Date) 0,"
+                                    + "\n"
+                                    + "    \"string\","
+                                    + "\n"
+                                    + "    (java.sql.Date) %s"
+                                    + "\n"
+                                    + ");",
+                            stringifiedDateArg);
 
             assertThat(e).hasMessageContaining(wanted);
 
             String actual =
-                    "\n"
-                            + "Actual invocations have different arguments:"
-                            + "\n"
-                            + "iMethods.overloadedMethodWithSameClassNameArguments("
-                            + "\n"
-                            + "    (java.sql.Date) 1970-01-01,"
-                            + "\n"
-                            + "    \"string\","
-                            + "\n"
-                            + "    (org.mockitousage.IMethods.Date) 0"
-                            + "\n"
-                            + ");";
+                    String.format(
+                            "\n"
+                                    + "Actual invocations have different arguments:"
+                                    + "\n"
+                                    + "iMethods.overloadedMethodWithSameClassNameArguments("
+                                    + "\n"
+                                    + "    (java.sql.Date) %s,"
+                                    + "\n"
+                                    + "    \"string\","
+                                    + "\n"
+                                    + "    (org.mockitousage.IMethods.Date) 0"
+                                    + "\n"
+                                    + ");",
+                            stringifiedDateArg);
             assertThat(e).hasMessageContaining(actual);
         }
     }

--- a/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
+++ b/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
@@ -456,7 +456,7 @@ public class DescriptiveMessagesWhenVerificationFailsTest extends TestBase {
 
         try {
             mock.overloadedMethodWithSameClassNameArguments(
-                dateArg, "string", new IMethods.Date(0));
+                    dateArg, "string", new IMethods.Date(0));
             verify(mock)
                     .overloadedMethodWithSameClassNameArguments(
                             new IMethods.Date(0), "string", dateArg);


### PR DESCRIPTION
Some tests are failing locally when OS timezone is not UTC. 
`new Date(0)` gives me `1969-12-31` (thats utc-5) while we are asserting `1970-01-01`.
Fixed them by using `new Date(0).toString()` to make the assertions.

## Checklist

 - [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [ ] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [ ] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [ ] Avoid other runtime dependencies
 - [ ] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [ ] The pull request follows coding style
 - [ ] Mention `Fixes #<issue number>` in the description _if relevant_
 - [ ] At least one commit should mention `Fixes #<issue number>` _if relevant_

