### PR TITLE
Fix copyMockMethodDispatcher task

### DIFF
--- a/gradle/mockito-core/inline-mock.gradle
+++ b/gradle/mockito-core/inline-mock.gradle
@@ -2,15 +2,19 @@ tasks.register('copyMockMethodDispatcher', Copy) {
     dependsOn compileJava
 
     from "${sourceSets.main.java.classesDirectory.get()}/org/mockito/internal/creation/bytebuddy/inject/MockMethodDispatcher.class"
-    into layout.buildDirectory.dir("generated/raw/org/mockito/internal/creation/bytebuddy/inject")
+    into layout.buildDirectory.dir("generated/resources/inline/org/mockito/internal/creation/bytebuddy/inject")
 
     rename '(.+)\\.class', '$1.raw'
 }
 classes.dependsOn(copyMockMethodDispatcher)
 
+sourceSets.main {
+    resources {
+        output.dir(layout.buildDirectory.dir("generated/resources/inline"))
+    }
+}
+
 jar {
     exclude("org/mockito/internal/creation/bytebuddy/inject/package-info.class")
     exclude("org/mockito/internal/creation/bytebuddy/inject/MockMethodDispatcher.class")
-
-    from(layout.buildDirectory.dir("generated/raw"))
 }

--- a/gradle/mockito-core/inline-mock.gradle
+++ b/gradle/mockito-core/inline-mock.gradle
@@ -1,25 +1,16 @@
-task copyMockMethodDispatcher {
+tasks.register('copyMockMethodDispatcher', Copy) {
     dependsOn compileJava
-    outputs.files files("${sourceSets.main.java.outputDir}/org/mockito/internal/creation/bytebuddy/inject")
-        .asFileTree
-        .matching { include "*.raw" }
-        .files
-        .collect { "${buildDir}/${it.name}" }
 
-    doLast {
-        copy {
-            from "${sourceSets.main.java.outputDir}/org/mockito/internal/creation/bytebuddy/inject"
-            into "${sourceSets.main.java.outputDir}/org/mockito/internal/creation/bytebuddy/inject"
-            include 'MockMethodDispatcher.class'
-            rename { String fileName ->
-                fileName.replace('.class', '.raw')
-            }
-        }
-    }
+    from "${sourceSets.main.java.classesDirectory.get()}/org/mockito/internal/creation/bytebuddy/inject/MockMethodDispatcher.class"
+    into layout.buildDirectory.dir("generated/raw/org/mockito/internal/creation/bytebuddy/inject")
+
+    rename '(.+)\\.class', '$1.raw'
 }
 classes.dependsOn(copyMockMethodDispatcher)
 
 jar {
     exclude("org/mockito/internal/creation/bytebuddy/inject/package-info.class")
     exclude("org/mockito/internal/creation/bytebuddy/inject/MockMethodDispatcher.class")
+
+    from(layout.buildDirectory.dir("generated/raw"))
 }


### PR DESCRIPTION
fixes: https://github.com/mockito/mockito/issues/2839

The task was incorrectly defining inputs and outputs, resulting in the task being marked 'UP-TO-DATE' and not re-running when the input changed or the output was removed.

The task now copies the 'raw' file into a new output directory and includes that directory in the jar.

This corrects the task inputs and outputs, while also avoiding warnings about shared output directories.
