### PR TITLE
Improve examples for InOrder

### DIFF
--- a/src/main/java/org/mockito/InOrder.java
+++ b/src/main/java/org/mockito/InOrder.java
@@ -12,13 +12,41 @@ import org.mockito.verification.VerificationMode;
  * Allows verification in order. E.g:
  *
  * <pre class="code"><code class="java">
+ * // Given
+ * First firstMock = mock(First.class);
+ * Second secondMock = mock(Second.class);
  * InOrder inOrder = inOrder(firstMock, secondMock);
  *
+ * // When
+ * firstMock.add("was called first");
+ * secondMock.add("was called second");
+ *
+ * // Then
  * inOrder.verify(firstMock).add("was called first");
  * inOrder.verify(secondMock).add("was called second");
+ * inOrder.verifyNoMoreInteractions();
  * </code></pre>
  *
- * As of Mockito 1.8.4 you can verifyNoMoreInteractions() in order-sensitive way. Read more: {@link InOrder#verifyNoMoreInteractions()}
+ * Static mocks can be verified alongside non-static mocks. E.g:
+ *
+ * <pre class="code"><code class="java">
+ * // Given
+ * First firstMock = mock(First.class);
+ * MockedStatic<StaticSecond> staticSecondMock = mockStatic(StaticSecond.class);
+ * InOrder inOrder = inOrder(firstMock, StaticSecond.class);
+ *
+ * // When
+ * firstMock.add("was called first");
+ * StaticSecond.doSomething("foobar");
+ *
+ * // Then
+ * inOrder.verify(firstMock).add("was called first");
+ * inOrder.verify(staticSecondMock, () -&gt; StaticSecond.doSomething("foobar"));
+ * inOrder.verifyNoMoreInteractions();
+ * </code></pre>
+ *
+ * As of Mockito 1.8.4 you can verifyNoMoreInteractions() in order-sensitive way. Read more:
+ * {@link InOrder#verifyNoMoreInteractions()}.
  * <p>
  *
  * See examples in javadoc for {@link Mockito} class
@@ -96,9 +124,9 @@ public interface InOrder {
      * @param mode         for example times(x) or atLeastOnce()
      */
     void verify(
-            MockedStatic<?> mockedStatic,
-            MockedStatic.Verification verification,
-            VerificationMode mode);
+        MockedStatic<?> mockedStatic,
+        MockedStatic.Verification verification,
+        VerificationMode mode);
 
     /**
      * Verifies that no more interactions happened <b>in order</b>.

--- a/src/main/java/org/mockito/InOrder.java
+++ b/src/main/java/org/mockito/InOrder.java
@@ -124,9 +124,9 @@ public interface InOrder {
      * @param mode         for example times(x) or atLeastOnce()
      */
     void verify(
-        MockedStatic<?> mockedStatic,
-        MockedStatic.Verification verification,
-        VerificationMode mode);
+            MockedStatic<?> mockedStatic,
+            MockedStatic.Verification verification,
+            VerificationMode mode);
 
     /**
      * Verifies that no more interactions happened <b>in order</b>.


### PR DESCRIPTION
Include some context in InOrder examples and add an example that uses a static mock as well.

I spent a while being unable to work out how to integrate InOrder with static mocks before realising the example of how to do this is currently encoded in a specific overload of a specific method within InOrder that I had missed as I was not using it.

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style


