### PR TITLE
Annotate `Mockito#{mock,spy}(T... reified)` with `@SafeVarargs`

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -1932,6 +1932,7 @@ public class Mockito extends ArgumentMatchers {
      * @return mock object
      * @since 4.9.0
      */
+    @SafeVarargs
     public static <T> T mock(T... reified) {
         if (reified.length > 0) {
             throw new IllegalArgumentException(
@@ -2161,6 +2162,7 @@ public class Mockito extends ArgumentMatchers {
      * @return spy object
      * @since 4.9.0
      */
+    @SafeVarargs
     public static <T> T spy(T... reified) {
         if (reified.length > 0) {
             throw new IllegalArgumentException(


### PR DESCRIPTION
This avoids "Unchecked generics array creation for varargs parameter" warnings at the call site.

