### PR TITLE
Fixes some mistakes and missing details in documentation

### DIFF
--- a/src/main/java/org/mockito/AdditionalAnswers.java
+++ b/src/main/java/org/mockito/AdditionalAnswers.java
@@ -276,7 +276,7 @@ public final class AdditionalAnswers {
      * This feature suffers from the same drawback as the spy.
      * The mock will call the delegate if you use regular when().then() stubbing style.
      * Since the real implementation is called this might have some side effects.
-     * Therefore you should use the doReturn|Throw|Answer|CallRealMethod stubbing style. Example:
+     * Therefore, you should use the doReturn|Throw|Answer|CallRealMethod stubbing style. Example:
      *
      * <pre class="code"><code class="java">
      *   List listWithDelegate = mock(List.class, AdditionalAnswers.delegatesTo(awesomeList));

--- a/src/main/java/org/mockito/ArgumentCaptor.java
+++ b/src/main/java/org/mockito/ArgumentCaptor.java
@@ -35,12 +35,13 @@ import org.mockito.internal.matchers.CapturingMatcher;
  *
  * <p>
  * <strong>Warning:</strong> it is recommended to use ArgumentCaptor with verification <strong>but not</strong> with stubbing.
- * Using ArgumentCaptor with stubbing may decrease test readability because captor is created outside of assert (aka verify or 'then') block.
- * Also it may reduce defect localization because if stubbed method was not called then no argument is captured.
+ * Using ArgumentCaptor with stubbing may decrease test readability because captor is created
+ * outside of assertion (aka verify or 'then') blocks.
+ * It may also reduce defect localization because if the stubbed method was not called, then no argument is captured.
  *
  * <p>
  * In a way ArgumentCaptor is related to custom argument matchers (see javadoc for {@link ArgumentMatcher} class).
- * Both techniques can be used for making sure certain arguments were passed to mocks.
+ * Both techniques can be used for making sure certain arguments were passed to mock objects.
  * However, ArgumentCaptor may be a better fit if:
  * <ul>
  * <li>custom argument matcher is not likely to be reused</li>

--- a/src/main/java/org/mockito/ArgumentMatcher.java
+++ b/src/main/java/org/mockito/ArgumentMatcher.java
@@ -10,7 +10,7 @@ package org.mockito;
  * and reduce the risk of version incompatibility.
  * Migration guide is included close to the bottom of this javadoc.
  * <p>
- * For non-trivial method arguments used in stubbing or verification, you have following options
+ * For non-trivial method arguments used in stubbing or verification, you have the following options
  * (in no particular order):
  * <ul>
  *     <li>refactor the code so that the interactions with collaborators are easier to test with mocks.
@@ -102,10 +102,10 @@ package org.mockito;
  *
  * </li>
  * </ul>
- * What option is right for you? If you don't mind compile dependency to hamcrest
- * then option b) is probably right for you.
- * Your choice should not have big impact and is fully reversible -
- * you can choose different option in future (and refactor the code)
+ * What option is right for you? If you don't mind having a compile-time dependency for Hamcrest,
+ * then the second option is probably right for you.
+ * Your choice should not have a big impact and is fully reversible -
+ * you can choose different option in future (and refactor the code)!
  *
  * @param <T> type of argument
  * @since 2.1.0

--- a/src/main/java/org/mockito/ArgumentMatchers.java
+++ b/src/main/java/org/mockito/ArgumentMatchers.java
@@ -914,7 +914,7 @@ public class ArgumentMatchers {
 
     /**
      * Allows creating custom <code>char</code> argument matchers.
-     *
+     * <p>
      * Note that {@link #argThat} will not work with primitive <code>char</code> matchers due to <code>NullPointerException</code> auto-unboxing caveat.
      * <p>
      * See examples in javadoc for {@link ArgumentMatchers} class
@@ -929,7 +929,7 @@ public class ArgumentMatchers {
 
     /**
      * Allows creating custom <code>boolean</code> argument matchers.
-     *
+     * <p>
      * Note that {@link #argThat} will not work with primitive <code>boolean</code> matchers due to <code>NullPointerException</code> auto-unboxing caveat.
      * <p>
      * See examples in javadoc for {@link ArgumentMatchers} class
@@ -944,7 +944,7 @@ public class ArgumentMatchers {
 
     /**
      * Allows creating custom <code>byte</code> argument matchers.
-     *
+     * <p>
      * Note that {@link #argThat} will not work with primitive <code>byte</code> matchers due to <code>NullPointerException</code> auto-unboxing caveat.
      * <p>
      * See examples in javadoc for {@link ArgumentMatchers} class
@@ -959,7 +959,7 @@ public class ArgumentMatchers {
 
     /**
      * Allows creating custom <code>short</code> argument matchers.
-     *
+     * <p>
      * Note that {@link #argThat} will not work with primitive <code>short</code> matchers due to <code>NullPointerException</code> auto-unboxing caveat.
      * <p>
      * See examples in javadoc for {@link ArgumentMatchers} class
@@ -974,7 +974,7 @@ public class ArgumentMatchers {
 
     /**
      * Allows creating custom <code>int</code> argument matchers.
-     *
+     * <p>
      * Note that {@link #argThat} will not work with primitive <code>int</code> matchers due to <code>NullPointerException</code> auto-unboxing caveat.
      * <p>
      * See examples in javadoc for {@link ArgumentMatchers} class
@@ -989,7 +989,7 @@ public class ArgumentMatchers {
 
     /**
      * Allows creating custom <code>long</code> argument matchers.
-     *
+     * <p>
      * Note that {@link #argThat} will not work with primitive <code>long</code> matchers due to <code>NullPointerException</code> auto-unboxing caveat.
      * <p>
      * See examples in javadoc for {@link ArgumentMatchers} class
@@ -1004,7 +1004,7 @@ public class ArgumentMatchers {
 
     /**
      * Allows creating custom <code>float</code> argument matchers.
-     *
+     * <p>
      * Note that {@link #argThat} will not work with primitive <code>float</code> matchers due to <code>NullPointerException</code> auto-unboxing caveat.
      * <p>
      * See examples in javadoc for {@link ArgumentMatchers} class
@@ -1019,7 +1019,7 @@ public class ArgumentMatchers {
 
     /**
      * Allows creating custom <code>double</code> argument matchers.
-     *
+     * <p>
      * Note that {@link #argThat} will not work with primitive <code>double</code> matchers due to <code>NullPointerException</code> auto-unboxing caveat.
      * <p>
      * See examples in javadoc for {@link ArgumentMatchers} class

--- a/src/main/java/org/mockito/Incubating.java
+++ b/src/main/java/org/mockito/Incubating.java
@@ -5,6 +5,7 @@
 package org.mockito;
 
 import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
@@ -22,7 +23,13 @@ import java.lang.annotation.RetentionPolicy;
  * and can change before release.
  * </li>
  * </ul>
+ *
+ * <p>
+ * Any components extending a class or interface annotated with this annotation should also
+ * be considered to be incubating, as the underlying implementation may be subject to future change
+ * before it is finalized.
  */
 @Retention(RetentionPolicy.RUNTIME)
+@Inherited
 @Documented
 public @interface Incubating {}

--- a/src/main/java/org/mockito/InjectMocks.java
+++ b/src/main/java/org/mockito/InjectMocks.java
@@ -158,6 +158,11 @@ import org.mockito.junit.MockitoJUnitRunner;
  * be it mocks/spies or real objects.
  * </p>
  *
+ * <p>
+ * Elements annotated with this annotation can also be spied upon by also adding the {@link Spy}
+ * annotation to the element.
+ * </p>
+ *
  * @see Mock
  * @see Spy
  * @see MockitoAnnotations#openMocks(Object)

--- a/src/main/java/org/mockito/MockSettings.java
+++ b/src/main/java/org/mockito/MockSettings.java
@@ -43,7 +43,7 @@ import org.mockito.stubbing.Answer;
  * </code></pre>
  * {@link MockSettings} has been introduced for two reasons.
  * Firstly, to make it easy to add another mock setting when the demand comes.
- * Secondly, to enable combining together different mock settings without introducing zillions of overloaded mock() methods.
+ * Secondly, to enable combining different mock settings without introducing zillions of overloaded mock() methods.
  */
 @NotExtensible
 public interface MockSettings extends Serializable {
@@ -64,7 +64,7 @@ public interface MockSettings extends Serializable {
      *   Baz baz = (Baz) foo;
      * </code></pre>
      *
-     * @param interfaces extra interfaces the should implement.
+     * @param interfaces extra interfaces the mock should implement.
      * @return settings instance so that you can fluently specify other settings
      */
     MockSettings extraInterfaces(Class<?>... interfaces);
@@ -94,7 +94,7 @@ public interface MockSettings extends Serializable {
      *
      * Sets the instance that will be spied. Actually copies the internal fields of the passed instance to the mock.
      * <p>
-     * As usual you are going to read <b>the partial mock warning</b>:
+     * As usual, you are going to read <b>the partial mock warning</b>:
      * Object oriented programming is more or less about tackling complexity by dividing the complexity into separate, specific, SRPy objects.
      * How does partial mock fit into this paradigm? Well, it just doesn't...
      * Partial mock usually means that the complexity has been moved to a different method on the same object.
@@ -133,10 +133,10 @@ public interface MockSettings extends Serializable {
 
     /**
      * Specifies default answers to interactions.
-     * It's quite advanced feature and typically you don't need it to write decent tests.
-     * However it can be helpful when working with legacy systems.
+     * It's quite advanced feature, and typically you don't need it to write decent tests.
+     * However, it can be helpful when working with legacy systems.
      * <p>
-     * It is the default answer so it will be used <b>only when you don't</b> stub the method call.
+     * It is the default answer, so it will be used <b>only when you don't</b> stub the method call.
      *
      * <pre class="code"><code class="java">
      *   Foo mock = mock(Foo.class, withSettings().defaultAnswer(RETURNS_SMART_NULLS));
@@ -209,7 +209,7 @@ public interface MockSettings extends Serializable {
     /**
      * Add stubbing lookup listener to the mock object.
      *
-     * Multiple listeners may be added and they will be notified orderly.
+     * Multiple listeners may be added, and they will be notified in an orderly fashion.
      *
      * For use cases and more info see {@link StubbingLookupListener}.
      *
@@ -228,7 +228,7 @@ public interface MockSettings extends Serializable {
      * Registers a listener for method invocations on this mock. The listener is
      * notified every time a method on this mock is called.
      * <p>
-     * Multiple listeners may be added and they will be notified in the order they were supplied.
+     * Multiple listeners may be added, and they will be notified in the order they were supplied.
      *
      * Example:
      * <pre class="code"><code class="java">
@@ -247,7 +247,7 @@ public interface MockSettings extends Serializable {
      * See {@link VerificationStartedListener} on how such listener can be useful.
      * <p>
      * When multiple listeners are added, they are notified in order they were supplied.
-     * There is no reason to supply multiple listeners but we wanted to keep the API
+     * There is no reason to supply multiple listeners, but we wanted to keep the API
      * simple and consistent with {@link #invocationListeners(InvocationListener...)}.
      * <p>
      * Throws exception when any of the passed listeners is null or when the entire vararg array is null.
@@ -313,7 +313,7 @@ public interface MockSettings extends Serializable {
     MockSettings outerInstance(Object outerClassInstance);
 
     /**
-     * By default, Mockito makes an attempt to preserve all annotation meta data on the mocked
+     * By default, Mockito makes an attempt to preserve all annotation metadata on the mocked
      * type and its methods to mirror the mocked type as closely as possible. If this is not
      * desired, this option can be used to disable this behavior.
      *

--- a/src/main/java/org/mockito/MockedConstruction.java
+++ b/src/main/java/org/mockito/MockedConstruction.java
@@ -21,19 +21,52 @@ import java.util.List;
  */
 public interface MockedConstruction<T> extends ScopedMock {
 
+    /**
+     * Get the constructed mocks.
+     *
+     * @return the constructed mocks.
+     */
     List<T> constructed();
 
+    /**
+     * The context for a construction mock.
+     */
     interface Context {
 
         int getCount();
 
+        /**
+         * Get the constructor that is invoked during the mock creation.
+         *
+         * @return the constructor.
+         */
         Constructor<?> constructor();
 
+        /**
+         * Get the arguments that were passed to the constructor.
+         *
+         * @return the arguments passed to the constructor, as a list.
+         */
         List<?> arguments();
     }
 
+    /**
+     * Functional interface that consumes a newly created mock and the mock context.
+     * <p>
+     * Used to attach behaviours to new mocks.
+     *
+     * @param <T> the mock type.
+     */
+    @FunctionalInterface
     interface MockInitializer<T> {
 
+        /**
+         * Configure the mock.
+         *
+         * @param mock the newly created mock.
+         * @param context the mock context.
+         * @throws Throwable any exception that may be thrown.
+         */
         void prepare(T mock, Context context) throws Throwable;
     }
 }

--- a/src/main/java/org/mockito/MockedStatic.java
+++ b/src/main/java/org/mockito/MockedStatic.java
@@ -62,8 +62,17 @@ public interface MockedStatic<T> extends ScopedMock {
      */
     void verifyNoInteractions();
 
+    /**
+     * Functional interface for a verification operation on a static mock.
+     */
+    @FunctionalInterface
     interface Verification {
 
+        /**
+         * Apply the verification operation.
+         *
+         * @throws Throwable any exception that may be thrown.
+         */
         void apply() throws Throwable;
     }
 }

--- a/src/main/java/org/mockito/MockingDetails.java
+++ b/src/main/java/org/mockito/MockingDetails.java
@@ -73,7 +73,7 @@ public interface MockingDetails {
      * What is 'stubbing'?
      * Stubbing is your when(x).then(y) declaration, e.g. configuring the mock to behave in a specific way,
      * when specific method with specific arguments is invoked on a mock.
-     * Typically stubbing is configuring mock to return X when method Y is invoked.
+     * Typically, stubbing is configuring mock to return X when method Y is invoked.
      * <p>
      * Why do you need to access stubbings of a mock?
      * In a normal workflow of creation clean tests, there is no need for this API.

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -71,7 +71,7 @@ import java.util.function.Function;
  *      <a href="#11">11. Stubbing with callbacks </a><br/>
  *      <a href="#12">12. <code>doReturn()</code>|<code>doThrow()</code>|<code>doAnswer()</code>|<code>doNothing()</code>|<code>doCallRealMethod()</code> family of methods</a><br/>
  *      <a href="#13">13. Spying on real objects </a><br/>
- *      <a href="#14">14. Changing default return values of unstubbed invocations (Since 1.7) </a><br/>
+ *      <a href="#14">14. Changing default return values of un-stubbed invocations (Since 1.7) </a><br/>
  *      <a href="#15">15. Capturing arguments for further assertions (Since 1.8.0) </a><br/>
  *      <a href="#16">16. Real partial mocks (Since 1.8.0) </a><br/>
  *      <a href="#17">17. Resetting mocks (Since 1.8.0) </a><br/>
@@ -226,7 +226,7 @@ import java.util.function.Function;
  *
  * <li> Stubbing can be overridden: for example common stubbing can go to
  * fixture setup but the test methods can override it.
- * Please note that overridding stubbing is a potential code smell that points out too much stubbing</li>
+ * Please note that overriding stubbing is a potential code smell that points out too much stubbing</li>
  *
  * <li> Once stubbed, the method will always return a stubbed value, regardless
  * of how many times it is called. </li>
@@ -652,7 +652,7 @@ import java.util.function.Function;
  * <li>Mockito <b>*does not*</b> delegate calls to the passed real instance, instead it actually creates a copy of it.
  * So if you keep the real instance and interact with it, don't expect the spied to be aware of those interaction
  * and their effect on real instance state.
- * The corollary is that when an <b>*unstubbed*</b> method is called <b>*on the spy*</b> but <b>*not on the real instance*</b>,
+ * The corollary is that when an <b>*un-stubbed*</b> method is called <b>*on the spy*</b> but <b>*not on the real instance*</b>,
  * you won't see any effects on the real instance.
  * </li>
  *
@@ -665,7 +665,7 @@ import java.util.function.Function;
  *
  *
  *
- * <h3 id="14">14. Changing <a class="meaningful_link" href="#defaultreturn" name="defaultreturn">default return values of unstubbed invocations</a> (Since 1.7)</h3>
+ * <h3 id="14">14. Changing <a class="meaningful_link" href="#defaultreturn" name="defaultreturn">default return values of un-stubbed invocations</a> (Since 1.7)</h3>
  *
  * You can create a mock with specified strategy for its return values.
  * It's quite an advanced feature and typically you don't need it to write decent tests.
@@ -1671,9 +1671,9 @@ public class Mockito extends ArgumentMatchers {
     /**
      * The default <code>Answer</code> of every mock <b>if</b> the mock was not stubbed.
      *
-     * Typically it just returns some empty value.
+     * Typically, it just returns some empty value.
      * <p>
-     * {@link Answer} can be used to define the return values of unstubbed invocations.
+     * {@link Answer} can be used to define the return values of un-stubbed invocations.
      * <p>
      * This implementation first tries the global configuration and if there is no global configuration then
      * it will use a default answer that returns zeros, empty collections, nulls, etc.
@@ -1683,12 +1683,14 @@ public class Mockito extends ArgumentMatchers {
     /**
      * Optional <code>Answer</code> to be used with {@link Mockito#mock(Class, Answer)}.
      * <p>
-     * {@link Answer} can be used to define the return values of unstubbed invocations.
+     * {@link Answer} can be used to define the return values of un-stubbed invocations.
      * <p>
      * This implementation can be helpful when working with legacy code.
-     * Unstubbed methods often return null. If your code uses the object returned by an unstubbed call you get a NullPointerException.
+     * Un-stubbed methods often return null. If your code uses the object returned by an un-stubbed call,
+     * you get a NullPointerException.
      * This implementation of Answer <b>returns SmartNull instead of null</b>.
-     * <code>SmartNull</code> gives nicer exception message than NPE because it points out the line where unstubbed method was called. You just click on the stack trace.
+     * <code>SmartNull</code> gives nicer exception messages than NPEs, because it points out the
+     * line where the un-stubbed method was called. You just click on the stack trace.
      * <p>
      * <code>ReturnsSmartNulls</code> first tries to return ordinary values (zeros, empty collections, empty string, etc.)
      * then it tries to return SmartNull. If the return type is final then plain <code>null</code> is returned.
@@ -1697,15 +1699,15 @@ public class Mockito extends ArgumentMatchers {
      * <pre class="code"><code class="java">
      *   Foo mock = mock(Foo.class, RETURNS_SMART_NULLS);
      *
-     *   //calling unstubbed method here:
+     *   //calling un-stubbed method here:
      *   Stuff stuff = mock.getStuff();
      *
-     *   //using object returned by unstubbed call:
+     *   //using object returned by un-stubbed call:
      *   stuff.doSomething();
      *
      *   //Above doesn't yield NullPointerException this time!
      *   //Instead, SmartNullPointerException is thrown.
-     *   //Exception's cause links to unstubbed <i>mock.getStuff()</i> - just click on the stack trace.
+     *   //Exception's cause links to un-stubbed <i>mock.getStuff()</i> - just click on the stack trace.
      * </code></pre>
      */
     public static final Answer<Object> RETURNS_SMART_NULLS = Answers.RETURNS_SMART_NULLS;
@@ -1713,7 +1715,7 @@ public class Mockito extends ArgumentMatchers {
     /**
      * Optional <code>Answer</code> to be used with {@link Mockito#mock(Class, Answer)}
      * <p>
-     * {@link Answer} can be used to define the return values of unstubbed invocations.
+     * {@link Answer} can be used to define the return values of un-stubbed invocations.
      * <p>
      * This implementation can be helpful when working with legacy code.
      * <p>
@@ -1814,14 +1816,14 @@ public class Mockito extends ArgumentMatchers {
      * Optional <code>Answer</code> to be used with {@link Mockito#mock(Class, Answer)}
      *
      * <p>
-     * {@link Answer} can be used to define the return values of unstubbed invocations.
+     * {@link Answer} can be used to define the return values of un-stubbed invocations.
      * <p>
      * This implementation can be helpful when working with legacy code.
-     * When this implementation is used, unstubbed methods will delegate to the real implementation.
+     * When this implementation is used, un-stubbed methods will delegate to the real implementation.
      * This is a way to create a partial mock object that calls real methods by default.
      * <p>
-     * As usual you are going to read <b>the partial mock warning</b>:
-     * Object oriented programming is more less tackling complexity by dividing the complexity into separate, specific, SRPy objects.
+     * As usual, you are going to read <b>the partial mock warning</b>:
+     * Object oriented programming is more-or-less tackling complexity by dividing the complexity into separate, specific, SRPy objects.
      * How does partial mock fit into this paradigm? Well, it just doesn't...
      * Partial mock usually means that the complexity has been moved to a different method on the same object.
      * In most cases, this is not the way you want to design your application.
@@ -2050,7 +2052,7 @@ public class Mockito extends ArgumentMatchers {
      * <p>See examples in javadoc for {@link Mockito} class</p>
      *
      * @param classToMock class or interface to mock
-     * @param defaultAnswer default answer for unstubbed methods
+     * @param defaultAnswer default answer for un-stubbed methods
      *
      * @return mock object
      */
@@ -2061,7 +2063,7 @@ public class Mockito extends ArgumentMatchers {
     /**
      * Creates a mock with some non-standard settings.
      * <p>
-     * The number of configuration points for a mock grows
+     * The number of configuration points for a mock will grow,
      * so we need a fluent way to introduce new configuration without adding more and more overloaded Mockito.mock() methods.
      * Hence {@link MockSettings}.
      * <pre class="code"><code class="java">
@@ -2071,7 +2073,7 @@ public class Mockito extends ArgumentMatchers {
      * </code></pre>
      * <b>Use it carefully and occasionally</b>. What might be reason your test needs non-standard mocks?
      * Is the code under test so complicated that it requires non-standard mocks?
-     * Wouldn't you prefer to refactor the code under test so it is testable in a simple way?
+     * Wouldn't you prefer to refactor the code under test, so that it is testable in a simple way?
      * <p>
      * See also {@link Mockito#withSettings()}
      * <p>
@@ -2090,7 +2092,7 @@ public class Mockito extends ArgumentMatchers {
      * <p>
      * Real spies should be used <b>carefully and occasionally</b>, for example when dealing with legacy code.
      * <p>
-     * As usual you are going to read <b>the partial mock warning</b>:
+     * As usual, you are going to read <b>the partial mock warning</b>:
      * Object oriented programming tackles complexity by dividing the complexity into separate, specific, SRPy objects.
      * How does partial mock fit into this paradigm? Well, it just doesn't...
      * Partial mock usually means that the complexity has been moved to a different method on the same object.
@@ -2145,7 +2147,7 @@ public class Mockito extends ArgumentMatchers {
      * <li>Mockito <b>*does not*</b> delegate calls to the passed real instance, instead it actually creates a copy of it.
      * So if you keep the real instance and interact with it, don't expect the spied to be aware of those interaction
      * and their effect on real instance state.
-     * The corollary is that when an <b>*unstubbed*</b> method is called <b>*on the spy*</b> but <b>*not on the real instance*</b>,
+     * The corollary is that when an <b>*un-stubbed*</b> method is called <b>*on the spy*</b> but <b>*not on the real instance*</b>,
      * you won't see any effects on the real instance.</li>
      *
      * <li>Watch out for final methods.
@@ -2228,7 +2230,7 @@ public class Mockito extends ArgumentMatchers {
      * test or the mock will remain active on the current thread.
      * <p>
      * <b>Note</b>: We recommend against mocking static methods of classes in the standard library or
-     * classes used by custom class loaders used to executed the block with the mocked class. A mock
+     * classes used by custom class loaders used to execute the block with the mocked class. A mock
      * maker might forbid mocking static methods of know classes that are known to cause problems.
      * Also, if a static method is a JVM-intrinsic, it cannot typically be mocked even if not
      * explicitly forbidden.
@@ -2248,7 +2250,7 @@ public class Mockito extends ArgumentMatchers {
      * test or the mock will remain active on the current thread.
      * <p>
      * <b>Note</b>: We recommend against mocking static methods of classes in the standard library or
-     * classes used by custom class loaders used to executed the block with the mocked class. A mock
+     * classes used by custom class loaders used to execute the block with the mocked class. A mock
      * maker might forbid mocking static methods of know classes that are known to cause problems.
      * Also, if a static method is a JVM-intrinsic, it cannot typically be mocked even if not
      * explicitly forbidden.
@@ -2269,7 +2271,7 @@ public class Mockito extends ArgumentMatchers {
      * test or the mock will remain active on the current thread.
      * <p>
      * <b>Note</b>: We recommend against mocking static methods of classes in the standard library or
-     * classes used by custom class loaders used to executed the block with the mocked class. A mock
+     * classes used by custom class loaders used to execute the block with the mocked class. A mock
      * maker might forbid mocking static methods of know classes that are known to cause problems.
      * Also, if a static method is a JVM-intrinsic, it cannot typically be mocked even if not
      * explicitly forbidden.
@@ -2290,7 +2292,7 @@ public class Mockito extends ArgumentMatchers {
      * test or the mock will remain active on the current thread.
      * <p>
      * <b>Note</b>: We recommend against mocking static methods of classes in the standard library or
-     * classes used by custom class loaders used to executed the block with the mocked class. A mock
+     * classes used by custom class loaders used to execute the block with the mocked class. A mock
      * maker might forbid mocking static methods of know classes that are known to cause problems.
      * Also, if a static method is a JVM-intrinsic, it cannot typically be mocked even if not
      * explicitly forbidden.
@@ -2358,7 +2360,7 @@ public class Mockito extends ArgumentMatchers {
      * See examples in javadoc for {@link Mockito} class
      *
      * @param classToMock non-abstract class of which constructions should be mocked.
-     * @param mockInitializer a callback to prepare a mock's methods after its instantiation.
+     * @param mockInitializer a callback to prepare the methods on a mock after its instantiation.
      * @return mock controller
      */
     public static <T> MockedConstruction<T> mockConstruction(
@@ -2408,7 +2410,7 @@ public class Mockito extends ArgumentMatchers {
      *
      * @param classToMock non-abstract class of which constructions should be mocked.
      * @param mockSettings the settings to use.
-     * @param mockInitializer a callback to prepare a mock's methods after its instantiation.
+     * @param mockInitializer a callback to prepare the methods on a mock after its instantiation.
      * @return mock controller
      */
     public static <T> MockedConstruction<T> mockConstruction(
@@ -2427,7 +2429,7 @@ public class Mockito extends ArgumentMatchers {
      *
      * @param classToMock non-abstract class of which constructions should be mocked.
      * @param mockSettingsFactory a function to create settings to use.
-     * @param mockInitializer a callback to prepare a mock's methods after its instantiation.
+     * @param mockInitializer a callback to prepare the methods on a mock after its instantiation.
      * @return mock controller
      */
     public static <T> MockedConstruction<T> mockConstruction(
@@ -2478,7 +2480,7 @@ public class Mockito extends ArgumentMatchers {
      * <p>
      * Stubbing can be overridden: for example common stubbing can go to fixture
      * setup but the test methods can override it.
-     * Please note that overridding stubbing is a potential code smell that points out too much stubbing.
+     * Please note that overriding stubbing is a potential code smell that points out too much stubbing.
      * <p>
      * Once stubbed, the method will always return stubbed value regardless
      * of how many times it is called.
@@ -2630,7 +2632,7 @@ public class Mockito extends ArgumentMatchers {
      * Some users who did a lot of classic, expect-run-verify mocking tend to use <code>verifyNoMoreInteractions()</code> very often, even in every test method.
      * <code>verifyNoMoreInteractions()</code> is not recommended to use in every test method.
      * <code>verifyNoMoreInteractions()</code> is a handy assertion from the interaction testing toolkit. Use it only when it's relevant.
-     * Abusing it leads to overspecified, less maintainable tests.
+     * Abusing it leads to over-specified, less maintainable tests.
      * <p>
      * This method will also detect unverified invocations that occurred before the test method,
      * for example: in <code>setUp()</code>, <code>&#064;Before</code> method or in constructor.
@@ -2723,7 +2725,8 @@ public class Mockito extends ArgumentMatchers {
 
     /**
      * Same as {@link #doThrow(Class)} but sets consecutive exception classes to be thrown. Remember to use
-     * <code>doThrow()</code> when you want to stub the void method to throw several exception of specified class.
+     * <code>doThrow()</code> when you want to stub the void method to throw several exceptions
+     * that are instances of the specified class.
      * <p>
      * A new exception instance will be created for each method invocation.
      * <p>
@@ -2752,8 +2755,8 @@ public class Mockito extends ArgumentMatchers {
     /**
      * Use <code>doCallRealMethod()</code> when you want to call the real implementation of a method.
      * <p>
-     * As usual you are going to read <b>the partial mock warning</b>:
-     * Object oriented programming is more less tackling complexity by dividing the complexity into separate, specific, SRPy objects.
+     * As usual, you are going to read <b>the partial mock warning</b>:
+     * Object oriented programming is more-or-less tackling complexity by dividing the complexity into separate, specific, SRPy objects.
      * How does partial mock fit into this paradigm? Well, it just doesn't...
      * Partial mock usually means that the complexity has been moved to a different method on the same object.
      * In most cases, this is not the way you want to design your application.
@@ -2891,7 +2894,7 @@ public class Mockito extends ArgumentMatchers {
      *
      * Above scenarios shows a tradeoff of Mockito's elegant syntax. Note that the scenarios are very rare, though.
      * Spying should be sporadic and overriding exception-stubbing is very rare. Not to mention that in general
-     * overridding stubbing is a potential code smell that points out too much stubbing.
+     * overriding stubbing is a potential code smell that points out too much stubbing.
      * <p>
      * See examples in javadoc for {@link Mockito} class
      *
@@ -2942,7 +2945,7 @@ public class Mockito extends ArgumentMatchers {
      *
      * Above scenarios shows a trade-off of Mockito's elegant syntax. Note that the scenarios are very rare, though.
      * Spying should be sporadic and overriding exception-stubbing is very rare. Not to mention that in general
-     * overridding stubbing is a potential code smell that points out too much stubbing.
+     * overriding stubbing is a potential code smell that points out too much stubbing.
      * <p>
      * See examples in javadoc for {@link Mockito} class
      *
@@ -2993,7 +2996,7 @@ public class Mockito extends ArgumentMatchers {
      * and provides other benefits.
      * <p>
      * <code>ignoreStubs()</code> is sometimes useful when coupled with <code>verifyNoMoreInteractions()</code> or verification <code>inOrder()</code>.
-     * Helps avoiding redundant verification of stubbed calls - typically we're not interested in verifying stubs.
+     * Helps to avoid redundant verification of stubbed calls - typically we're not interested in verifying stubs.
      * <p>
      * <b>Warning</b>, <code>ignoreStubs()</code> might lead to overuse of <code>verifyNoMoreInteractions(ignoreStubs(...));</code>
      * Bear in mind that Mockito does not recommend bombarding every test with <code>verifyNoMoreInteractions()</code>
@@ -3240,7 +3243,7 @@ public class Mockito extends ArgumentMatchers {
 
     /**
      * Verification will be triggered after given amount of millis, allowing testing of async code.
-     * Useful when interactions with the mock object did not happened yet.
+     * Useful when interactions with the mock object have yet to occur.
      * Extensive use of {@code after()} method can be a code smell - there are better ways of testing concurrent code.
      * <p>
      * Not yet implemented to work with InOrder verification.
@@ -3400,7 +3403,7 @@ public class Mockito extends ArgumentMatchers {
 
     /**
      * {@code MockitoSession} is an optional, highly recommended feature
-     * that helps driving cleaner tests by eliminating boilerplate code and adding extra validation.
+     * that drives writing cleaner tests by eliminating boilerplate code and adding extra validation.
      * <p>
      * For more information, including use cases and sample code, see the javadoc for {@link MockitoSession}.
      *
@@ -3422,7 +3425,7 @@ public class Mockito extends ArgumentMatchers {
      * Most mocks in most tests don't need leniency and should happily prosper with {@link Strictness#STRICT_STUBS}.
      * <ul>
      *     <li>If a specific stubbing needs to be lenient - use this method</li>
-     *     <li>If a specific mock need to have stubbings lenient - use {@link MockSettings#lenient()}</li>
+     *     <li>If a specific mock need to have lenient stubbings - use {@link MockSettings#strictness(Strictness)}</li>
      *     <li>If a specific test method / test class needs to have all stubbings lenient
      *          - configure strictness using our JUnit support ({@link MockitoJUnit} or Mockito Session ({@link MockitoSession})</li>
      *

--- a/src/main/java/org/mockito/MockitoFramework.java
+++ b/src/main/java/org/mockito/MockitoFramework.java
@@ -26,11 +26,11 @@ public interface MockitoFramework {
      * Adds listener to Mockito.
      * For a list of supported listeners, see the interfaces that extend {@link MockitoListener}.
      * <p>
-     * Listeners can be useful for engs that extend Mockito framework.
+     * Listeners can be useful for components that extend Mockito framework.
      * They are used in the implementation of unused stubbings warnings ({@link org.mockito.quality.MockitoHint}).
      * <p>
      * Make sure you remove the listener when the job is complete, see {@link #removeListener(MockitoListener)}.
-     * Currently the listeners list is thread local so you need to remove listener from the same thread otherwise
+     * Currently, the listeners list is thread local, so you need to remove listener from the same thread otherwise
      * remove is ineffectual.
      * In typical scenarios, it is not a problem, because adding and removing listeners typically happens in the same thread.
      * <p>
@@ -56,7 +56,7 @@ public interface MockitoFramework {
 
     /**
      * When you add listener using {@link #addListener(MockitoListener)} make sure to remove it.
-     * Currently the listeners list is thread local so you need to remove listener from the same thread otherwise
+     * Currently, the listeners list is thread local, so you need to remove listener from the same thread otherwise
      * remove is ineffectual.
      * In typical scenarios, it is not a problem, because adding and removing listeners typically happens in the same thread.
      * <p>
@@ -92,7 +92,7 @@ public interface MockitoFramework {
     /**
      * Clears up internal state of all inline mocks.
      * This method is only meaningful if inline mock maker is in use.
-     * Otherwise this method is a no-op and need not be used.
+     * For all other intents and purposes, this method is a no-op and need not be used.
      * <p>
      * This method is useful to tackle subtle memory leaks that are possible due to the nature of inline mocking
      * (issue <a href="https://github.com/mockito/mockito/pull/1619">#1619</a>).

--- a/src/main/java/org/mockito/MockitoSession.java
+++ b/src/main/java/org/mockito/MockitoSession.java
@@ -17,12 +17,12 @@ import org.mockito.session.MockitoSessionBuilder;
 
 /**
  * {@code MockitoSession} is an optional, highly recommended feature
- * that helps driving cleaner tests by eliminating boilerplate code and adding extra validation.
+ * that drives writing cleaner tests by eliminating boilerplate code and adding extra validation.
  * If you already use {@link MockitoJUnitRunner} or {@link MockitoRule}
  * *you don't need* {@code MockitoSession} because it is used by the runner/rule.
  * <p>
  * {@code MockitoSession} is a session of mocking, during which the user creates and uses Mockito mocks.
- * Typically the session is an execution of a single test method.
+ * Typically, the session is an execution of a single test method.
  * {@code MockitoSession} initializes mocks, validates usage and detects incorrect stubbing.
  * When the session is started it must be concluded with {@link #finishMocking()}
  * otherwise {@link UnfinishedMockingSessionException} is triggered when the next session is created.

--- a/src/main/java/org/mockito/NotExtensible.java
+++ b/src/main/java/org/mockito/NotExtensible.java
@@ -19,7 +19,7 @@ import java.lang.annotation.RetentionPolicy;
  * Public types are all types that are *not* under "org.mockito.internal.*" package.
  * <p>
  * Absence of {@code NotExtensible} annotation on a type *does not* mean it is intended to be extended.
- * The annotation has been introduced late and therefore it is not used frequently in the codebase.
+ * The annotation has been introduced late, and therefore it is not used frequently in the codebase.
  * Many public types from Mockito API are not intended for extension, even though they do not have this annotation applied.
  *
  * @since 2.10.0

--- a/src/main/java/org/mockito/Spy.java
+++ b/src/main/java/org/mockito/Spy.java
@@ -14,7 +14,7 @@ import java.lang.annotation.Target;
 import org.mockito.junit.MockitoJUnitRunner;
 
 /**
- * Allows shorthand wrapping of field instances in an spy object.
+ * Allows shorthand wrapping of field instances in a spy object.
  *
  * <p>
  * Example:
@@ -79,7 +79,7 @@ import org.mockito.junit.MockitoJUnitRunner;
  * <li>Mockito <b>*does not*</b> delegate calls to the passed real instance, instead it actually creates a copy of it.
  * So if you keep the real instance and interact with it, don't expect the spied to be aware of those interaction
  * and their effect on real instance state.
- * The corollary is that when an <b>*unstubbed*</b> method is called <b>*on the spy*</b> but <b>*not on the real instance*</b>,
+ * The corollary is that when an <b>*un-stubbed*</b> method is called <b>*on the spy*</b> but <b>*not on the real instance*</b>,
  * you won't see any effects on the real instance.</li>
  *
  * <li>Watch out for final methods.

--- a/src/main/java/org/mockito/configuration/IMockitoConfiguration.java
+++ b/src/main/java/org/mockito/configuration/IMockitoConfiguration.java
@@ -13,7 +13,7 @@ import org.mockito.stubbing.Answer;
  * In most cases you don't really need to configure Mockito. For example in case of working with legacy code,
  * when you might want to have different 'mocking style' this interface might be helpful.
  * A reason of configuring Mockito might be if you disagree with the {@link org.mockito.Answers#RETURNS_DEFAULTS}
- * unstubbed mocks return.
+ * un-stubbed mocks return.
  *
  * <p>
  * To configure Mockito create exactly <b>org.mockito.configuration.MockitoConfiguration</b> class
@@ -38,7 +38,7 @@ import org.mockito.stubbing.Answer;
 public interface IMockitoConfiguration {
 
     /**
-     * Allows configuring the default answers of unstubbed invocations
+     * Allows configuring the default answers of un-stubbed invocations
      * <p>
      * See javadoc for {@link IMockitoConfiguration}
      */

--- a/src/main/java/org/mockito/internal/debugging/LoggingListener.java
+++ b/src/main/java/org/mockito/internal/debugging/LoggingListener.java
@@ -82,7 +82,7 @@ public class LoggingListener implements FindingsListener {
         if (!unstubbedCalls.isEmpty()) {
             lines.add("[Mockito]");
             lines.add(
-                    "[Mockito] Unstubbed method invocations (perhaps missing stubbing in the test?):");
+                    "[Mockito] Un-stubbed method invocations (perhaps missing stubbing in the test?):");
             lines.add("[Mockito]");
             addOrderedList(lines, unstubbedCalls);
         }

--- a/src/main/java/org/mockito/internal/stubbing/answers/CallsRealMethods.java
+++ b/src/main/java/org/mockito/internal/stubbing/answers/CallsRealMethods.java
@@ -17,10 +17,10 @@ import org.mockito.stubbing.ValidableAnswer;
 /**
  * Optional Answer that adds partial mocking support
  * <p>
- * {@link Answer} can be used to define the return values of unstubbed invocations.
+ * {@link Answer} can be used to define the return values of un-stubbed invocations.
  * <p>
  * This implementation can be helpful when working with legacy code.
- * When this implementation is used, unstubbed methods will delegate to the real implementation.
+ * When this implementation is used, un-stubbed methods will delegate to the real implementation.
  * This is a way to create a partial mock object that calls real methods by default.
  * <p>
  * As usual you are going to read <b>the partial mock warning</b>:

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNulls.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNulls.java
@@ -25,12 +25,12 @@ import org.mockito.stubbing.Answer;
  * Optional Answer that can be used with
  * {@link Mockito#mock(Class, Answer)}
  * <p>
- * This implementation can be helpful when working with legacy code. Unstubbed
+ * This implementation can be helpful when working with legacy code. Un-stubbed
  * methods often return null. If your code uses the object returned by an
- * unstubbed call you get a NullPointerException. This implementation of
+ * un-stubbed call, you get a NullPointerException. This implementation of
  * Answer returns SmartNulls instead of nulls.
  * SmartNull gives nicer exception message than NPE because it points out the
- * line where unstubbed method was called. You just click on the stack trace.
+ * line where un-stubbed method was called. You just click on the stack trace.
  * <p>
  * ReturnsSmartNulls first tries to return ordinary return values (see
  * {@link ReturnsMoreEmptyValues}) then it tries to return SmartNull. If the
@@ -90,7 +90,7 @@ public class ReturnsSmartNulls implements Answer<Object>, Serializable {
         @Override
         public Object answer(InvocationOnMock currentInvocation) throws Throwable {
             if (isToStringMethod(currentInvocation.getMethod())) {
-                return "SmartNull returned by this unstubbed method call on a mock:\n"
+                return "SmartNull returned by this un-stubbed method call on a mock:\n"
                         + unstubbedInvocation;
             } else if (isMethodOf(
                     MockAccess.class, currentInvocation.getMock(), currentInvocation.getMethod())) {

--- a/src/test/java/org/mockito/internal/debugging/LoggingListenerTest.java
+++ b/src/test/java/org/mockito/internal/debugging/LoggingListenerTest.java
@@ -97,7 +97,7 @@ public class LoggingListenerTest extends TestBase {
                         + "[Mockito]\n"
                         + "[Mockito] 1. at com.FooTest:30\n"
                         + "[Mockito]\n"
-                        + "[Mockito] Unstubbed method invocations (perhaps missing stubbing in the test?):\n"
+                        + "[Mockito] Un-stubbed method invocations (perhaps missing stubbing in the test?):\n"
                         + "[Mockito]\n"
                         + "[Mockito] 1. at com.Foo:96",
                 listener.getStubbingInfo());
@@ -127,7 +127,7 @@ public class LoggingListenerTest extends TestBase {
         assertEquals(
                 "[Mockito] Additional stubbing information (see javadoc for StubbingInfo class):\n"
                         + "[Mockito]\n"
-                        + "[Mockito] Unstubbed method invocations (perhaps missing stubbing in the test?):\n"
+                        + "[Mockito] Un-stubbed method invocations (perhaps missing stubbing in the test?):\n"
                         + "[Mockito]\n"
                         + "[Mockito] 1. com.Foo:20",
                 listener.getStubbingInfo());


### PR DESCRIPTION
- Makes static mock verification and construction initialisers into
  functional interfaces, and adds some missing documentation notes.
  Since Java 8 is the minimum target, this seems reasonable to
  include.
- Fixes a number of grammar/spelling typos.
- Replaces an instance of a JavaDoc comment suggesting to use a
  deprecated method with a reference to the suggested replacement.
- Adds a note about supporting chaining of Spy with InjectMocks into
  the InjectMocks documentation.

