### PR TITLE
CI on Android API level 33 for Java 11 compatibility testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       if: matrix.java == 11 && matrix.entry.mock-maker == 'mock-maker-default' # SINGLE-MATRIX-JOB
       run: ./gradlew spotlessCheck
 
-    - name: 6. Build on Java ${{ matrix.java }} with ${{ matrix.entry.mock-maker }} and ${{ matrix.entry.member-accessor }} 
+    - name: 6. Build on Java ${{ matrix.java }} with ${{ matrix.entry.mock-maker }} and ${{ matrix.entry.member-accessor }}
       run: ./gradlew build idea --scan
       env:
         MOCK_MAKER: ${{ matrix.entry.mock-maker }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,13 @@ jobs:
     # Definition of the build matrix
     strategy:
       matrix:
-        android-api: [ 26 ]
+        include:
+          # Minimum supported
+          - android-api: 26
+            android-image-type: default
+          # Maximum available
+          - android-api: 33
+            android-image-type: google_apis
 
     # All build steps
     steps:
@@ -115,6 +121,7 @@ jobs:
       with:
         arch: x86_64
         api-level: ${{ matrix.android-api }}
+        target: ${{ matrix.android-image-type }}
         script: ./gradlew :androidTest:connectedCheck --no-daemon --no-build-cache
 
   #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,6 @@ jobs:
     # Definition of the build matrix
     strategy:
       matrix:
-        java: [ 11 ]
         android-api: [ 26 ]
 
     # All build steps
@@ -105,13 +104,13 @@ jobs:
       with:
         fetch-depth: '0' # https://github.com/shipkit/shipkit-changelog#fetch-depth-on-ci
 
-    - name: 2. Set up Java ${{ matrix.java }}
+    - name: 2. Set up Java 11
       uses: actions/setup-java@v3
       with:
         distribution: 'zulu'
-        java-version: ${{ matrix.java }}
+        java-version: 11
 
-    - name: 3. Run Android tests on Java ${{ matrix.java }} with Android API level ${{ matrix.android-api }}
+    - name: 3. Run Android tests on Android API level ${{ matrix.android-api }}
       uses: reactivecircus/android-emulator-runner@v2
       with:
         arch: x86_64


### PR DESCRIPTION
Followup on https://github.com/mockito/mockito/pull/2893#discussion_r1094999173

## Goal
Adding API 33 to the testing suite, because it might bring significant changes which affect the internals of Mockito.

## Additional changes
 * needed to split the up the CI matrix into `include:` because [Google doesn't supply `default` emulator images for 32 and 33](https://issuetracker.google.com/issues/267458959). We found out [the hard way here](https://github.com/mockito/mockito/pull/2893#discussion_r1093297683).
 * Inlined Java version because it's not relevant what you use to build the .jar, only what's packaged into the APK. 11 also matches how the releases of Mockito are packaged
https://github.com/mockito/mockito/blob/e9784550dc773c14efbddba8880f9d6750cb9f9b/.github/workflows/ci.yml#L146
and
https://github.com/mockito/mockito/blob/e9784550dc773c14efbddba8880f9d6750cb9f9b/gradle/java-library.gradle#L17-L18

## Motivation
Android 13 / API 33 introduced Java 11 support:
https://developer.android.com/about/versions/13/features#core-libraries
https://android-developers.googleblog.com/2022/08/android-13-is-in-aosp.html
https://vived.io/android-gets-support-for-jdk-11-jvm-weekly-100/

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_
