### PR TITLE
Android CI improvements, improves #2892

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,8 +143,8 @@ jobs:
           adb logcat --clear || true
           # Capture full logcat output to a file.
           adb logcat > emulator.log & PID_LOGCAT_FILE=$!
-          # Output instrumentation test logs and all other errors to the GitHub Actions output.
-          adb logcat "*:E MonitoringInstr:V AndroidJUnitRunner:V TestRequestBuilder:V TestExecutor:V TestRunner:V" --format=color & PID_LOGCAT_CONSOLE=$!
+          # Output instrumentation test logs to the GitHub Actions output.
+          adb logcat "MonitoringInstr:V AndroidJUnitRunner:V TestRequestBuilder:V TestExecutor:V TestRunner:V" --format=color & PID_LOGCAT_CONSOLE=$!
           # Run the actual tests (ignore build failures, so that kill can execute after).
           ./gradlew :androidTest:connectedCheck --no-daemon --no-build-cache || true
           # Stop capturing logcat output.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,11 @@ jobs:
           # Capture logcat output from "Launch Emulator" to a file.
           adb logcat -d > emulator-startup.log
           # Shorten the logcat output, by truncating at this point, the relevant part is yet to come.
-          adb logcat --clear
+          # Best effort, could fail with "failed to clear the 'main' log",
+          # because something is locking logcat, so try a few times, and ignore errors each time.
+          adb logcat --clear || true
+          adb logcat --clear || true
+          adb logcat --clear || true
           # Capture full logcat output to a file.
           adb logcat > emulator.log & PID_LOGCAT_FILE=$!
           # Output instrumentation test logs and all other errors to the GitHub Actions output.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,7 @@ jobs:
         arch: x86_64
         api-level: ${{ matrix.android-api }}
         target: ${{ matrix.android-image-type }}
+        emulator-build: 7425822
         # Override default "-no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim"
         emulator-options: >
           -no-window

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,7 @@ jobs:
           # Output instrumentation test logs to the GitHub Actions output.
           adb logcat "*:S MonitoringInstr:V AndroidJUnitRunner:V TestRequestBuilder:V TestExecutor:V TestRunner:V" --format=color & echo $! > logcat_console.pid
 
+          echo 0 > gradle.exit # Set a default exit code.
           # Run the actual tests (suppress build failures by saving the exit code).
           ./gradlew :androidTest:connectedCheck --no-daemon --no-build-cache || echo $? > gradle.exit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,8 +119,8 @@ jobs:
         api-level: ${{ matrix.android-api }}
         # Workaround for https://issuetracker.google.com/issues/267458959
         target: ${{ matrix.android-api >= 32 && 'google_apis' || 'default' }}
-        # Workaround for https://github.com/ReactiveCircus/android-emulator-runner/issues/160.
-        emulator-build: 7425822
+        # Workaround for https://github.com/ReactiveCircus/android-emulator-runner/issues/160, but newer version.
+        emulator-build: 9322596 # 31.3.14.0 got it via `emulator -version`
         # Override default "-no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim"
         # See emulator manual for reference: https://developer.android.com/studio/run/emulator-commandline
         emulator-options: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,14 +132,22 @@ jobs:
           -no-boot-anim
           -camera-back none
           -camera-front none
-        script: ./gradlew :androidTest:connectedCheck --no-daemon --no-build-cache
+        script: |
+          # Capture full logcat output to a file.
+          adb logcat > emulator.log &
+          # Output warnings and errors to the GitHub Actions output.
+          adb logcat *:W -v color &
+          # Run the actual tests.
+          ./gradlew :androidTest:connectedCheck --no-daemon --no-build-cache
 
     - name: 4. Upload artifact "androidTest-results-${{ matrix.android-api }}"
       if: success() || failure()
       uses: actions/upload-artifact@v3
       with:
         name: androidTest-results-${{ matrix.android-api }}
-        path: subprojects/androidTest/build/reports/androidTests/connected/**
+        path: |
+          ${{ github.workspace }}/subprojects/androidTest/build/reports/androidTests/connected/**
+          ${{ github.workspace }}/emulator.log
 
   #
   # Release job, only for pushes to the main development branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,8 +122,10 @@ jobs:
         arch: x86_64
         api-level: ${{ matrix.android-api }}
         target: ${{ matrix.android-image-type }}
+        # Workaround for https://github.com/ReactiveCircus/android-emulator-runner/issues/160.
         emulator-build: 7425822
         # Override default "-no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim"
+        # See emulator manual for reference: https://developer.android.com/studio/run/emulator-commandline
         emulator-options: >
           -no-window
           -gpu swiftshader_indirect
@@ -132,6 +134,7 @@ jobs:
           -no-boot-anim
           -camera-back none
           -camera-front none
+        # See logcat manual for reference: https://developer.android.com/studio/command-line/logcat
         script: |
           # Capture full logcat output to a file.
           adb logcat > emulator.log &

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,8 +145,10 @@ jobs:
           adb logcat > emulator.log & echo $! > logcat_file.pid
           # Output instrumentation test logs to the GitHub Actions output.
           adb logcat "*:S MonitoringInstr:V AndroidJUnitRunner:V TestRequestBuilder:V TestExecutor:V TestRunner:V" --format=color & echo $! > logcat_console.pid
+
           # Run the actual tests (suppress build failures by saving the exit code).
           ./gradlew :androidTest:connectedCheck --no-daemon --no-build-cache || echo $? > gradle.exit
+
           # Stop capturing logcat output.
           kill $(cat logcat_file.pid)    || echo "::warning file=.github/workflows/ci.yml::Logcat process $(cat logcat_file.pid) didn't exist."
           kill $(cat logcat_console.pid) || echo "::warning file=.github/workflows/ci.yml::Logcat process $(cat logcat_console.pid) didn't exist."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
   #
   build:
     runs-on: ubuntu-latest
-    if: false
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
 
     # Definition of the build matrix
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,13 @@ jobs:
         target: ${{ matrix.android-image-type }}
         script: ./gradlew :androidTest:connectedCheck --no-daemon --no-build-cache
 
+    - name: 4. Upload artifact "androidTest-results-${{ matrix.android-api }}"
+      if: success() || failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: androidTest-results-${{ matrix.android-api }}
+        path: subprojects/androidTest/build/reports/androidTests/connected/**
+
   #
   # Release job, only for pushes to the main development branch
   #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
           # Capture full logcat output to a file.
           adb logcat > emulator.log & export PID_LOGCAT_FILE=$!
           # Output instrumentation test logs to the GitHub Actions output.
-          adb logcat "MonitoringInstr:V AndroidJUnitRunner:V TestRequestBuilder:V TestExecutor:V TestRunner:V" --format=color & export PID_LOGCAT_CONSOLE=$!
+          adb logcat "*:S MonitoringInstr:V AndroidJUnitRunner:V TestRequestBuilder:V TestExecutor:V TestRunner:V" --format=color & export PID_LOGCAT_CONSOLE=$!
           # Run the actual tests (ignore build failures, so that kill can execute after).
           ./gradlew :androidTest:connectedCheck --no-daemon --no-build-cache || true
           # Stop capturing logcat output.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,12 +133,19 @@ jobs:
           -camera-front none
         # See logcat manual for reference: https://developer.android.com/studio/command-line/logcat
         script: |
+          # Capture logcat output from "Launch Emulator" to a file.
+          adb logcat -d > emulator-startup.log
+          # Shorten the logcat output, by truncating at this point, the relevant part is yet to come.
+          adb logcat --clear
           # Capture full logcat output to a file.
-          adb logcat > emulator.log &
+          adb logcat > emulator.log & PID_LOGCAT_FILE=$!
           # Output warnings and errors to the GitHub Actions output.
-          adb logcat *:W -v color &
-          # Run the actual tests.
-          ./gradlew :androidTest:connectedCheck --no-daemon --no-build-cache
+          adb logcat *:W --format=color & PID_LOGCAT_CONSOLE=$!
+          # Run the actual tests (ignore build failures, so that kill can execute after).
+          ./gradlew :androidTest:connectedCheck --no-daemon --no-build-cache || true
+          # Stop capturing logcat output.
+          kill $PID_LOGCAT_FILE    || echo "::warning file=.github/workflows/ci.yml::Logcat process $PID_LOGCAT_FILE didn't exist."
+          kill $PID_LOGCAT_CONSOLE || echo "::warning file=.github/workflows/ci.yml::Logcat process $PID_LOGCAT_CONSOLE didn't exist."
 
     - name: 4. Upload artifact "androidTest-results-${{ matrix.android-api }}"
       if: success() || failure()
@@ -148,6 +155,7 @@ jobs:
         path: |
           ${{ github.workspace }}/subprojects/androidTest/build/reports/androidTests/connected/**
           ${{ github.workspace }}/emulator.log
+          ${{ github.workspace }}/emulator-startup.log
 
   #
   # Release job, only for pushes to the main development branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,8 @@ jobs:
           -no-snapshot
           -noaudio
           -no-boot-anim
+          -camera-back none
+          -camera-front none
         script: ./gradlew :androidTest:connectedCheck --no-daemon --no-build-cache
 
     - name: 4. Upload artifact "androidTest-results-${{ matrix.android-api }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,11 +145,13 @@ jobs:
           adb logcat > emulator.log & echo $! > logcat_file.pid
           # Output instrumentation test logs to the GitHub Actions output.
           adb logcat "*:S MonitoringInstr:V AndroidJUnitRunner:V TestRequestBuilder:V TestExecutor:V TestRunner:V" --format=color & echo $! > logcat_console.pid
-          # Run the actual tests (ignore build failures, so that kill can execute after).
-          ./gradlew :androidTest:connectedCheck --no-daemon --no-build-cache || true
+          # Run the actual tests (suppress build failures by saving the exit code).
+          ./gradlew :androidTest:connectedCheck --no-daemon --no-build-cache || echo $? > gradle.exit
           # Stop capturing logcat output.
           kill $(cat logcat_file.pid)    || echo "::warning file=.github/workflows/ci.yml::Logcat process $(cat logcat_file.pid) didn't exist."
           kill $(cat logcat_console.pid) || echo "::warning file=.github/workflows/ci.yml::Logcat process $(cat logcat_console.pid) didn't exist."
+          # Make sure the step fails if the tests failed.
+          exit $(cat gradle.exit)
 
     - name: 4. Upload artifact "androidTest-results-${{ matrix.android-api }}"
       if: success() || failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
   android:
     runs-on: macos-latest
     if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
+    timeout-minutes: 30
 
     # Definition of the build matrix
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,9 +142,9 @@ jobs:
           adb logcat --clear || true
           adb logcat --clear || true
           # Capture full logcat output to a file.
-          adb logcat > emulator.log & PID_LOGCAT_FILE=$!
+          adb logcat > emulator.log & export PID_LOGCAT_FILE=$!
           # Output instrumentation test logs to the GitHub Actions output.
-          adb logcat "MonitoringInstr:V AndroidJUnitRunner:V TestRequestBuilder:V TestExecutor:V TestRunner:V" --format=color & PID_LOGCAT_CONSOLE=$!
+          adb logcat "MonitoringInstr:V AndroidJUnitRunner:V TestRequestBuilder:V TestExecutor:V TestRunner:V" --format=color & export PID_LOGCAT_CONSOLE=$!
           # Run the actual tests (ignore build failures, so that kill can execute after).
           ./gradlew :androidTest:connectedCheck --no-daemon --no-build-cache || true
           # Stop capturing logcat output.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
   #
   build:
     runs-on: ubuntu-latest
-    if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
+    if: false
 
     # Definition of the build matrix
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,13 +95,8 @@ jobs:
     # Definition of the build matrix
     strategy:
       matrix:
-        include:
-          # Minimum supported
-          - android-api: 26
-            android-image-type: default
-          # Maximum available
-          - android-api: 33
-            android-image-type: google_apis
+        # Minimum supported and maximum available.
+        android-api: [ 26, 33 ]
 
     # All build steps
     steps:
@@ -121,7 +116,8 @@ jobs:
       with:
         arch: x86_64
         api-level: ${{ matrix.android-api }}
-        target: ${{ matrix.android-image-type }}
+        # Workaround for https://issuetracker.google.com/issues/267458959
+        target: ${{ matrix.android-api >= 32 && 'google_apis' || 'default' }}
         # Workaround for https://github.com/ReactiveCircus/android-emulator-runner/issues/160.
         emulator-build: 7425822
         # Override default "-no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,14 +142,14 @@ jobs:
           adb logcat --clear || true
           adb logcat --clear || true
           # Capture full logcat output to a file.
-          adb logcat > emulator.log & export PID_LOGCAT_FILE=$!
+          adb logcat > emulator.log & echo $! > logcat_file.pid
           # Output instrumentation test logs to the GitHub Actions output.
-          adb logcat "*:S MonitoringInstr:V AndroidJUnitRunner:V TestRequestBuilder:V TestExecutor:V TestRunner:V" --format=color & export PID_LOGCAT_CONSOLE=$!
+          adb logcat "*:S MonitoringInstr:V AndroidJUnitRunner:V TestRequestBuilder:V TestExecutor:V TestRunner:V" --format=color & echo $! > logcat_console.pid
           # Run the actual tests (ignore build failures, so that kill can execute after).
           ./gradlew :androidTest:connectedCheck --no-daemon --no-build-cache || true
           # Stop capturing logcat output.
-          kill $PID_LOGCAT_FILE    || echo "::warning file=.github/workflows/ci.yml::Logcat process $PID_LOGCAT_FILE didn't exist."
-          kill $PID_LOGCAT_CONSOLE || echo "::warning file=.github/workflows/ci.yml::Logcat process $PID_LOGCAT_CONSOLE didn't exist."
+          kill $(cat logcat_file.pid)    || echo "::warning file=.github/workflows/ci.yml::Logcat process $(cat logcat_file.pid) didn't exist."
+          kill $(cat logcat_console.pid) || echo "::warning file=.github/workflows/ci.yml::Logcat process $(cat logcat_console.pid) didn't exist."
 
     - name: 4. Upload artifact "androidTest-results-${{ matrix.android-api }}"
       if: success() || failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,13 @@ jobs:
         arch: x86_64
         api-level: ${{ matrix.android-api }}
         target: ${{ matrix.android-image-type }}
+        # Override default "-no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim"
+        emulator-options: >
+          -no-window
+          -gpu swiftshader_indirect
+          -no-snapshot
+          -noaudio
+          -no-boot-anim
         script: ./gradlew :androidTest:connectedCheck --no-daemon --no-build-cache
 
     - name: 4. Upload artifact "androidTest-results-${{ matrix.android-api }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,8 +139,8 @@ jobs:
           adb logcat --clear
           # Capture full logcat output to a file.
           adb logcat > emulator.log & PID_LOGCAT_FILE=$!
-          # Output warnings and errors to the GitHub Actions output.
-          adb logcat *:W --format=color & PID_LOGCAT_CONSOLE=$!
+          # Output instrumentation test logs and all other errors to the GitHub Actions output.
+          adb logcat "*:E MonitoringInstr:V AndroidJUnitRunner:V TestRequestBuilder:V TestExecutor:V TestRunner:V" --format=color & PID_LOGCAT_CONSOLE=$!
           # Run the actual tests (ignore build failures, so that kill can execute after).
           ./gradlew :androidTest:connectedCheck --no-daemon --no-build-cache || true
           # Stop capturing logcat output.

--- a/subprojects/androidTest/src/androidTest/java/org/mockitousage/androidtest/BasicInstrumentedTests.kt
+++ b/subprojects/androidTest/src/androidTest/java/org/mockitousage/androidtest/BasicInstrumentedTests.kt
@@ -35,7 +35,6 @@ class BasicInstrumentedTests {
     fun mockAndUseBasicClassUsingAnnotatedMock() {
         val basicClass = BasicOpenClassReceiver(mockedViaAnnotationBasicOpenClass)
         basicClass.callDependencyMethod()
-        error("Simulate failing test")
     }
 
     @Test

--- a/subprojects/androidTest/src/androidTest/java/org/mockitousage/androidtest/BasicInstrumentedTests.kt
+++ b/subprojects/androidTest/src/androidTest/java/org/mockitousage/androidtest/BasicInstrumentedTests.kt
@@ -35,6 +35,7 @@ class BasicInstrumentedTests {
     fun mockAndUseBasicClassUsingAnnotatedMock() {
         val basicClass = BasicOpenClassReceiver(mockedViaAnnotationBasicOpenClass)
         basicClass.callDependencyMethod()
+        error("Simulate failing test")
     }
 
     @Test


### PR DESCRIPTION
followup on #2893 and #2899, fixes #2892

## Changes
 * Lock in `emulator-build` for reproducibility and hopefully stability.
 * Add more `emulator-options` to make the emulator more stable.
 * Upload instrumentation test results as GHA artifact.
 * Upload logcat from device as GHA artifact.
 * Output relevant logcat to GHA logs in-line.
 * Simplify how the versions are determined.

## Investigation details

My first idea (finding) was cold-boot, but apparently that's default behavior via `--no-snapshot`.
 
Anyway, I had a look about recent failures, and found the below and made some change in hopes of a more stable CI:
   
 * <details><summary><code>Error: Timeout waiting for emulator to boot.</code></summary>
   
   [Job](https://github.com/mockito/mockito/actions/runs/4076245148/jobs/7023715242#step:4:981) 
   
   ```
     The process '/Users/runner/Library/Android/sdk/platform-tools/adb' failed with exit code 1
     /Users/runner/Library/Android/sdk/platform-tools/adb shell getprop sys.boot_completed
     adb: no devices/emulators found
     The process '/Users/runner/Library/Android/sdk/platform-tools/adb' failed with exit code 1
     /Users/runner/Library/Android/sdk/platform-tools/adb shell getprop sys.boot_completed
     adb: no devices/emulators found
     ...
   ```
   </details>
   
   Stumbled upon this issue https://github.com/ReactiveCircus/android-emulator-runner/issues/160 in one of the comments in the example CIs. I guess I agree that locking in a known-good version is better than be at the mercy of unstable "stable" releases. Google has blindsided us with a "no-repro" at https://issuetracker.google.com/issues/191799887.
   
   Fix: added explicit `emulator-build`

 * <details><summary><code>Unknown failure: cmd: Can't find service: package</code></summary>
   
   [Job](https://github.com/mockito/mockito/actions/runs/4106509220/jobs/7084834115#step:4:613)
   
   ```
   > Task :androidTest:connectedDebugAndroidTest
   Exception thrown during onBeforeAll invocation of plugin com.google.testing.platform.plugin.android.AndroidDevicePlugin.
   Failed to install APK(s): /Users/runner/work/mockito/mockito/subprojects/androidTest/build/outputs/apk/androidTest/debug/androidTest-debug-androidTest.apk
   Unknown failure: cmd: Can't find service: package
   com.android.ddmlib.InstallException: Unknown failure: cmd: Can't find service: package
   	at com.android.ddmlib.internal.DeviceImpl.installRemotePackage(DeviceImpl.java:1315)
   	at com.android.ddmlib.internal.DeviceImpl.installPackage(DeviceImpl.java:1141)
   	at com.android.tools.utp.plugins.deviceprovider.ddmlib.DdmlibAndroidDevice.installPackage(DdmlibAndroidDevice.kt)
   	at com.android.tools.utp.plugins.deviceprovider.ddmlib.DdmlibAndroidDeviceController$executeAsync$deferred$1.invokeSuspend(DdmlibAndroidDeviceController.kt:173)
   	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
   	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
   	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
   	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
   	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
   	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
   
   > Task :androidTest:connectedDebugAndroidTest FAILED
   ```
   </details>
   
   Strange error, it looks like the emulator is in a bad state. This could happen because the GitHub Actions runners might be shared between different jobs, and the emulator might be in a bad state when we try to use it. This sounds weird, because I'm sure GHA ensures a clean state, but not sure about it. Anyway, I haven't found any other suggestion than to kill the emulator and cold-boot it. Which is achieved by the default `-no-snapshot` flag. The only option I see here is to retry somehow.
   
   Fix: N/A so far, 🤞 `emulator-build` helps. 
   
 * <details><summary><code>Unknown failure: cmd: Failure calling service package: Broken pipe (32)</code></summary>
   
   [Job](https://github.com/mockito/mockito/actions/runs/4106655761/jobs/7085158611#step:4:496)
   
   ```
   > Task :androidTest:connectedDebugAndroidTest
   Exception thrown during onBeforeAll invocation of plugin com.google.testing.platform.plugin.android.AndroidDevicePlugin.
   Failed to install APK(s): /Users/runner/work/mockito/mockito/subprojects/androidTest/build/outputs/apk/debug/androidTest-debug.apk
   Unknown failure: cmd: Failure calling service package: Broken pipe (32)
   com.android.ddmlib.InstallException: Unknown failure: cmd: Failure calling service package: Broken pipe (32)
   	at com.android.ddmlib.internal.DeviceImpl.installRemotePackage(DeviceImpl.java:1315)
   	at com.android.ddmlib.internal.DeviceImpl.installPackage(DeviceImpl.java:1141)
   	at com.android.tools.utp.plugins.deviceprovider.ddmlib.DdmlibAndroidDevice.installPackage(DdmlibAndroidDevice.kt)
   	at com.android.tools.utp.plugins.deviceprovider.ddmlib.DdmlibAndroidDeviceController$executeAsync$deferred$1.invokeSuspend(DdmlibAndroidDeviceController.kt:173)
   	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
   	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
   	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
   	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
   	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
   	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
   
   
   > Task :androidTest:connectedDebugAndroidTest FAILED
   ```
   </details>
   
   Not a clue what's happening here, let's assume it's the "same" problem as above.
   Retry might help in this case, but it's quite complex, not sure that we want to adopt this.
   https://github.com/kiwix/kiwix-android/blob/develop/contrib/instrumentation.sh
   
   Fix: N/A so far, 🤞 `emulator-build` helps.
   
 * <details><summary><code>Mockito cannot mock this class: interface org.mockitousage.androidtest.BasicInterface.</code></summary>
   
   [Job](https://github.com/mockito/mockito/actions/runs/4106511182/jobs/7085124984#step:4:674)
   
   ```
   > Task :androidTest:connectedDebugAndroidTest
   Starting 6 tests on test(AVD) - 13
   
   org.mockitousage.androidtest.BasicInstrumentedTests > mockAndUseBasicClassWithVerify[test(AVD) - 13] FAILED 
   	org.mockito.exceptions.base.MockitoException:
   	Mockito cannot mock this class: interface org.mockitousage.androidtest.BasicInterface.
   
   org.mockitousage.androidtest.BasicInstrumentedTests > mockAndUseBasicClassUsingLocalMock[test(AVD) - 13] FAILED 
   	org.mockito.exceptions.base.MockitoException:
   	Mockito cannot mock this class: interface org.mockitousage.androidtest.BasicInterface.
   
   org.mockitousage.androidtest.BasicInstrumentedTests > mockAndUseBasicInterfaceUsingAnnotatedMock[test(AVD) - 13] FAILED 
   	org.mockito.exceptions.base.MockitoException:
   	Mockito cannot mock this class: interface org.mockitousage.androidtest.BasicInterface.
   
   org.mockitousage.androidtest.BasicInstrumentedTests > mockAndUseBasicClassUsingAnnotatedMock[test(AVD) - 13] FAILED 
   	org.mockito.exceptions.base.MockitoException:
   	Mockito cannot mock this class: interface org.mockitousage.androidtest.BasicInterface.
   
   org.mockitousage.androidtest.BasicInstrumentedTests > mockAndUseBasicInterfaceAndVerify[test(AVD) - 13] FAILED 
   	org.mockito.exceptions.base.MockitoException:
   	Mockito cannot mock this class: interface org.mockitousage.androidtest.BasicInterface.
   
   org.mockitousage.androidtest.BasicInstrumentedTests > mockAndUseBasicInterfaceUsingLocalMock[test(AVD) - 13] FAILED 
   	org.mockito.exceptions.base.MockitoException:
   	Mockito cannot mock this class: interface org.mockitousage.androidtest.BasicInterface.
   Tests on test(AVD) - 13 failed: There was 6 failure(s).
   
   > Task :androidTest:connectedDebugAndroidTest FAILED
   ```
   
   </details>
   
   Undiagnosable as per https://github.com/mockito/mockito/pull/2893#discussion_r1094978058. What we know: the emulator started, the Gradle build completed, and app deployed, and tests are discovered. At this point it's usually the production/test code that's wrong, but not reproducible locally.

   Fix: Added artifact for the test results.

---

Note: I went through all referenced CIs here:
https://github.com/ReactiveCircus/android-emulator-runner#who-is-using-android-emulator-runner
to find some ideas on how to improve the Mockito CI.
Most of them used verbatim runners as we've set up, but some (major ones) used some extra options.

Additional findings, that I ignored for now:
 * https://github.com/slackhq/keeper/blob/b2847d74cc9f80b275a56efbda94c310ff7b668b/.github/workflows/run_instrumentation_tests.sh#L7  
   Source: https://github.com/slackhq/keeper/commit/ae8638aa1005cf317333ee86d54882254896e896 in https://github.com/slackhq/keeper/pull/58
 * https://github.com/google/android-fhir/pull/1709; they deleted it, but have a backup infrastructure internally at Google.
 * https://github.com/dotanuki-labs/norris/pull/578; they have heavy UI tests/screenshot tests, and for performance moved to emulator.wtf

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [ ] At least one commit should mention `Fixes #<issue number>` _if relevant_

