### PR TITLE
Fix most Gradle warnings in build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,9 @@ allprojects { proj ->
 
 configurations {
     testUtil //TODO move to separate project
+    // Putting 'provided' dependencies on test compile and runtime classpath.
+    testCompileOnly.extendsFrom(compileOnly)
+    testRuntimeOnly.extendsFrom(compileOnly)
 }
 
 dependencies {
@@ -91,10 +94,6 @@ dependencies {
     implementation libraries.objenesis
 
     testImplementation libraries.assertj
-
-    //putting 'provided' dependencies on test compile and runtime classpath
-    testCompileOnly configurations.compileOnly
-    testRuntimeOnly configurations.compileOnly
 
     testUtil sourceSets.test.output
 

--- a/gradle/java-library.gradle
+++ b/gradle/java-library.gradle
@@ -30,8 +30,8 @@ apply from: "$rootDir/gradle/retry-test.gradle"
 
 tasks.withType(Checkstyle) {
     reports {
-        xml.enabled false
-        html.enabled true
+        xml.required = false
+        html.required = true
         html.stylesheet resources.text.fromFile("$rootDir/config/checkstyle/checkstyle.xsl")
     }
 }

--- a/gradle/java-publication.gradle
+++ b/gradle/java-publication.gradle
@@ -58,7 +58,7 @@ publishing {
                     //Gradle does not write 'jar' packaging to the pom (unlike other packaging types).
                     //This is OK because 'jar' is implicit/default:
                     // https://maven.apache.org/guides/introduction/introduction-to-the-pom.html#minimal-pom
-                    packaging = project.tasks.jar.extension
+                    packaging = project.tasks.jar.archiveExtension.get()
                 }
 
                 url = "https://github.com/mockito/mockito"

--- a/gradle/mockito-core/osgi.gradle
+++ b/gradle/mockito-core/osgi.gradle
@@ -8,7 +8,7 @@ jar {
             'Bundle-SymbolicName': 'org.mockito.mockito-core',
             'Bundle-Version': "\${version_cleanup;${project.version}}",
             '-versionpolicy': '[${version;==;${@}},${version;+;${@}})',
-            'Export-Package': "org.mockito.internal.*;status=INTERNAL;mandatory:=status;version=${version},org.mockito.*;version=${version}",
+            'Export-Package': "org.mockito.internal.*;status=INTERNAL;mandatory:=status;version=${archiveVersion.get()},org.mockito.*;version=${archiveVersion.get()}",
             'Import-Package': [
                     'net.bytebuddy.*;version="[1.6.0,2.0)"',
                     'junit.*;resolution:=optional',

--- a/gradle/root/coverage.gradle
+++ b/gradle/root/coverage.gradle
@@ -35,8 +35,8 @@ task mockitoCoverage(type: JacocoReport) {
     }
 
     reports {
-        xml.enabled true
-        html.enabled true
+        xml.required = true
+        html.required = true
         html.destination file("${buildDir}/jacocoHtml")
     }
 

--- a/subprojects/junit-jupiter/junit-jupiter.gradle
+++ b/subprojects/junit-jupiter/junit-jupiter.gradle
@@ -25,7 +25,7 @@ jar {
             'Bundle-SymbolicName': 'org.mockito.junit-jupiter',
             'Bundle-Version': "\${version_cleanup;${project.version}}",
             '-versionpolicy': '[${version;==;${@}},${version;+;${@}})',
-            'Export-Package': "org.mockito.junit.jupiter.*;version=${version}",
+            'Export-Package': "org.mockito.junit.jupiter.*;version=${archiveVersion.get()}",
             '-removeheaders': 'Private-Package',
             'Automatic-Module-Name': 'org.mockito.junit.jupiter',
             '-noextraheaders': 'true',


### PR DESCRIPTION
Goal: reduce Gradle build using old approaches and prepare for upcoming breaking changes.

Originally on `main` there were warnings, these are hidden because the default Gradle behavior is to hide them, but they *will* break at on point.

```
Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.6/userguide/command_line_interface.html#sec:command_line_warnings
```

To see them in all their glory, run `./gradlew --warning-mode=all --stacktrace`.

<details><summary><code>gradlew --warning-mode=all</code> on <code>main</code></summary>

Note that some warnings don't show up here that have been  fixed, because they're deduplicated by Gradle. Gradle 8 will solve this, but right now we have to fix one to see one.
```
> Configure project :
Building version '5.1.2-SNAPSHOT'
  - reason: shipkit-auto-version deduced snapshot based on tag: 'v5.1.1'
The org.gradle.util.ConfigureUtil type has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/7.6/userguide/upgrading_version_7.html#org_gradle_util_reports
_deprecations
        at shipkit_91h1hqg1wr0a5t608js79f84t$_run_closure3.doCall(P:\projects\contrib\github-mockito\gradle\shipkit.gradle:22)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
The AbstractArchiveTask.extension property has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the archiveExtension property instead. See https://docs.gradle.org/7.6/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask
.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:extension for more details.
        at java_publication_3m1q2um515b0jc9w5l4jkv2vf$_run_closure3$_closure11$_closure13$_closure16$_closure17.doCall(P:\projects\contrib\github-mockito\gradle\java-publication.gradle:61)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
The Report.enabled property has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the required property instead. See https://docs.gradle.org/7.6/dsl/org.gradle.api.reporting.Report.html#org.gradle.api.reporting.Report:ena
bled for more details.
        at coverage_bdrf6ncoyqn26tscdjn3v6kje$_run_closure1$_closure4.doCall(P:\projects\contrib\github-mockito\gradle\root\coverage.gradle:38)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
The AbstractArchiveTask.version property has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the archiveVersion property instead. See https://docs.gradle.org/7.6/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.htm
l#org.gradle.api.tasks.bundling.AbstractArchiveTask:version for more details.
        at osgi_1s7hu8z26iat6hd1sfy12d5of$_run_closure1$_closure2.doCall(P:\projects\contrib\github-mockito\gradle\mockito-core\osgi.gradle:6)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
Adding a Configuration as a dependency is a confusing behavior which isn't recommended. This behaviour has been deprecated and is scheduled to be removed in Gradle 8.0. If you're interested in inheriting the dependencies from the Configuration yo
u are adding, you should use Configuration#extendsFrom instead. See https://docs.gradle.org/7.6/dsl/org.gradle.api.artifacts.Configuration.html#org.gradle.api.artifacts.Configuration:extendsFrom(org.gradle.api.artifacts.Configuration[]) for more
details.
        at build_e6jjcbuu9ezmj4rzb0cym1acv$_run_closure3.doCall(P:\projects\contrib\github-mockito\build.gradle:96)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```

</details>

<details><summary><code>gradlew --warning-mode=all</code> on this PR</summary>

```
> Configure project :
The org.gradle.util.ConfigureUtil type has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/7.6/userguide/upgrading_version_7.html#org_gradle_util_reports
_deprecations
        at shipkit_91h1hqg1wr0a5t608js79f84t$_run_closure3.doCall(P:\projects\contrib\github-mockito\gradle\shipkit.gradle:22)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```

</details>

<details><summary>Remaining problems with <code>gradlew build --warning-mode=all --stacktrace</code></summary>

```
> Task :programmatic-test:test
Resolution of the configuration :jacocoAgent was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behaviour has been deprecated and is scheduled to be removed in Gradle 8.0. See https://docs.gradle.org/7.6/userguide/viewing_debugging_dependencies.html#sub:resolving-unsafe-configuration-resolution-errors for more details.
        at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.resolveToStateOrLater(DefaultConfiguration.java:607)
        at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.access$1900(DefaultConfiguration.java:159)
        at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration$SelectedArtifactsProvider.getValue(DefaultConfiguration.java:1443)
        at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration$SelectedArtifactsProvider.getValue(DefaultConfiguration.java:1433)
        at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration$ConfigurationFileCollection.getSelectedArtifacts(DefaultConfiguration.java:1510)
        at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration$ConfigurationFileCollection.visitContents(DefaultConfiguration.java:1497)
        at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.visitContents(DefaultConfiguration.java:510)
        at org.gradle.api.internal.file.AbstractFileCollection.visitStructure(AbstractFileCollection.java:375)
        at org.gradle.api.internal.file.CompositeFileCollection.lambda$visitContents$0(CompositeFileCollection.java:119)
        at org.gradle.api.internal.file.collections.UnpackingVisitor.add(UnpackingVisitor.java:64)
        at org.gradle.api.internal.file.collections.UnpackingVisitor.add(UnpackingVisitor.java:89)
        at org.gradle.api.internal.file.DefaultFileCollectionFactory$ResolvingFileCollection.visitChildren(DefaultFileCollectionFactory.java:333)
        at org.gradle.api.internal.file.CompositeFileCollection.visitContents(CompositeFileCollection.java:119)
        at org.gradle.api.internal.file.AbstractFileCollection.visitStructure(AbstractFileCollection.java:375)
        at org.gradle.api.internal.file.CompositeFileCollection.lambda$visitContents$0(CompositeFileCollection.java:119)
        at org.gradle.api.internal.tasks.PropertyFileCollection.visitChildren(PropertyFileCollection.java:48)
        at org.gradle.api.internal.file.CompositeFileCollection.visitContents(CompositeFileCollection.java:119)
        at org.gradle.api.internal.file.AbstractFileCollection.visitStructure(AbstractFileCollection.java:375)
        at org.gradle.internal.fingerprint.impl.DefaultFileCollectionSnapshotter.snapshot(DefaultFileCollectionSnapshotter.java:51)
        at org.gradle.internal.execution.fingerprint.impl.DefaultInputFingerprinter$InputCollectingVisitor.visitInputFileProperty(DefaultInputFingerprinter.java:131)
        at org.gradle.api.internal.tasks.execution.TaskExecution.visitRegularInputs(TaskExecution.java:322)
        at org.gradle.internal.execution.fingerprint.impl.DefaultInputFingerprinter.fingerprintInputProperties(DefaultInputFingerprinter.java:61)
        at org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep.captureExecutionStateWithOutputs(CaptureStateBeforeExecutionStep.java:193)
        at org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep.lambda$captureExecutionState$1(CaptureStateBeforeExecutionStep.java:141)
        at org.gradle.internal.execution.steps.BuildOperationStep$1.call(BuildOperationStep.java:37)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:199)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:157)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor.call(DefaultBuildOperationExecutor.java:73)
        at org.gradle.internal.execution.steps.BuildOperationStep.operation(BuildOperationStep.java:34)
        at org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep.captureExecutionState(CaptureStateBeforeExecutionStep.java:130)
        at org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep.lambda$execute$0(CaptureStateBeforeExecutionStep.java:75)
        at java.base/java.util.Optional.flatMap(Optional.java:294)
        at org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep.execute(CaptureStateBeforeExecutionStep.java:75)
        at org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep.execute(CaptureStateBeforeExecutionStep.java:50)
        at org.gradle.internal.execution.steps.SkipEmptyWorkStep.executeWithNoEmptySources(SkipEmptyWorkStep.java:254)
        at org.gradle.internal.execution.steps.SkipEmptyWorkStep.executeWithNoEmptySources(SkipEmptyWorkStep.java:209)
        at org.gradle.internal.execution.steps.SkipEmptyWorkStep.execute(SkipEmptyWorkStep.java:88)
        at org.gradle.internal.execution.steps.SkipEmptyWorkStep.execute(SkipEmptyWorkStep.java:56)
        at org.gradle.internal.execution.steps.RemoveUntrackedExecutionStateStep.execute(RemoveUntrackedExecutionStateStep.java:32)
        at org.gradle.internal.execution.steps.RemoveUntrackedExecutionStateStep.execute(RemoveUntrackedExecutionStateStep.java:21)
        at org.gradle.internal.execution.steps.legacy.MarkSnapshottingInputsStartedStep.execute(MarkSnapshottingInputsStartedStep.java:38)
        at org.gradle.internal.execution.steps.LoadPreviousExecutionStateStep.execute(LoadPreviousExecutionStateStep.java:43)
        at org.gradle.internal.execution.steps.LoadPreviousExecutionStateStep.execute(LoadPreviousExecutionStateStep.java:31)
        at org.gradle.internal.execution.steps.AssignWorkspaceStep.lambda$execute$0(AssignWorkspaceStep.java:40)
        at org.gradle.api.internal.tasks.execution.TaskExecution$4.withWorkspace(TaskExecution.java:281)
        at org.gradle.internal.execution.steps.AssignWorkspaceStep.execute(AssignWorkspaceStep.java:40)
        at org.gradle.internal.execution.steps.AssignWorkspaceStep.execute(AssignWorkspaceStep.java:30)
        at org.gradle.internal.execution.steps.IdentityCacheStep.execute(IdentityCacheStep.java:37)
        at org.gradle.internal.execution.steps.IdentityCacheStep.execute(IdentityCacheStep.java:27)
        at org.gradle.internal.execution.steps.IdentifyStep.execute(IdentifyStep.java:44)
        at org.gradle.internal.execution.steps.IdentifyStep.execute(IdentifyStep.java:33)
        at org.gradle.internal.execution.impl.DefaultExecutionEngine$1.execute(DefaultExecutionEngine.java:76)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeIfValid(ExecuteActionsTaskExecuter.java:139)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.execute(ExecuteActionsTaskExecuter.java:128)
        at org.gradle.api.internal.tasks.execution.CleanupStaleOutputsExecuter.execute(CleanupStaleOutputsExecuter.java:77)
        at org.gradle.api.internal.tasks.execution.FinalizePropertiesTaskExecuter.execute(FinalizePropertiesTaskExecuter.java:46)
        at org.gradle.api.internal.tasks.execution.ResolveTaskExecutionModeExecuter.execute(ResolveTaskExecutionModeExecuter.java:51)
        at org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter.execute(SkipTaskWithNoActionsExecuter.java:57)
        at org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter.execute(SkipOnlyIfTaskExecuter.java:57)
        at org.gradle.api.internal.tasks.execution.CatchExceptionTaskExecuter.execute(CatchExceptionTaskExecuter.java:36)
        at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.executeTask(EventFiringTaskExecuter.java:77)
        at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:55)
        at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:52)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:199)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:157)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor.call(DefaultBuildOperationExecutor.java:73)
        at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter.execute(EventFiringTaskExecuter.java:52)
        at org.gradle.execution.plan.LocalTaskNodeExecutor.execute(LocalTaskNodeExecutor.java:69)
        at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:322)
        at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:309)
        at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:302)
        at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:288)
        at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.execute(DefaultPlanExecutor.java:462)
        at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.run(DefaultPlanExecutor.java:379)
        at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
        at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:49)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:834)
```

</details>

### Invidiual problems and their fixes.

GitHub doesn't support >65536 character comment 😅, so will post them separately as conversations on the relevant lines.

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [ ] Mention `Fixes #<issue number>` in the description _if relevant_
 - [ ] At least one commit should mention `Fixes #<issue number>` _if relevant_

