### PR TITLE
Fixes #2905 : ThreadLocal classes can be mocked.

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
@@ -168,7 +168,7 @@ public class MockMethodAdvice extends MockMethodDispatcher {
 
     @Override
     public boolean isMocked(Object instance) {
-        return selfCallInfo.checkSelfCall(instance) && isMock(instance);
+        return isMock(instance) && selfCallInfo.checkSelfCall(instance);
     }
 
     @Override

--- a/src/test/java/org/mockitousage/bugs/ThreadLocalTest.java
+++ b/src/test/java/org/mockitousage/bugs/ThreadLocalTest.java
@@ -20,39 +20,47 @@ public class ThreadLocalTest extends TestBase {
 
     @Test
     public void mock_ThreadLocal_does_not_raise_StackOverflowError() {
-        StackOverflowError stackOverflowError = Assertions.catchThrowableOfType(() -> {
-            mock(ThreadLocal.class, RETURNS_MOCKS);
-        }, StackOverflowError.class);
+        StackOverflowError stackOverflowError =
+                Assertions.catchThrowableOfType(
+                        () -> {
+                            mock(ThreadLocal.class, RETURNS_MOCKS);
+                        },
+                        StackOverflowError.class);
         Assertions.assertThat(stackOverflowError).isNull();
     }
 
     @Test
     public void mock_class_extending_ThreadLocal_does_not_raise_StackOverflowError() {
-        StackOverflowError stackOverflowError = Assertions.catchThrowableOfType(() -> {
-            mock(SomeThreadLocal.class, RETURNS_MOCKS);
-        }, StackOverflowError.class);
+        StackOverflowError stackOverflowError =
+                Assertions.catchThrowableOfType(
+                        () -> {
+                            mock(SomeThreadLocal.class, RETURNS_MOCKS);
+                        },
+                        StackOverflowError.class);
         Assertions.assertThat(stackOverflowError).isNull();
     }
 
     @Test
     public void spy_ThreadLocal_does_not_raise_StackOverflowError() {
-        StackOverflowError stackOverflowError = Assertions.catchThrowableOfType(() -> {
-            spy(ThreadLocal.class);
-        }, StackOverflowError.class);
+        StackOverflowError stackOverflowError =
+                Assertions.catchThrowableOfType(
+                        () -> {
+                            spy(ThreadLocal.class);
+                        },
+                        StackOverflowError.class);
         Assertions.assertThat(stackOverflowError).isNull();
     }
 
     @Test
     public void spy_class_extending_ThreadLocal_does_not_raise_StackOverflowError() {
-        StackOverflowError stackOverflowError = Assertions.catchThrowableOfType(() -> {
-            spy(SomeThreadLocal.class);
-        }, StackOverflowError.class);
+        StackOverflowError stackOverflowError =
+                Assertions.catchThrowableOfType(
+                        () -> {
+                            spy(SomeThreadLocal.class);
+                        },
+                        StackOverflowError.class);
         Assertions.assertThat(stackOverflowError).isNull();
     }
 
-    static class SomeThreadLocal<T> extends ThreadLocal<T> {
-
-    }
-
+    static class SomeThreadLocal<T> extends ThreadLocal<T> {}
 }
-

--- a/src/test/java/org/mockitousage/bugs/ThreadLocalTest.java
+++ b/src/test/java/org/mockitousage/bugs/ThreadLocalTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage.bugs;
+
+import static org.mockito.Mockito.RETURNS_MOCKS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockitoutil.TestBase;
+
+/**
+ * This was an issue reported in #2905. Mocking {@link ThreadLocal} or classes extending {@link ThreadLocal} was
+ * throwing a {@link StackOverflowError}.
+ */
+public class ThreadLocalTest extends TestBase {
+
+    @Test
+    public void mock_ThreadLocal_does_not_raise_StackOverflowError() {
+        StackOverflowError stackOverflowError = Assertions.catchThrowableOfType(() -> {
+            mock(ThreadLocal.class, RETURNS_MOCKS);
+        }, StackOverflowError.class);
+        Assertions.assertThat(stackOverflowError).isNull();
+    }
+
+    @Test
+    public void mock_class_extending_ThreadLocal_does_not_raise_StackOverflowError() {
+        StackOverflowError stackOverflowError = Assertions.catchThrowableOfType(() -> {
+            mock(SomeThreadLocal.class, RETURNS_MOCKS);
+        }, StackOverflowError.class);
+        Assertions.assertThat(stackOverflowError).isNull();
+    }
+
+    @Test
+    public void spy_ThreadLocal_does_not_raise_StackOverflowError() {
+        StackOverflowError stackOverflowError = Assertions.catchThrowableOfType(() -> {
+            spy(ThreadLocal.class);
+        }, StackOverflowError.class);
+        Assertions.assertThat(stackOverflowError).isNull();
+    }
+
+    @Test
+    public void spy_class_extending_ThreadLocal_does_not_raise_StackOverflowError() {
+        StackOverflowError stackOverflowError = Assertions.catchThrowableOfType(() -> {
+            spy(SomeThreadLocal.class);
+        }, StackOverflowError.class);
+        Assertions.assertThat(stackOverflowError).isNull();
+    }
+
+    static class SomeThreadLocal<T> extends ThreadLocal<T> {
+
+    }
+
+}
+

--- a/src/test/java/org/mockitousage/bugs/ThreadLocalTest.java
+++ b/src/test/java/org/mockitousage/bugs/ThreadLocalTest.java
@@ -10,8 +10,6 @@ import static org.mockito.Mockito.spy;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockitoutil.TestBase;
 
 /**


### PR DESCRIPTION
Fixes https://github.com/mockito/mockito/issues/2905

## Changes
- `MockMethodAdvice` way of checking if an object was a mock didn't work for `ThreadLocal` classes. The only change here is in method `MockMethodAdvice#isMocked(Object)` where the two conditions are flipped in order to avoid hitting the `get()` method from `ThreadLocal` used to check if the object was calling itself.

_Note_: this was working in Mockito 4.9.0, didn't check what happens in 5.0.0 and 5.1.0.

<!-- Hey,
Thanks for the contribution, this is awesome.
As you may have read, project members have somehow an opinionated view on what and how should be
Mockito, e.g. we don't want mockito to be a feature bloat.
There may be a thorough review, with feedback -> code change loop.
-->
<!--
If you have a suggestion for this template you can fix it in the .github/PULL_REQUEST_TEMPLATE.md file
-->
## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

