### PR TITLE
Make project relocatable by using relative paths in the OSGi test task

### DIFF
--- a/subprojects/osgi-test/osgi-test.gradle
+++ b/subprojects/osgi-test/osgi-test.gradle
@@ -30,10 +30,27 @@ dependencies {
 }
 
 test {
+    jvmArgumentProviders.add(
+        new RuntimeBundlesProvider(files: configurations.testRuntimeBundles.asFileTree)
+    )
     dependsOn configurations.testRuntimeBundles
-    inputs.files(sourceSets.testBundle.allSource)
-    inputs.files(sourceSets.otherBundle.allSource)
-    systemProperty 'testRuntimeBundles', configurations.testRuntimeBundles.asPath
+    inputs.files(sourceSets.testBundle.allSource).withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.files(sourceSets.otherBundle.allSource).withPathSensitivity(PathSensitivity.RELATIVE)
     useJUnit()
 }
 
+/**
+ * A helper class to pass classpath elements as relative paths. This allows the build
+ * to be checked out in different locations on the file system and still hit the cache.
+ */
+class RuntimeBundlesProvider implements CommandLineArgumentProvider {
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    FileTree files
+
+    @Override
+    Iterable<String> asArguments() {
+        String[] absolutePaths = files.stream().map {it.absolutePath}.toArray()
+        ["-DtestRuntimeBundles=${CollectionUtils.join(File.pathSeparator, absolutePaths)}".toString()]
+    }
+}


### PR DESCRIPTION
Make classpath elements and sources use relative paths, instead of the default absolute paths. This makes the build more cacheable when the checkout locations are different on the file system.
