### PR TITLE
Feature 2921 generic types

### DIFF
--- a/src/main/java/org/mockito/MockSettings.java
+++ b/src/main/java/org/mockito/MockSettings.java
@@ -5,6 +5,7 @@
 package org.mockito;
 
 import java.io.Serializable;
+import java.lang.reflect.Type;
 
 import org.mockito.exceptions.misusing.PotentialStubbingProblem;
 import org.mockito.exceptions.misusing.UnnecessaryStubbingException;
@@ -403,4 +404,11 @@ public interface MockSettings extends Serializable {
      * @since 4.8.0
      */
     MockSettings mockMaker(String mockMaker);
+
+    /**
+     * Specifies the generic type of the mock, preserving the information lost to Java type erasure.
+     * @param genericTypeToMock
+     * @return
+     */
+    MockSettings genericTypeToMock(Type genericTypeToMock);
 }

--- a/src/main/java/org/mockito/internal/configuration/MockAnnotationProcessor.java
+++ b/src/main/java/org/mockito/internal/configuration/MockAnnotationProcessor.java
@@ -57,6 +57,8 @@ public class MockAnnotationProcessor implements FieldAnnotationProcessor<Mock> {
             mockSettings.mockMaker(annotation.mockMaker());
         }
 
+        mockSettings.genericTypeToMock(genericType.get());
+
         // see @Mock answer default value
         mockSettings.defaultAnswer(annotation.answer());
 

--- a/src/main/java/org/mockito/internal/configuration/SpyAnnotationEngine.java
+++ b/src/main/java/org/mockito/internal/configuration/SpyAnnotationEngine.java
@@ -87,6 +87,7 @@ public class SpyAnnotationEngine implements AnnotationEngine {
         return Mockito.mock(
                 instance.getClass(),
                 withSettings()
+                        .genericTypeToMock(field.getGenericType())
                         .spiedInstance(instance)
                         .defaultAnswer(CALLS_REAL_METHODS)
                         .name(field.getName()));
@@ -96,7 +97,10 @@ public class SpyAnnotationEngine implements AnnotationEngine {
             throws InstantiationException, IllegalAccessException, InvocationTargetException {
         // TODO: Add mockMaker option for @Spy annotation (#2740)
         MockSettings settings =
-                withSettings().defaultAnswer(CALLS_REAL_METHODS).name(field.getName());
+                withSettings()
+                        .genericTypeToMock(field.getGenericType())
+                        .defaultAnswer(CALLS_REAL_METHODS)
+                        .name(field.getName());
         Class<?> type = field.getType();
         if (type.isInterface()) {
             return Mockito.mock(type, settings.useConstructor());

--- a/src/main/java/org/mockito/internal/configuration/injection/PropertyAndSetterInjection.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/PropertyAndSetterInjection.java
@@ -81,6 +81,7 @@ public class PropertyAndSetterInjection extends MockInjectionStrategy {
                     injectMockCandidates(
                             fieldClass,
                             fieldInstanceNeedingInjection,
+                            injectMocksField,
                             newMockSafeHashSet(mockCandidates));
             fieldClass = fieldClass.getSuperclass();
         }
@@ -100,24 +101,32 @@ public class PropertyAndSetterInjection extends MockInjectionStrategy {
     }
 
     private boolean injectMockCandidates(
-            Class<?> awaitingInjectionClazz, Object injectee, Set<Object> mocks) {
+            Class<?> awaitingInjectionClazz,
+            Object injectee,
+            Field injectMocksField,
+            Set<Object> mocks) {
         boolean injectionOccurred;
         List<Field> orderedCandidateInjecteeFields =
                 orderedInstanceFieldsFrom(awaitingInjectionClazz);
         // pass 1
         injectionOccurred =
                 injectMockCandidatesOnFields(
-                        mocks, injectee, false, orderedCandidateInjecteeFields);
+                        mocks, injectee, injectMocksField, false, orderedCandidateInjecteeFields);
         // pass 2
         injectionOccurred |=
                 injectMockCandidatesOnFields(
-                        mocks, injectee, injectionOccurred, orderedCandidateInjecteeFields);
+                        mocks,
+                        injectee,
+                        injectMocksField,
+                        injectionOccurred,
+                        orderedCandidateInjecteeFields);
         return injectionOccurred;
     }
 
     private boolean injectMockCandidatesOnFields(
             Set<Object> mocks,
             Object injectee,
+            Field injectMocksField,
             boolean injectionOccurred,
             List<Field> orderedCandidateInjecteeFields) {
         for (Iterator<Field> it = orderedCandidateInjecteeFields.iterator(); it.hasNext(); ) {
@@ -125,7 +134,11 @@ public class PropertyAndSetterInjection extends MockInjectionStrategy {
             Object injected =
                     mockCandidateFilter
                             .filterCandidate(
-                                    mocks, candidateField, orderedCandidateInjecteeFields, injectee)
+                                    mocks,
+                                    candidateField,
+                                    orderedCandidateInjecteeFields,
+                                    injectee,
+                                    injectMocksField)
                             .thenInject();
             if (injected != null) {
                 injectionOccurred |= true;

--- a/src/main/java/org/mockito/internal/configuration/injection/filter/MockCandidateFilter.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/filter/MockCandidateFilter.java
@@ -13,5 +13,6 @@ public interface MockCandidateFilter {
             Collection<Object> mocks,
             Field candidateFieldToBeInjected,
             List<Field> allRemainingCandidateFields,
-            Object injectee);
+            Object injectee,
+            Field injectMocksField);
 }

--- a/src/main/java/org/mockito/internal/configuration/injection/filter/NameBasedCandidateFilter.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/filter/NameBasedCandidateFilter.java
@@ -23,7 +23,8 @@ public class NameBasedCandidateFilter implements MockCandidateFilter {
             final Collection<Object> mocks,
             final Field candidateFieldToBeInjected,
             final List<Field> allRemainingCandidateFields,
-            final Object injectee) {
+            final Object injectee,
+            final Field injectMocksField) {
         if (mocks.size() == 1
                 && anotherCandidateMatchesMockName(
                         mocks, candidateFieldToBeInjected, allRemainingCandidateFields)) {
@@ -34,7 +35,8 @@ public class NameBasedCandidateFilter implements MockCandidateFilter {
                 tooMany(mocks) ? selectMatchingName(mocks, candidateFieldToBeInjected) : mocks,
                 candidateFieldToBeInjected,
                 allRemainingCandidateFields,
-                injectee);
+                injectee,
+                injectMocksField);
     }
 
     private boolean tooMany(Collection<Object> mocks) {

--- a/src/main/java/org/mockito/internal/configuration/injection/filter/TerminalMockCandidateFilter.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/filter/TerminalMockCandidateFilter.java
@@ -28,7 +28,8 @@ public class TerminalMockCandidateFilter implements MockCandidateFilter {
             final Collection<Object> mocks,
             final Field candidateFieldToBeInjected,
             final List<Field> allRemainingCandidateFields,
-            final Object injectee) {
+            final Object injectee,
+            final Field injectMocksField) {
         if (mocks.size() == 1) {
             final Object matchingMock = mocks.iterator().next();
 

--- a/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
@@ -5,9 +5,12 @@
 package org.mockito.internal.configuration.injection.filter;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
+import org.mockito.internal.util.MockUtil;
 
 public class TypeBasedCandidateFilter implements MockCandidateFilter {
 
@@ -26,7 +29,16 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
         List<Object> mockTypeMatches = new ArrayList<>();
         for (Object mock : mocks) {
             if (candidateFieldToBeInjected.getType().isAssignableFrom(mock.getClass())) {
-                mockTypeMatches.add(mock);
+                Type genericTypeToMock = MockUtil.getMockSettings(mock).getGenericTypeToMock();
+                Type genericType = candidateFieldToBeInjected.getGenericType();
+                // be more specific if generic type information is available
+                if (genericTypeToMock!=null || genericType!=null) {
+                    if (genericTypeToMock!=null && genericType!=null && genericTypeToMock.getTypeName().equals(genericType.getTypeName())) {
+                        mockTypeMatches.add(mock);
+                    } // else: filter out mock, as generic types don't match
+                } else {
+                    mockTypeMatches.add(mock);
+                }
             }
         }
 

--- a/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
@@ -32,11 +32,14 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
                 Type genericTypeToMock = MockUtil.getMockSettings(mock).getGenericTypeToMock();
                 Type genericType = candidateFieldToBeInjected.getGenericType();
                 // be more specific if generic type information is available
-                if (genericTypeToMock!=null || genericType!=null) {
-                    // would rather like to use Type.getTypeName(), but that doesn't exist in Android SDK 26
-                    // which Mockito aims to maintain compatibility with.
-                    // Type.getTypeName() is documented to simply call Type.toString(), so use that instead
-                    if (genericTypeToMock!=null && genericType!=null && genericTypeToMock.toString().equals(genericType.toString())) {
+                if (genericTypeToMock != null || genericType != null) {
+                    // would rather like to use Type.getTypeName(), but that doesn't exist in
+                    // Android SDK 26 which Mockito aims to maintain compatibility with.
+                    // Type.getTypeName() is documented to simply call Type.toString(), so use that
+                    // instead
+                    if (genericTypeToMock != null
+                            && genericType != null
+                            && genericTypeToMock.toString().equals(genericType.toString())) {
                         mockTypeMatches.add(mock);
                     } // else: filter out mock, as generic types don't match
                 } else {

--- a/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
@@ -99,6 +99,10 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
                     }
                 }
                 if (variableIndex != -1) {
+                    // now test whether actual type with same index is compatible, e.g. for
+                    //   class ClassUnderTest<T1, T2> {..}
+                    // T1 would be the String in
+                    //   ClassUnderTest<String, Integer> underTest = ..
                     isCompatible &= isCompatibleTypes(injectMocksFieldTypeParameters[variableIndex], actualTypeArgument2, injectMocksField);
                 } else {
                     isCompatible = false;

--- a/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
@@ -39,14 +39,15 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
                 ParameterizedType genericMockType = (ParameterizedType) mockType;
                 Type[] actualTypeArguments = genericTypeToMock.getActualTypeArguments();
                 Type[] actualTypeArguments2 = genericMockType.getActualTypeArguments();
-                // getRawType() says "the Type object representing the class or interface that declares this type",
+                // getRawType() says "the Type object representing the class or interface that
+                // declares this type",
                 // no clue why that's a Type rather than a Class as return type anyway
                 Class rawType = (Class) genericTypeToMock.getRawType();
                 Class rawType2 = (Class) genericMockType.getRawType();
-                if (Objects.equals(genericTypeToMock.getOwnerType(), genericMockType.getOwnerType()) &&
-                    // e.g. Tree and TreeSet
-                    rawType.isAssignableFrom(rawType2) &&
-                    actualTypeArguments.length == actualTypeArguments2.length ) {
+                if (Objects.equals(genericTypeToMock.getOwnerType(), genericMockType.getOwnerType())
+                        // e.g. Tree and TreeSet
+                        && rawType.isAssignableFrom(rawType2)
+                        && actualTypeArguments.length == actualTypeArguments2.length) {
                     // descend into recursion on type arguments
                     for (int i = 0; i < actualTypeArguments.length; i++) {
                         return isCompatibleTypes(actualTypeArguments[i], actualTypeArguments2[i]);
@@ -61,9 +62,11 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
             Type[] upperBounds = wildcardTypeToMock.getUpperBounds();
             return Arrays.stream(upperBounds).anyMatch(t -> isCompatibleTypes(t, mockType));
         } else if (typeToMock instanceof GenericArrayType && mockType instanceof GenericArrayType) {
-            return isCompatibleTypes(((GenericArrayType)typeToMock).getGenericComponentType(), ((GenericArrayType)mockType).getGenericComponentType());
+            return isCompatibleTypes(
+                    ((GenericArrayType) typeToMock).getGenericComponentType(),
+                    ((GenericArrayType) mockType).getGenericComponentType());
         } else if (typeToMock instanceof Class && mockType instanceof Class) {
-            return ((Class)typeToMock).isAssignableFrom((Class) mockType);
+            return ((Class) typeToMock).isAssignableFrom((Class) mockType);
         }
         return false;
     }
@@ -79,12 +82,13 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
             if (candidateFieldToBeInjected.getType().isAssignableFrom(mock.getClass())) {
                 Type genericMockType = MockUtil.getMockSettings(mock).getGenericTypeToMock();
                 Type genericType = candidateFieldToBeInjected.getGenericType();
-                boolean bothHaveGenericTypeInfo = genericType!=null && genericMockType!=null;
+                boolean bothHaveGenericTypeInfo = genericType != null && genericMockType != null;
                 // be more specific if generic type information is available
                 if (!bothHaveGenericTypeInfo || isCompatibleTypes(genericType, genericMockType)) {
                     mockTypeMatches.add(mock);
                 } else { // filter out mock, as generic types don't match
-                    //System.out.println("types don't match " + candidateFieldToBeInjected + " " + genericType + " " + genericMockType);
+                    // System.out.println("types don't match " + candidateFieldToBeInjected + " " +
+                    // genericType + " " + genericMockType);
                 }
             }
         }

--- a/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
@@ -79,7 +79,7 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
             Type actualTypeArgument = actualTypeArguments[i];
             Type actualTypeArgument2 = actualTypeArguments2[i];
             if (actualTypeArgument instanceof TypeVariable) {
-                TypeVariable<?> typeVariable = (TypeVariable<?>)actualTypeArgument;
+                TypeVariable<?> typeVariable = (TypeVariable<?>) actualTypeArgument;
                 // this is a TypeVariable declared by the class under test that turned
                 // up in one of its fields,
                 // e.g. class ClassUnderTest<T1, T2> { List<T1> tList; Set<T2> tSet}
@@ -89,8 +89,10 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
                 Type[] injectMocksFieldTypeParameters =
                         ((ParameterizedType) injectMocksField.getGenericType())
                                 .getActualTypeArguments();
-                // Find index of given TypeVariable where it was defined, e.g. 0 for T1 in ClassUnderTest<T1, T2>
-                TypeVariable<?>[] genericTypeParameters = injectMocksField.getType().getTypeParameters();
+                // Find index of given TypeVariable where it was defined, e.g. 0 for T1 in
+                // ClassUnderTest<T1, T2>
+                TypeVariable<?>[] genericTypeParameters =
+                        injectMocksField.getType().getTypeParameters();
                 int variableIndex = -1;
                 for (int i2 = 0; i2 < genericTypeParameters.length; i2++) {
                     if (genericTypeParameters[i2].equals(typeVariable)) {
@@ -103,7 +105,11 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
                     //   class ClassUnderTest<T1, T2> {..}
                     // T1 would be the String in
                     //   ClassUnderTest<String, Integer> underTest = ..
-                    isCompatible &= isCompatibleTypes(injectMocksFieldTypeParameters[variableIndex], actualTypeArgument2, injectMocksField);
+                    isCompatible &=
+                            isCompatibleTypes(
+                                    injectMocksFieldTypeParameters[variableIndex],
+                                    actualTypeArgument2,
+                                    injectMocksField);
                 } else {
                     isCompatible = false;
                     break;

--- a/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
@@ -33,7 +33,10 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
                 Type genericType = candidateFieldToBeInjected.getGenericType();
                 // be more specific if generic type information is available
                 if (genericTypeToMock!=null || genericType!=null) {
-                    if (genericTypeToMock!=null && genericType!=null && genericTypeToMock.getTypeName().equals(genericType.getTypeName())) {
+                    // would rather like to use Type.getTypeName(), but that doesn't exist in Android SDK 26
+                    // which Mockito aims to maintain compatibility with.
+                    // Type.getTypeName() is documented to simply call Type.toString(), so use that instead
+                    if (genericTypeToMock!=null && genericType!=null && genericTypeToMock.toString().equals(genericType.toString())) {
                         mockTypeMatches.add(mock);
                     } // else: filter out mock, as generic types don't match
                 } else {

--- a/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
@@ -5,10 +5,15 @@
 package org.mockito.internal.configuration.injection.filter;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 import org.mockito.internal.util.MockUtil;
 
@@ -20,6 +25,49 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
         this.next = next;
     }
 
+    protected boolean isCompatibleTypes(Type typeToMock, Type mockType) {
+        if (typeToMock instanceof ParameterizedType && mockType instanceof ParameterizedType) {
+            // ParameterizedType.equals() is documented as: 
+            // "Instances of classes that implement this interface must implement
+            // an equals() method that equates any two instances that share the
+            // same generic type declaration and have equal type parameters."
+            // Unfortunately, e.g. Wildcard parameter "?" doesn't equal java.lang.String
+            if (typeToMock.equals(mockType)) {
+                return true;
+            } else {
+                ParameterizedType genericTypeToMock = (ParameterizedType) typeToMock;
+                ParameterizedType genericMockType = (ParameterizedType) mockType;
+                Type[] actualTypeArguments = genericTypeToMock.getActualTypeArguments();
+                Type[] actualTypeArguments2 = genericMockType.getActualTypeArguments();
+                // getRawType() says "the Type object representing the class or interface that declares this type", 
+                // no clue why that's a Type rather than a Class as return type anyway
+                Class rawType = (Class) genericTypeToMock.getRawType();
+                Class rawType2 = (Class) genericMockType.getRawType();
+                if (Objects.equals(genericTypeToMock.getOwnerType(), genericMockType.getOwnerType()) &&
+                    // e.g. Tree and TreeSet
+                    rawType.isAssignableFrom(rawType2) &&
+                    actualTypeArguments.length == actualTypeArguments2.length ) {
+                    // descend into recursion on type arguments
+                    for (int i = 0; i < actualTypeArguments.length; i++) {
+                        return isCompatibleTypes(actualTypeArguments[i], actualTypeArguments2[i]);
+                    }
+                } else {
+                    // owner type, raw type or type arguments length don't match
+                    return false;
+                }
+            }
+        } else if (typeToMock instanceof WildcardType) {
+            WildcardType wildcardTypeToMock = (WildcardType) typeToMock;
+            Type[] upperBounds = wildcardTypeToMock.getUpperBounds();
+            return Arrays.stream(upperBounds).anyMatch(t -> isCompatibleTypes(t, mockType));
+        } else if (typeToMock instanceof GenericArrayType && mockType instanceof GenericArrayType) {
+            return isCompatibleTypes(((GenericArrayType)typeToMock).getGenericComponentType(), ((GenericArrayType)mockType).getGenericComponentType());
+        } else if (typeToMock instanceof Class && mockType instanceof Class) {
+            return ((Class)typeToMock).isAssignableFrom((Class) mockType);
+        }
+        return false;
+    }
+
     @Override
     public OngoingInjector filterCandidate(
             final Collection<Object> mocks,
@@ -29,22 +77,16 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
         List<Object> mockTypeMatches = new ArrayList<>();
         for (Object mock : mocks) {
             if (candidateFieldToBeInjected.getType().isAssignableFrom(mock.getClass())) {
-                Type genericTypeToMock = MockUtil.getMockSettings(mock).getGenericTypeToMock();
+                Type genericMockType = MockUtil.getMockSettings(mock).getGenericTypeToMock();
                 Type genericType = candidateFieldToBeInjected.getGenericType();
+                boolean bothHaveGenericTypeInfo = genericType!=null && genericMockType!=null;
                 // be more specific if generic type information is available
-                if (genericTypeToMock != null || genericType != null) {
-                    // would rather like to use Type.getTypeName(), but that doesn't exist in
-                    // Android SDK 26 which Mockito aims to maintain compatibility with.
-                    // Type.getTypeName() is documented to simply call Type.toString(), so use that
-                    // instead
-                    if (genericTypeToMock != null
-                            && genericType != null
-                            && genericTypeToMock.toString().equals(genericType.toString())) {
-                        mockTypeMatches.add(mock);
-                    } // else: filter out mock, as generic types don't match
-                } else {
+                if (!bothHaveGenericTypeInfo || isCompatibleTypes(genericType, genericMockType)) {
                     mockTypeMatches.add(mock);
-                }
+                } else {
+                    // else: filter out mock, as generic types don't match
+                    System.out.println("types don't macht " + candidateFieldToBeInjected + " " + genericType + " " + genericMockType);
+                } 
             }
         }
 

--- a/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
@@ -40,11 +40,6 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
                 ParameterizedType genericMockType = (ParameterizedType) mockType;
                 Type[] actualTypeArguments = genericTypeToMock.getActualTypeArguments();
                 Type[] actualTypeArguments2 = genericMockType.getActualTypeArguments();
-                // getRawType() says "the Type object representing the class or interface that
-                // declares this type",
-                // no clue why that returns a Type rather than a Class anyway
-                Class<?> rawType = (Class<?>) genericTypeToMock.getRawType();
-                Class<?> rawType2 = (Class<?>) genericMockType.getRawType();
                 // Recurse on type parameters, so we properly test whether e.g. Wildcard bounds
                 // have a match
                 return recurseOnTypeArguments(

--- a/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
@@ -7,6 +7,7 @@ package org.mockito.internal.configuration.injection.filter;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -24,13 +25,15 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
         this.next = next;
     }
 
-    protected boolean isCompatibleTypes(Type typeToMock, Type mockType) {
+    protected boolean isCompatibleTypes(Type typeToMock, Type mockType, Field injectMocksField) {
         if (typeToMock instanceof ParameterizedType && mockType instanceof ParameterizedType) {
             // ParameterizedType.equals() is documented as:
             // "Instances of classes that implement this interface must implement
             // an equals() method that equates any two instances that share the
             // same generic type declaration and have equal type parameters."
-            // Unfortunately, e.g. Wildcard parameter "?" doesn't equal java.lang.String
+            // Unfortunately, e.g. Wildcard parameter "?" doesn't equal java.lang.String,
+            // and e.g. Set doesn't equal TreeSet, so roll our own comparison if
+            // ParameterizedTypeImpl.equals() returns false
             if (typeToMock.equals(mockType)) {
                 return true;
             } else {
@@ -43,32 +46,62 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
                 // no clue why that's a Type rather than a Class as return type anyway
                 Class rawType = (Class) genericTypeToMock.getRawType();
                 Class rawType2 = (Class) genericMockType.getRawType();
+                // Test similar to how ParameterizedTypeImpl.equals() does, but recurse on type
+                // parameters,
+                // so we properly test whether e.g. Wildcard bounds have a match
                 if (Objects.equals(genericTypeToMock.getOwnerType(), genericMockType.getOwnerType())
-                        // e.g. Tree and TreeSet
+                        // e.g. Set and TreeSet
                         && rawType.isAssignableFrom(rawType2)
                         && actualTypeArguments.length == actualTypeArguments2.length) {
                     // descend into recursion on type arguments
-                    boolean isCompatible = true;
-                    for (int i = 0; i < actualTypeArguments.length; i++) {
-                        isCompatible =
-                                isCompatible
-                                        && isCompatibleTypes(
-                                                actualTypeArguments[i], actualTypeArguments2[i]);
-                    }
-                    return isCompatible;
-                } else {
-                    // owner type, raw type or type arguments length don't match
-                    return false;
+                    return recurseOnTypeArguments(
+                            injectMocksField, actualTypeArguments, actualTypeArguments2);
                 }
             }
         } else if (typeToMock instanceof WildcardType) {
             WildcardType wildcardTypeToMock = (WildcardType) typeToMock;
             Type[] upperBounds = wildcardTypeToMock.getUpperBounds();
-            return Arrays.stream(upperBounds).anyMatch(t -> isCompatibleTypes(t, mockType));
+            return Arrays.stream(upperBounds)
+                    .anyMatch(t -> isCompatibleTypes(t, mockType, injectMocksField));
         } else if (typeToMock instanceof Class && mockType instanceof Class) {
             return ((Class) typeToMock).isAssignableFrom((Class) mockType);
         } // no need to check for GenericArrayType, as Mockito cannot mock this anyway
+
+        // can only happen if there is a new subclass of Type that we don't know about yet,
+        // must have return statement here to be able to compile
         return false;
+    }
+
+    private boolean recurseOnTypeArguments(
+            Field injectMocksField, Type[] actualTypeArguments, Type[] actualTypeArguments2) {
+        boolean isCompatible = true;
+        for (int i = 0; i < actualTypeArguments.length; i++) {
+            Type actualTypeArgument = actualTypeArguments[i];
+            Type actualTypeArgument2 = actualTypeArguments2[i];
+            if (actualTypeArgument instanceof TypeVariable) {
+                // this is a TypeVariable declared by the class under test that turned
+                // up in one of its fields,
+                // e.g. class ClassUnderTest<T1, T2> { List<T1> tList; Set<T2> tSet}
+                // The TypeVariable`s actual type is declared by the field containing
+                // the object under test, i.e. the field annotated with @InjectMocks
+                // e.g. @InjectMocks ClassUnderTest<String, Integer> underTest = ..
+                Type[] injectMocksFieldTypeParameter =
+                        ((ParameterizedType) injectMocksField.getGenericType())
+                                .getActualTypeArguments();
+                // Try to find any type parameter of the injectMocksField that matches
+                isCompatible &=
+                        Arrays.stream(injectMocksFieldTypeParameter)
+                                .anyMatch(
+                                        t ->
+                                                isCompatibleTypes(
+                                                        t, actualTypeArgument2, injectMocksField));
+            } else {
+                isCompatible &=
+                        isCompatibleTypes(
+                                actualTypeArgument, actualTypeArgument2, injectMocksField);
+            }
+        }
+        return isCompatible;
     }
 
     @Override
@@ -76,7 +109,8 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
             final Collection<Object> mocks,
             final Field candidateFieldToBeInjected,
             final List<Field> allRemainingCandidateFields,
-            final Object injectee) {
+            final Object injectee,
+            final Field injectMocksField) {
         List<Object> mockTypeMatches = new ArrayList<>();
         for (Object mock : mocks) {
             if (candidateFieldToBeInjected.getType().isAssignableFrom(mock.getClass())) {
@@ -84,13 +118,18 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
                 Type genericType = candidateFieldToBeInjected.getGenericType();
                 boolean bothHaveGenericTypeInfo = genericType != null && genericMockType != null;
                 // be more specific if generic type information is available
-                if (!bothHaveGenericTypeInfo || isCompatibleTypes(genericType, genericMockType)) {
+                if (!bothHaveGenericTypeInfo
+                        || isCompatibleTypes(genericType, genericMockType, injectMocksField)) {
                     mockTypeMatches.add(mock);
                 } // else filter out mock, as generic types don't match
             }
         }
 
         return next.filterCandidate(
-                mockTypeMatches, candidateFieldToBeInjected, allRemainingCandidateFields, injectee);
+                mockTypeMatches,
+                candidateFieldToBeInjected,
+                allRemainingCandidateFields,
+                injectee,
+                injectMocksField);
     }
 }

--- a/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
@@ -43,14 +43,16 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
                 Type[] actualTypeArguments2 = genericMockType.getActualTypeArguments();
                 // Recurse on type parameters, so we properly test whether e.g. Wildcard bounds
                 // have a match
-                result = recurseOnTypeArguments(
-                        injectMocksField, actualTypeArguments, actualTypeArguments2);
+                result =
+                        recurseOnTypeArguments(
+                                injectMocksField, actualTypeArguments, actualTypeArguments2);
             }
         } else if (typeToMock instanceof WildcardType) {
             WildcardType wildcardTypeToMock = (WildcardType) typeToMock;
             Type[] upperBounds = wildcardTypeToMock.getUpperBounds();
-            result = Arrays.stream(upperBounds)
-                    .anyMatch(t -> isCompatibleTypes(t, mockType, injectMocksField));
+            result =
+                    Arrays.stream(upperBounds)
+                            .anyMatch(t -> isCompatibleTypes(t, mockType, injectMocksField));
         } else if (typeToMock instanceof Class && mockType instanceof Class) {
             result = ((Class) typeToMock).isAssignableFrom((Class) mockType);
         } // no need to check for GenericArrayType, as Mockito cannot mock this anyway

--- a/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
@@ -27,7 +27,7 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
 
     protected boolean isCompatibleTypes(Type typeToMock, Type mockType) {
         if (typeToMock instanceof ParameterizedType && mockType instanceof ParameterizedType) {
-            // ParameterizedType.equals() is documented as: 
+            // ParameterizedType.equals() is documented as:
             // "Instances of classes that implement this interface must implement
             // an equals() method that equates any two instances that share the
             // same generic type declaration and have equal type parameters."
@@ -39,7 +39,7 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
                 ParameterizedType genericMockType = (ParameterizedType) mockType;
                 Type[] actualTypeArguments = genericTypeToMock.getActualTypeArguments();
                 Type[] actualTypeArguments2 = genericMockType.getActualTypeArguments();
-                // getRawType() says "the Type object representing the class or interface that declares this type", 
+                // getRawType() says "the Type object representing the class or interface that declares this type",
                 // no clue why that's a Type rather than a Class as return type anyway
                 Class rawType = (Class) genericTypeToMock.getRawType();
                 Class rawType2 = (Class) genericMockType.getRawType();
@@ -83,10 +83,9 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
                 // be more specific if generic type information is available
                 if (!bothHaveGenericTypeInfo || isCompatibleTypes(genericType, genericMockType)) {
                     mockTypeMatches.add(mock);
-                } else {
-                    // else: filter out mock, as generic types don't match
-                    System.out.println("types don't macht " + candidateFieldToBeInjected + " " + genericType + " " + genericMockType);
-                } 
+                } else { // filter out mock, as generic types don't match
+                    //System.out.println("types don't match " + candidateFieldToBeInjected + " " + genericType + " " + genericMockType);
+                }
             }
         }
 

--- a/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
@@ -49,9 +49,11 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
                         && rawType.isAssignableFrom(rawType2)
                         && actualTypeArguments.length == actualTypeArguments2.length) {
                     // descend into recursion on type arguments
+                    boolean isCompatible = true;
                     for (int i = 0; i < actualTypeArguments.length; i++) {
-                        return isCompatibleTypes(actualTypeArguments[i], actualTypeArguments2[i]);
+                        isCompatible = isCompatible && isCompatibleTypes(actualTypeArguments[i], actualTypeArguments2[i]);
                     }
+                    return isCompatible;
                 } else {
                     // owner type, raw type or type arguments length don't match
                     return false;
@@ -86,10 +88,7 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
                 // be more specific if generic type information is available
                 if (!bothHaveGenericTypeInfo || isCompatibleTypes(genericType, genericMockType)) {
                     mockTypeMatches.add(mock);
-                } else { // filter out mock, as generic types don't match
-                    // System.out.println("types don't match " + candidateFieldToBeInjected + " " +
-                    // genericType + " " + genericMockType);
-                }
+                } // else filter out mock, as generic types don't match
             }
         }
 

--- a/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
@@ -5,7 +5,6 @@
 package org.mockito.internal.configuration.injection.filter;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.WildcardType;
@@ -63,13 +62,9 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
             WildcardType wildcardTypeToMock = (WildcardType) typeToMock;
             Type[] upperBounds = wildcardTypeToMock.getUpperBounds();
             return Arrays.stream(upperBounds).anyMatch(t -> isCompatibleTypes(t, mockType));
-        } else if (typeToMock instanceof GenericArrayType && mockType instanceof GenericArrayType) {
-            return isCompatibleTypes(
-                    ((GenericArrayType) typeToMock).getGenericComponentType(),
-                    ((GenericArrayType) mockType).getGenericComponentType());
         } else if (typeToMock instanceof Class && mockType instanceof Class) {
             return ((Class) typeToMock).isAssignableFrom((Class) mockType);
-        }
+        } // no need to check for GenericArrayType, as Mockito cannot mock this anyway
         return false;
     }
 

--- a/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
@@ -50,7 +50,10 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
                     // descend into recursion on type arguments
                     boolean isCompatible = true;
                     for (int i = 0; i < actualTypeArguments.length; i++) {
-                        isCompatible = isCompatible && isCompatibleTypes(actualTypeArguments[i], actualTypeArguments2[i]);
+                        isCompatible =
+                                isCompatible
+                                        && isCompatibleTypes(
+                                                actualTypeArguments[i], actualTypeArguments2[i]);
                     }
                     return isCompatible;
                 } else {

--- a/src/main/java/org/mockito/internal/creation/MockSettingsImpl.java
+++ b/src/main/java/org/mockito/internal/creation/MockSettingsImpl.java
@@ -16,6 +16,7 @@ import static org.mockito.internal.exceptions.Reporter.strictnessDoesNotAcceptNu
 import static org.mockito.internal.util.collections.Sets.newSet;
 
 import java.io.Serializable;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -257,6 +258,12 @@ public class MockSettingsImpl<T> extends CreationSettings<T>
     @Override
     public MockSettings mockMaker(String mockMaker) {
         this.mockMaker = mockMaker;
+        return this;
+    }
+
+    @Override
+    public MockSettings genericTypeToMock(Type genericType) {
+        this.genericTypeToMock = genericType;
         return this;
     }
 

--- a/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
+++ b/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
@@ -5,6 +5,7 @@
 package org.mockito.internal.creation.settings;
 
 import java.io.Serializable;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -25,6 +26,7 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
     private static final long serialVersionUID = -6789800638070123629L;
 
     protected Class<T> typeToMock;
+    protected Type genericTypeToMock;
     protected Set<Class<?>> extraInterfaces = new LinkedHashSet<>();
     protected String name;
     protected Object spiedInstance;
@@ -54,6 +56,7 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
     public CreationSettings(CreationSettings copy) {
         // TODO can we have a reflection test here? We had a couple of bugs here in the past.
         this.typeToMock = copy.typeToMock;
+        this.genericTypeToMock = copy.genericTypeToMock;
         this.extraInterfaces = copy.extraInterfaces;
         this.name = copy.name;
         this.spiedInstance = copy.spiedInstance;
@@ -79,6 +82,11 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
 
     public CreationSettings<T> setTypeToMock(Class<T> typeToMock) {
         this.typeToMock = typeToMock;
+        return this;
+    }
+
+    public CreationSettings<T> setGenericTypeToMock(Type genericTypeToMock) {
+        this.genericTypeToMock = genericTypeToMock;
         return this;
     }
 
@@ -184,5 +192,10 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
     @Override
     public String getMockMaker() {
         return mockMaker;
+    }
+
+    @Override
+    public Type getGenericTypeToMock() {
+        return genericTypeToMock;
     }
 }

--- a/src/main/java/org/mockito/mock/MockCreationSettings.java
+++ b/src/main/java/org/mockito/mock/MockCreationSettings.java
@@ -4,6 +4,7 @@
  */
 package org.mockito.mock;
 
+import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Set;
 
@@ -26,6 +27,11 @@ public interface MockCreationSettings<T> {
      * Mocked type. An interface or class the mock should implement / extend.
      */
     Class<T> getTypeToMock();
+
+    /**
+     * The generic type of the mock, if any.
+     */
+    Type getGenericTypeToMock();
 
     /**
      * the extra interfaces the mock object should implement.

--- a/subprojects/junit-jupiter/src/test/java/org/mockitousage/GenericTypeMockTest.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockitousage/GenericTypeMockTest.java
@@ -1,0 +1,39 @@
+package org.mockitousage;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class GenericTypeMockTest {
+    
+    public static class UnderTest {
+        List<String> stringListProvider;
+        List<Integer> intListProvider;
+    }
+
+    @Mock
+    private List<String> stringProviderMock;
+
+    @Mock
+    private List<Integer> intProviderMock;
+
+    @InjectMocks
+    private UnderTest underTest;
+
+    /**
+     * Verify that InjectMocks will correctly match fields with same generic type but different type parameters, without using the same field name.
+     */
+    @Test
+    public void testInjectMock() {
+        assertNotNull(underTest.stringListProvider);
+        assertNotNull(underTest.intListProvider);
+    }
+
+}

--- a/subprojects/junit-jupiter/src/test/java/org/mockitousage/GenericTypeMockTest.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockitousage/GenericTypeMockTest.java
@@ -7,6 +7,7 @@ package org.mockitousage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.sql.Time;
 import java.util.Collection;
@@ -143,6 +144,51 @@ public class GenericTypeMockTest {
 
             assertEquals(stringTreeSetMock, underTestWithGenericSubclass.stringSet);
             assertEquals(intHashSetMock, underTestWithGenericSubclass.intSet);
+        }
+    }
+
+    @Nested
+    public class MultipleCandidatesByTypeTest {
+        public class UnderTestWithMultipleCandidatesByType {
+            List<String> stringList;
+        }
+
+        @Mock
+        List<String> stringList1;
+
+        @Mock
+        List<String> stringList2;
+
+        @InjectMocks
+        UnderTestWithMultipleCandidatesByType underTestWithMultipleCandidates = new UnderTestWithMultipleCandidatesByType();
+
+        @Test
+        void testMultipleCandidatesByTypes() {
+            // verify that when mutiple mock candidates exist with same type (but not matching by field names), none will be injected
+            assertNull(underTestWithMultipleCandidates.stringList);
+        }
+    }
+
+    @Nested
+    public class MultipleCandidatesOneByNameTest {
+        public class UnderTestWithMultipleCandidatesOneByName {
+            List<String> stringList;
+        }
+
+        @Mock
+        List<String> stringList;
+
+        @Mock
+        List<String> stringListMock;
+
+        @InjectMocks
+        UnderTestWithMultipleCandidatesOneByName underTestWithMultipleCandidatesOneByName = new UnderTestWithMultipleCandidatesOneByName();
+
+        @Test
+        void testMultipleCandidatesOneByName() {
+            // verify that when multiple mock candidates exist by type, and one of them matches by field name, that one is injected
+            assertNotNull(underTestWithMultipleCandidatesOneByName.stringList);
+            assertEquals(stringList, underTestWithMultipleCandidatesOneByName.stringList);
         }
     }
 

--- a/subprojects/junit-jupiter/src/test/java/org/mockitousage/GenericTypeMockTest.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockitousage/GenericTypeMockTest.java
@@ -195,4 +195,95 @@ public class GenericTypeMockTest {
         }
     }
 
+    @Nested
+    public class NoneMatchByTypeParameterTest {
+        public class UnderTestWithNoMatches {
+            List<Integer> intList;
+        }
+
+        @Mock
+        List<String> stringList;
+
+        @InjectMocks
+        UnderTestWithNoMatches underTestWithNoMatches = new UnderTestWithNoMatches();
+
+        @Test
+        void testNoneMatchByTypeParameter() {
+            assertNotNull(stringList);
+
+            // verify that when no candidate matches by type parameter, none is injected
+            assertNull(underTestWithNoMatches.intList);
+        }
+    }
+
+    @Nested
+    public class NoneMatchByRawTypeTest {
+        public class UnderTestWithNoMatches {
+            List<Integer> intList;
+        }
+
+        @Mock
+        Set<Integer> intSet;
+
+        @InjectMocks
+        UnderTestWithNoMatches underTestWithNoMatchesByRawType = new UnderTestWithNoMatches();
+
+        @Test
+        void testNoneMatchByRawType() {
+            assertNotNull(intSet);
+
+            // verify that when no candidate matches by raw type, none is injected
+            assertNull(underTestWithNoMatchesByRawType.intList);
+        }
+    }
+
+
+    @Nested
+    public class ClassWithTypeParameterNoMatchTest {
+        public class UnderTestWithTypeParameter<T> {
+            List<T> tList;
+        }
+
+        @Mock
+        List<Integer> intList;
+
+        @InjectMocks
+        UnderTestWithTypeParameter<String> underTestWithTypeParameterNoMatch = new UnderTestWithTypeParameter<String>();
+
+        @Test
+        void testWithTypeParameterNoMatch() {
+            assertNotNull(intList);
+
+            // verify that when no candidate matches by type parameter of class under test, none is injected
+            assertNull(underTestWithTypeParameterNoMatch.tList);
+        }
+    }
+
+    @Nested
+    public class ClassWithTypeParametersTest {
+        public class UnderTestWithTypeParameter<T1, T2> {
+            List<T1> t1List;
+            Set<T2> t2Set;
+        }
+
+        @Mock
+        List<String> stringList;
+
+        @Mock
+        Set<Integer> intSet;
+
+        @InjectMocks
+        UnderTestWithTypeParameter<String, Integer> underTestWithTypeParameter = new UnderTestWithTypeParameter<String, Integer>();
+
+        @Test
+        void testWithTypeParameters() {
+            assertNotNull(stringList);
+            assertNotNull(intSet);
+
+            // verify that can match the type parameters of the class under test
+            assertEquals(stringList, underTestWithTypeParameter.t1List);
+            assertEquals(intSet, underTestWithTypeParameter.t2Set);
+        }
+    }
+
 }

--- a/subprojects/junit-jupiter/src/test/java/org/mockitousage/GenericTypeMockTest.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockitousage/GenericTypeMockTest.java
@@ -8,7 +8,9 @@ package org.mockitousage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -26,6 +28,7 @@ public class GenericTypeMockTest {
         List<String> stringList;
         List<Integer> intList;
         Set<?> anySet;
+        Map<Integer, ? extends Collection<String>> intStringCollectionMap;
     }
 
     @Mock
@@ -35,7 +38,10 @@ public class GenericTypeMockTest {
     private List<Integer> intProviderMock;
 
     @Mock
-    private TreeSet<String> treeSet = Mockito.mock(TreeSet.class);;
+    private TreeSet<String> treeSetMock = Mockito.mock(TreeSet.class);;
+
+    @Mock
+    private Map<Integer, List<String>> intStringListMapMock;
 
     @InjectMocks
     private UnderTest underTest;
@@ -52,11 +58,12 @@ public class GenericTypeMockTest {
         assertNotNull(underTest.stringList);
         assertNotNull(underTest.intList);
         assertNotNull(underTest.anySet);
+        assertNotNull(underTest.intStringCollectionMap);
 
         assertEquals(stringProviderMock, underTest.stringList);
         assertEquals(intProviderMock, underTest.intList);
-        assertEquals(treeSet, underTest.anySet);
-
+        assertEquals(treeSetMock, underTest.anySet);
+        assertEquals(intStringListMapMock, underTest.intStringCollectionMap);
     }
 
 }

--- a/subprojects/junit-jupiter/src/test/java/org/mockitousage/GenericTypeMockTest.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockitousage/GenericTypeMockTest.java
@@ -164,6 +164,9 @@ public class GenericTypeMockTest {
 
         @Test
         void testMultipleCandidatesByTypes() {
+            assertNotNull(stringList1);
+            assertNotNull(stringList2);
+
             // verify that when mutiple mock candidates exist with same type (but not matching by field names), none will be injected
             assertNull(underTestWithMultipleCandidates.stringList);
         }

--- a/subprojects/junit-jupiter/src/test/java/org/mockitousage/GenericTypeMockTest.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockitousage/GenericTypeMockTest.java
@@ -5,22 +5,27 @@
 
 package org.mockitousage;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class GenericTypeMockTest {
 
     public static class UnderTest {
-        List<String> stringListProvider;
-        List<Integer> intListProvider;
+        List<String> stringList;
+        List<Integer> intList;
+        Set<?> anySet;
     }
 
     @Mock
@@ -28,6 +33,9 @@ public class GenericTypeMockTest {
 
     @Mock
     private List<Integer> intProviderMock;
+
+    @Mock
+    private TreeSet<String> treeSet = Mockito.mock(TreeSet.class);;
 
     @InjectMocks
     private UnderTest underTest;
@@ -41,8 +49,14 @@ public class GenericTypeMockTest {
         // this used to fail without any error message hinting at the problem, as soon as a class under test has
         // a second field of the same generic type, but with different type parameter. The programmer then
         // had to know that mock field names have to match field names in the class under test.
-        assertNotNull(underTest.stringListProvider);
-        assertNotNull(underTest.intListProvider);
+        assertNotNull(underTest.stringList);
+        assertNotNull(underTest.intList);
+        assertNotNull(underTest.anySet);
+
+        assertEquals(stringProviderMock, underTest.stringList);
+        assertEquals(intProviderMock, underTest.intList);
+        assertEquals(treeSet, underTest.anySet);
+
     }
 
 }

--- a/subprojects/junit-jupiter/src/test/java/org/mockitousage/GenericTypeMockTest.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockitousage/GenericTypeMockTest.java
@@ -28,10 +28,14 @@ public class GenericTypeMockTest {
     private UnderTest underTest;
 
     /**
-     * Verify that InjectMocks will correctly match fields with same generic type but different type parameters, without using the same field name.
+     * Verify that InjectMocks will correctly match fields with same generic type but different type parameters, 
+     * without using the same field name.
      */
     @Test
     public void testInjectMock() {
+        // this used to fail without any error message hinting at the problem, as soon as a class under test has 
+        // a second field of the same generic type, but with different type parameter. The programmer then
+        // had to know that mock field names have to match field names in the class under test.
         assertNotNull(underTest.stringListProvider);
         assertNotNull(underTest.intListProvider);
     }

--- a/subprojects/junit-jupiter/src/test/java/org/mockitousage/GenericTypeMockTest.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockitousage/GenericTypeMockTest.java
@@ -261,28 +261,28 @@ public class GenericTypeMockTest {
 
     @Nested
     public class ClassWithTypeParametersTest {
-        public class UnderTestWithTypeParameter<T1, T2> {
+        public class UnderTestWithTypeParameters<T1, T2> {
             List<T1> t1List;
-            Set<T2> t2Set;
+            List<T2> t2List;
         }
 
         @Mock
         List<String> stringList;
 
         @Mock
-        Set<Integer> intSet;
+        List<Integer> intList;
 
         @InjectMocks
-        UnderTestWithTypeParameter<String, Integer> underTestWithTypeParameter = new UnderTestWithTypeParameter<String, Integer>();
+        UnderTestWithTypeParameters<String, Integer> underTestWithTypeParameters = new UnderTestWithTypeParameters<String, Integer>();
 
         @Test
         void testWithTypeParameters() {
             assertNotNull(stringList);
-            assertNotNull(intSet);
+            assertNotNull(intList);
 
-            // verify that can match the type parameters of the class under test
-            assertEquals(stringList, underTestWithTypeParameter.t1List);
-            assertEquals(intSet, underTestWithTypeParameter.t2Set);
+            // verify that we can match the type parameters of the class under test
+            assertEquals(stringList, underTestWithTypeParameters.t1List);
+            assertEquals(intList, underTestWithTypeParameters.t2List);
         }
     }
 

--- a/subprojects/junit-jupiter/src/test/java/org/mockitousage/GenericTypeMockTest.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockitousage/GenericTypeMockTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2023 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
 package org.mockitousage;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -12,7 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class GenericTypeMockTest {
-    
+
     public static class UnderTest {
         List<String> stringListProvider;
         List<Integer> intListProvider;
@@ -28,12 +33,12 @@ public class GenericTypeMockTest {
     private UnderTest underTest;
 
     /**
-     * Verify that InjectMocks will correctly match fields with same generic type but different type parameters, 
+     * Verify that InjectMocks will correctly match fields with same generic type but different type parameters,
      * without using the same field name.
      */
     @Test
     public void testInjectMock() {
-        // this used to fail without any error message hinting at the problem, as soon as a class under test has 
+        // this used to fail without any error message hinting at the problem, as soon as a class under test has
         // a second field of the same generic type, but with different type parameter. The programmer then
         // had to know that mock field names have to match field names in the class under test.
         assertNotNull(underTest.stringListProvider);


### PR DESCRIPTION
Fixes #2921 by preserving and using the generic Java type information that was previously lost to type erasure. 

Contains a JUnit test with usage example, demonstrating that fields with generic types do not need to have matching names anymore.
