### PR TITLE
Fixes 2933: IOUtils does not depend on platform encoding any more

### DIFF
--- a/src/main/java/org/mockito/internal/util/io/IOUtil.java
+++ b/src/main/java/org/mockito/internal/util/io/IOUtil.java
@@ -7,11 +7,12 @@ package org.mockito.internal.util.io;
 import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.PrintWriter;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -24,12 +25,12 @@ import org.mockito.exceptions.base.MockitoException;
 public final class IOUtil {
 
     /**
-     * Writes text to file
+     * Writes text to file in UTF-8.
      */
     public static void writeText(String text, File output) {
-        PrintWriter pw = null;
+        OutputStreamWriter pw = null;
         try {
-            pw = new PrintWriter(new FileWriter(output));
+            pw = new OutputStreamWriter(new FileOutputStream(output), StandardCharsets.UTF_8);
             pw.write(text);
         } catch (Exception e) {
             throw new MockitoException("Problems writing text to file: " + output, e);
@@ -38,9 +39,12 @@ public final class IOUtil {
         }
     }
 
+    /**
+     * Reads all lines from the given stream. Uses UTF-8.
+     */
     public static Collection<String> readLines(InputStream is) {
         List<String> out = new LinkedList<>();
-        BufferedReader r = new BufferedReader(new InputStreamReader(is));
+        BufferedReader r = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
         String line;
         try {
             while ((line = r.readLine()) != null) {


### PR DESCRIPTION
Fixes a problem that occured on platforms that had non-ASCII-based default encodings: https://github.com/mockito/mockito/issues/2933

I tested it on IBM z/OS and the problem mentioned in the issue with garbled class names disappeared. Sadly, it still doesn't fully work, but that's probably an unrelated problem, perhaps https://github.com/mockito/mockito/issues/801

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

