### PR TITLE
Fixes 2947: correct visibility check to respect nestmates

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
@@ -4,8 +4,8 @@
  */
 package org.mockito.internal.creation.bytebuddy;
 
+import static net.bytebuddy.matcher.ElementMatchers.isAccessibleTo;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
-import static net.bytebuddy.matcher.ElementMatchers.isPrivate;
 import static net.bytebuddy.matcher.ElementMatchers.isStatic;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 
@@ -398,7 +398,7 @@ public class MockMethodAdvice extends MockMethodDispatcher {
                                 .getSuperClass()
                                 .asErasure()
                                 .getDeclaredMethods()
-                                .filter(isConstructor().and(not(isPrivate())));
+                                .filter(isConstructor().and(isAccessibleTo(instrumentedType)));
                 int arguments = Integer.MAX_VALUE;
                 boolean packagePrivate = true;
                 MethodDescription.InDefinedShape current = null;

--- a/src/test/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMakerTest.java
+++ b/src/test/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMakerTest.java
@@ -81,6 +81,22 @@ public class InlineDelegateByteBuddyMockMakerTest
     }
 
     @Test
+    public void should_create_mock_from_accessible_inner_spy() throws Exception {
+        MockCreationSettings<Outer.Inner> settings = settingsFor(Outer.Inner.class);
+        Optional<Outer.Inner> proxy =
+                mockMaker.createSpy(
+                        settings,
+                        new MockHandlerImpl<>(settings),
+                        new Outer.Inner(new Object(), new Object()));
+        assertThat(proxy)
+                .hasValueSatisfying(
+                        spy -> {
+                            assertThat(spy.p1).isNotNull();
+                            assertThat(spy.p2).isNotNull();
+                        });
+    }
+
+    @Test
     public void should_create_mock_from_non_constructable_class() throws Exception {
         MockCreationSettings<NonConstructableClass> settings =
                 settingsFor(NonConstructableClass.class);
@@ -643,6 +659,25 @@ public class InlineDelegateByteBuddyMockMakerTest
             int i = 0;
             if (test != i) {
                 throw new IOException("fatal");
+            }
+        }
+    }
+
+    static class Outer {
+
+        final Object p1;
+
+        private Outer(final Object p1) {
+            this.p1 = p1;
+        }
+
+        private static class Inner extends Outer {
+
+            final Object p2;
+
+            Inner(final Object p1, final Object p2) {
+                super(p1);
+                this.p2 = p2;
             }
         }
     }


### PR DESCRIPTION
Since Java 11, subclasses can invoke private constructors if they are nested classes and the access right is registered in the nestmate property of both classes. Without recognizing such rights, Mockito cannot create a synthetic constructor hierarchy that sets fields for spies as the constructor generation is skipped due to a missing super constructor that is considered valid.
