### PR TITLE
Add `ArgumentMatchers#assertArg` method.

### DIFF
--- a/src/main/java/org/mockito/ArgumentMatchers.java
+++ b/src/main/java/org/mockito/ArgumentMatchers.java
@@ -14,6 +14,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
 import org.mockito.internal.matchers.Any;
@@ -910,6 +911,22 @@ public class ArgumentMatchers {
     public static <T> T argThat(ArgumentMatcher<T> matcher) {
         reportMatcher(matcher);
         return null;
+    }
+
+    /**
+     * Allows creating custom argument matchers where matching is considered successful when the consumer given by parameter does not throw an exception.
+     * <p>
+     * Typically used with {@link Mockito#verify(Object)} to execute assertions on parameters passed to the verified method invocation.
+     *
+     * @param consumer executes assertions on the verified argument
+     * @return <code>null</code>.
+     */
+    public static <T> T assertArg(Consumer<T> consumer) {
+        return argThat(
+                argument -> {
+                    consumer.accept(argument);
+                    return true;
+                });
     }
 
     /**

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -39,6 +39,7 @@ import org.mockito.verification.VerificationAfterDelay;
 import org.mockito.verification.VerificationMode;
 import org.mockito.verification.VerificationWithTimeout;
 
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -1661,6 +1662,19 @@ import java.util.function.Function;
  * With an implicit type, the Java compiler is unable to automatically determine the type of a mock and you need
  * to pass in the {@code Class} explicitly.
  * </p>
+ *
+ * <h3 id="55">55. <a class="meaningful_link" href="#verification_with_assertions" name="verification_with_assertions">
+ *  Verification with assertions</a> (Since 5.3.0)</h3>
+ *
+ * To validate arguments during verification, instead of capturing them with {@link ArgumentCaptor}, you can now
+ * use {@link ArgumentMatchers#assertArg(Consumer)}}:
+ *
+ * <pre class="code"><code class="java">
+ *   verify(serviceMock).doStuff(assertArg(param -> {
+ *     assertThat(param.getField1()).isEqualTo("foo");
+ *     assertThat(param.getField2()).isEqualTo("bar");
+ *   }));
+ * </code></pre>
  */
 @CheckReturnValue
 @SuppressWarnings("unchecked")

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -1670,7 +1670,7 @@ import java.util.function.Function;
  * use {@link ArgumentMatchers#assertArg(Consumer)}}:
  *
  * <pre class="code"><code class="java">
- *   verify(serviceMock).doStuff(assertArg(param -> {
+ *   verify(serviceMock).doStuff(assertArg(param -&gt; {
  *     assertThat(param.getField1()).isEqualTo("foo");
  *     assertThat(param.getField2()).isEqualTo("bar");
  *   }));

--- a/src/test/java/org/mockitousage/matchers/MatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/MatchersTest.java
@@ -20,6 +20,7 @@ import static org.mockito.AdditionalMatchers.leq;
 import static org.mockito.AdditionalMatchers.lt;
 import static org.mockito.AdditionalMatchers.not;
 import static org.mockito.AdditionalMatchers.or;
+import static org.mockito.ArgumentMatchers.assertArg;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.any;
@@ -52,6 +53,7 @@ import java.util.List;
 import java.util.RandomAccess;
 import java.util.regex.Pattern;
 
+import org.junit.ComparisonFailure;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
@@ -623,5 +625,24 @@ public class MatchersTest extends TestBase {
         mock.oneArg(Character.valueOf('\u20AC'));
 
         verify(mock, times(2)).oneArg(nullable(Character.class));
+    }
+
+    @Test
+    public void assertArg_matcher() throws Exception {
+        mock.oneArg("hello");
+
+        verify(mock).oneArg(assertArg((String it) -> assertEquals("hello", it)));
+    }
+
+    @Test
+    public void assertArg_matcher_fails_when_assertion_fails() throws Exception {
+        mock.oneArg("hello");
+
+        try {
+            verify(mock).oneArg(assertArg((String it) -> assertEquals("not-hello", it)));
+            fail("Should throw an exception");
+        } catch (ComparisonFailure e) {
+            // do nothing
+        }
     }
 }

--- a/src/test/java/org/mockitousage/matchers/MatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/MatchersTest.java
@@ -645,4 +645,32 @@ public class MatchersTest extends TestBase {
             // do nothing
         }
     }
+
+    @Test
+    public void can_invoke_method_on_mock_after_assert_arg() throws Exception {
+        mock.oneArg("hello");
+
+        try {
+            verify(mock).oneArg(assertArg((String it) -> assertEquals("not-hello", it)));
+            fail("Should throw an exception");
+        } catch (ComparisonFailure e) {
+            // do nothing
+        }
+
+        mock.oneArg("hello");
+    }
+
+    @Test
+    public void can_verify_on_mock_after_assert_arg() throws Exception {
+        mock.oneArg("hello");
+
+        try {
+            verify(mock).oneArg(assertArg((String it) -> assertEquals("not-hello", it)));
+            fail("Should throw an exception");
+        } catch (ComparisonFailure e) {
+            // do nothing
+        }
+
+        verify(mock).oneArg("hello");
+    }
 }


### PR DESCRIPTION
Fixes #2285

Enables convenient alternative to `ArgumentCaptor` to assert arguments during verification:

```java
verify(otherServiceMock).doStuff(assertArg(param -> {
    assertThat(param.getField1()).isEqualTo("value1");
    assertThat(param.getField2()).isEqualTo("value2");
}));
```

Verification succeeds as long as no exception is thrown from the lambda passed to `assertArg`, which means it works with any assertions (JUnit, AssertJ, ...).

Since this is my first PR to Mockito, I may have missed something, or perhaps the documentation should be improved. Feedback is very welcome!

<!-- Hey,
Thanks for the contribution, this is awesome.
As you may have read, project members have somehow an opinionated view on what and how should be
Mockito, e.g. we don't want mockito to be a feature bloat.
There may be a thorough review, with feedback -> code change loop.
-->
<!--
If you have a suggestion for this template you can fix it in the .github/PULL_REQUEST_TEMPLATE.md file
-->
## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

