### PR TITLE
Fixes 2972: Weakens visibility constraint

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
@@ -4,7 +4,7 @@
  */
 package org.mockito.internal.creation.bytebuddy;
 
-import static net.bytebuddy.matcher.ElementMatchers.isAccessibleTo;
+import static net.bytebuddy.matcher.ElementMatchers.isVisibleTo;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.isStatic;
 import static net.bytebuddy.matcher.ElementMatchers.not;
@@ -398,7 +398,7 @@ public class MockMethodAdvice extends MockMethodDispatcher {
                                 .getSuperClass()
                                 .asErasure()
                                 .getDeclaredMethods()
-                                .filter(isConstructor().and(isAccessibleTo(instrumentedType)));
+                                .filter(isConstructor().and(isVisibleTo(instrumentedType)));
                 int arguments = Integer.MAX_VALUE;
                 boolean packagePrivate = true;
                 MethodDescription.InDefinedShape current = null;

--- a/src/test/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMakerTest.java
+++ b/src/test/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMakerTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.mockito.Answers;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.creation.MockSettingsImpl;
+import org.mockito.internal.creation.bytebuddy.sample.DifferentPackage;
 import org.mockito.internal.creation.settings.CreationSettings;
 import org.mockito.internal.handler.MockHandlerImpl;
 import org.mockito.internal.stubbing.answers.Returns;
@@ -88,6 +89,22 @@ public class InlineDelegateByteBuddyMockMakerTest
                         settings,
                         new MockHandlerImpl<>(settings),
                         new Outer.Inner(new Object(), new Object()));
+        assertThat(proxy)
+                .hasValueSatisfying(
+                        spy -> {
+                            assertThat(spy.p1).isNotNull();
+                            assertThat(spy.p2).isNotNull();
+                        });
+    }
+
+    @Test
+    public void should_create_mock_from_visible_inner_spy() throws Exception {
+        MockCreationSettings<DifferentPackage> settings = settingsFor(DifferentPackage.class);
+        Optional<DifferentPackage> proxy =
+                mockMaker.createSpy(
+                        settings,
+                        new MockHandlerImpl<>(settings),
+                        new DifferentPackage(new Object(), new Object()));
         assertThat(proxy)
                 .hasValueSatisfying(
                         spy -> {
@@ -667,7 +684,7 @@ public class InlineDelegateByteBuddyMockMakerTest
 
         final Object p1;
 
-        private Outer(final Object p1) {
+        private Outer(Object p1) {
             this.p1 = p1;
         }
 
@@ -675,10 +692,19 @@ public class InlineDelegateByteBuddyMockMakerTest
 
             final Object p2;
 
-            Inner(final Object p1, final Object p2) {
+            Inner(Object p1, Object p2) {
                 super(p1);
                 this.p2 = p2;
             }
+        }
+    }
+
+    public static class SamePackage {
+
+        public final Object p1;
+
+        protected SamePackage(Object p1) {
+            this.p1 = p1;
         }
     }
 }

--- a/src/test/java/org/mockito/internal/creation/bytebuddy/sample/DifferentPackage.java
+++ b/src/test/java/org/mockito/internal/creation/bytebuddy/sample/DifferentPackage.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.creation.bytebuddy.sample;
+
+import org.mockito.internal.creation.bytebuddy.InlineDelegateByteBuddyMockMakerTest;
+
+public class DifferentPackage extends InlineDelegateByteBuddyMockMakerTest.SamePackage {
+
+    public final Object p2;
+
+    public DifferentPackage(Object p1, Object p2) {
+        super(p1);
+        this.p2 = p2;
+    }
+}


### PR DESCRIPTION
Breaks spying on encapsulated objects where a super type in a different package declares only a protected constructor.