### PR TITLE
Fix #2915 Forbid spy on mocked interface

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -10,6 +10,7 @@ import org.mockito.internal.MockitoCore;
 import org.mockito.internal.creation.MockSettingsImpl;
 import org.mockito.internal.framework.DefaultMockitoFramework;
 import org.mockito.internal.session.DefaultMockitoSessionBuilder;
+import org.mockito.internal.util.MockUtil;
 import org.mockito.internal.verification.VerificationModeFactory;
 import org.mockito.invocation.Invocation;
 import org.mockito.invocation.InvocationFactory;
@@ -2167,6 +2168,10 @@ public class Mockito extends ArgumentMatchers {
      * @return a spy of the real object
      */
     public static <T> T spy(T object) {
+        if (MockUtil.isMock(object)) {
+            throw new IllegalArgumentException(
+                    "Please don't pass mock here. Spy is not allowed on mock.");
+        }
         return MOCKITO_CORE.mock(
                 (Class<T>) object.getClass(),
                 withSettings().spiedInstance(object).defaultAnswer(CALLS_REAL_METHODS));

--- a/src/test/java/org/mockitousage/constructor/CreatingMocksWithConstructorTest.java
+++ b/src/test/java/org/mockitousage/constructor/CreatingMocksWithConstructorTest.java
@@ -409,6 +409,18 @@ public class CreatingMocksWithConstructorTest extends TestBase {
         assertEquals("value", testBug.getValue(0));
     }
 
+    @Test
+    public void forbid_spy_on_mock() {
+        try {
+            spy(mock(List.class));
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertThat(e)
+                    .hasMessageContaining(
+                            "Please don't pass mock here. Spy is not allowed on mock.");
+        }
+    }
+
     public abstract class SomeAbstractClass<T> {
 
         protected abstract String getRealValue(T value);


### PR DESCRIPTION
A proposition of implementation for [2915](https://github.com/mockito/mockito/issues/2915) 

I only raise exception for interface since it's working with class. 



