### PR TITLE
Provide a variant of assertArg that works well with checked exceptions 

### DIFF
--- a/src/main/java/org/mockito/ArgumentMatchers.java
+++ b/src/main/java/org/mockito/ArgumentMatchers.java
@@ -940,10 +940,10 @@ public class ArgumentMatchers {
      */
     public static <T> T assertArg(ThrowingConsumer<T> consumer) {
         return argThat(
-            argument -> {
-                consumer.accept(argument);
-                return true;
-            });
+                argument -> {
+                    consumer.accept(argument);
+                    return true;
+                });
     }
 
     /**

--- a/src/main/java/org/mockito/ArgumentMatchers.java
+++ b/src/main/java/org/mockito/ArgumentMatchers.java
@@ -930,6 +930,23 @@ public class ArgumentMatchers {
     }
 
     /**
+     * Allows creating custom argument matchers where matching is considered successful when the consumer given by parameter does not throw an exception.
+     * Consumer is allowed to throw exception other than RuntimeException
+     * <p>
+     * Typically used with {@link Mockito#verify(Object)} to execute assertions on parameters passed to the verified method invocation.
+     *
+     * @param consumer executes assertions on the verified argument
+     * @return <code>null</code>.
+     */
+    public static <T> T assertArg(ThrowingConsumer<T> consumer) {
+        return argThat(
+            argument -> {
+                consumer.accept(argument);
+                return true;
+            });
+    }
+
+    /**
      * Allows creating custom <code>char</code> argument matchers.
      * <p>
      * Note that {@link #argThat} will not work with primitive <code>char</code> matchers due to <code>NullPointerException</code> auto-unboxing caveat.

--- a/src/main/java/org/mockito/ThrowingConsumer.java
+++ b/src/main/java/org/mockito/ThrowingConsumer.java
@@ -6,6 +6,7 @@ package org.mockito;
 
 import java.util.function.Consumer;
 
+@SuppressWarnings("FunctionalInterfaceMethodChanged")
 @FunctionalInterface
 public interface ThrowingConsumer<T> extends Consumer<T> {
     @Override

--- a/src/main/java/org/mockito/ThrowingConsumer.java
+++ b/src/main/java/org/mockito/ThrowingConsumer.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2023 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
 package org.mockito;
 
 import java.util.function.Consumer;

--- a/src/main/java/org/mockito/ThrowingConsumer.java
+++ b/src/main/java/org/mockito/ThrowingConsumer.java
@@ -1,0 +1,19 @@
+package org.mockito;
+
+import java.util.function.Consumer;
+
+@FunctionalInterface
+public interface ThrowingConsumer<T> extends Consumer<T> {
+    @Override
+    default void accept(final T input) {
+        try {
+            acceptThrows(input);
+        } catch (final RuntimeException | AssertionError e) {
+            throw e;
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    void acceptThrows(T input) throws Throwable;
+}

--- a/src/test/java/org/mockitousage/matchers/MatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/MatchersTest.java
@@ -62,7 +62,6 @@ import org.mockito.Mockito;
 import org.mockito.exceptions.verification.WantedButNotInvoked;
 import org.mockito.exceptions.verification.opentest4j.ArgumentsAreDifferent;
 import org.mockitousage.IMethods;
-import org.mockitousage.stubbing.StubbingUsingDoReturnTest;
 import org.mockitoutil.TestBase;
 
 @SuppressWarnings("unchecked")

--- a/src/test/java/org/mockitousage/matchers/MatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/MatchersTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyShort;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.contains;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.endsWith;
 import static org.mockito.Mockito.isA;
 import static org.mockito.Mockito.isNotNull;
@@ -47,6 +48,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -60,6 +62,7 @@ import org.mockito.Mockito;
 import org.mockito.exceptions.verification.WantedButNotInvoked;
 import org.mockito.exceptions.verification.opentest4j.ArgumentsAreDifferent;
 import org.mockitousage.IMethods;
+import org.mockitousage.stubbing.StubbingUsingDoReturnTest;
 import org.mockitoutil.TestBase;
 
 @SuppressWarnings("unchecked")
@@ -647,9 +650,17 @@ public class MatchersTest extends TestBase {
     }
 
     @Test
-    public void assertArg_matcher_fails_when_assertion_fails_with_ioException() throws Exception {
+    public void assertArg_matcher_can_accept_throwing_consumer() throws Exception {
+        mock.oneArg("hello");
+
         try {
-            verify(mock).simpleMethod(assertArg((Object o) -> mock.throwsIOException(0)));
+            verify(mock)
+                    .oneArg(
+                            assertArg(
+                                    (String it) -> {
+                                        assertEquals("not-hello", it);
+                                        doThrow(new IOException()).when(mock).throwsIOException(0);
+                                    }));
             fail("Should throw an exception");
         } catch (ComparisonFailure e) {
             // do nothing
@@ -676,30 +687,6 @@ public class MatchersTest extends TestBase {
 
         try {
             verify(mock).oneArg(assertArg((String it) -> assertEquals("not-hello", it)));
-            fail("Should throw an exception");
-        } catch (ComparisonFailure e) {
-            // do nothing
-        }
-
-        verify(mock).oneArg("hello");
-    }
-
-    @Test
-    public void can_invoke_method_on_mock_after_assert_arg_with_ioException() throws Exception {
-        try {
-            verify(mock).simpleMethod(assertArg((Object o) -> mock.throwsIOException(0)));
-            fail("Should throw an exception");
-        } catch (ComparisonFailure e) {
-            // do nothing
-        }
-
-        mock.oneArg("hello");
-    }
-
-    @Test
-    public void can_verify_on_mock_after_assert_arg_with_ioException() throws Exception {
-        try {
-            verify(mock).simpleMethod(assertArg((Object o) -> mock.throwsIOException(0)));
             fail("Should throw an exception");
         } catch (ComparisonFailure e) {
             // do nothing

--- a/src/test/java/org/mockitousage/matchers/MatchersTest.java
+++ b/src/test/java/org/mockitousage/matchers/MatchersTest.java
@@ -647,6 +647,16 @@ public class MatchersTest extends TestBase {
     }
 
     @Test
+    public void assertArg_matcher_fails_when_assertion_fails_with_ioException() throws Exception {
+        try {
+            verify(mock).simpleMethod(assertArg((Object o) -> mock.throwsIOException(0)));
+            fail("Should throw an exception");
+        } catch (ComparisonFailure e) {
+            // do nothing
+        }
+    }
+
+    @Test
     public void can_invoke_method_on_mock_after_assert_arg() throws Exception {
         mock.oneArg("hello");
 
@@ -666,6 +676,30 @@ public class MatchersTest extends TestBase {
 
         try {
             verify(mock).oneArg(assertArg((String it) -> assertEquals("not-hello", it)));
+            fail("Should throw an exception");
+        } catch (ComparisonFailure e) {
+            // do nothing
+        }
+
+        verify(mock).oneArg("hello");
+    }
+
+    @Test
+    public void can_invoke_method_on_mock_after_assert_arg_with_ioException() throws Exception {
+        try {
+            verify(mock).simpleMethod(assertArg((Object o) -> mock.throwsIOException(0)));
+            fail("Should throw an exception");
+        } catch (ComparisonFailure e) {
+            // do nothing
+        }
+
+        mock.oneArg("hello");
+    }
+
+    @Test
+    public void can_verify_on_mock_after_assert_arg_with_ioException() throws Exception {
+        try {
+            verify(mock).simpleMethod(assertArg((Object o) -> mock.throwsIOException(0)));
             fail("Should throw an exception");
         } catch (ComparisonFailure e) {
             // do nothing


### PR DESCRIPTION
fixes: https://github.com/mockito/mockito/issues/2982

- add new FunctionalInterface `ThrowingConsumer<T> extends Consumer<T>`
- add variant of `assertArg` that takes a `ThrowingConsumer` rather than a `Consumer`

I might be biting more than I can chew here, but here goes. My first PR here and I am very new to the whole open source in general, so feedbacks are most appreciated.

<!-- Hey,
Thanks for the contribution, this is awesome.
As you may have read, project members have somehow an opinionated view on what and how should be
Mockito, e.g. we don't want mockito to be a feature bloat.
There may be a thorough review, with feedback -> code change loop.
-->
<!--
If you have a suggestion for this template you can fix it in the .github/PULL_REQUEST_TEMPLATE.md file
-->
## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

