### PR TITLE
Add a Json Matcher

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,8 @@ dependencies {
 
     compileOnly libraries.junit4, libraries.hamcrest, libraries.opentest4j
     implementation libraries.objenesis
+    implementation 'jakarta.json:jakarta.json-api:2.1.1'
+
 
     testImplementation libraries.assertj
 

--- a/src/main/java/org/mockito/ArgumentMatchers.java
+++ b/src/main/java/org/mockito/ArgumentMatchers.java
@@ -22,6 +22,7 @@ import org.mockito.internal.matchers.Contains;
 import org.mockito.internal.matchers.EndsWith;
 import org.mockito.internal.matchers.Equals;
 import org.mockito.internal.matchers.InstanceOf;
+import org.mockito.internal.matchers.JsonEquals;
 import org.mockito.internal.matchers.Matches;
 import org.mockito.internal.matchers.NotNull;
 import org.mockito.internal.matchers.Null;
@@ -663,6 +664,11 @@ public class ArgumentMatchers {
      */
     public static <T> T refEq(T value, String... excludeFields) {
         reportMatcher(new ReflectionEquals(value, excludeFields));
+        return null;
+    }
+
+    public static String jsonEq(String value) {
+        reportMatcher(new JsonEquals(value));
         return null;
     }
 

--- a/src/main/java/org/mockito/internal/matchers/JsonEquals.java
+++ b/src/main/java/org/mockito/internal/matchers/JsonEquals.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.matchers;
+
+import jakarta.json.Json;
+import jakarta.json.JsonStructure;
+import jakarta.json.stream.JsonGenerator;
+import java.io.IOException;
+import java.io.Serializable;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.Map;
+
+import org.mockito.ArgumentMatcher;
+
+public class JsonEquals implements ArgumentMatcher<String>, Serializable {
+
+    private static final Map<String, Object> OPTIONS = Collections.singletonMap(JsonGenerator.PRETTY_PRINTING, true);
+    private final String value;
+    private final JsonStructure json;
+
+    public JsonEquals(final String value) {
+        if (value == null) throw new IllegalArgumentException("string value is null");
+        this.value = value;
+        this.json = Json.createReader(new StringReader(value)).read();
+    }
+
+    @Override
+    public boolean matches(String arg) {
+        final JsonStructure argJson = Json.createReader(new StringReader(arg)).read();
+
+        return json.equals(argJson);
+    }
+
+    @Override
+    public String toString() {
+        try (final StringWriter writer = new StringWriter()) {
+            Json.createWriterFactory(OPTIONS)
+                .createWriter(writer)
+                .write(json);
+            return writer.toString();
+        } catch (final IOException e) {
+            e.printStackTrace();
+            return value;
+        }
+    }
+}

--- a/src/test/java/org/mockito/internal/matchers/JsonEqualsTest.java
+++ b/src/test/java/org/mockito/internal/matchers/JsonEqualsTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.matchers;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class JsonEqualsTest {
+
+    @Test
+    public void shouldBeEqual() {
+        assertEquals(new JsonEquals("{}"), new JsonEquals("{}"));
+        assertTrue(new JsonEquals("{}").matches("{}"));
+
+        assertEquals(new JsonEquals("{\"firstName\":\"Bill\", \"lastName\":\"Gates\"}"), new JsonEquals("{\"lastName\":\"Gates\", \"firstName\":\"Bill\"}"));
+        assertTrue(new JsonEquals("{\"firstName\":\"Bill\", \"lastName\":\"Gates\"}").matches("{\"lastName\":\"Gates\", \"firstName\":\"Bill\"}"));
+
+        assertEquals(new JsonEquals("[]"), new JsonEquals("[]"));
+        assertTrue(new JsonEquals("[]").matches("[]"));
+    }
+
+}


### PR DESCRIPTION
I find myself needing to create a custom _ArgumentMatcher_ for handling json structures occasionally so thought it may be worth having this available within mockito itself