### PR TITLE
Fix #3005 (and #3006) draft

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -10,6 +10,7 @@ versions.errorprone = '2.19.1'
 
 libraries.junit4 = 'junit:junit:4.13.2'
 libraries.junitJupiterApi = "org.junit.jupiter:junit-jupiter-api:${versions.junitJupiter}"
+libraries.junitJupiterParams = "org.junit.jupiter:junit-jupiter-params:${versions.junitJupiter}"
 libraries.junitPlatformLauncher = 'org.junit.platform:junit-platform-launcher:1.9.3'
 libraries.junitJupiterEngine = "org.junit.jupiter:junit-jupiter-engine:${versions.junitJupiter}"
 libraries.junitVintageEngine = "org.junit.vintage:junit-vintage-engine:${versions.junitJupiter}"

--- a/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
+++ b/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
@@ -7,17 +7,15 @@ package org.mockito.internal.configuration.injection.filter;
 import static org.mockito.internal.exceptions.Reporter.moreThanOneMockCandidate;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.lang.reflect.TypeVariable;
-import java.lang.reflect.WildcardType;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Stream;
+import java.util.Optional;
 
 import org.mockito.internal.util.MockUtil;
+import org.mockito.internal.util.reflection.generic.GenericTypeMatch;
+import org.mockito.mock.MockCreationSettings;
 
 public class TypeBasedCandidateFilter implements MockCandidateFilter {
 
@@ -25,128 +23,6 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
 
     public TypeBasedCandidateFilter(MockCandidateFilter next) {
         this.next = next;
-    }
-
-    protected boolean isCompatibleTypes(Type typeToMock, Type mockType, Field injectMocksField) {
-        boolean result = false;
-        if (typeToMock instanceof ParameterizedType) {
-            if (mockType instanceof ParameterizedType) {
-                // ParameterizedType.equals() is documented as:
-                // "Instances of classes that implement this interface must implement
-                // an equals() method that equates any two instances that share the
-                // same generic type declaration and have equal type parameters."
-                // Unfortunately, e.g. Wildcard parameter "?" doesn't equal java.lang.String,
-                // and e.g. Set doesn't equal TreeSet, so roll our own comparison if
-                // ParameterizedTypeImpl.equals() returns false
-                if (typeToMock.equals(mockType)) {
-                    result = true;
-                } else {
-                    ParameterizedType genericTypeToMock = (ParameterizedType) typeToMock;
-                    ParameterizedType genericMockType = (ParameterizedType) mockType;
-                    Type[] actualTypeArguments = genericTypeToMock.getActualTypeArguments();
-                    Type[] actualTypeArguments2 = genericMockType.getActualTypeArguments();
-                    // Recurse on type parameters, so we properly test whether e.g. Wildcard bounds
-                    // have a match
-                    result =
-                            recurseOnTypeArguments(
-                                    injectMocksField, actualTypeArguments, actualTypeArguments2);
-                }
-            } else {
-                // mockType is a non-parameterized Class, i.e. a concrete class.
-                // so walk concrete class' type hierarchy
-                Class<?> concreteMockClass = (Class<?>) mockType;
-                Stream<Type> mockSuperTypes = getSuperTypes(concreteMockClass);
-                result =
-                        mockSuperTypes.anyMatch(
-                                mockSuperType ->
-                                        isCompatibleTypes(
-                                                typeToMock, mockSuperType, injectMocksField));
-            }
-        } else if (typeToMock instanceof WildcardType) {
-            WildcardType wildcardTypeToMock = (WildcardType) typeToMock;
-            Type[] upperBounds = wildcardTypeToMock.getUpperBounds();
-            result =
-                    Arrays.stream(upperBounds)
-                            .anyMatch(t -> isCompatibleTypes(t, mockType, injectMocksField));
-        } else if (typeToMock instanceof Class && mockType instanceof Class) {
-            result = ((Class<?>) typeToMock).isAssignableFrom((Class<?>) mockType);
-        } // no need to check for GenericArrayType, as Mockito cannot mock this anyway
-
-        return result;
-    }
-
-    private Stream<Type> getSuperTypes(Class<?> concreteMockClass) {
-        Stream<Type> mockInterfaces = Arrays.stream(concreteMockClass.getGenericInterfaces());
-        Type genericSuperclass = concreteMockClass.getGenericSuperclass();
-        // for java.lang.Object, genericSuperclass is null
-        if (genericSuperclass != null) {
-            Stream<Type> mockSuperTypes =
-                    Stream.concat(mockInterfaces, Stream.of(genericSuperclass));
-            return mockSuperTypes;
-        } else {
-            return mockInterfaces;
-        }
-    }
-
-    private boolean recurseOnTypeArguments(
-            Field injectMocksField, Type[] actualTypeArguments, Type[] actualTypeArguments2) {
-        boolean isCompatible = true;
-        for (int i = 0; i < actualTypeArguments.length; i++) {
-            Type actualTypeArgument = actualTypeArguments[i];
-            Type actualTypeArgument2 = actualTypeArguments2[i];
-            if (actualTypeArgument instanceof TypeVariable) {
-                TypeVariable<?> typeVariable = (TypeVariable<?>) actualTypeArgument;
-                // this is a TypeVariable declared by the class under test that turned
-                // up in one of its fields,
-                // e.g. class ClassUnderTest<T1, T2> { List<T1> tList; Set<T2> tSet}
-                // The TypeVariable`s actual type is declared by the field containing
-                // the object under test, i.e. the field annotated with @InjectMocks
-                // e.g. @InjectMocks ClassUnderTest<String, Integer> underTest = ..
-
-                Type genericType = injectMocksField.getGenericType();
-                if (genericType instanceof ParameterizedType) {
-                    Type[] injectMocksFieldTypeParameters =
-                            ((ParameterizedType) genericType).getActualTypeArguments();
-                    // Find index of given TypeVariable where it was defined, e.g. 0 for T1 in
-                    // ClassUnderTest<T1, T2>
-                    // (we're always able to find it, otherwise test class wouldn't have compiled))
-                    TypeVariable<?>[] genericTypeParameters =
-                            injectMocksField.getType().getTypeParameters();
-                    int variableIndex = -1;
-                    for (int i2 = 0; i2 < genericTypeParameters.length; i2++) {
-                        if (genericTypeParameters[i2].equals(typeVariable)) {
-                            variableIndex = i2;
-                            break;
-                        }
-                    }
-                    // now test whether actual type for the type variable is compatible, e.g. for
-                    //   class ClassUnderTest<T1, T2> {..}
-                    // T1 would be the String in
-                    //   ClassUnderTest<String, Integer> underTest = ..
-                    isCompatible &=
-                            isCompatibleTypes(
-                                    injectMocksFieldTypeParameters[variableIndex],
-                                    actualTypeArgument2,
-                                    injectMocksField);
-                } else {
-                    // must be a concrete class, recurse on super types that may have type
-                    // parameters
-                    isCompatible &=
-                            getSuperTypes((Class<?>) genericType)
-                                    .anyMatch(
-                                            superType ->
-                                                    isCompatibleTypes(
-                                                            superType,
-                                                            actualTypeArgument2,
-                                                            injectMocksField));
-                }
-            } else {
-                isCompatible &=
-                        isCompatibleTypes(
-                                actualTypeArgument, actualTypeArgument2, injectMocksField);
-            }
-        }
-        return isCompatible;
     }
 
     @Override
@@ -159,14 +35,28 @@ public class TypeBasedCandidateFilter implements MockCandidateFilter {
         List<Object> mockTypeMatches = new ArrayList<>();
         for (Object mock : mocks) {
             if (candidateFieldToBeInjected.getType().isAssignableFrom(mock.getClass())) {
-                Type mockType = MockUtil.getMockSettings(mock).getGenericTypeToMock();
-                Type typeToMock = candidateFieldToBeInjected.getGenericType();
-                boolean bothHaveTypeInfo = typeToMock != null && mockType != null;
-                if (bothHaveTypeInfo) {
+                MockCreationSettings<?> mockSettings = MockUtil.getMockSettings(mock);
+                Type genericMockType = mockSettings.getGenericTypeToMock();
+                Class<?> rawMockType = mockSettings.getTypeToMock();
+                if (genericMockType != null && rawMockType != null) {
                     // be more specific if generic type information is available
-                    if (isCompatibleTypes(typeToMock, mockType, injectMocksField)) {
-                        mockTypeMatches.add(mock);
-                    } // else filter out mock, as generic types don't match
+                    GenericTypeMatch targetDeclarationTypeMatch = GenericTypeMatch.ofField(injectMocksField);
+                    // we need to populate generic type information from injectMockField to
+                    // candidateFieldToBeInjected by stepping up the type hierarchy
+                    // finding the place where it is declared
+                    Optional<GenericTypeMatch> targetTypeMatch =
+                        targetDeclarationTypeMatch.findDeclaredField(candidateFieldToBeInjected);
+                    if (targetTypeMatch.isPresent()) {
+                        // we lost the field declared with @Mock at this place but use the
+                        // information provided by MockCreationSettings instead
+                        GenericTypeMatch sourceTypeMatch = GenericTypeMatch.ofGenericAndRawType(genericMockType, rawMockType);
+                        // with generic type information collected, try to match mock with candidate
+                        // field
+                        if (targetTypeMatch.get().matches(sourceTypeMatch)) {
+                            mockTypeMatches.add(mock);
+                        }
+                        // else filter out mock, as generic types don't match
+                    }
                 } else {
                     // field is assignable from mock class, but no generic type information
                     // is available (can happen with programmatically created Mocks where no

--- a/src/main/java/org/mockito/internal/util/reflection/generic/GenericTypeHelper.java
+++ b/src/main/java/org/mockito/internal/util/reflection/generic/GenericTypeHelper.java
@@ -1,0 +1,66 @@
+package org.mockito.internal.util.reflection.generic;
+
+import java.lang.reflect.*;
+import java.util.Optional;
+
+public final class GenericTypeHelper {
+
+    private GenericTypeHelper() {}
+
+    public static Class<?> getRawTypeOfType(Type type, VariableResolver resolver) {
+        if (type instanceof Class) {
+            return (Class<?>) type;
+        }
+        else if (type instanceof ParameterizedType) {
+            return (Class<?>) ((ParameterizedType) type).getRawType();
+        }
+        else if (type instanceof TypeVariable && resolver != null) {
+            return getRawTypeOfVariable((TypeVariable<?>) type, resolver);
+        }
+        else if (type instanceof GenericArrayType) {
+            return getRawTypeOfComponentType((GenericArrayType) type, resolver);
+        }
+        else if (type instanceof WildcardType) {
+            return getRawTypeOfWildcard((WildcardType) type, resolver);
+        }
+        else if (type instanceof HasClass) {
+            return ((HasClass)type).getTheClass();
+        }
+        else {
+            return Object.class;
+        }
+    }
+
+    private static Class<?> getRawTypeOfVariable(TypeVariable<?> typeVariable, VariableResolver resolver) {
+        Optional<Type> optionalResolved = resolver.resolve(typeVariable);
+        if (optionalResolved.isPresent()) {
+            Type resolvedType = optionalResolved.get();
+            Class<?> rawType = getRawTypeOfType(resolvedType, resolver);
+            if (Object.class.equals(rawType)) {
+                Type[] upperBounds = typeVariable.getBounds();
+                if (upperBounds.length > 0) {
+                    return getRawTypeOfType(upperBounds[0], resolver);
+                }
+            }
+            return rawType;
+        }
+        else {
+            return Object.class;
+        }
+    }
+
+    private static Class<?> getRawTypeOfComponentType(GenericArrayType genericArrayType, VariableResolver resolver) {
+        Class<?> rawType = getRawTypeOfType(genericArrayType.getGenericComponentType(), resolver);
+        return Array.newInstance(rawType, 0).getClass();
+    }
+
+    private static Class<?> getRawTypeOfWildcard(WildcardType type, VariableResolver resolver) {
+        Type[] upperBounds = type.getUpperBounds();
+        if (upperBounds.length > 0) {
+            return getRawTypeOfType(upperBounds[0], resolver);
+        }
+        else {
+            return Object.class;
+        }
+    }
+}

--- a/src/main/java/org/mockito/internal/util/reflection/generic/GenericTypeMatch.java
+++ b/src/main/java/org/mockito/internal/util/reflection/generic/GenericTypeMatch.java
@@ -1,0 +1,113 @@
+package org.mockito.internal.util.reflection.generic;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+public class GenericTypeMatch {
+
+    private final MatchType matchType;
+    private final VariableResolver resolver;
+
+    private GenericTypeMatch(MatchType matchType, VariableResolver resolver) {
+        this.matchType = matchType;
+        this.resolver = resolver;
+    }
+
+    public boolean matches(GenericTypeMatch other) {
+        return matchType.matches(other.matchType);
+    }
+
+    public static GenericTypeMatch ofField(Field field) {
+        VariableResolver resolver = VariableResolver.ofField(field);
+        MatchType matchType = MatchType.ofClassAndResolver(field.getType(), resolver);
+        return new GenericTypeMatch(matchType, resolver);
+    }
+
+    public static GenericTypeMatch ofGenericAndRawType(Type genericType, Class<?> rawType) {
+        VariableResolver resolver = genericType instanceof ParameterizedType
+            ? VariableResolver.ofParameterizedAndRawType((ParameterizedType) genericType, rawType, null)
+            : VariableResolver.empty();
+        MatchType matchType = MatchType.ofClassAndResolver(rawType, resolver);
+        return new GenericTypeMatch(matchType, resolver);
+    }
+
+    public Optional<GenericTypeMatch> findDeclaredField(Field field) {
+        if (this.matchType instanceof HasClass) {
+            Class<?> clazz = ((HasClass) this.matchType).getTheClass();
+            Class<?> declaringClass = field.getDeclaringClass();
+            if (declaringClass.equals(clazz)) {
+                return createFieldTypeMatch(field);
+            }
+            else {
+                return findAncestor(clazz, declaringClass).flatMap(typeMatch -> typeMatch.createFieldTypeMatch(field));
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Optional<GenericTypeMatch> createFieldTypeMatch(Field field) {
+        if (field.getGenericType() instanceof TypeVariable && this.resolver != null) {
+            Optional<Type> resolved = this.resolver.resolve((TypeVariable<?>) field.getGenericType());
+            if (resolved.isPresent() && resolved.get() instanceof MatchType) {
+                return createFileTypeMatchForVariable((MatchType) resolved.get());
+            }
+        }
+        VariableResolver resolver = VariableResolver.ofFieldAndResolver(field, this.resolver);
+        MatchType matchType = MatchType.ofClassAndResolver(field.getType(), resolver);
+        return Optional.of(new GenericTypeMatch(matchType, resolver));
+    }
+
+    private static Optional<GenericTypeMatch> createFileTypeMatchForVariable(MatchType matchType) {
+        VariableResolver resolver = matchType instanceof MatchParameterizedClass
+            ? ((MatchParameterizedClass) matchType).toResolver()
+            : VariableResolver.empty();
+        return Optional.of(new GenericTypeMatch(matchType, resolver));
+    }
+
+    private Optional<GenericTypeMatch> findAncestor(Class<?> derived, Class<?> declaringClass) {
+        Optional<GenericTypeMatch> optionalTypeMatch = forEachAncestor(derived, (genericType, rawType) ->
+            declaringClass.equals(rawType)
+                ? createAncestorTypeMatch(genericType, rawType)
+                : Optional.empty());
+        if (optionalTypeMatch.isEmpty()) {
+            optionalTypeMatch = forEachAncestor(derived, (genericType, rawType) -> createAncestorTypeMatch(genericType, rawType)
+                .flatMap(typeMatch -> typeMatch.findAncestor(rawType, declaringClass)));
+        }
+        return optionalTypeMatch;
+    }
+
+    private <T> Optional<T> forEachAncestor(Class<?> derived, BiFunction<Type, Class<?>, Optional<T>> mapper) {
+        Class<?> superClass = derived.getSuperclass();
+        if (superClass != null) {
+            Optional<T> result = mapper.apply(derived.getGenericSuperclass(), superClass);
+            if (result.isPresent()) {
+                return result;
+            }
+        }
+        Class<?>[] rawInterfaces = derived.getInterfaces();
+        Type[] genericInterfaces = derived.getGenericInterfaces();
+        for (int i = 0; i < rawInterfaces.length; i++) {
+            Optional<T> result = mapper.apply(genericInterfaces[i], rawInterfaces[i]);
+            if (result.isPresent()) {
+                return result;
+            }
+        }
+        return Optional.empty();
+    }
+
+    Optional<GenericTypeMatch> createAncestorTypeMatch(Type genericAncestorType, Class<?> rawAncectorClass) {
+        VariableResolver resolver;
+        if (genericAncestorType instanceof ParameterizedType) {
+            resolver = VariableResolver.ofParameterizedAndRawType((ParameterizedType) genericAncestorType, rawAncectorClass, this.resolver);
+        }
+        else {
+            resolver = VariableResolver.empty();
+        }
+        MatchType matchType = MatchType.ofClassAndResolver(rawAncectorClass, resolver);
+        return Optional.of(new GenericTypeMatch(matchType, resolver));
+    }
+}

--- a/src/main/java/org/mockito/internal/util/reflection/generic/HasClass.java
+++ b/src/main/java/org/mockito/internal/util/reflection/generic/HasClass.java
@@ -1,0 +1,6 @@
+package org.mockito.internal.util.reflection.generic;
+
+public interface HasClass {
+
+    Class<?> getTheClass();
+}

--- a/src/main/java/org/mockito/internal/util/reflection/generic/MatchArrayClass.java
+++ b/src/main/java/org/mockito/internal/util/reflection/generic/MatchArrayClass.java
@@ -1,0 +1,22 @@
+package org.mockito.internal.util.reflection.generic;
+
+public class MatchArrayClass extends MatchClass {
+
+    private final MatchType componentMatchType;
+
+    protected MatchArrayClass(Class<?> clazz, MatchType componentMatchType) {
+        super(clazz);
+        this.componentMatchType = componentMatchType;
+    }
+
+    @Override
+    public boolean matches(MatchType other) {
+        return super.matches(other) && other instanceof MatchArrayClass
+            && componentMatchType.matches(((MatchArrayClass) other).componentMatchType);
+    }
+
+    static MatchType ofClassAndResolver(Class<?> clazz, VariableResolver resolver) {
+        MatchType componentMatchType = MatchType.ofClassAndResolver(clazz.getComponentType(), resolver);
+        return new MatchArrayClass(clazz, componentMatchType);
+    }
+}

--- a/src/main/java/org/mockito/internal/util/reflection/generic/MatchClass.java
+++ b/src/main/java/org/mockito/internal/util/reflection/generic/MatchClass.java
@@ -1,0 +1,24 @@
+package org.mockito.internal.util.reflection.generic;
+
+public class MatchClass implements MatchType, HasClass {
+
+    private final Class<?> clazz;
+
+    protected MatchClass(Class<?> clazz) {
+        this.clazz = clazz;
+    }
+
+    @Override
+    public boolean matches(MatchType other) {
+        return other instanceof MatchClass && this.clazz.isAssignableFrom(((MatchClass)other).clazz);
+    }
+
+    static MatchType ofClass(Class<?> clazz) {
+        return new MatchClass(clazz);
+    }
+
+    @Override
+    public Class<?> getTheClass() {
+        return clazz;
+    }
+}

--- a/src/main/java/org/mockito/internal/util/reflection/generic/MatchParameterizedClass.java
+++ b/src/main/java/org/mockito/internal/util/reflection/generic/MatchParameterizedClass.java
@@ -1,0 +1,116 @@
+package org.mockito.internal.util.reflection.generic;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.*;
+
+public class MatchParameterizedClass extends MatchClass implements MatchType {
+
+    private final List<Type> resolvedTypes;
+
+    protected MatchParameterizedClass(Class<?> clazz, List<Type> resolvedTypes) {
+        super(clazz);
+        this.resolvedTypes = resolvedTypes;
+    }
+
+    @Override
+    public boolean matches(MatchType other) {
+        return super.matches(other)
+            && (other instanceof MatchParameterizedClass && resolvedTypesMatch((MatchParameterizedClass) other)
+            || matchesSuperTypeOfOther(other));
+    }
+
+    private boolean matchesSuperTypeOfOther(MatchType other) {
+        if (other instanceof HasClass) {
+            Class<?> clazz = ((HasClass) other).getTheClass();
+            Type genericSuperclass = clazz.getGenericSuperclass();
+            if (genericSuperclass instanceof ParameterizedType) {
+                Optional<MatchType> matchTypeSuper = ofParameterizedType((ParameterizedType) genericSuperclass);
+                if (matchTypeSuper.isPresent()) {
+                    return this.matches(matchTypeSuper.get());
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean resolvedTypesMatch(MatchParameterizedClass other) {
+        if (resolvedTypes.equals(other.resolvedTypes)) {
+            return true;
+        }
+        Iterator<Type> targetIterator = this.resolvedTypes.iterator();
+        Iterator<Type> sourceIterator = other.resolvedTypes.iterator();
+        boolean typesMatch = true;
+        while (targetIterator.hasNext() && sourceIterator.hasNext() && typesMatch) {
+            Type nextTarget = targetIterator.next();
+            Type nextSource = sourceIterator.next();
+            if (nextTarget instanceof MatchType && nextSource instanceof MatchType) {
+                typesMatch = ((MatchType) nextTarget).matches((MatchType) nextSource);
+            }
+            else if (nextTarget instanceof MatchWildcard) {
+                typesMatch = ((MatchWildcard) nextTarget).matches(nextSource);
+            }
+            else if (nextSource instanceof MatchWildcard) {
+                typesMatch = ((MatchWildcard) nextSource).targetMatches(nextTarget);
+            }
+            else if (nextTarget instanceof TypeVariable && nextSource instanceof Class) {
+                typesMatch = checkBounds((TypeVariable<?>) nextTarget, (Class<?>) nextSource);
+            }
+            else if (nextTarget instanceof Class && nextSource instanceof Class) {
+                typesMatch = nextTarget.equals(nextSource);
+            }
+            else {
+                typesMatch = false;
+            }
+        }
+        return typesMatch && !targetIterator.hasNext() && !sourceIterator.hasNext();
+    }
+
+    private boolean checkBounds(TypeVariable<?> target, Class<?> source) {
+        Type[] bounds = target.getBounds();
+        if (bounds.length > 0) {
+            boolean success = true;
+            for (Type bound : bounds) {
+                success = bound instanceof Class && ((Class<?>) bound).isAssignableFrom(source);
+                if (!success) {
+                    break;
+                }
+            }
+            return success;
+        }
+        return false;
+    }
+
+    public VariableResolver toResolver() {
+        Map<TypeVariable<?>, Type> argumentMap = new HashMap<>();
+        TypeVariable<? extends Class<?>>[] parameters = this.getTheClass().getTypeParameters();
+        for (int i = 0; i < parameters.length; i++) {
+            TypeVariable<?> parameter = parameters[i];
+            Type resolvedType = this.resolvedTypes.get(i);
+            argumentMap.put(parameter, resolvedType);
+        }
+        return typeVariable -> Optional.of(argumentMap.get(typeVariable));
+    }
+
+    static MatchType ofClassAndResolver(Class<?> clazz, VariableResolver resolver) {
+        TypeVariable<?>[] parameters = clazz.getTypeParameters();
+        List<Type> resolvedTypes = new ArrayList<>(parameters.length);
+        for (TypeVariable<?> parameter : parameters) {
+            Optional<Type> optionalResolved = resolver.resolve(parameter);
+            optionalResolved.ifPresent(resolvedTypes::add);
+        }
+        return new MatchParameterizedClass(clazz, resolvedTypes);
+    }
+
+    static Optional<MatchType> ofParameterizedType(ParameterizedType parameterizedType) {
+        if (parameterizedType.getRawType() instanceof Class<?>) {
+            Type[] typeArguments = parameterizedType.getActualTypeArguments();
+            List<Type> resolvedTypes = Arrays.asList(typeArguments);
+            return Optional.of(new MatchParameterizedClass((Class<?>) parameterizedType.getRawType(), resolvedTypes));
+        }
+        else {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/org/mockito/internal/util/reflection/generic/MatchType.java
+++ b/src/main/java/org/mockito/internal/util/reflection/generic/MatchType.java
@@ -1,0 +1,23 @@
+package org.mockito.internal.util.reflection.generic;
+
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+
+public interface MatchType extends Type {
+
+    boolean matches(MatchType other);
+
+    static MatchType ofClassAndResolver(Class<?> clazz, VariableResolver resolver) {
+        TypeVariable<? extends Class<?>>[] parameters = clazz.getTypeParameters();
+        if (parameters.length > 0) {
+            return MatchParameterizedClass.ofClassAndResolver(clazz, resolver);
+        }
+        else if (clazz.isArray()) {
+            return MatchArrayClass.ofClassAndResolver(clazz, resolver);
+        }
+        else {
+            return MatchClass.ofClass(clazz);
+        }
+    }
+
+}

--- a/src/main/java/org/mockito/internal/util/reflection/generic/MatchWildcard.java
+++ b/src/main/java/org/mockito/internal/util/reflection/generic/MatchWildcard.java
@@ -1,0 +1,84 @@
+package org.mockito.internal.util.reflection.generic;
+
+import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
+
+public class MatchWildcard implements MatchType {
+
+    private final WildcardType wildcard;
+    private final boolean captured;
+
+    protected MatchWildcard(WildcardType wildcard, boolean captured) {
+        this.wildcard = wildcard;
+        this.captured = captured;
+    }
+
+    @Override
+    public boolean matches(MatchType other) {
+        if (!captured && other instanceof MatchWildcard) {
+            MatchWildcard matchWildcardOther = (MatchWildcard) other;
+            Type[] upperBoundsThis = this.wildcard.getUpperBounds();
+            Type[] upperBoundsOther = matchWildcardOther.wildcard.getUpperBounds();
+            if (upperBoundsOther.length == upperBoundsThis.length) {
+                boolean matches = true;
+                for (int i = 0; i < upperBoundsThis.length && matches; i++) {
+                    matches = isUpperBoundAssignableFrom(upperBoundsThis[i], upperBoundsOther[i]);
+                }
+                return matches;
+            }
+            else {
+                return false;
+            }
+        }
+        else {
+            return false;
+        }
+    }
+
+    static MatchType ofWildcardType(WildcardType wildcardType) {
+        return new MatchWildcard(wildcardType, false);
+    }
+
+    MatchType makeCaptured() {
+        return this.captured
+            ? this
+            : new MatchWildcard(wildcard, true);
+    }
+
+    public boolean matches(Type type) {
+        return !captured && testUpperBounds(upperBound -> isUpperBoundAssignableFrom(upperBound, type));
+    }
+
+    public boolean targetMatches(Type targetType) {
+        return testUpperBounds(upperBound -> isUpperBoundAssignableTo(upperBound, targetType));
+    }
+
+    private boolean testUpperBounds(Predicate<Type> predicate) {
+        boolean success = true;
+        for (Type upperBound : wildcard.getUpperBounds()) {
+            success = predicate.test(upperBound);
+            if (!success) {
+                break;
+            }
+        }
+        return success;
+    }
+
+    private static boolean isUpperBoundAssignableFrom(Type upperBound, Type type) {
+        return testClassTypes(upperBound, type, Class::isAssignableFrom);
+    }
+
+    private static boolean isUpperBoundAssignableTo(Type upperBound, Type type) {
+        return testClassTypes(upperBound, type, reverse(Class::isAssignableFrom));
+    }
+
+    private static boolean testClassTypes(Type upperBound, Type type, BiPredicate<Class<?>, Class<?>> biPredicate) {
+        return upperBound instanceof Class && type instanceof Class && biPredicate.test((Class<?>) upperBound, (Class<?>) type);
+    }
+
+    private static <T> BiPredicate<T, T> reverse(BiPredicate<T, T> biPredicate) {
+        return (t1, t2) -> biPredicate.test(t2, t1);
+    }
+}

--- a/src/main/java/org/mockito/internal/util/reflection/generic/VariableResolver.java
+++ b/src/main/java/org/mockito/internal/util/reflection/generic/VariableResolver.java
@@ -1,0 +1,126 @@
+package org.mockito.internal.util.reflection.generic;
+
+import java.lang.reflect.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public interface VariableResolver {
+
+    Optional<Type> resolve(TypeVariable<?> variable);
+
+    default boolean isEmpty() {
+        return false;
+    }
+
+    static VariableResolver ofField(Field field) {
+        return Factory.ofField(field);
+    }
+
+    static VariableResolver ofFieldAndResolver(Field field, VariableResolver remapResolver) {
+        return Factory.ofFieldAndResolver(field, remapResolver);
+    }
+
+    static VariableResolver ofParameterizedAndRawType(ParameterizedType parameterizedType, Class<?> rawType, VariableResolver remapResolver) {
+        return Factory.ofParameterizedAndRawType(parameterizedType, rawType, remapResolver);
+    }
+
+    static VariableResolver empty() {
+        return Factory.empty();
+    }
+
+    class Factory {
+
+        public static final VariableResolver EMPTY_RESOLVER = new VariableResolver() {
+            @Override
+            public Optional<Type> resolve(TypeVariable<?> variable) {
+                return Optional.empty();
+            }
+
+            @Override
+            public boolean isEmpty() {
+                return true;
+            }
+        };
+
+        private static VariableResolver ofField(Field field) {
+            return ofFieldAndResolver(field, null);
+        }
+
+        private static VariableResolver ofFieldAndResolver(Field field, VariableResolver remapResolver) {
+            return ofGenericAndRawType(field.getGenericType(), field.getType(), remapResolver);
+        }
+
+        private static VariableResolver ofGenericAndRawType(Type genericType, Class<?> rawType, VariableResolver remapResolver) {
+            if (genericType instanceof ParameterizedType) {
+                return ofParameterizedAndRawType((ParameterizedType) genericType, rawType, remapResolver);
+            }
+            else if (genericType instanceof GenericArrayType && rawType.isArray()) {
+                return ofGenericAndRawType(
+                    ((GenericArrayType) genericType).getGenericComponentType(),
+                    rawType.getComponentType(),
+                    remapResolver);
+            }
+            else {
+                return empty();
+            }
+        }
+
+        private static VariableResolver ofParameterizedAndRawType(ParameterizedType parameterizedType,
+                                                                  Class<?> rawType,
+                                                                  VariableResolver remapResolver) {
+            TypeVariable<?>[] parameters = rawType.getTypeParameters();
+            Type[] arguments = parameterizedType.getActualTypeArguments();
+            Map<TypeVariable<?>, Type> typeOfArguments = new HashMap<>();
+            for (int i = 0; i < parameters.length; i++) {
+                TypeVariable<?> parameter = parameters[i];
+                Type argument = arguments[i];
+                typeOfArguments.put(parameter, argument);
+            }
+            remap(typeOfArguments, remapResolver);
+            return variable -> Optional.ofNullable(typeOfArguments.get(variable));
+        }
+
+        private static void remap(Map<TypeVariable<?>, Type> typeOfArguments, VariableResolver remapResolver) {
+            for (Map.Entry<TypeVariable<?>, Type> entry : typeOfArguments.entrySet()) {
+                TypeVariable<?> key = entry.getKey();
+                Type value = entry.getValue();
+                Type replacement = null;
+                if (value instanceof WildcardType) {
+                    replacement = MatchWildcard.ofWildcardType((WildcardType) value);
+                }
+                else if (value instanceof TypeVariable && remapResolver != null) {
+                    Optional<Type> optReplacement = remapResolver.resolve((TypeVariable<?>) value);
+                    if (optReplacement.isPresent()) {
+                        replacement = optReplacement.get();
+                        if (replacement instanceof MatchWildcard) {
+                            replacement = ((MatchWildcard) replacement).makeCaptured();
+                        }
+                    }
+                }
+                else if (value instanceof ParameterizedType) {
+                    ParameterizedType parameterizedType = (ParameterizedType) value;
+                    if (remapResolver != null && !remapResolver.isEmpty() && parameterizedType.getRawType() instanceof Class) {
+                        replacement = MatchParameterizedClass.ofClassAndResolver((Class<?>) parameterizedType.getRawType(), remapResolver);
+                    }
+                    else {
+                        Optional<MatchType> optMatchType = MatchParameterizedClass.ofParameterizedType(parameterizedType);
+                        if (optMatchType.isPresent()) {
+                            replacement = optMatchType.get();
+                        }
+                    }
+                }
+                else if (value instanceof GenericArrayType) {
+                    replacement = GenericTypeHelper.getRawTypeOfType(value, remapResolver);
+                }
+                if (replacement != null) {
+                    typeOfArguments.put(key, replacement);
+                }
+            }
+        }
+
+        private static VariableResolver empty() {
+            return EMPTY_RESOLVER;
+        }
+    }
+}

--- a/subprojects/junit-jupiter/junit-jupiter.gradle
+++ b/subprojects/junit-jupiter/junit-jupiter.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation libraries.junitJupiterApi
     testImplementation libraries.assertj
     testImplementation libraries.junitPlatformLauncher
+    testImplementation libraries.junitJupiterParams
     testRuntimeOnly libraries.junitJupiterEngine
 }
 

--- a/subprojects/junit-jupiter/src/test/java/org/mockito/internal/util/reflection/generic/GenericTypeMatchTest.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockito/internal/util/reflection/generic/GenericTypeMatchTest.java
@@ -1,0 +1,417 @@
+package org.mockito.internal.util.reflection.generic;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("unused")
+public class GenericTypeMatchTest {
+
+    public static final String STATIC_CLASS_PREFIX = GenericTypeMatchTest.class.getName() + "$";
+
+    @Nested
+    public class SimpleTypesTest {
+
+        private Integer integer;
+        private Number number;
+        private String string;
+
+        @ParameterizedTest
+        @CsvSource({
+            "integer  ,integer  ,true",
+            "integer  ,number   ,true",
+            "number   ,integer  ,false",
+            "integer  ,string   ,false",
+            "string   ,integer  ,false"
+        })
+        public void testSimpleTypes(String sourceFieldName, String targetFieldName, boolean matches) throws NoSuchFieldException {
+            Field sourceField = SimpleTypesTest.class.getDeclaredField(sourceFieldName);
+            Field targetField = SimpleTypesTest.class.getDeclaredField(targetFieldName);
+            GenericTypeMatch sourceMatch = GenericTypeMatch.ofField(sourceField);
+            GenericTypeMatch targetMatch = GenericTypeMatch.ofField(targetField);
+            assertEquals(matches, targetMatch.matches(sourceMatch));
+        }
+
+    }
+
+    @Nested
+    public class ParameterizedTypesTest {
+
+        private List<Integer> integerList;
+        private Collection<Integer> integerCollection;
+        private List<String> stringList;
+        private List<?> wildcardList;
+        private List<? extends Integer> wildcardListInteger;
+        private Map<String, Integer> mapStringInteger;
+        private Map<?, ?> wildcardMap;
+        private Map<? extends String, ? extends Number> wildcardMapStringNumber;
+
+        @ParameterizedTest
+        @CsvSource({
+            "integerList          ,integerList          ,true",
+            "integerList          ,integerCollection    ,true",
+            "integerCollection    ,integerList          ,false",
+            "integerList          ,stringList           ,false",
+            "stringList           ,integerList          ,false",
+
+            "stringList           ,wildcardList         ,true",
+            "wildcardList         ,stringList           ,false",
+            "wildcardList         ,wildcardList         ,true",
+            "wildcardListInteger  ,integerList          ,true",
+            "wildcardListInteger  ,stringList           ,false",
+            "wildcardListInteger  ,wildcardListInteger  ,true",
+            "wildcardListInteger  ,wildcardList         ,true",
+            "wildcardList         ,wildcardListInteger  ,false",
+
+            "mapStringInteger         ,mapStringInteger         ,true",
+            "wildcardMap              ,mapStringInteger         ,false",
+            "wildcardMapStringNumber  ,mapStringInteger         ,false",
+            "mapStringInteger         ,wildcardMap              ,true",
+            "wildcardMap              ,wildcardMap              ,true",
+            "wildcardMapStringNumber  ,wildcardMap              ,true",
+            "mapStringInteger         ,wildcardMapStringNumber  ,true",
+            "wildcardMapStringNumber  ,wildcardMapStringNumber  ,true",
+            "wildcardMap              ,wildcardMapStringNumber  ,false",
+        })
+        public void testParameterizedTypes(String sourceFieldName, String targetFieldName, boolean matches) throws NoSuchFieldException {
+            Field sourceField = ParameterizedTypesTest.class.getDeclaredField(sourceFieldName);
+            Field targetField = ParameterizedTypesTest.class.getDeclaredField(targetFieldName);
+            GenericTypeMatch sourceMatch = GenericTypeMatch.ofField(sourceField);
+            GenericTypeMatch targetMatch = GenericTypeMatch.ofField(targetField);
+            assertEquals(matches, targetMatch.matches(sourceMatch));
+        }
+    }
+
+    @Nested
+    public class ArrayTypesTest {
+
+        private Integer[] integerArray;
+        private String[] stringArray;
+        private Object[] objectArray;
+
+        @ParameterizedTest
+        @CsvSource({
+            "integerArray  ,integerArray  ,true",
+            "stringArray   ,integerArray  ,false",
+            "objectArray   ,integerArray  ,false",
+            "stringArray   ,stringArray   ,true",
+            "integerArray  ,stringArray   ,false",
+            "objectArray   ,stringArray   ,false",
+            "objectArray   ,objectArray   ,true",
+            "stringArray   ,objectArray   ,true",
+            "integerArray  ,objectArray   ,true",
+        })
+        public void testArrayTypes(String sourceFieldName, String targetFieldName, boolean matches) throws NoSuchFieldException {
+            Field sourceField = ArrayTypesTest.class.getDeclaredField(sourceFieldName);
+            Field targetField = ArrayTypesTest.class.getDeclaredField(targetFieldName);
+            GenericTypeMatch sourceMatch = GenericTypeMatch.ofField(sourceField);
+            GenericTypeMatch targetMatch = GenericTypeMatch.ofField(targetField);
+            assertEquals(matches, targetMatch.matches(sourceMatch));
+        }
+    }
+
+    static class CollectionBox<T> {
+        private Collection<T> collection;
+    }
+
+    static class SubOfBox<S> extends CollectionBox<S> {}
+
+    static class ConcreteSubOfBox extends CollectionBox<Integer> {}
+
+    static class SubOfSubOfBox<S> extends SubOfBox<S> {}
+
+    static class SubOfConcrete extends ConcreteSubOfBox {}
+
+    static abstract class Change {}
+
+    static class ChangeCollection<T extends Change> {
+        private List<T> changes;
+    }
+
+    @Nested
+    public class NestedFieldTest {
+
+        private CollectionBox<Integer> integerCollectionBox;
+        private CollectionBox<String> stringCollectionBox;
+        private CollectionBox<?> wildcardCollectionBox;
+        @SuppressWarnings("rawtypes")
+        private CollectionBox rawCollectionBox;
+
+        private SubOfBox<Integer> integerSubOfBox;
+        private SubOfBox<String> stringSubOfBox;
+        private SubOfBox<?> wildcardSubOfBox;
+
+        private ConcreteSubOfBox concreteSubOfBox;
+        private SubOfConcrete subOfConcrete;
+
+        private SubOfSubOfBox<Integer> integerSubOfSubOfBox;
+        private SubOfSubOfBox<String> stringSubOfSubOfBox;
+
+        @SuppressWarnings("rawtypes")
+        private ChangeCollection changesTargetRaw;
+
+        private List<Integer> integerList;
+        private List<String> stringList;
+        private Collection<?> wildcardCollection;
+
+        private List<Change> changeList;
+
+        @ParameterizedTest
+        @CsvSource({
+            "integerList         ,integerCollectionBox   ,CollectionBox  ,collection  ,true",
+            "integerList         ,stringCollectionBox    ,CollectionBox  ,collection  ,false",
+            "integerList         ,wildcardCollectionBox  ,CollectionBox  ,collection  ,false",
+            "wildcardCollection  ,wildcardCollectionBox  ,CollectionBox  ,collection  ,false",
+
+            "integerList         ,integerSubOfBox        ,CollectionBox  ,collection  ,true",
+            "integerList         ,stringSubOfBox         ,CollectionBox  ,collection  ,false",
+            "integerList         ,wildcardSubOfBox       ,CollectionBox  ,collection  ,false",
+            "wildcardCollection  ,wildcardSubOfBox       ,CollectionBox  ,collection  ,false",
+
+            "integerList         ,concreteSubOfBox       ,CollectionBox  ,collection  ,true",
+            "stringList          ,concreteSubOfBox       ,CollectionBox  ,collection  ,false",
+            "integerList         ,subOfConcrete          ,CollectionBox  ,collection  ,true",
+
+            "integerList         ,integerSubOfSubOfBox   ,CollectionBox  ,collection  ,true",
+            "integerList         ,stringSubOfSubOfBox    ,CollectionBox  ,collection  ,false",
+
+            "integerList         ,rawCollectionBox       ,CollectionBox  ,collection  ,true",
+            "stringList          ,rawCollectionBox       ,CollectionBox  ,collection  ,true",
+
+            "changeList          ,changesTargetRaw       ,ChangeCollection  ,changes  ,true",
+            "integerList         ,changesTargetRaw       ,ChangeCollection  ,changes  ,false",
+        })
+        public void testNestedFields(String sourceFieldName,
+                                     String containingFieldName,
+                                     String targetClassName,
+                                     String targetFieldName,
+                                     boolean matches) throws NoSuchFieldException, ClassNotFoundException {
+            Field sourceField = NestedFieldTest.class.getDeclaredField(sourceFieldName);
+            Field containingField = NestedFieldTest.class.getDeclaredField(containingFieldName);
+            String className = STATIC_CLASS_PREFIX + targetClassName;
+            Class<?> targetClass = Class.forName(className);
+            Field targetField = targetClass.getDeclaredField(targetFieldName);
+            GenericTypeMatch sourceMatch = GenericTypeMatch.ofField(sourceField);
+            GenericTypeMatch containingMatch = GenericTypeMatch.ofField(containingField);
+            Optional<GenericTypeMatch> optTargetMatch = containingMatch.findDeclaredField(targetField);
+            assertTrue(optTargetMatch.isPresent());
+            assertEquals(matches, optTargetMatch.get().matches(sourceMatch));
+        }
+    }
+
+    static class Box<X> {}
+
+    static class WithBox<T> {
+        Box<T> box;
+    }
+
+    static class WithBoxArray<T> {
+        Box<T>[] boxArray;
+    }
+
+    static class WithArrayBox<T> {
+        Box<T[]> arrayBox;
+    }
+
+    static class WithBoxArrayTwoDim<T> {
+        private Box<T>[][] boxArrayTwoDim;
+    }
+
+    static class ArgToArray<T> extends WithBox<T[]> {}
+    static class ArgToArrayTwoDim<T> extends WithBox<T[][]> {}
+    static class ArgToArrayWithArray<T> extends WithBoxArray<T[]> {}
+
+    @Nested
+    public class GenericArrayTypesTest {
+
+        private WithBoxArray<String> withStringBoxArray;
+        private WithBoxArrayTwoDim<String> withStringBoxArrayTwoDim;
+        private WithArrayBox<String> withStringArrayBox;
+        private ArgToArray<String> stringArgToArray;
+        private ArgToArrayTwoDim<String> stringArgToArrayTwoDim;
+        private ArgToArrayWithArray<String> stringArgToArrayWithArray;
+        private ArgToArray<?> wildcardArgToArray;
+
+        private Box<String>[] stringBoxArray;
+        private Box<Integer>[] integerBoxArray;
+        private Box<String>[][] stringBoxArrayTwoDim;
+        private Box<Integer>[][] integerBoxArrayTwoDim;
+        private Box<String[]> stringArrayBox;
+        private Box<Integer[]> integerArrayBox;
+        private Box<String[][]> stringArrayBoxTwoDim;
+        private Box<String[]>[] stringArrayBoxArray;
+        private Box<?> wildcardBox;
+
+        @ParameterizedTest
+        @CsvSource({
+            "stringBoxArray         ,withStringBoxArray         ,WithBoxArray        ,boxArray        ,true",
+            "integerBoxArray        ,withStringBoxArray         ,WithBoxArray        ,boxArray        ,false",
+            "stringBoxArrayTwoDim   ,withStringBoxArray         ,WithBoxArray        ,boxArray        ,false",
+
+            "stringBoxArrayTwoDim   ,withStringBoxArrayTwoDim   ,WithBoxArrayTwoDim  ,boxArrayTwoDim  ,true",
+            "integerBoxArrayTwoDim  ,withStringBoxArrayTwoDim   ,WithBoxArrayTwoDim  ,boxArrayTwoDim  ,false",
+            "stringBoxArray         ,withStringBoxArrayTwoDim   ,WithBoxArrayTwoDim  ,boxArrayTwoDim  ,false",
+
+            "stringArrayBox         ,stringArgToArray           ,WithBox             ,box             ,true",
+            "integerArrayBox        ,stringArgToArray           ,WithBox             ,box             ,false",
+            "wildcardBox            ,stringArgToArray           ,WithBox             ,box             ,false",
+            "stringArrayBox         ,wildcardArgToArray         ,WithBox             ,box             ,false",
+            "integerArrayBox        ,wildcardArgToArray         ,WithBox             ,box             ,false",
+            "wildcardBox            ,wildcardArgToArray         ,WithBox             ,box             ,false",
+            "stringArrayBoxTwoDim   ,stringArgToArrayTwoDim     ,WithBox             ,box             ,true",
+            "stringArrayBox         ,stringArgToArrayTwoDim     ,WithBox             ,box             ,false",
+
+            "stringArrayBox         ,withStringArrayBox         ,WithArrayBox        ,arrayBox        ,true",
+            "integerArrayBox        ,withStringArrayBox         ,WithArrayBox        ,arrayBox        ,false",
+
+            "stringArrayBoxArray    ,stringArgToArrayWithArray  ,WithBoxArray        ,boxArray        ,true",
+            "stringArrayBox         ,stringArgToArrayWithArray  ,WithBoxArray        ,boxArray        ,false",
+            "stringBoxArray         ,stringArgToArrayWithArray  ,WithBoxArray        ,boxArray        ,false",
+        })
+        public void testGenericArrayTypes(String sourceFieldName,
+                                          String containingFieldName,
+                                          String targetClassName,
+                                          String targetFieldName,
+                                          boolean matches) throws NoSuchFieldException, ClassNotFoundException {
+            Field sourceField = GenericArrayTypesTest.class.getDeclaredField(sourceFieldName);
+            Field containingField = GenericArrayTypesTest.class.getDeclaredField(containingFieldName);
+            String className = STATIC_CLASS_PREFIX + targetClassName;
+            Class<?> targetClass = Class.forName(className);
+            Field targetField = targetClass.getDeclaredField(targetFieldName);
+            GenericTypeMatch sourceMatch = GenericTypeMatch.ofField(sourceField);
+            GenericTypeMatch containingMatch = GenericTypeMatch.ofField(containingField);
+            Optional<GenericTypeMatch> optTargetMatch = containingMatch.findDeclaredField(targetField);
+            assertTrue(optTargetMatch.isPresent());
+            assertEquals(matches, optTargetMatch.get().matches(sourceMatch));
+        }
+    }
+
+    interface Interface0<P0> {
+        P0 getParamInterface0();
+    }
+
+    interface Interface1<P1, P2 extends Interface1<P1, P2>> extends Interface0<P2> {
+        @Override
+        P2 getParamInterface0();
+        P1 getParamInterface1();
+    }
+
+    interface Interface2<P3 extends Interface2<P3, P4>, P4> extends Interface1<P4, P3> {}
+
+    interface Interface3<P5 extends Interface3<P5, P6, P7>, P6 extends Interface1<P7, P6> & Interface2<P6, P7>, P7>
+        extends Interface1<P7, P6>, Interface2<P6, P7> {
+        @Override
+        P6 getParamInterface0();
+        @Override
+        P7 getParamInterface1();
+        P5 getParamInterface3();
+    }
+
+    interface Interface4<P8 extends Interface4<P8>> extends Interface3<P8, P8, P8>, Interface1<P8, P8> {
+        @Override
+        P8 getParamInterface0();
+    }
+
+    static class Usage1 implements Interface4<Usage1> {
+        private final Usage1 usage1Field = this;
+        @Override
+        public Usage1 getParamInterface0() {
+            return usage1Field;
+        }
+
+        @Override
+        public Usage1 getParamInterface1() {
+            return usage1Field;
+        }
+
+        @Override
+        public Usage1 getParamInterface3() {
+            return usage1Field;
+        }
+    }
+
+    static class Usage2<T> implements Interface4<Usage2<T>> {
+        private final Usage2<T> usage2Field = this;
+        @Override
+        public Usage2<T> getParamInterface0() {
+            return usage2Field;
+        }
+        @Override
+        public Usage2<T> getParamInterface1() {
+            return usage2Field;
+        }
+
+        @Override
+        public Usage2<T> getParamInterface3() {
+            return usage2Field;
+        }
+    }
+
+    static class Usage3<T extends Usage3<T, U, V>, U extends T, V> implements Interface3<T, U, V> {
+        private T usage3FieldT;
+        private U usage3FieldU;
+        private V usage3FieldV;
+        @Override
+        public U getParamInterface0() {
+            return usage3FieldU;
+        }
+        @Override
+        public V getParamInterface1() {
+            return usage3FieldV;
+        }
+        @Override
+        public T getParamInterface3() {
+            return usage3FieldU;
+        }
+    }
+
+    static class Usage4<T> extends Usage3<Usage4<T>, Usage4<T>, Usage1> {}
+
+    @Nested
+    public class ExtensiveGenericsTest {
+
+        private final Usage1 usage1 = new Usage1();
+        private final Usage2<String> usage2 = new Usage2<>();
+        private final Usage2<Integer> usage2Invalid = new Usage2<>();
+        private final Usage4<String> usage4 = new Usage4<>();
+        private final Usage4<Integer> usage4Invalid = new Usage4<>();
+
+        @ParameterizedTest
+        @CsvSource({
+            "usage1  ,usage1         ,base   ,usage1Field   ,true",
+            "usage2  ,usage2         ,base   ,usage2Field   ,true",
+            "usage2  ,usage2Invalid  ,base   ,usage2Field   ,false",
+            "usage4  ,usage4         ,super  ,usage3FieldT  ,true",
+            "usage4  ,usage4         ,super  ,usage3FieldU  ,true",
+            "usage1  ,usage4         ,super  ,usage3FieldV  ,true",
+            "usage4  ,usage4Invalid  ,super  ,usage3FieldT  ,false",
+            "usage4  ,usage4Invalid  ,super  ,usage3FieldU  ,false",
+            "usage1  ,usage4Invalid  ,super  ,usage3FieldV  ,true",
+        })
+        public void textExtensiveGenerics(String sourceFieldName,
+                                          String targetInstanceName,
+                                          String fieldOfBaseOrSuper,
+                                          String targetFieldName,
+                                          boolean expectedMatch) throws ReflectiveOperationException {
+            Field sourceField = ExtensiveGenericsTest.class.getDeclaredField(sourceFieldName);
+            Field containingField = ExtensiveGenericsTest.class.getDeclaredField(targetInstanceName);
+            Field targetField = "base".equals(fieldOfBaseOrSuper)
+                ? containingField.getType().getDeclaredField(targetFieldName)
+                : containingField.getType().getSuperclass().getDeclaredField(targetFieldName);
+            GenericTypeMatch sourceMatch = GenericTypeMatch.ofField(sourceField);
+            GenericTypeMatch containingMatch = GenericTypeMatch.ofField(containingField);
+            Optional<GenericTypeMatch> optTargetMatch = containingMatch.findDeclaredField(targetField);
+            assertTrue(optTargetMatch.isPresent());
+            assertEquals(expectedMatch, optTargetMatch.get().matches(sourceMatch));
+        }
+    }
+}

--- a/subprojects/junit-jupiter/src/test/java/org/mockitousage/GenericTypeMockTest.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockitousage/GenericTypeMockTest.java
@@ -5,10 +5,7 @@
 
 package org.mockitousage;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.MockitoAnnotations.*;
 
 import java.sql.Time;
@@ -28,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.internal.util.MockUtil;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
@@ -371,6 +369,39 @@ public class GenericTypeMockTest {
             assertSame(innerList, spiedImpl.changes);
         }
 
+    }
+
+    static class Regression3005Classes {
+
+        static class AbstractJob<A extends AbstractJob<A>> {
+            JobInstance<A> instance;
+        }
+
+        static class JobInstance<J extends AbstractJob<J>> {}
+
+        static class ConcreteJob extends AbstractJob<ConcreteJob> {}
+    }
+
+    /**
+     * Verify regression https://github.com/mockito/mockito/issues/3005 is fixed.
+     */
+    @Nested
+    public class RegressionClassCastExceptionWithWildcards {
+
+        @InjectMocks
+        protected Regression3005Classes.ConcreteJob job;
+        @Mock
+        Regression3005Classes.JobInstance<?> instance;
+
+        @Test
+        public void testNoClassCastException() {
+            assertNotNull(job);
+            assertNotNull(instance);
+            assertTrue(MockUtil.isMock(instance));
+            // instance cannot (or should not) be assigned to job.instance according to compiler:
+            // Incompatible types. Found: 'JobInstance<capture<?>>', required: 'JobInstance<ConcreteJob>'
+            assertNull(job.instance);
+        }
     }
 }
 

--- a/subprojects/junit-jupiter/src/test/java/org/mockitousage/GenericTypeMockTest.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockitousage/GenericTypeMockTest.java
@@ -403,5 +403,44 @@ public class GenericTypeMockTest {
             assertNull(job.instance);
         }
     }
+
+    static class Regression3006Classes {
+
+        interface JobData {}
+
+        static class AbstractJob<D extends JobData, A extends AbstractJob<D, A>> {
+            JobInstance<D,A> instance;
+        }
+
+        static class JobInstance<D extends JobData, J extends AbstractJob<D, J>> {}
+
+        static class ConcreteJob<D extends JobData> extends AbstractJob<D,ConcreteJob<D>> {}
+    }
+
+    /**
+     * Verify regression https://github.com/mockito/mockito/issues/3006 is fixed.
+     */
+    @Nested
+    public class Regression3006ArrayIndexOutOfBounds {
+
+        @InjectMocks
+        protected Regression3006Classes.ConcreteJob<Regression3006Classes.JobData> job;
+
+        @Mock
+        Regression3006Classes.JobInstance<
+            Regression3006Classes.JobData,
+            Regression3006Classes.ConcreteJob<Regression3006Classes.JobData>
+            > instance;
+
+        @Test
+        public void testMockExistsAndUsed() {
+            assertNotNull(job);
+            assertNotNull(instance);
+            assertTrue(MockUtil.isMock(instance));
+            // compiler allows job.instance = instance, and so does @InjectMocks
+            assertEquals(instance, job.instance);
+        }
+    }
+
 }
 

--- a/subprojects/junit-jupiter/src/test/java/org/mockitousage/GenericTypeMockTest.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockitousage/GenericTypeMockTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.internal.util.MockUtil;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -439,6 +440,57 @@ public class GenericTypeMockTest {
             assertTrue(MockUtil.isMock(instance));
             // compiler allows job.instance = instance, and so does @InjectMocks
             assertEquals(instance, job.instance);
+        }
+    }
+
+    static class Regression3019Classes {
+
+        static class Something {}
+
+        static class ParameterizedInjectedObject<T extends Something> {
+            public void init() {}
+        }
+
+        static class AbstractGenericClass<T extends Something> {
+
+            ParameterizedInjectedObject<T> object;
+
+            public void init() {
+                object.init();
+            }
+        }
+
+        static class EntryPoint extends AbstractGenericClass<Something> {
+
+            @Override
+            public void init() {
+                super.init();
+                // do other things ...
+            }
+        }
+    }
+
+    /**
+     * Verify regression https://github.com/mockito/mockito/issues/3019 is fixed.
+     */
+    @Nested
+    public class Regression3019MissingInjection {
+
+        @Mock
+        private Regression3019Classes.ParameterizedInjectedObject<Regression3019Classes.Something> injected;
+
+        @InjectMocks
+        private Regression3019Classes.EntryPoint subject;
+
+        @Test
+        public void testSuccessfullyInjected() {
+            assertNotNull(injected);
+            assertTrue(MockUtil.isMock(injected));
+            assertNotNull(subject);
+            assertNotNull(subject.object);
+            // test it does not throw NPE
+            subject.init();
+            Mockito.verify(injected).init();
         }
     }
 

--- a/subprojects/junit-jupiter/src/test/java/org/mockitousage/regression/Regression3000Test.java
+++ b/subprojects/junit-jupiter/src/test/java/org/mockitousage/regression/Regression3000Test.java
@@ -1,0 +1,84 @@
+package org.mockitousage.regression;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SuppressWarnings({ "unused", "rawtypes" })
+public class Regression3000Test {
+
+    @Target(ElementType.TYPE)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Dependent {
+    }
+
+    @Target(ElementType.FIELD)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Inject {
+    }
+
+    public interface Instance<T> {
+        T get();
+    }
+
+    public interface ObjectMapper {
+    }
+
+    public interface EntityManager {
+    }
+
+    public interface Storable<T> {
+    }
+
+    public interface StorageMessage {
+    }
+
+    public interface AbstractEntityController<T, U> {
+    }
+
+    public static class MessageControllerBase<T extends StorageMessage, U extends Storable> {
+    }
+
+    @Dependent
+    public static class StorageMessageBaseController extends MessageControllerBase<StorageMessage, Storable> {
+
+        @Inject
+        Instance<AbstractEntityController<? extends Storable, ?>> controllerInstance;
+        @Inject
+        Instance<Storable<?>> storableInstance;
+        @Inject
+        ObjectMapper objectMapper;
+    }
+
+    @Mock
+    Instance<Storable<?>> storableInstance;
+    @Mock
+    EntityManager em;
+    @Spy
+    @InjectMocks
+    StorageMessageBaseController testee;
+
+    /**
+     * Verify regression <a href="https://github.com/mockito/mockito/issues/3000">issue #3000</a> is fixed.
+     */
+    @Test
+    public void testNoArrayIndexOutOfBoundsExceptionAndMockInjected() {
+        assertNotNull(testee);
+        assertNotNull(testee.storableInstance);
+        assertEquals(storableInstance, testee.storableInstance);
+    }
+}


### PR DESCRIPTION
<!-- Hey,
Thanks for the contribution, this is awesome.
As you may have read, project members have somehow an opinionated view on what and how should be
Mockito, e.g. we don't want mockito to be a feature bloat.
There may be a thorough review, with feedback -> code change loop.
-->
<!--
If you have a suggestion for this template you can fix it in the .github/PULL_REQUEST_TEMPLATE.md file
-->
Hello @TimvdLippe ,

this is an early preview of an attempt to fix several issues that occur currently with `@InjectMocks` in combination with generic types. It is not ready to merge yet, but I provide it in order to possibly receive early feedback and also to signal that I am working on a solution.

It contains a (partly) reimplementation of the logic in `TypeBasedCandidateFilter`. The `isCompatibleTypes` method in this class evolved from a simple use case with matching generic parameters of collections and starts with the assumption that the field to be injected has the same number of generic parameters as generic arguments present on the mocked field. This is not necessarily the case and I found it to be the main cause for the issues around.

Instead in the code provided with this PR, I attempt to fill in generic arguments into generic parameters from the declaration of `@InjectMocks` down to the candidate injection field by using the type hierarchy. The main logic for it is in `GenericTypeUse.findExactAncestor()`.

Additionally I make a (hopefully clear) distinction of collecting generic type information  - and the actual comparison of that information. The collection happens in the classes `GenericTypeUse` and `GenericTypeResolver` - emitting the type `MappedType` while the comparison happens in class `AssignmentMatcher` and then reads as follows:

```java
    public boolean matches() {
        when(bothAreClasses()).then(checkClassesAreAssignable());
        when(bothAreMappedTypes()).then(checkRawTypesAreAssignable())
                .andThen(checkDimensionsAreEqual())
                .andThen(recursivelyCheckMappedTypes()
                    .or(elseWhen(sourceIsEmptyMappedType().and(targetIsMappedType()))
                        .then(retryWithSuperTypeOfSource())));
        when(bothAreWildcards()).then(checkWildcardsHaveNoBounds());
        when(sourceIsClass().and(targetIsWildcard())).then(checkWildcardBounds());
        when(sourceIsClass().and(targetIsTypeVariable())).then(checkTypeVariableBounds());
        when(sourceIsEmptyMappedType().and(targetIsClass())).then(compareWithRawTypeOfSource());
        return success;
    }
```

I admit there are similarities with the already present class `GenericMetadataSupport` (both carry a map of type parameters to actual arguments), but I could not reuse it as is right now, because it has been crafted for return types for the case of mocking, while here we have to handle fields.

I hope that this PR goes in the right direction and if not, please let me know. Thank you!

## Todos

- add Copyright header
- add more comments explaining the code
- format code according to spotless
- run Android tests (I could need some help here)
- maybe get rid of `MappedTypeSimple` and `MappedTypeWildcard` again
- try to remember prevously collected generic information for candidate fields presented earlier to the same instance of `TypeBasedCandidateFilter`

## Checklist

 - [X] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [X] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [X] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [X] Avoid other runtime dependencies
 - [X] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [ ] The pull request follows coding style
 - [X] Mention `Fixes #<issue number>` in the description _if relevant_
 - [X] At least one commit should mention `Fixes #<issue number>` _if relevant_

