### PR TITLE
Add another hint to no argument value captured

### DIFF
--- a/src/main/java/org/mockito/internal/exceptions/Reporter.java
+++ b/src/main/java/org/mockito/internal/exceptions/Reporter.java
@@ -711,7 +711,8 @@ public class Reporter {
                 join(
                         "No argument value was captured!",
                         "You might have forgotten to use argument.capture() in verify()...",
-                        "...or you used capture() in stubbing but stubbed method was not called.",
+                        "...or you used capture() in stubbing but stubbed method was not called,",
+                        "...or you used capture.getValue() in the thenReturn() instead of thenAnswer()."
                         "Be aware that it is recommended to use capture() only with verify()",
                         "",
                         "Examples of correct argument capturing:",


### PR DESCRIPTION
Hi, 

I've just hit that and having this case on the list of hints would be extremely helpful.

It is quite common for me to alternate between `thenReturn` and `thenAnswer`. However, if you forgot to change to `thenAnswer` when using `argumentCaptor.getCapture()` your code will still compile but it will fail in runtime. 

Example:
```java
when(service.call(captor.capture())).thenReturn(Response(captor.getValue().toString()))
```
in order to fix it, the code needs to be changed to:
```java
when(service.call(captor.capture())).thenAnswer(i-> Response(captor.getValue().toString()))
```
which I am sure is obvious for a lot of people who use mockito a lot, but it isn't for newcomers and seasonal users. 


<!-- Hey,
Thanks for the contribution, this is awesome.
As you may have read, project members have somehow an opinionated view on what and how should be
Mockito, e.g. we don't want mockito to be a feature bloat.
There may be a thorough review, with feedback -> code change loop.
-->
<!--
If you have a suggestion for this template you can fix it in the .github/PULL_REQUEST_TEMPLATE.md file
-->
## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [ ] Mention `Fixes #<issue number>` in the description _if relevant_
 - [ ] At least one commit should mention `Fixes #<issue number>` _if relevant_

