### PR TITLE
Rewire Jacoco for Gradle 8/9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,6 @@ jobs:
       with:
         files: build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml
         fail_ci_if_error: true
-        verbose: true
 
   #
   # Android build job
@@ -167,7 +166,6 @@ jobs:
       with:
         files: subprojects/androidTest/build/reports/coverage/androidTest/debug/connected/report.xml
         fail_ci_if_error: true
-        verbose: true
 
   #
   # Release job, only for pushes to the main development branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,20 +70,15 @@ jobs:
         MOCK_MAKER: ${{ matrix.entry.mock-maker }}
         MEMBER_ACCESSOR: ${{ matrix.entry.member-accessor }}
 
-    - name: 7. Upload coverage report
-      run: |
-        ./gradlew coverageReport -s --scan && cp build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml jacoco.xml
-        curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
+    - name: 7. Generate coverage report
+      run: ./gradlew coverageReport --stacktrace --scan
 
-        curl -Os https://uploader.codecov.io/latest/linux/codecov
-        curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-        curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
-
-        gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
-        shasum -a 256 -c codecov.SHA256SUM
-
-        chmod +x codecov
-        ./codecov
+    - name: 8. Upload coverage report
+      uses: codecov/codecov-action@v3
+      with:
+        files: build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml
+        fail_ci_if_error: true
+        verbose: true
 
   #
   # Android build job
@@ -166,21 +161,13 @@ jobs:
           ${{ github.workspace }}/emulator.log
           ${{ github.workspace }}/emulator-startup.log
 
+    # :androidTest:connectedCheck (which depends on :androidTest:createDebugAndroidTestCoverageReport) already generated coverage report.
     - name: 5. Upload coverage report
-      run: |
-        # :androidTest:connectedCheck (which depends on :androidTest:createDebugAndroidTestCoverageReport) already generated coverage report.
-
-        curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
-
-        curl -Os https://uploader.codecov.io/latest/macos/codecov
-        curl -Os https://uploader.codecov.io/latest/macos/codecov.SHA256SUM
-        curl -Os https://uploader.codecov.io/latest/macos/codecov.SHA256SUM.sig
-
-        gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
-        shasum -a 256 -c codecov.SHA256SUM
-
-        chmod +x codecov
-        ./codecov -f subprojects/androidTest/build/reports/coverage/androidTest/debug/connected/report.xml
+      uses: codecov/codecov-action@v3
+      with:
+        files: subprojects/androidTest/build/reports/coverage/androidTest/debug/connected/report.xml
+        fail_ci_if_error: true
+        verbose: true
 
   #
   # Release job, only for pushes to the main development branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
         shasum -a 256 -c codecov.SHA256SUM
 
         chmod +x codecov
-        ./codecov -f build/reports/coverage/androidTest/debug/connected/report.xml
+        ./codecov -f subprojects/androidTest/build/reports/coverage/androidTest/debug/connected/report.xml
 
   #
   # Release job, only for pushes to the main development branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,22 @@ jobs:
           ${{ github.workspace }}/emulator.log
           ${{ github.workspace }}/emulator-startup.log
 
+    - name: 5. Upload coverage report
+      run: |
+        # :androidTest:connectedCheck (which depends on :androidTest:createDebugAndroidTestCoverageReport) already generated coverage report.
+
+        curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
+
+        curl -Os https://uploader.codecov.io/latest/linux/codecov
+        curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+        curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+
+        gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+        shasum -a 256 -c codecov.SHA256SUM
+
+        chmod +x codecov
+        ./codecov -f build/reports/coverage/androidTest/debug/connected/report.xml
+
   #
   # Release job, only for pushes to the main development branch
   #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,9 +172,9 @@ jobs:
 
         curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
 
-        curl -Os https://uploader.codecov.io/latest/linux/codecov
-        curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-        curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+        curl -Os https://uploader.codecov.io/latest/macos/codecov
+        curl -Os https://uploader.codecov.io/latest/macos/codecov.SHA256SUM
+        curl -Os https://uploader.codecov.io/latest/macos/codecov.SHA256SUM.sig
 
         gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
         shasum -a 256 -c codecov.SHA256SUM

--- a/gradle/root/coverage.gradle
+++ b/gradle/root/coverage.gradle
@@ -10,10 +10,23 @@ allprojects { project ->
 def mockitoCoverage = tasks.register("mockitoCoverage", JacocoReport) { mockitoCoverage ->
     allprojects { Project currentProject ->
         plugins.withId("jacoco") {
+            // JacocoReport.sourceSets() appends both sourceDirectories and classDirectories.
             mockitoCoverage.sourceSets currentProject.sourceSets.main
             Test test = currentProject.tasks.test
             mockitoCoverage.executionData(currentProject.files(test.jacoco.destinationFile).builtBy(test))
         }
+    }
+
+    gradle.taskGraph.whenReady { // Theoretically Gradle.projectsEvaluated, but not possible here.
+        // Run this after all projects' sourceSets have been added (which is delayed to when the jacoco plugin is applied).
+        classDirectories.setFrom(
+            classDirectories.files.collect {
+                fileTree(
+                    dir: it,
+                    exclude: ["**/internal/util/concurrent/**"]
+                )
+            }
+        )
     }
 
     reports {
@@ -25,19 +38,6 @@ def mockitoCoverage = tasks.register("mockitoCoverage", JacocoReport) { mockitoC
     doLast {
         def reportFile = new File(reports.html.outputLocation.get().asFile, "index.html")
         logger.lifecycle "Jacoco HTML created: file://${reportFile.toURI().path}"
-    }
-}
-
-gradle.taskGraph.whenReady {
-    mockitoCoverage.configure {
-        classDirectories.setFrom(
-            classDirectories.files.collect {
-                fileTree(
-                    dir: it,
-                    exclude: ["**/internal/util/concurrent/**"]
-                )
-            }
-        )
     }
 }
 

--- a/gradle/root/coverage.gradle
+++ b/gradle/root/coverage.gradle
@@ -8,7 +8,7 @@ allprojects { project ->
 }
 
 def mockitoCoverage = tasks.register("mockitoCoverage", JacocoReport) { mockitoCoverage ->
-    allprojects { currentProject ->
+    allprojects { Project currentProject ->
         plugins.withId("jacoco") {
             mockitoCoverage.sourceSets currentProject.sourceSets.main
             Test test = currentProject.tasks.test

--- a/gradle/root/coverage.gradle
+++ b/gradle/root/coverage.gradle
@@ -7,7 +7,7 @@ allprojects { project ->
     }
 }
 
-task mockitoCoverage(type: JacocoReport) {
+def mockitoCoverage = tasks.register("mockitoCoverage", JacocoReport) { mockitoCoverage ->
     allprojects { currentProject ->
         plugins.withId("jacoco") {
             mockitoCoverage.sourceSets currentProject.sourceSets.main
@@ -29,14 +29,18 @@ task mockitoCoverage(type: JacocoReport) {
 }
 
 gradle.taskGraph.whenReady {
-    mockitoCoverage.classDirectories.setFrom(
-        mockitoCoverage.classDirectories.files.collect {
-            fileTree(
-                dir: it,
-                exclude: [ "**/internal/util/concurrent/**" ]
-            )
-        }
-    )
+    mockitoCoverage.configure {
+        classDirectories.setFrom(
+            classDirectories.files.collect {
+                fileTree(
+                    dir: it,
+                    exclude: ["**/internal/util/concurrent/**"]
+                )
+            }
+        )
+    }
 }
 
-task coverageReport(dependsOn: ["mockitoCoverage"]) {}
+tasks.register("coverageReport") {
+    dependsOn(mockitoCoverage)
+}

--- a/gradle/root/coverage.gradle
+++ b/gradle/root/coverage.gradle
@@ -1,21 +1,18 @@
+allprojects { project ->
+    plugins.withId("java") {
+        project.apply plugin: "jacoco"
+        project.jacoco {
+            toolVersion = '0.8.8'
+        }
+    }
+}
+
 task mockitoCoverage(type: JacocoReport) {
 
     allprojects { currentProject ->
-        // These tests do not have a `test` task.
-        if (currentProject.name in ['android']) {
-            return
-        }
         plugins.withId("java") {
             mockitoCoverage.sourceSets currentProject.sourceSets.main
-
-            apply plugin: "jacoco"
-
             jacoco {
-                toolVersion = '0.8.8'
-
-                if (currentProject != rootProject) {   //already automatically enhanced in mockito main project as "java" plugin was applied before
-                    applyTo test
-                }
                 test.jacoco.destinationFile = file("${currentProject.buildDir}/jacoco/test.exec")
             }
 

--- a/gradle/root/coverage.gradle
+++ b/gradle/root/coverage.gradle
@@ -11,7 +11,8 @@ task mockitoCoverage(type: JacocoReport) {
     allprojects { currentProject ->
         plugins.withId("jacoco") {
             mockitoCoverage.sourceSets currentProject.sourceSets.main
-            mockitoCoverage.executionData(files(test.jacoco.destinationFile).builtBy(test))
+            Test test = currentProject.tasks.test
+            mockitoCoverage.executionData(currentProject.files(test.jacoco.destinationFile).builtBy(test))
         }
     }
 

--- a/gradle/root/coverage.gradle
+++ b/gradle/root/coverage.gradle
@@ -8,9 +8,8 @@ allprojects { project ->
 }
 
 task mockitoCoverage(type: JacocoReport) {
-
     allprojects { currentProject ->
-        plugins.withId("java") {
+        plugins.withId("jacoco") {
             mockitoCoverage.sourceSets currentProject.sourceSets.main
             mockitoCoverage.executionData(files(test.jacoco.destinationFile).builtBy(test))
         }

--- a/gradle/root/coverage.gradle
+++ b/gradle/root/coverage.gradle
@@ -12,10 +12,6 @@ task mockitoCoverage(type: JacocoReport) {
     allprojects { currentProject ->
         plugins.withId("java") {
             mockitoCoverage.sourceSets currentProject.sourceSets.main
-            jacoco {
-                test.jacoco.destinationFile = file("${currentProject.buildDir}/jacoco/test.exec")
-            }
-
             mockitoCoverage.executionData(files(test.jacoco.destinationFile).builtBy(test))
         }
     }

--- a/gradle/root/coverage.gradle
+++ b/gradle/root/coverage.gradle
@@ -20,17 +20,6 @@ task mockitoCoverage(type: JacocoReport) {
             }
 
             mockitoCoverage.executionData(files(test.jacoco.destinationFile).builtBy(test))
-
-            afterEvaluate {
-                classDirectories.setFrom(
-                    classDirectories.files.collect {
-                        fileTree(
-                            dir: it,
-                            exclude: ["**/internal/util/concurrent/**"]
-                        )
-                    }
-                )
-            }
         }
     }
 
@@ -44,6 +33,17 @@ task mockitoCoverage(type: JacocoReport) {
         def reportFile = new File(reports.html.outputLocation.get().asFile, "index.html")
         logger.lifecycle "Jacoco HTML created: file://${reportFile.toURI().path}"
     }
+}
+
+gradle.taskGraph.whenReady {
+    mockitoCoverage.classDirectories.setFrom(
+        mockitoCoverage.classDirectories.files.collect {
+            fileTree(
+                dir: it,
+                exclude: [ "**/internal/util/concurrent/**" ]
+            )
+        }
+    )
 }
 
 task coverageReport(dependsOn: ["mockitoCoverage"]) {}

--- a/gradle/root/coverage.gradle
+++ b/gradle/root/coverage.gradle
@@ -19,7 +19,7 @@ def mockitoCoverage = tasks.register("mockitoCoverage", JacocoReport) { mockitoC
     reports {
         xml.required = true
         html.required = true
-        html.outputLocation = file("${buildDir}/jacocoHtml")
+        html.outputLocation = rootProject.layout.buildDirectory.dir("jacocoHtml")
     }
 
     doLast {

--- a/gradle/root/coverage.gradle
+++ b/gradle/root/coverage.gradle
@@ -10,10 +10,28 @@ allprojects { project ->
 def mockitoCoverage = tasks.register("mockitoCoverage", JacocoReport) { mockitoCoverage ->
     allprojects { Project currentProject ->
         plugins.withId("jacoco") {
-            // JacocoReport.sourceSets() appends both sourceDirectories and classDirectories.
-            mockitoCoverage.sourceSets currentProject.sourceSets.main
-            Test test = currentProject.tasks.test
-            mockitoCoverage.executionData(currentProject.files(test.jacoco.destinationFile).builtBy(test))
+            plugins.withId("java") {
+                // JacocoReport.sourceSets() appends both sourceDirectories and classDirectories.
+                mockitoCoverage.sourceSets currentProject.sourceSets.main
+                Test test = currentProject.tasks.test
+                mockitoCoverage.executionData(currentProject.files(test.jacoco.destinationFile).builtBy(test))
+            }
+            plugins.withId("com.android.base") {
+                // The :androidTest project only contains test infrastructure, so there's no need to grab sources/classes.
+
+                def androidTest = currentProject.tasks.connectedDebugAndroidTest
+                def instrumentationCoverage = currentProject
+                    .layout.buildDirectory.dir("outputs/code_coverage/debugAndroidTest/connected")
+                    .map { it.asFileTree.matching { include "*/coverage.ec" } }
+                mockitoCoverage.executionData(currentProject.files(instrumentationCoverage))
+                mockitoCoverage.mustRunAfter(androidTest)
+
+                def unitTest = currentProject.tasks.testDebugUnitTest
+                def coverageFiles = currentProject
+                    .layout.buildDirectory.dir("outputs/unit_test_code_coverage/debugUnitTest")
+                    .map { it.asFileTree.matching { include "testDebugUnitTest.exec" } }
+                mockitoCoverage.executionData(currentProject.files(coverageFiles).builtBy(unitTest))
+            }
         }
     }
 

--- a/subprojects/android/src/test/README.md
+++ b/subprojects/android/src/test/README.md
@@ -1,0 +1,1 @@
+Tests are located in :androidTest subproject.

--- a/subprojects/androidTest/androidTest.gradle
+++ b/subprojects/androidTest/androidTest.gradle
@@ -18,10 +18,18 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    buildTypes {
+        debug {
+            enableUnitTestCoverage true
+            enableAndroidTestCoverage true
+        }
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11
     }
+
     kotlinOptions {
         jvmTarget = '11'
     }
@@ -37,6 +45,11 @@ apply from: "$rootDir/gradle/dependencies.gradle"
 
 dependencies {
     implementation libraries.kotlin.stdlib
+
+    // Add :android on the classpath so that AGP's jacoco setup thinks it's "production code to be tested".
+    runtimeOnly project(":android")
+    // Exclude :android from JVM tests, because otherwise it clashes with mockito-core/project(":").
+    configurations.testImplementation { exclude group: 'org.mockito', module: 'android' }
 
     testImplementation project(":")
     testImplementation libraries.junit4

--- a/subprojects/androidTest/androidTest.gradle
+++ b/subprojects/androidTest/androidTest.gradle
@@ -30,10 +30,15 @@ android {
         tasks.createDebugAndroidTestCoverageReport { com.android.build.gradle.internal.coverage.JacocoReportTask task ->
             rootProject.allprojects { Project currentProject ->
                 plugins.withId("java") {
+                    SourceSetContainer sourceSets = currentProject.sourceSets
                     // Mimic org.gradle.testing.jacoco.tasks.JacocoReportBase.sourceSets().
                     // Not possible to set task.javaSources because it's initialized with setDisallowChanges.
-                    //task.javaSources.add({ [ currentProject.sourceSets.main.allJava.srcDirs ] })
-                    task.classFileCollection.from(currentProject.sourceSets.main.output)
+                    //task.javaSources.add({ [ sourceSets.main.allJava.srcDirs ] })
+                    task.classFileCollection.from(
+                        sourceSets.main.output.asFileTree.matching {
+                            exclude("**/internal/util/concurrent/**")
+                        }
+                    )
                 }
             }
         }

--- a/subprojects/androidTest/androidTest.gradle
+++ b/subprojects/androidTest/androidTest.gradle
@@ -28,6 +28,8 @@ android {
         // Enable coverage of mockito classes which are not part of this module.
         // Without these added classFileCollection dependencies the coverage data/report is empty.
         tasks.createDebugAndroidTestCoverageReport { com.android.build.gradle.internal.coverage.JacocoReportTask task ->
+            // Clear the production code of this module: src/main/java, it has no mockito-user-visible code.
+            task.classFileCollection.setFrom()
             rootProject.allprojects { Project currentProject ->
                 plugins.withId("java") {
                     SourceSetContainer sourceSets = currentProject.sourceSets
@@ -66,6 +68,7 @@ dependencies {
     implementation libraries.kotlin.stdlib
 
     // Add :android on the classpath so that AGP's jacoco setup thinks it's "production code to be tested".
+    // Essentially a way to say: tasks.createDebugAndroidTestCoverageReport.classFileCollection.from(project(":android"))
     runtimeOnly project(":android")
     // Exclude :android from JVM tests, because otherwise it clashes with mockito-core/project(":").
     configurations.testImplementation { exclude group: 'org.mockito', module: 'android' }

--- a/subprojects/androidTest/androidTest.gradle
+++ b/subprojects/androidTest/androidTest.gradle
@@ -24,6 +24,20 @@ android {
             enableAndroidTestCoverage true
         }
     }
+    afterEvaluate {
+        // Enable coverage of mockito classes which are not part of this module.
+        // Without these added classFileCollection dependencies the coverage data/report is empty.
+        tasks.createDebugAndroidTestCoverageReport { com.android.build.gradle.internal.coverage.JacocoReportTask task ->
+            rootProject.allprojects { Project currentProject ->
+                plugins.withId("java") {
+                    // Mimic org.gradle.testing.jacoco.tasks.JacocoReportBase.sourceSets().
+                    // Not possible to set task.javaSources because it's initialized with setDisallowChanges.
+                    //task.javaSources.add({ [ currentProject.sourceSets.main.allJava.srcDirs ] })
+                    task.classFileCollection.from(currentProject.sourceSets.main.output)
+                }
+            }
+        }
+    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11


### PR DESCRIPTION
Fixes the `:jacocoAgent` warning listed in https://github.com/mockito/mockito/pull/3051, see individual commits to make sense of the "full rewrite". cc @szpak for review because https://github.com/mockito/mockito/pull/1229#discussion_r148213888.

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [ ] At least one commit should mention `Fixes #<issue number>` _if relevant_

