### PR TITLE
Gradle 8.2: work around fix for release publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:3.1.0'
 
         classpath "io.github.gradle-nexus:publish-plugin:1.3.0"
+        // TODO check if https://github.com/shipkit/shipkit-changelog/issues/103 is fixed, and remove workaround in shipkit.gradle.
         classpath 'org.shipkit:shipkit-changelog:1.2.0'
         classpath 'org.shipkit:shipkit-auto-version:1.2.2'
 

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -6,6 +6,10 @@ tasks.named('generateChangelog') {
     previousRevision = project.ext.'shipkit-auto-version.previous-tag'
     githubToken = System.getenv('GITHUB_TOKEN')
     repository = 'mockito/mockito'
+    // Workarounds for https://github.com/shipkit/shipkit-changelog/issues/103
+    doNotTrackState("GenerateChangelogTask tracks the entire repo, which results is locking problems hashing the .gradle folder.")
+    // GenerateChangelogTask uses the entire repo as input, which means it needs to "depend on" all other tasks' outputs.
+    mustRunAfter(allprojects.collectMany { it.tasks }.grep { it.path != ":generateChangelog" && it.path != ":githubRelease" })
 }
 
 tasks.named("githubRelease") {

--- a/subprojects/extTest/extTest.gradle
+++ b/subprojects/extTest/extTest.gradle
@@ -16,6 +16,7 @@ dependencies {
     testImplementation libraries.junitJupiterApi
     testRuntimeOnly libraries.junitJupiterEngine
     testRuntimeOnly libraries.junitVintageEngine
+    testRuntimeOnly libraries.junitPlatformLauncher
 }
 
 tasks.withType(Test) {


### PR DESCRIPTION
Missed a spot in :test warnings and workaround for https://github.com/shipkit/shipkit-changelog/issues/103 triggered by https://github.com/mockito/mockito/actions/runs/5457593285/jobs/9931914322

See https://github.com/mockito/mockito/pull/3051#issuecomment-1621198659

## Testing
I was able to get past the problem shown in the CI by setting env vars and applying the workaround. The failure is now at real publishing, so it should be ok 🤞:

```
$ set NEXUS_TOKEN_USER=bad
$ set NEXUS_TOKEN_PWD=bad
$ gradlew githubRelease publishToSonatype closeAndReleaseStagingRepository releaseSummary

> Task :bom:publishJavaLibraryPublicationToSonatypeRepository FAILED
> Task :junit-jupiter:publishJavaLibraryPublicationToSonatypeRepository FAILED
> Task :proxy:publishJavaLibraryPublicationToSonatypeRepository FAILED
> Task :subclass:publishJavaLibraryPublicationToSonatypeRepository FAILED
> Task :errorprone:publishJavaLibraryPublicationToSonatypeRepository FAILED
> Task :android:publishJavaLibraryPublicationToSonatypeRepository FAILED
> Task :publishJavaLibraryPublicationToSonatypeRepository FAILED

all failures: Received status code 401 from server: Unauthorized
```

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [ ] At least one commit should mention `Fixes #<issue number>` _if relevant_

