### PR TITLE
Move LocationFactory to plugins to allow overriding it

### DIFF
--- a/src/main/java/org/mockito/internal/MockedConstructionImpl.java
+++ b/src/main/java/org/mockito/internal/MockedConstructionImpl.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 import org.mockito.MockedConstruction;
 import org.mockito.exceptions.base.MockitoException;
-import org.mockito.internal.debugging.LocationFactory;
+import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.invocation.Location;
 import org.mockito.plugins.MockMaker;
 
@@ -21,7 +21,7 @@ public final class MockedConstructionImpl<T> implements MockedConstruction<T> {
 
     private boolean closed;
 
-    private final Location location = LocationFactory.create();
+    private final Location location = Plugins.getLocationFactory().create();
 
     protected MockedConstructionImpl(MockMaker.ConstructionMockControl<T> control) {
         this.control = control;

--- a/src/main/java/org/mockito/internal/MockedStaticImpl.java
+++ b/src/main/java/org/mockito/internal/MockedStaticImpl.java
@@ -17,7 +17,7 @@ import org.mockito.MockingDetails;
 import org.mockito.Mockito;
 import org.mockito.exceptions.base.MockitoAssertionError;
 import org.mockito.exceptions.base.MockitoException;
-import org.mockito.internal.debugging.LocationFactory;
+import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.internal.listeners.VerificationStartedNotifier;
 import org.mockito.internal.progress.MockingProgress;
 import org.mockito.internal.stubbing.InvocationContainerImpl;
@@ -35,7 +35,7 @@ public final class MockedStaticImpl<T> implements MockedStatic<T> {
 
     private boolean closed;
 
-    private final Location location = LocationFactory.create();
+    private final Location location = Plugins.getLocationFactory().create();
 
     protected MockedStaticImpl(MockMaker.StaticMockControl<T> control) {
         this.control = control;

--- a/src/main/java/org/mockito/internal/configuration/plugins/DefaultMockitoPlugins.java
+++ b/src/main/java/org/mockito/internal/configuration/plugins/DefaultMockitoPlugins.java
@@ -13,6 +13,7 @@ import org.mockito.MockMakers;
 import org.mockito.plugins.AnnotationEngine;
 import org.mockito.plugins.DoNotMockEnforcer;
 import org.mockito.plugins.InstantiatorProvider2;
+import org.mockito.plugins.LocationFactory;
 import org.mockito.plugins.MemberAccessor;
 import org.mockito.plugins.MockMaker;
 import org.mockito.plugins.MockitoLogger;
@@ -63,6 +64,9 @@ public class DefaultMockitoPlugins implements MockitoPlugins {
         DEFAULT_PLUGINS.put(
                 DoNotMockEnforcer.class.getName(),
                 "org.mockito.internal.configuration.DefaultDoNotMockEnforcer");
+        DEFAULT_PLUGINS.put(
+                LocationFactory.class.getName(),
+                "org.mockito.internal.debugging.DefaultLocationFactory");
 
         MOCK_MAKER_ALIASES.add(INLINE_ALIAS);
         MOCK_MAKER_ALIASES.add(PROXY_ALIAS);

--- a/src/main/java/org/mockito/internal/configuration/plugins/PluginRegistry.java
+++ b/src/main/java/org/mockito/internal/configuration/plugins/PluginRegistry.java
@@ -8,6 +8,7 @@ import java.util.List;
 import org.mockito.plugins.AnnotationEngine;
 import org.mockito.plugins.DoNotMockEnforcer;
 import org.mockito.plugins.InstantiatorProvider2;
+import org.mockito.plugins.LocationFactory;
 import org.mockito.plugins.MemberAccessor;
 import org.mockito.plugins.MockMaker;
 import org.mockito.plugins.MockResolver;
@@ -48,6 +49,9 @@ class PluginRegistry {
 
     private final DoNotMockEnforcer doNotMockEnforcer =
             new PluginLoader(pluginSwitch).loadPlugin(DoNotMockEnforcer.class);
+
+    private final LocationFactory locationFactory =
+            new PluginLoader(pluginSwitch).loadPlugin(LocationFactory.class);
 
     PluginRegistry() {
         instantiatorProvider =
@@ -121,6 +125,16 @@ class PluginRegistry {
      */
     DoNotMockEnforcer getDoNotMockEnforcer() {
         return doNotMockEnforcer;
+    }
+
+    /**
+     * Returns the location factory available for the current runtime.
+     *
+     * <p> Returns {@link org.mockito.internal.debugging.DefaultLocationFactory} if no
+     * {@link LocationFactory} extension exists or is visible in the current classpath.</p>
+     */
+    LocationFactory getLocationFactory() {
+        return locationFactory;
     }
 
     /**

--- a/src/main/java/org/mockito/internal/configuration/plugins/Plugins.java
+++ b/src/main/java/org/mockito/internal/configuration/plugins/Plugins.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.mockito.plugins.AnnotationEngine;
 import org.mockito.plugins.DoNotMockEnforcer;
 import org.mockito.plugins.InstantiatorProvider2;
+import org.mockito.plugins.LocationFactory;
 import org.mockito.plugins.MemberAccessor;
 import org.mockito.plugins.MockMaker;
 import org.mockito.plugins.MockResolver;
@@ -103,6 +104,16 @@ public final class Plugins {
      */
     public static DoNotMockEnforcer getDoNotMockEnforcer() {
         return registry.getDoNotMockEnforcer();
+    }
+
+    /**
+     * Returns the {@link LocationFactory} available for the current runtime.
+     *
+     * <p> Returns {@link org.mockito.internal.debugging.DefaultLocationFactory} if no
+     * {@link LocationFactory} extension exists or is visible in the current classpath.</p>
+     */
+    public static LocationFactory getLocationFactory() {
+        return registry.getLocationFactory();
     }
 
     private Plugins() {}

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
@@ -51,7 +51,6 @@ import net.bytebuddy.utility.OpenedClassReader;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.internal.creation.bytebuddy.inject.MockMethodDispatcher;
-import org.mockito.internal.debugging.LocationFactory;
 import org.mockito.internal.exceptions.stacktrace.ConditionalStackTraceFilter;
 import org.mockito.internal.invocation.RealMethod;
 import org.mockito.internal.invocation.SerializableMethod;
@@ -132,7 +131,11 @@ public class MockMethodAdvice extends MockMethodDispatcher {
         }
         return new ReturnValueWrapper(
                 interceptor.doIntercept(
-                        instance, origin, arguments, realMethod, LocationFactory.create(true)));
+                        instance,
+                        origin,
+                        arguments,
+                        realMethod,
+                        Plugins.getLocationFactory().create(true)));
     }
 
     @Override
@@ -150,7 +153,7 @@ public class MockMethodAdvice extends MockMethodDispatcher {
                                 origin,
                                 arguments,
                                 new StaticMethodCall(selfCallInfo, type, origin, arguments),
-                                LocationFactory.create(true)));
+                                Plugins.getLocationFactory().create(true)));
     }
 
     @Override

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodInterceptor.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodInterceptor.java
@@ -22,7 +22,7 @@ import net.bytebuddy.implementation.bind.annotation.RuntimeType;
 import net.bytebuddy.implementation.bind.annotation.StubValue;
 import net.bytebuddy.implementation.bind.annotation.SuperCall;
 import net.bytebuddy.implementation.bind.annotation.This;
-import org.mockito.internal.debugging.LocationFactory;
+import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.internal.invocation.RealMethod;
 import org.mockito.invocation.Location;
 import org.mockito.invocation.MockHandler;
@@ -53,7 +53,8 @@ public class MockMethodInterceptor implements Serializable {
 
     Object doIntercept(Object mock, Method invokedMethod, Object[] arguments, RealMethod realMethod)
             throws Throwable {
-        return doIntercept(mock, invokedMethod, arguments, realMethod, LocationFactory.create());
+        return doIntercept(
+                mock, invokedMethod, arguments, realMethod, Plugins.getLocationFactory().create());
     }
 
     Object doIntercept(

--- a/src/main/java/org/mockito/internal/creation/proxy/ProxyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/proxy/ProxyMockMaker.java
@@ -5,7 +5,7 @@
 package org.mockito.internal.creation.proxy;
 
 import org.mockito.exceptions.base.MockitoException;
-import org.mockito.internal.debugging.LocationFactory;
+import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.internal.invocation.RealMethod;
 import org.mockito.internal.util.Platform;
 import org.mockito.invocation.MockHandler;
@@ -158,7 +158,7 @@ public class ProxyMockMaker implements MockMaker {
                                     args,
                                     realMethod,
                                     settings,
-                                    LocationFactory.create()));
+                                    Plugins.getLocationFactory().create()));
         }
     }
 

--- a/src/main/java/org/mockito/internal/debugging/DefaultLocationFactory.java
+++ b/src/main/java/org/mockito/internal/debugging/DefaultLocationFactory.java
@@ -5,17 +5,16 @@
 package org.mockito.internal.debugging;
 
 import org.mockito.invocation.Location;
+import org.mockito.plugins.LocationFactory;
 
-public final class LocationFactory {
-    private static final Factory factory = createLocationFactory();
+public final class DefaultLocationFactory implements LocationFactory {
+    private final Factory factory = createLocationFactory();
 
-    private LocationFactory() {}
-
-    public static Location create() {
+    public Location create() {
         return create(false);
     }
 
-    public static Location create(boolean inline) {
+    public Location create(boolean inline) {
         return factory.create(inline);
     }
 
@@ -29,7 +28,7 @@ public final class LocationFactory {
             // available, in this case we have to fallback to Java 8 style of stack
             // traversing.
             Class.forName("java.lang.StackWalker");
-            return new DefaultLocationFactory();
+            return new StackWalkerLocationFactory();
         } catch (ClassNotFoundException e) {
             return new Java8LocationFactory();
         }
@@ -42,7 +41,7 @@ public final class LocationFactory {
         }
     }
 
-    private static final class DefaultLocationFactory implements Factory {
+    private static final class StackWalkerLocationFactory implements Factory {
         @Override
         public Location create(boolean inline) {
             return new LocationImpl(inline);

--- a/src/main/java/org/mockito/internal/debugging/Localized.java
+++ b/src/main/java/org/mockito/internal/debugging/Localized.java
@@ -4,6 +4,7 @@
  */
 package org.mockito.internal.debugging;
 
+import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.invocation.Location;
 
 public class Localized<T> {
@@ -13,7 +14,7 @@ public class Localized<T> {
 
     public Localized(T object) {
         this.object = object;
-        location = LocationFactory.create();
+        location = Plugins.getLocationFactory().create();
     }
 
     public T getObject() {

--- a/src/main/java/org/mockito/internal/exceptions/Reporter.java
+++ b/src/main/java/org/mockito/internal/exceptions/Reporter.java
@@ -42,7 +42,7 @@ import org.mockito.exceptions.verification.TooFewActualInvocations;
 import org.mockito.exceptions.verification.TooManyActualInvocations;
 import org.mockito.exceptions.verification.VerificationInOrderFailure;
 import org.mockito.exceptions.verification.WantedButNotInvoked;
-import org.mockito.internal.debugging.LocationFactory;
+import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.internal.exceptions.util.ScenarioPrinter;
 import org.mockito.internal.junit.ExceptionFactory;
 import org.mockito.internal.matchers.LocalizedMatcher;
@@ -106,7 +106,7 @@ public class Reporter {
         return new MockitoException(
                 join(
                         "Incorrect use of API detected here:",
-                        LocationFactory.create(),
+                        Plugins.getLocationFactory().create(),
                         "",
                         "You probably stored a reference to OngoingStubbing returned by when() and called stubbing methods like thenReturn() on this reference more than once.",
                         "Examples of correct usage:",
@@ -284,7 +284,7 @@ public class Reporter {
                         "Invalid use of argument matchers inside additional matcher "
                                 + additionalMatcherName
                                 + " !",
-                        LocationFactory.create(),
+                        Plugins.getLocationFactory().create(),
                         "",
                         expectedSubMatchersCount
                                 + " sub matchers expected, "
@@ -317,7 +317,7 @@ public class Reporter {
         return new InvalidUseOfMatchersException(
                 join(
                         "No matchers found for additional matcher " + additionalMatcherName,
-                        LocationFactory.create(),
+                        Plugins.getLocationFactory().create(),
                         ""));
     }
 
@@ -348,7 +348,7 @@ public class Reporter {
                 .append("Argument(s) are different! Wanted:\n")
                 .append(wanted)
                 .append("\n")
-                .append(LocationFactory.create())
+                .append(Plugins.getLocationFactory().create())
                 .append("\n")
                 .append("Actual invocations have different arguments");
 
@@ -419,7 +419,11 @@ public class Reporter {
     }
 
     private static String createWantedButNotInvokedMessage(DescribedInvocation wanted) {
-        return join("Wanted but not invoked:", wanted.toString(), LocationFactory.create(), "");
+        return join(
+                "Wanted but not invoked:",
+                wanted.toString(),
+                Plugins.getLocationFactory().create(),
+                "");
     }
 
     public static MockitoAssertionError wantedButNotInvokedInOrder(
@@ -429,7 +433,7 @@ public class Reporter {
                         "Verification in order failure",
                         "Wanted but not invoked:",
                         wanted.toString(),
-                        LocationFactory.create(),
+                        Plugins.getLocationFactory().create(),
                         "Wanted anywhere AFTER following interaction:",
                         previous.toString(),
                         previous.getLocation(),
@@ -454,7 +458,7 @@ public class Reporter {
         return join(
                 wanted.toString(),
                 "Wanted " + pluralize(wantedCount) + ":",
-                LocationFactory.create(),
+                Plugins.getLocationFactory().create(),
                 "But was " + pluralize(actualCount) + ":",
                 createAllLocationsMessage(invocations),
                 "");
@@ -467,7 +471,7 @@ public class Reporter {
                 join(
                         wanted.toString(),
                         "Never wanted here:",
-                        LocationFactory.create(),
+                        Plugins.getLocationFactory().create(),
                         "But invoked here:",
                         createAllLocationsArgsMessage(invocations)));
     }
@@ -517,7 +521,7 @@ public class Reporter {
                 "Wanted "
                         + discrepancy.getPluralizedWantedCount()
                         + (discrepancy.getWantedCount() == 0 ? "." : ":"),
-                LocationFactory.create(),
+                Plugins.getLocationFactory().create(),
                 "But was "
                         + discrepancy.getPluralizedActualCount()
                         + (discrepancy.getActualCount() == 0 ? "." : ":"),
@@ -550,7 +554,7 @@ public class Reporter {
         return new NoInteractionsWanted(
                 join(
                         "No interactions wanted here:",
-                        LocationFactory.create(),
+                        Plugins.getLocationFactory().create(),
                         "But found this interaction on mock '"
                                 + MockUtil.getMockName(undesired.getMock())
                                 + "':",
@@ -562,7 +566,7 @@ public class Reporter {
         return new VerificationInOrderFailure(
                 join(
                         "No interactions wanted here:",
-                        LocationFactory.create(),
+                        Plugins.getLocationFactory().create(),
                         "But found this interaction on mock '"
                                 + MockUtil.getMockName(undesired.getMock())
                                 + "':",
@@ -581,7 +585,7 @@ public class Reporter {
         return new NoInteractionsWanted(
                 join(
                         "No interactions wanted here:",
-                        LocationFactory.create(),
+                        Plugins.getLocationFactory().create(),
                         "But found these interactions on mock '"
                                 + MockUtil.getMockName(mock)
                                 + "':",
@@ -699,7 +703,7 @@ public class Reporter {
         return new SmartNullPointerException(
                 join(
                         "You have a NullPointerException here:",
-                        LocationFactory.create(),
+                        Plugins.getLocationFactory().create(),
                         "because this method call was *not* stubbed correctly:",
                         location,
                         invocation,

--- a/src/main/java/org/mockito/internal/invocation/DefaultInvocationFactory.java
+++ b/src/main/java/org/mockito/internal/invocation/DefaultInvocationFactory.java
@@ -7,8 +7,8 @@ package org.mockito.internal.invocation;
 import java.lang.reflect.Method;
 import java.util.concurrent.Callable;
 
+import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.internal.creation.DelegatingMethod;
-import org.mockito.internal.debugging.LocationFactory;
 import org.mockito.internal.invocation.mockref.MockWeakReference;
 import org.mockito.internal.progress.SequenceNumber;
 import org.mockito.invocation.Invocation;
@@ -71,7 +71,12 @@ public class DefaultInvocationFactory implements InvocationFactory {
             RealMethod realMethod,
             MockCreationSettings settings) {
         return createInvocation(
-                mock, invokedMethod, arguments, realMethod, settings, LocationFactory.create());
+                mock,
+                invokedMethod,
+                arguments,
+                realMethod,
+                settings,
+                Plugins.getLocationFactory().create());
     }
 
     private static MockitoMethod createMockitoMethod(Method method, MockCreationSettings settings) {

--- a/src/main/java/org/mockito/internal/matchers/LocalizedMatcher.java
+++ b/src/main/java/org/mockito/internal/matchers/LocalizedMatcher.java
@@ -5,7 +5,7 @@
 package org.mockito.internal.matchers;
 
 import org.mockito.ArgumentMatcher;
-import org.mockito.internal.debugging.LocationFactory;
+import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.invocation.Location;
 
 @SuppressWarnings("unchecked")
@@ -16,7 +16,7 @@ public class LocalizedMatcher {
 
     public LocalizedMatcher(ArgumentMatcher<?> matcher) {
         this.matcher = matcher;
-        this.location = LocationFactory.create();
+        this.location = Plugins.getLocationFactory().create();
     }
 
     public Location getLocation() {

--- a/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
+++ b/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
@@ -13,8 +13,8 @@ import java.util.List;
 import java.util.Set;
 
 import org.mockito.internal.configuration.GlobalConfiguration;
+import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.internal.debugging.Localized;
-import org.mockito.internal.debugging.LocationFactory;
 import org.mockito.internal.exceptions.Reporter;
 import org.mockito.internal.listeners.AutoCleanableListener;
 import org.mockito.invocation.Location;
@@ -105,7 +105,7 @@ public class MockingProgressImpl implements MockingProgress {
     @Override
     public void stubbingStarted() {
         validateState();
-        stubbingInProgress = LocationFactory.create();
+        stubbingInProgress = Plugins.getLocationFactory().create();
     }
 
     @Override

--- a/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNulls.java
+++ b/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNulls.java
@@ -12,9 +12,9 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 
 import org.mockito.Mockito;
+import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.internal.creation.MockSettingsImpl;
 import org.mockito.internal.creation.bytebuddy.MockAccess;
-import org.mockito.internal.debugging.LocationFactory;
 import org.mockito.internal.util.MockUtil;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.invocation.Location;
@@ -65,7 +65,8 @@ public class ReturnsSmartNulls implements Answer<Object>, Serializable {
                         MockCreationSettings<?> mockSettings =
                                 MockUtil.getMockSettings(invocation.getMock());
                         Answer<?> defaultAnswer =
-                                new ThrowsSmartNullPointer(invocation, LocationFactory.create());
+                                new ThrowsSmartNullPointer(
+                                        invocation, Plugins.getLocationFactory().create());
 
                         return Mockito.mock(
                                 type,

--- a/src/main/java/org/mockito/invocation/Location.java
+++ b/src/main/java/org/mockito/invocation/Location.java
@@ -4,12 +4,9 @@
  */
 package org.mockito.invocation;
 
-import org.mockito.NotExtensible;
-
 /**
  * Describes the location of something in the source code.
  */
-@NotExtensible
 public interface Location {
 
     /**

--- a/src/main/java/org/mockito/plugins/LocationFactory.java
+++ b/src/main/java/org/mockito/plugins/LocationFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.plugins;
+
+import org.mockito.invocation.Location;
+
+/**
+ * LocationFactory, which is used to create a {@link Location} to point at source code.
+ */
+public interface LocationFactory {
+
+    /**
+     * Creates a {@link Location}, which contains the source code line, which triggert the creation.
+     * Note that the method is not directly called and if you implement this method,
+     * you should filter out any mockito calls.
+     *
+     * @return the Location in source where this method was called.
+     */
+    Location create();
+
+    /**
+     * Creates a {@link Location}, which contains the source code line, which triggert the creation.
+     * Note that the method is not directly called and if you implement this method,
+     * you should filter out any mockito calls.
+     *
+     * @param inline whether it is inline or not.
+     * @return the Location in source where this method was called.
+     */
+    Location create(boolean inline);
+}

--- a/src/test/java/org/mockito/internal/invocation/InvocationBuilder.java
+++ b/src/test/java/org/mockito/internal/invocation/InvocationBuilder.java
@@ -13,7 +13,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.mockito.Mockito;
-import org.mockito.internal.debugging.LocationFactory;
+import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.internal.invocation.mockref.MockReference;
 import org.mockito.internal.invocation.mockref.MockStrongReference;
 import org.mockito.invocation.Invocation;
@@ -72,7 +72,7 @@ public class InvocationBuilder {
                         new SerializableMethod(method),
                         args,
                         NO_OP,
-                        location == null ? LocationFactory.create() : location,
+                        location == null ? Plugins.getLocationFactory().create() : location,
                         1);
         if (verified) {
             i.markVerified();

--- a/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNullsTest.java
+++ b/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNullsTest.java
@@ -20,7 +20,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ThrowableAssert;
 import org.junit.Test;
 import org.mockito.exceptions.verification.SmartNullPointerException;
-import org.mockito.internal.debugging.LocationFactory;
+import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.internal.invocation.InterceptedInvocation;
 import org.mockito.internal.invocation.SerializableMethod;
 import org.mockito.internal.invocation.mockref.MockStrongReference;
@@ -146,7 +146,7 @@ public class ReturnsSmartNullsTest extends TestBase {
                         GenericFooBar.class.getMethod("methodWithArgs", int.class, Object.class)),
                 new Object[] {1, obj},
                 InterceptedInvocation.NO_OP,
-                LocationFactory.create(),
+                Plugins.getLocationFactory().create(),
                 1);
     }
 
@@ -269,7 +269,7 @@ public class ReturnsSmartNullsTest extends TestBase {
                                 "methodWithVarArgs", int.class, Object[].class)),
                 new Object[] {1, obj},
                 InterceptedInvocation.NO_OP,
-                LocationFactory.create(),
+                Plugins.getLocationFactory().create(),
                 1);
     }
 

--- a/src/test/java/org/mockitousage/internal/debugging/LocationFactoryTest.java
+++ b/src/test/java/org/mockitousage/internal/debugging/LocationFactoryTest.java
@@ -5,7 +5,7 @@
 package org.mockitousage.internal.debugging;
 
 import org.junit.Test;
-import org.mockito.internal.debugging.LocationFactory;
+import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockitoutil.TestBase;
 
 import java.util.ArrayList;
@@ -18,7 +18,7 @@ public class LocationFactoryTest extends TestBase {
 
     @Test
     public void shouldLocationNotContainGetStackTraceMethod() {
-        assertThat(LocationFactory.create().toString())
+        assertThat(Plugins.getLocationFactory().create().toString())
                 .contains("shouldLocationNotContainGetStackTraceMethod");
     }
 
@@ -28,7 +28,7 @@ public class LocationFactoryTest extends TestBase {
         final List<String> files = new ArrayList<String>();
         new Runnable() { // anonymous inner class adds stress to the check
             public void run() {
-                files.add(LocationFactory.create().getSourceFile());
+                files.add(Plugins.getLocationFactory().create().getSourceFile());
             }
         }.run();
 

--- a/src/test/java/org/mockitoutil/TestBase.java
+++ b/src/test/java/org/mockitoutil/TestBase.java
@@ -17,7 +17,7 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.StateMaster;
 import org.mockito.internal.MockitoCore;
 import org.mockito.internal.configuration.ConfigurationAccess;
-import org.mockito.internal.debugging.LocationFactory;
+import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.internal.invocation.InterceptedInvocation;
 import org.mockito.internal.invocation.InvocationBuilder;
 import org.mockito.internal.invocation.InvocationMatcher;
@@ -84,7 +84,7 @@ public class TestBase {
                 new SerializableMethod(type.getMethod(methodName, types)),
                 args,
                 InterceptedInvocation.NO_OP,
-                LocationFactory.create(),
+                Plugins.getLocationFactory().create(),
                 1);
     }
 

--- a/subprojects/memory-test/src/test/java/org/mockito/memorytest/LocationFactoryAllocationRateTest.java
+++ b/subprojects/memory-test/src/test/java/org/mockito/memorytest/LocationFactoryAllocationRateTest.java
@@ -6,7 +6,7 @@ package org.mockito.memorytest;
 
 import com.sun.management.ThreadMXBean;
 import org.junit.Test;
-import org.mockito.internal.debugging.LocationFactory;
+import org.mockito.internal.configuration.plugins.Plugins;
 
 import java.lang.management.ManagementFactory;
 import java.util.stream.IntStream;
@@ -27,7 +27,7 @@ public class LocationFactoryAllocationRateTest {
         // On Java 8, this will use the internal approach. On Java 9, the StackWalker approach will
         // be used.
         new Throwable().fillInStackTrace();
-        LocationFactory.create();
+        Plugins.getLocationFactory().create();
         long baseline =
             countMemoryAllocations(
                 () ->
@@ -39,7 +39,7 @@ public class LocationFactoryAllocationRateTest {
                 () ->
                     recurseAndThen(
                         RECURSION_LIMIT,
-                        repeat(() -> LocationFactory.create(false))));
+                        repeat(() -> Plugins.getLocationFactory().create(false))));
         assertThat(actual * EXPECTED_IMPROVEMENT)
             .as(
                 "stack walker approach (%d) expected to be at least %fx better than exception approach (%d)",


### PR DESCRIPTION
<!-- Hey,
Thanks for the contribution, this is awesome.
As you may have read, project members have somehow an opinionated view on what and how should be
Mockito, e.g. we don't want mockito to be a feature bloat.
There may be a thorough review, with feedback -> code change loop.
-->
<!--
If you have a suggestion for this template you can fix it in the .github/PULL_REQUEST_TEMPLATE.md file
-->
As part of a rework on a project I'm contributing to, Mockito was added to replace the use of InvocationHandler.
One particular test class validates the behavior of around 1000 objects, with each other, resulting in a particular set of code running over 1 million times, using the mock a few times in the process. This results in the mock object being used over 15 millions times.

Oversimplified current use:

```java
public class TestClass {

    // Takes 1 minute 2 seconds with normal Location logic
    // Takes 17 seconds with dummy location factory extensions
    @Test
    public void test() {
        Object object = mock();
        when(object.toString()).thenReturn("Hello");

        for (int i = 0; i < 15000000; i++) {
            assertEquals("Hello", object.toString());
        }
    }
}
```

Resulting in the execution time of this particular test class to rise from a few seconds to over 2 minutes. After some profiling, we found that a huge part is caused by Mocktio's Location feature.

This PR moves the LocationFactory over to plugins, to allow others to override it. Which in our case we would use to return a dummy empty Location. Using a dummy Location reduced the execution time of our test class to under 1 minute. And after some other changes in our code base, not related to this PR, to around 20 seconds (which will it is not a few seconds as before, is much better than 2 minutes).

Will we understand and are thankful that Mockito wants to provide helpful error messages, in our particular use case we would like the faster testing time, so that this test can also be easily run during normal development. If the need for Location information arise, we could still just remove the extension and run it slower for a particular time.

Looking at some GitHub issues and PR, such as #2723 which also wanted to add a system property to use a dummy Location, it seems we are not the only one which would benefit from such an extension option.

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [ ] Mention `Fixes #<issue number>` in the description _if relevant_
 - [ ] At least one commit should mention `Fixes #<issue number>` _if relevant_

