### PR TITLE
Gradle 8.3 compatibility: buildDir -> layout.buildDirectory

### DIFF
--- a/gradle/java-publication.gradle
+++ b/gradle/java-publication.gradle
@@ -99,7 +99,7 @@ publishing {
     }
 
     //useful for testing - running "publish" will create artifacts/pom in a local dir
-    repositories { maven { url = "$buildDir/repo" } }
+    repositories { maven { url = layout.buildDirectory.dir("repo") } }
 }
 
 plugins.withId("java") {

--- a/gradle/mockito-core/javadoc.gradle
+++ b/gradle/mockito-core/javadoc.gradle
@@ -9,7 +9,7 @@ javadoc {
     // see https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html
 
     source = sourceSets.main.allJava
-    destinationDir = file("$buildDir/javadoc")
+    destinationDir = layout.buildDirectory.dir("javadoc").get().asFile
     title = "Mockito ${project.version} API"
 
     // The way *gradle* javadoc task works and due to *gradle exclusion* the log output triggers javadoc warning and
@@ -57,7 +57,7 @@ javadoc {
     doLast {
         copy {
             from "src/javadoc"
-            into "$buildDir/javadoc"
+            into layout.buildDirectory.dir("javadoc")
         }
     }
 }

--- a/gradle/retry-test.gradle
+++ b/gradle/retry-test.gradle
@@ -45,7 +45,7 @@ test {
     }
     afterSuite { descriptor, result ->
         if (!descriptor.parent) { //root
-            def failuresReport = new File(buildDir, name + "-failures.txt")
+            def failuresReport = layout.buildDirectory.file(name + "-failures.txt").get().asFile
             def deletion = !failuresReport.exists() || failuresReport.delete()
             if (!deletion) {
                 throw new GradleException("Problems deleting failures file: $reportPath. Please delete manually and retry.")


### PR DESCRIPTION
Not a breaking change in Gradle 8.3, just future-proofing code as Project.buildDir is deprecated in Gradle 8.3-rc-1.

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [ ] Mention `Fixes #<issue number>` in the description _if relevant_
 - [ ] At least one commit should mention `Fixes #<issue number>` _if relevant_

