### PR TITLE
Fixes #3077 : Report unused stubbing exceptions when test filter is no-op

### DIFF
--- a/src/test/java/org/mockitousage/junitrunner/StrictRunnerTest.java
+++ b/src/test/java/org/mockitousage/junitrunner/StrictRunnerTest.java
@@ -11,9 +11,12 @@ import static org.mockito.Mockito.when;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.Description;
 import org.junit.runner.JUnitCore;
+import org.junit.runner.Request;
 import org.junit.runner.Result;
 import org.junit.runner.RunWith;
+import org.junit.runner.manipulation.Filter;
 import org.mockito.Mock;
 import org.mockito.exceptions.misusing.UnnecessaryStubbingException;
 import org.mockito.junit.MockitoJUnit;
@@ -82,6 +85,34 @@ public class StrictRunnerTest extends TestBase {
 
         // then
         JUnitResultAssert.assertThat(result).isSuccessful();
+    }
+
+    @Test
+    public void does_not_report_unused_stubs_when_test_is_filtered() {
+        // This class has two test methods; run only the test method that does not use the stubbing
+        // set up in before
+        Request request = Request.method(StubbingInBeforeUsed.class, "dummy");
+
+        // when
+        Result result = runner.run(request);
+
+        // then
+        JUnitResultAssert.assertThat(result).isSuccessful();
+    }
+
+    @Test
+    public void fails_when_stubs_were_not_used_with_noop_filter() {
+        Class[] tests = {
+            StubbingInConstructorUnused.class,
+            StubbingInBeforeUnused.class,
+            StubbingInTestUnused.class
+        };
+
+        // when
+        Result result = runner.run(Request.classes(tests).filterWith(new NoOpFilter()));
+
+        // then
+        JUnitResultAssert.assertThat(result).fails(3, UnnecessaryStubbingException.class);
     }
 
     @RunWith(MockitoJUnitRunner.class)
@@ -199,6 +230,19 @@ public class StrictRunnerTest extends TestBase {
                     };
             t.start();
             t.join();
+        }
+    }
+
+    private static class NoOpFilter extends Filter {
+
+        @Override
+        public boolean shouldRun(Description description) {
+            return true;
+        }
+
+        @Override
+        public String describe() {
+            return "No-op filter";
         }
     }
 }


### PR DESCRIPTION
Fixes #3077 

## Summary

Adds granularity to the logic that skips reporting of unused stubbings when tests are filtered. Instead of simply detecting the use of any kind of filter, intercepts uses of that filter and only skips reporting of unused stubbings when the filter actually prevents one or more tests from being run.

This allows filters (such as JUnit category excludes, which themselves can be used to separate unit and integration tests) to be applied during a test run without sacrificing the benefits of strict stubbing.

Testing coverage is added for this newly-handled case (i.e., when a filter does not prevent any tests from being run), as well as existing cases (i.e., when a filter does prevent at least one test from being run).

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

