### PR TITLE
Add regression test to demonstrate the issue with creating a mock using a varargs constructor when using the inline mock maker and member-accessor-module

### DIFF
--- a/src/test/java/org/mockitousage/constructor/CreatingMocksWithConstructorTest.java
+++ b/src/test/java/org/mockitousage/constructor/CreatingMocksWithConstructorTest.java
@@ -17,7 +17,6 @@ import static org.mockito.Mockito.withSettings;
 import java.util.List;
 
 import org.junit.Test;
-import org.mockito.MockMakers;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.mock.SerializableMode;
 import org.mockitousage.IMethods;
@@ -471,9 +470,7 @@ public class CreatingMocksWithConstructorTest extends TestBase {
         ClassWithVarargsConstructor mock =
                 mock(
                         ClassWithVarargsConstructor.class,
-                        withSettings()
-                                .mockMaker(MockMakers.INLINE)
-                                .useConstructor(10, new String[] {"abc"}));
+                        withSettings().useConstructor(10, new String[] {"abc"}));
     }
 
     private static class ClassWithVarargsConstructor {

--- a/src/test/java/org/mockitousage/constructor/CreatingMocksWithConstructorTest.java
+++ b/src/test/java/org/mockitousage/constructor/CreatingMocksWithConstructorTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.withSettings;
 import java.util.List;
 
 import org.junit.Test;
+import org.mockito.MockMakers;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.mock.SerializableMode;
 import org.mockitousage.IMethods;
@@ -463,5 +464,19 @@ public class CreatingMocksWithConstructorTest extends TestBase {
                                 .useConstructor("String", 7)
                                 .defaultAnswer(CALLS_REAL_METHODS));
         assertEquals("String", mock.getData());
+    }
+
+    @Test
+    public void constructor_with_varargs() {
+        ClassWithVarargsConstructor mock =
+                mock(
+                        ClassWithVarargsConstructor.class,
+                        withSettings()
+                                .mockMaker(MockMakers.INLINE)
+                                .useConstructor(10, new String[] {"abc"}));
+    }
+
+    private static class ClassWithVarargsConstructor {
+        public ClassWithVarargsConstructor(int x, String... y) {}
     }
 }

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MemberAccessor
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MemberAccessor
@@ -1,0 +1,1 @@
+member-accessor-module

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MemberAccessor
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MemberAccessor
@@ -1,1 +1,0 @@
-member-accessor-module


### PR DESCRIPTION
- Adds a regression test for https://github.com/mockito/mockito/issues/2601 to demonstrate the issue with creating a mock using a varargs constructor when using the inline mock maker and `member-accessor-module`.
- The newly added test fails with:
```
org.mockitousage.constructor.CreatingMocksWithConstructorTest > constructor_with_varargs FAILED
    org.mockito.exceptions.base.MockitoException: Unable to create mock instance of type 'ClassWithVarargsConstructor'
        at app//org.mockito.internal.creation.bytebuddy.InlineDelegateByteBuddyMockMaker.doCreateMock(InlineDelegateByteBuddyMockMaker.java:389)
        at app//org.mockito.internal.creation.bytebuddy.InlineDelegateByteBuddyMockMaker.createMock(InlineDelegateByteBuddyMockMaker.java:334)
        at app//org.mockito.internal.creation.bytebuddy.InlineByteBuddyMockMaker.createMock(InlineByteBuddyMockMaker.java:56)
        at app//org.mockito.internal.util.MockUtil.createMock(MockUtil.java:99)
        at app//org.mockito.internal.MockitoCore.mock(MockitoCore.java:88)
        at app//org.mockito.Mockito.mock(Mockito.java:2037)
        at app//org.mockitousage.constructor.CreatingMocksWithConstructorTest.constructor_with_varargs(CreatingMocksWithConstructorTest.java:459)
        Caused by:
        org.mockito.creation.instance.InstantiationException: 
        Unable to create instance of 'ClassWithVarargsConstructor'.
        Please ensure the target class has a constructor that matches these argument types: [java.lang.Integer, [Ljava.lang.String;] and executes cleanly.
            at app//org.mockito.internal.creation.instance.ConstructorInstantiator.paramsException(ConstructorInstantiator.java:75)
            at app//org.mockito.internal.creation.instance.ConstructorInstantiator.withParams(ConstructorInstantiator.java:56)
            at app//org.mockito.internal.creation.instance.ConstructorInstantiator.newInstance(ConstructorInstantiator.java:39)
            at app//org.mockito.internal.creation.bytebuddy.InlineDelegateByteBuddyMockMaker.doCreateMock(InlineDelegateByteBuddyMockMaker.java:364)
            ... 6 more
            Caused by:
            java.lang.reflect.InvocationTargetException
                at org.mockito.internal.util.reflection.InstrumentationMemberAccessor.newInstance(InstrumentationMemberAccessor.java:198)
                at org.mockito.internal.util.reflection.InstrumentationMemberAccessor.newInstance(InstrumentationMemberAccessor.java:161)
                at org.mockito.internal.util.reflection.ModuleMemberAccessor.newInstance(ModuleMemberAccessor.java:42)
                at org.mockito.internal.creation.instance.ConstructorInstantiator.invokeConstructor(ConstructorInstantiator.java:70)
                at org.mockito.internal.creation.instance.ConstructorInstantiator.withParams(ConstructorInstantiator.java:53)
                ... 8 more
                Caused by:
                java.lang.ClassCastException: Cannot cast [Ljava.lang.String; to java.lang.String
                    at java.base/java.lang.Class.cast(Class.java:3889)
                    at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:732)
                    at java.base/java.lang.invoke.MethodHandleImpl$AsVarargsCollector.invokeWithArguments(MethodHandleImpl.java:535)
                    at org.mockito.internal.util.reflection.InstrumentationMemberAccessor$Dispatcher$ByteBuddy$XAC2Ka0U.invokeWithArguments(Unknown Source)
                    at org.mockito.internal.util.reflection.InstrumentationMemberAccessor.lambda$newInstance$0(InstrumentationMemberAccessor.java:191)
                    at org.mockito.internal.util.reflection.InstrumentationMemberAccessor.newInstance(InstrumentationMemberAccessor.java:188)
                    ... 12 more
```
- The test passes when using the subclass mock maker or when using the default reflection member accessor with the inline mock maker.
- The test also passes when using Java 8 or older because the `ModuleMemberAccessor` delegates to the `ReflectionMemberAccessor` for Java 8 and older - 
https://github.com/mockito/mockito/blob/f5ad9e9f9a338bcea6180fc474a562acc13f2c84/src/main/java/org/mockito/internal/util/reflection/ModuleMemberAccessor.java#L19-L37