### PR TITLE
Fixes 3087 : Add note on backporting to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Still on Mockito 1.x? See [what's new](https://github.com/mockito/mockito/wiki/W
 [Mockito 3](https://github.com/mockito/mockito/releases/tag/v3.0.0) does not introduce any breaking API changes, but now requires Java 8 over Java 6 for Mockito 2.
 [Mockito 4](https://github.com/mockito/mockito/releases/tag/v4.0.0) removes deprecated API.
 [Mockito 5](https://github.com/mockito/mockito/releases/tag/v5.0.0) switches the default mockmaker to mockito-inline, and now requires Java 11.
-
+Only one major version is supported at a time, and changes are not backported to older versions.
 
 ## Mockito for enterprise
 


### PR DESCRIPTION
Fixes https://github.com/mockito/mockito/issues/3087

Adds a (very brief) note stating that backporting does not take place and older major versions are not supported.