### PR TITLE
Added JavaFlightRecorder options for Tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ allprojects { proj ->
     }
     plugins.withId('java') {
         proj.apply from: "$rootDir/gradle/errorprone.gradle"
+        proj.apply from: "$rootDir/gradle/jfr.gradle"
     }
     tasks.withType(JavaCompile) {
         //I don't believe those warnings add value given modern IDEs

--- a/config/jfr/jfr_config.jfc
+++ b/config/jfr/jfr_config.jfc
@@ -1,0 +1,836 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration version="2.0" label="Mockito_JFR_Config" description="Profiling for test execution" provider="Mockito">
+
+    <event name="jdk.ThreadAllocationStatistics">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.ClassLoadingStatistics">
+      <setting name="enabled">true</setting>
+      <setting name="period">1000 ms</setting>
+    </event>
+
+    <event name="jdk.ClassLoaderStatistics">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.JavaThreadStatistics">
+      <setting name="enabled">true</setting>
+      <setting name="period">1000 ms</setting>
+    </event>
+
+    <event name="jdk.SymbolTableStatistics">
+      <setting name="enabled">true</setting>
+      <setting name="period">10 s</setting>
+    </event>
+
+    <event name="jdk.StringTableStatistics">
+      <setting name="enabled">true</setting>
+      <setting name="period">10 s</setting>
+    </event>
+
+    <event name="jdk.PlaceholderTableStatistics">
+      <setting name="enabled">true</setting>
+      <setting name="period">10 s</setting>
+    </event>
+
+    <event name="jdk.LoaderConstraintsTableStatistics">
+      <setting name="enabled">true</setting>
+      <setting name="period">10 s</setting>
+    </event>
+
+    <event name="jdk.ProtectionDomainCacheTableStatistics">
+      <setting name="enabled">true</setting>
+      <setting name="period">10 s</setting>
+    </event>
+
+    <event name="jdk.ThreadStart">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.ThreadEnd">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.ThreadSleep">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold" control="locking-threshold">10 ms</setting>
+    </event>
+
+    <event name="jdk.ThreadPark">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold" control="locking-threshold">10 ms</setting>
+    </event>
+
+    <event name="jdk.JavaMonitorEnter">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold" control="locking-threshold">10 ms</setting>
+    </event>
+
+    <event name="jdk.JavaMonitorWait">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold" control="locking-threshold">10 ms</setting>
+    </event>
+
+    <event name="jdk.JavaMonitorInflate">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold" control="locking-threshold">10 ms</setting>
+    </event>
+
+    <event name="jdk.SyncOnValueBasedClass">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.BiasedLockRevocation">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.BiasedLockSelfRevocation">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.BiasedLockClassRevocation">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ReservedStackActivation">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.ClassLoad">
+      <setting name="enabled" control="class-loading">false</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ClassDefine">
+      <setting name="enabled" control="class-loading">false</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.RedefineClasses">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.RetransformClasses">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ClassRedefinition">
+      <setting name="enabled" control="class-loading">true</setting>
+    </event>
+
+    <event name="jdk.ClassUnload">
+      <setting name="enabled" control="class-loading">false</setting>
+    </event>
+
+    <event name="jdk.JVMInformation">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.InitialSystemProperty">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.ExecutionSample">
+      <setting name="enabled" control="method-sampling-enabled">true</setting>
+      <setting name="period" control="method-sampling-java-interval">2 ms</setting>
+    </event>
+
+    <event name="jdk.NativeMethodSample">
+      <setting name="enabled" control="method-sampling-enabled">true</setting>
+      <setting name="period" control="method-sampling-native-interval">20 ms</setting>
+    </event>
+
+    <event name="jdk.SafepointBegin">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.SafepointStateSynchronization">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.SafepointCleanup">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.SafepointCleanupTask">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.SafepointEnd">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ExecuteVMOperation">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.Shutdown">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.ThreadDump">
+      <setting name="enabled" control="thread-dump-enabled">true</setting>
+      <setting name="period" control="thread-dump">10 s</setting>
+    </event>
+
+    <event name="jdk.IntFlag">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.UnsignedIntFlag">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.LongFlag">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.UnsignedLongFlag">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.DoubleFlag">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.BooleanFlag">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.StringFlag">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.IntFlagChanged">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.UnsignedIntFlagChanged">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.LongFlagChanged">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.UnsignedLongFlagChanged">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.DoubleFlagChanged">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.BooleanFlagChanged">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.StringFlagChanged">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.ObjectCount">
+      <setting name="enabled" control="gc-enabled-all">false</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.GCConfiguration">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.GCHeapConfiguration">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.YoungGenerationConfiguration">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.GCTLABConfiguration">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.GCSurvivorConfiguration">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.ObjectCountAfterGC">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event name="jdk.GCHeapSummary">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.PSHeapSummary">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.G1HeapSummary">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.MetaspaceSummary">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.MetaspaceGCThreshold">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.MetaspaceAllocationFailure">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.MetaspaceOOM">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.MetaspaceChunkFreeListSummary">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.GarbageCollection">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.SystemGC">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.ParallelOldGarbageCollection">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.YoungGarbageCollection">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.OldGarbageCollection">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.G1GarbageCollection">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.GCPhasePause">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.GCPhasePauseLevel1">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.GCPhasePauseLevel2">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.GCPhasePauseLevel3">
+      <setting name="enabled" control="gc-enabled-high">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.GCPhasePauseLevel4">
+      <setting name="enabled" control="gc-enabled-high">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.GCPhaseConcurrent">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.GCPhaseConcurrentLevel1">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.GCReferenceStatistics">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.PromotionFailed">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.EvacuationFailed">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.EvacuationInformation">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.G1MMU">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.G1EvacuationYoungStatistics">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.G1EvacuationOldStatistics">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.GCPhaseParallel">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.G1BasicIHOP">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.G1AdaptiveIHOP">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.PromoteObjectInNewPLAB">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+    </event>
+
+    <event name="jdk.PromoteObjectOutsidePLAB">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+    </event>
+
+    <event name="jdk.ConcurrentModeFailure">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.AllocationRequiringGC">
+      <setting name="enabled" control="gc-enabled-high">false</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.TenuringDistribution">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+    </event>
+
+    <event name="jdk.G1HeapRegionInformation">
+      <setting name="enabled" control="gc-enabled-high">false</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.G1HeapRegionTypeChange">
+      <setting name="enabled" control="gc-enabled-high">false</setting>
+    </event>
+
+    <event name="jdk.ShenandoahHeapRegionInformation">
+      <setting name="enabled" control="gc-enabled-high">false</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.ShenandoahHeapRegionStateChange">
+      <setting name="enabled" control="gc-enabled-high">false</setting>
+    </event>
+
+    <event name="jdk.OldObjectSample">
+      <setting name="enabled" control="old-objects-enabled">true</setting>
+      <setting name="stackTrace" control="old-objects-stack-trace">true</setting>
+      <setting name="cutoff" control="old-objects-cutoff">0 ns</setting>
+    </event>
+
+    <event name="jdk.CompilerConfiguration">
+      <setting name="enabled" control="compiler-enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.CompilerStatistics">
+      <setting name="enabled" control="compiler-enabled">true</setting>
+      <setting name="period">1000 ms</setting>
+    </event>
+
+    <event name="jdk.Compilation">
+      <setting name="enabled" control="compiler-enabled">true</setting>
+      <setting name="threshold" control="compiler-compilation-threshold">100 ms</setting>
+    </event>
+
+    <event name="jdk.CompilerPhase">
+      <setting name="enabled" control="compiler-enabled">true</setting>
+      <setting name="threshold" control="compiler-phase-threshold">10 s</setting>
+    </event>
+
+    <event name="jdk.CompilationFailure">
+      <setting name="enabled" control="compiler-enabled-failure">true</setting>
+    </event>
+
+    <event name="jdk.CompilerInlining">
+      <setting name="enabled" control="compiler-enabled-failure">true</setting>
+    </event>
+
+    <event name="jdk.JITRestart">
+      <setting name="enabled" control="compiler-enabled">true</setting>
+    </event>
+
+    <event name="jdk.CodeSweeperConfiguration">
+      <setting name="enabled" control="compiler-enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.CodeSweeperStatistics">
+      <setting name="enabled" control="compiler-enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.SweepCodeCache">
+      <setting name="enabled" control="compiler-enabled">true</setting>
+      <setting name="threshold" control="compiler-sweeper-threshold">100 ms</setting>
+    </event>
+
+    <event name="jdk.CodeCacheConfiguration">
+      <setting name="enabled" control="compiler-enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.CodeCacheStatistics">
+      <setting name="enabled" control="compiler-enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.CodeCacheFull">
+      <setting name="enabled" control="compiler-enabled">true</setting>
+    </event>
+
+    <event name="jdk.OSInformation">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.VirtualizationInformation">
+     <setting name="enabled">true</setting>
+     <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.ContainerConfiguration">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.ContainerCPUUsage">
+      <setting name="enabled">true</setting>
+      <setting name="period">30 s</setting>
+    </event>
+
+    <event name="jdk.ContainerCPUThrottling">
+      <setting name="enabled">true</setting>
+      <setting name="period">30 s</setting>
+    </event>
+
+    <event name="jdk.ContainerMemoryUsage">
+      <setting name="enabled">true</setting>
+      <setting name="period">30 s</setting>
+    </event>
+
+    <event name="jdk.ContainerIOUsage">
+      <setting name="enabled">true</setting>
+      <setting name="period">30 s</setting>
+    </event>
+
+    <event name="jdk.CPUInformation">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.ThreadContextSwitchRate">
+      <setting name="enabled" control="compiler-enabled">true</setting>
+      <setting name="period">10 s</setting>
+    </event>
+
+    <event name="jdk.CPULoad">
+      <setting name="enabled">true</setting>
+      <setting name="period">1000 ms</setting>
+    </event>
+
+    <event name="jdk.ThreadCPULoad">
+      <setting name="enabled">true</setting>
+      <setting name="period">10 s</setting>
+    </event>
+
+    <event name="jdk.CPUTimeStampCounter">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.SystemProcess">
+      <setting name="enabled">true</setting>
+      <setting name="period">endChunk</setting>
+    </event>
+
+    <event name="jdk.ProcessStart">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.NetworkUtilization">
+      <setting name="enabled">true</setting>
+      <setting name="period">5 s</setting>
+    </event>
+
+    <event name="jdk.InitialEnvironmentVariable">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.PhysicalMemory">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.ObjectAllocationInNewTLAB">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.ObjectAllocationOutsideTLAB">
+      <setting name="enabled" control="gc-enabled-high">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.ObjectAllocationSample">
+      <setting name="enabled" control="object-allocation-enabled">true</setting>
+      <setting name="throttle" control="allocation-profiling">1000/s</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.NativeLibrary">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.ModuleRequire">
+      <setting name="enabled">true</setting>
+      <setting name="period">endChunk</setting>
+    </event>
+
+    <event name="jdk.ModuleExport">
+      <setting name="enabled">true</setting>
+      <setting name="period">endChunk</setting>
+    </event>
+
+    <event name="jdk.FileForce">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold" control="file-threshold">10 ms</setting>
+    </event>
+
+    <event name="jdk.FileRead">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold" control="file-threshold">10 ms</setting>
+    </event>
+
+    <event name="jdk.FileWrite">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold" control="file-threshold">10 ms</setting>
+    </event>
+
+    <event name="jdk.SocketRead">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold" control="socket-threshold">10 ms</setting>
+    </event>
+
+    <event name="jdk.SocketWrite">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold" control="socket-threshold">10 ms</setting>
+    </event>
+
+    <event name="jdk.Deserialization">
+       <setting name="enabled">false</setting>
+       <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.InitialSecurityProperty">
+      <setting name="enabled">true</setting>
+      <setting name="period">beginChunk</setting>
+    </event>
+
+    <event name="jdk.SecurityPropertyModification">
+       <setting name="enabled">false</setting>
+       <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.SecurityProviderService">
+       <setting name="enabled">false</setting>
+       <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.TLSHandshake">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.X509Validation">
+       <setting name="enabled">false</setting>
+       <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.X509Certificate">
+       <setting name="enabled">false</setting>
+       <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.JavaExceptionThrow">
+      <setting name="enabled" control="enable-exceptions">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.JavaErrorThrow">
+      <setting name="enabled" control="enable-errors">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.ExceptionStatistics">
+      <setting name="enabled">true</setting>
+      <setting name="period">1000 ms</setting>
+    </event>
+
+    <event name="jdk.ActiveRecording">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.ActiveSetting">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.Flush">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">0 ns</setting>
+    </event>
+
+    <event name="jdk.DataLoss">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.DumpReason">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event name="jdk.ZAllocationStall">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ZPageAllocation">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">1 ms</setting>
+    </event>
+
+    <event name="jdk.ZRelocationSet">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ZRelocationSetGroup">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ZStatisticsCounter">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ZStatisticsSampler">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ZThreadPhase">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ZUncommit">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.ZUnmap">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event name="jdk.Deoptimization">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.HeapDump">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ns</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.DirectBufferStatistics">
+      <setting name="enabled">true</setting>
+      <setting name="period">5 s</setting>
+    </event>
+
+    <event name="jdk.GCLocker">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">100 ms</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+</configuration>

--- a/gradle/jfr.gradle
+++ b/gradle/jfr.gradle
@@ -1,0 +1,31 @@
+tasks.withType(Test).configureEach {
+    def taskName = name
+    /*
+     * If the gradle option -Pjfr is set during test execution, JFR will be activated for that execution.
+     */
+    if (project.extensions.extraProperties.has("jfr")) {
+        def jfrDir = "build/jfr"
+        def jfrConfigFile = rootProject.file("config/jfr/jfr_config.jfc")
+        def jfrFile = project.file("$jfrDir/${taskName}_Exec.jfr")
+
+        jvmArgs(
+            //https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html
+            // Search for -XX:FlightRecorderOptions and -XX:StartFlightRecording for more details in the documentation
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:+DebugNonSafepoints",
+            "-XX:FlightRecorderOptions=stackdepth=1024",
+            "-XX:StartFlightRecording=name=TestExec_$taskName,disk=true,maxsize=1g,dumponexit=true,filename=$jfrFile,settings=${jfrConfigFile.absolutePath}")
+
+        //We do not want to be UP-TO-DATE, if we are doing a Java Flight Recording. We always want a new recording.
+        outputs.upToDateWhen { false }
+
+        doFirst {
+            //Ensure that the jfr folder exists, otherwise the Java process start will fail.
+            project.file(jfrDir).mkdirs()
+        }
+
+        doLast{
+            println("Java Flight Recording was written to: $jfrFile")
+        }
+    }
+}


### PR DESCRIPTION
This allows you to create JFR recordings with the flag -Pjfr when running Gradle Test tasks.

The jfr_config.jfc provides a profiling config for the JFR. It tracks the TLAB allocations in addition to the normal profiling config in JDKs (JDK/lib/jfr/profile.jfc). It has also the following changes:
 * Method sampling interval of 2 ms
 * Thread dump  interval of 10 s
 * CompilerInlining true
 * ObjectAllocationSample throttle 1000/s
 * JavaExceptionThrow true

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [ ] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [ ] Mention `Fixes #<issue number>` in the description _if relevant_
 - [ ] At least one commit should mention `Fixes #<issue number>` _if relevant_

