### PR TITLE
Resolve more Gradle Tasks lazily

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,19 +56,19 @@ allprojects { proj ->
     plugins.withId('java') {
         proj.apply from: "$rootDir/gradle/errorprone.gradle"
     }
-    tasks.withType(JavaCompile) {
+    tasks.withType(JavaCompile).configureEach {
         //I don't believe those warnings add value given modern IDEs
         options.warnings = false
         options.encoding = 'UTF-8'
     }
-    tasks.withType(Javadoc) {
+    tasks.withType(Javadoc).configureEach {
         options.addStringOption('Xdoclint:none', '-quiet')
         options.addStringOption('encoding', 'UTF-8')
         options.addStringOption('charSet', 'UTF-8')
         options.setSource('11')
     }
 
-    tasks.withType(AbstractArchiveTask) {
+    tasks.withType(AbstractArchiveTask).configureEach {
         preserveFileTimestamps = false
         reproducibleFileOrder = true
         dirMode = Integer.parseInt("0755", 8)

--- a/gradle/java-library.gradle
+++ b/gradle/java-library.gradle
@@ -20,7 +20,7 @@ java {
     targetCompatibility = 11
 }
 
-test {
+tasks.named("test", Test) {
     include "**/*Test.class"
 
     testLogging {
@@ -31,7 +31,7 @@ test {
 
 apply from: "$rootDir/gradle/retry-test.gradle"
 
-tasks.withType(Checkstyle) {
+tasks.withType(Checkstyle).configureEach {
     reports {
         xml.required = false
         html.required = true

--- a/gradle/java-publication.gradle
+++ b/gradle/java-publication.gradle
@@ -7,30 +7,30 @@ plugins.withId("java") {
         include "LICENSE"
     }
 
-    task sourcesJar(type: Jar, dependsOn: classes) {
+   def sourcesJarTask = tasks.register("sourcesJar", Jar) {
         archiveClassifier = 'sources'
         from sourceSets.main.allSource
         with licenseSpec
     }
 
-    task javadocJar(type: Jar, dependsOn: javadoc) {
+    def javadocJarTask = tasks.register("javadocJar", Jar) {
         archiveClassifier = 'javadoc'
         from tasks.javadoc
         with licenseSpec
     }
 
     artifacts {
-        archives sourcesJar
-        archives javadocJar
+        archives sourcesJarTask
+        archives javadocJarTask
     }
 
-    jar {
+    tasks.named("jar", Jar) {
         with licenseSpec
     }
 }
 
 
-tasks.withType(GenerateModuleMetadata) {
+tasks.withType(GenerateModuleMetadata).configureEach {
     enabled = false
 }
 
@@ -41,8 +41,8 @@ publishing {
         javaLibrary(MavenPublication) {
             plugins.withId("java") {
                 from components.java
-                artifact sourcesJar
-                artifact javadocJar
+                artifact tasks.named("sourcesJar")
+                artifact tasks.named("javadocJar")
             }
             plugins.withId("java-platform") {
                 from components.javaPlatform
@@ -103,8 +103,10 @@ publishing {
 }
 
 plugins.withId("java") {
-//fleshes out problems with Maven pom generation when building
-    tasks.build.dependsOn("publishJavaLibraryPublicationToMavenLocal")
+    //fleshes out problems with Maven pom generation when building
+    tasks.named("build") {
+        dependsOn("publishJavaLibraryPublicationToMavenLocal")
+    }
 }
 
 apply plugin: 'signing' //https://docs.gradle.org/current/userguide/signing_plugin.html

--- a/gradle/java-test.gradle
+++ b/gradle/java-test.gradle
@@ -3,7 +3,9 @@ apply from: "$rootDir/gradle/test-launcher.gradle"
 
 // Test modules don't need to be published, so there's no need to build javadoc for them.
 // Most test modules don't have src/main, but this is here in shared configuration just in case.
-tasks.javadoc.enabled = false
+tasks.named("javadoc", Javadoc) {
+    enabled = false
+}
 
 java {
     sourceCompatibility = 11

--- a/gradle/mockito-core/inline-mock.gradle
+++ b/gradle/mockito-core/inline-mock.gradle
@@ -6,7 +6,7 @@ tasks.register('copyMockMethodDispatcher', Copy) {
 
     rename '(.+)\\.class', '$1.raw'
 }
-classes.dependsOn(copyMockMethodDispatcher)
+classes.dependsOn("copyMockMethodDispatcher")
 
 sourceSets.main {
     resources {
@@ -14,7 +14,7 @@ sourceSets.main {
     }
 }
 
-jar {
+tasks.named("jar", Jar) {
     exclude("org/mockito/internal/creation/bytebuddy/inject/package-info.class")
     exclude("org/mockito/internal/creation/bytebuddy/inject/MockMethodDispatcher.class")
 }

--- a/gradle/mockito-core/javadoc.gradle
+++ b/gradle/mockito-core/javadoc.gradle
@@ -2,7 +2,7 @@
 //such as link to packages, https://groups.google.com/d/msg/gradle-dev/R83dy_6PHMc/bgw0cUTMFAAJ
 def javaDocsDir = 'gradle/mockito-core/java-docs'
 
-javadoc {
+tasks.named("javadoc", Javadoc) {
     description "Creates javadoc html for Mockito API."
 
     // For more details on the format

--- a/gradle/mockito-core/osgi.gradle
+++ b/gradle/mockito-core/osgi.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'biz.aQute.bnd.builder'
 
-jar {
+tasks.named("jar", Jar) {
     bundle { // this: BundleTaskExtension
         classpath = project.configurations.compileClasspath
         bnd(

--- a/gradle/mockito-core/testing.gradle
+++ b/gradle/mockito-core/testing.gradle
@@ -1,12 +1,12 @@
 def java11 = System.env.SIMULATE_JAVA11
 if (java11 != null) {
-    test {
+    tasks.named("test", Test) {
         logger.info("$it.path - use Java11 simluation: ${java11}")
         systemProperty "org.mockito.internal.noUnsafeInjection", java11
     }
 }
 
-task(createTestResources) {
+tasks.register("createTestResources") {
     doLast {
         // Configure MockMaker from environment (if specified), otherwise use default
         def mockMakerFile = new File("$sourceSets.test.output.resourcesDir/mockito-extensions/org.mockito.plugins.MockMaker")
@@ -32,17 +32,23 @@ task(createTestResources) {
     }
 }
 
-task(removeTestResources).doLast {
-    def mockMakerFile = new File("$sourceSets.test.output.resourcesDir/mockito-extensions/org.mockito.plugins.MockMaker")
-    if (mockMakerFile.exists()) {
-        mockMakerFile.delete()
-    }
+tasks.register("removeTestResources"){
+    doLast {
+        def mockMakerFile = new File("$sourceSets.test.output.resourcesDir/mockito-extensions/org.mockito.plugins.MockMaker")
+        if (mockMakerFile.exists()) {
+            mockMakerFile.delete()
+        }
 
-    def memberAccessorFile = new File("$sourceSets.test.output.resourcesDir/mockito-extensions/org.mockito.plugins.MemberAccessor")
-    if (memberAccessorFile.exists()) {
-        memberAccessorFile.delete()
+        def memberAccessorFile = new File("$sourceSets.test.output.resourcesDir/mockito-extensions/org.mockito.plugins.MemberAccessor")
+        if (memberAccessorFile.exists()) {
+            memberAccessorFile.delete()
+        }
     }
 }
 
-processTestResources.finalizedBy(createTestResources)
-test.finalizedBy(removeTestResources)
+tasks.named("processTestResources") {
+    finalizedBy(createTestResources)
+}
+tasks.named("test") {
+    finalizedBy(removeTestResources)
+}

--- a/gradle/retry-test.gradle
+++ b/gradle/retry-test.gradle
@@ -6,7 +6,7 @@ Long term, we can evolve retry-test script plugin to a binary plugin or make it 
 
 Plugin adds 'retryTest' task that runs tests that failed during the execution of 'test' task.
 */
-task retryTest(type: Test) {
+def retryTestTask = tasks.register("retryTest", Test) {
     description = "Retries failed tests (if present)"
     enabled = false
     doFirst {
@@ -34,8 +34,8 @@ task retryTest(type: Test) {
     }
 }
 
-test {
-    finalizedBy retryTest
+tasks.named("test", Test) {
+    finalizedBy retryTestTask
     ext.failedTests = []
     afterTest { descriptor, result ->
         if (!descriptor.composite /* e.g. is not a parent */ && result.failedTestCount > 0 ) {

--- a/gradle/root/gradle-fix.gradle
+++ b/gradle/root/gradle-fix.gradle
@@ -2,7 +2,7 @@
 // GradleWorkerMain ignores options available in the environment, so we have to pass them there
 
 allprojects {
-    tasks.withType(JavaForkOptions) {
+    tasks.withType(JavaForkOptions).configureEach {
         // should improve memory on a 64bit JVM
         jvmArgs "-XX:+UseCompressedOops"
 


### PR DESCRIPTION
Changes the configuration and registration of Gradle Tasks to use the lazy API of Gradle. This shall speed up the configuration phase e.g. during single test execution.

Note: the tasks.withType() API has currently no overload with Action as the tasks.named() has, so we need to configureEach to be lazy.

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [ ] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [ ] Mention `Fixes #<issue number>` in the description _if relevant_
 - [ ] At least one commit should mention `Fixes #<issue number>` _if relevant_

