### PR TITLE
Use spdx identifier for license name

### DIFF
--- a/gradle/java-publication.gradle
+++ b/gradle/java-publication.gradle
@@ -66,7 +66,7 @@ publishing {
                 url = "https://github.com/mockito/mockito"
                 licenses {
                     license {
-                        name = 'The MIT License'
+                        name = 'MIT'
                         url = 'https://github.com/mockito/mockito/blob/main/LICENSE'
                         distribution = 'repo'
                     }


### PR DESCRIPTION
Hello mocki-devs 👋 

in our company we just added [licensee](https://github.com/cashapp/licensee) to our code base to make sure we are only using dependencies with licenses we agree on.

Behind the scense, the plugin scan the POM file and check the license name.
The plugin allow only license names that are part of the [SPDX Specification](https://spdx.org/licenses/).
For whatever reasons, we can't add any arbitrary license names to it, without adding the license URL.
This means, adding the license name `The MIT License` (what you are currently use) **without** adding the license URL (https://github.com/mockito/mockito/blob/main/LICENSE) is not working. It will fail with an error message.

Because mockito uses the default MIT License without any modification I guess it make sense to align this and use the SPDX Identifier, which is just `MIT`.

If we use this, the plugin will not fail anymore. Because it detects the official SPDX Identifier and is there "sure" that this is a valid license.

Honestly, I'm not sure you want this change. 😁 
So feel free to close it and just go with the current license name you have been using for years.
On the other hand, why not stick to an official specification? Shouldn't hurt anyway, right? 🤷 


## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [ ] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [ ] Avoid other runtime dependencies
 - [ ] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [ ] The pull request follows coding style
 - [ ] Mention `Fixes #<issue number>` in the description _if relevant_
 - [ ] At least one commit should mention `Fixes #<issue number>` _if relevant_

