### PR TITLE
Feat: add generic-inferred methods for constructing ArgumentCaptors

### DIFF
--- a/src/main/java/org/mockito/ArgumentCaptor.java
+++ b/src/main/java/org/mockito/ArgumentCaptor.java
@@ -135,15 +135,6 @@ public class ArgumentCaptor<T> {
     }
 
     /**
-     * Get the raw class being captured.
-     *
-     * @return the raw class that is being captured by this captor.
-     */
-    public Class<? extends T> getCaptorType() {
-        return clazz;
-    }
-
-    /**
      * Build a new <code>ArgumentCaptor</code>.
      * <p>
      * An <code>ArgumentCaptor</code> will perform type checks (since Mockito 5.0.0).
@@ -208,5 +199,14 @@ public class ArgumentCaptor<T> {
         }
 
         return forClass((Class<U>) reified.getClass().getComponentType());
+    }
+
+    /**
+     * Get the raw class being captured.
+     *
+     * @return the raw class that is being captured by this captor.
+     */
+    Class<? extends T> getCaptorType() {
+        return clazz;
     }
 }

--- a/src/main/java/org/mockito/ArgumentCaptor.java
+++ b/src/main/java/org/mockito/ArgumentCaptor.java
@@ -135,6 +135,15 @@ public class ArgumentCaptor<T> {
     }
 
     /**
+     * Get the raw class being captured.
+     *
+     * @return the raw class that is being captured by this captor.
+     */
+    public Class<? extends T> getCaptorType() {
+        return clazz;
+    }
+
+    /**
      * Build a new <code>ArgumentCaptor</code>.
      * <p>
      * An <code>ArgumentCaptor</code> will perform type checks (since Mockito 5.0.0).
@@ -146,5 +155,58 @@ public class ArgumentCaptor<T> {
      */
     public static <U, S extends U> ArgumentCaptor<U> forClass(Class<S> clazz) {
         return new ArgumentCaptor<>(clazz);
+    }
+
+    /**
+     * Build a new <code>ArgumentCaptor</code> by inferring the class type.
+     * <p>
+     * This enables inferring the generic type of an argument captor without
+     * providing a raw class reference, which enables working around generic
+     * limitations of the Java compiler without producing compile-time warnings
+     * unlike {@link #forClass} which would require explicit casting or warning
+     * suppression.
+     * <p>
+     * Example usage:
+     *
+     * <pre class="code"><code class="java">
+     *   // Given
+     *   UserRepository repository = mock();
+     *   UserService service = new UserService(repository);
+     *
+     *   Map&lt;String, User&gt; expectedUsers = Map.of(
+     *       "12345", new User("12345", "Bob"),
+     *       "45678", new User("45678", "Dave")
+     *   );
+     *
+     *   ArgumentCaptor&lt;Map&lt;String, User&gt;&gt; captor = ArgumentCaptor.captor();
+     *
+     *   doNothing().when(repository).storeUsers(captor.capture());
+     *
+     *   // When
+     *   service.createUsers(List.of(
+     *       new User("12345", "Bob"),
+     *       new User("45678", "Dave")
+     *   ));
+     *
+     *   // Then
+     *   Map&lt;String, User&gt; actualUsers = captor.getValue();
+     *
+     *   assertThat(expectedUsers).isEqualTo(actualUsers);
+     * </code></pre>
+     *
+     * @param reified do not pass any value here. This is used to trick the compiler
+     *     into reifying the return type without needing casts.
+     * @param <U> the type of argument to be captured by this captor.
+     * @return A new ArgumentCaptor.
+     * @throws IllegalArgumentException if any arguments are passed to this method.
+     */
+    @SafeVarargs
+    @SuppressWarnings({"varargs", "unchecked"})
+    public static <U> ArgumentCaptor<U> captor(U... reified) {
+        if (reified == null || reified.length > 0) {
+            throw new IllegalArgumentException("Do not provide any arguments to the 'captor' call");
+        }
+
+        return forClass((Class<U>) reified.getClass().getComponentType());
     }
 }

--- a/src/test/java/org/mockito/ArgumentCaptorTest.java
+++ b/src/test/java/org/mockito/ArgumentCaptorTest.java
@@ -5,11 +5,14 @@
 package org.mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.validateMockitoUsage;
 
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.exceptions.misusing.InvalidUseOfMatchersException;
+
+import java.util.Map;
 
 public class ArgumentCaptorTest {
 
@@ -29,5 +32,39 @@ public class ArgumentCaptorTest {
 
         ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
         assertThat(captor.capture()).isNull();
+    }
+
+    @Test
+    public void getCaptorType_returns_captor_type() throws Exception {
+        class Foo {
+        }
+
+        class Bar {
+        }
+
+        ArgumentCaptor<Foo> fooCaptor = ArgumentCaptor.forClass(Foo.class);
+        ArgumentCaptor<Bar> barCaptor = ArgumentCaptor.forClass(Bar.class);
+
+        assertThat(fooCaptor.getCaptorType()).isEqualTo(Foo.class);
+        assertThat(barCaptor.getCaptorType()).isEqualTo(Bar.class);
+    }
+
+    @Test
+    public void captor_calls_forClass_with_the_inferred_argument() throws Exception {
+        ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.captor();
+        assertThat(captor.getCaptorType()).isEqualTo(Map.class);
+    }
+
+    @Test
+    public void captor_called_with_explicit_varargs_is_invalid() throws Exception {
+        // Test passing a single argument.
+        assertThatThrownBy(() -> ArgumentCaptor.captor(1234L))
+                .isInstanceOf(IllegalArgumentException.class);
+        // Test passing multiple arguments.
+        assertThatThrownBy(() -> ArgumentCaptor.captor("this shouldn't", "be here"))
+                .isInstanceOf(IllegalArgumentException.class);
+        // Test passing a totally null varargs array.
+        assertThatThrownBy(() -> ArgumentCaptor.<String>captor((String[]) null))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/org/mockito/ArgumentCaptorTest.java
+++ b/src/test/java/org/mockito/ArgumentCaptorTest.java
@@ -36,11 +36,9 @@ public class ArgumentCaptorTest {
 
     @Test
     public void getCaptorType_returns_captor_type() throws Exception {
-        class Foo {
-        }
+        class Foo {}
 
-        class Bar {
-        }
+        class Bar {}
 
         ArgumentCaptor<Foo> fooCaptor = ArgumentCaptor.forClass(Foo.class);
         ArgumentCaptor<Bar> barCaptor = ArgumentCaptor.forClass(Bar.class);


### PR DESCRIPTION
Added a new method .captor(U...) on the ArgumentCaptor class that has the same interface as Mockito.mock(U...) with the goal of removing the need for unchecked-warning suppression when users make use of generic types in argument captors.

This allows the following usage without raising compiler warnings:

```java
ArgumentCaptor<List<Thingy>> thingyCaptor = ArgumentCaptor.captor();
```

...rather than the current solution, which is less elegant...

```java
@SuppressWarnings({"unchecked", "rawtypes"})
ArgumentCaptor<List<Thingy>> thingyCaptor = (ArgumentCaptor<List<Thingy>>) ArgumentCaptor.forClass(List.class);
```

A side effect of wanting to write tests for this meant I needed to expose the class held within a captor, so an additional method named `.getCaptorType()` has also been added. I have added this as public as it feels like a useful thing to expose anyway, given the user will know what is held internally. However, if this is unacceptable then I am happy to demote it to package-private or remove it and replace it with something like `assertThat(captor).hasPropertyOrFieldWithValue("clazz", expectedClass);`, or anything else that is suggested.

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style

