### PR TITLE
Disable fail-fast in CI build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
           - { mock-maker: 'mock-maker-subclass', member-accessor: 'member-accessor-module' }
           - { mock-maker: 'mock-maker-subclass', member-accessor: 'member-accessor-reflection' }
           - { mock-maker: 'mock-maker-inline', member-accessor: 'member-accessor-reflection' }
+      fail-fast: false
 
     # All build steps
     # SINGLE-MATRIX-JOB means that the step does not need to be executed on every job in the matrix


### PR DESCRIPTION
This option is needed to be disabled to collect information on failures from all build matrix entries. Otherwise the first failure cancels the executions of all other entries.

<!-- Hey,
Thanks for the contribution, this is awesome.
As you may have read, project members have somehow an opinionated view on what and how should be
Mockito, e.g. we don't want mockito to be a feature bloat.
There may be a thorough review, with feedback -> code change loop.
-->
<!--
If you have a suggestion for this template you can fix it in the .github/PULL_REQUEST_TEMPLATE.md file
-->
## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [ ] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [ ] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [ ] The pull request follows coding style
 - [ ] Mention `Fixes #<issue number>` in the description _if relevant_
 - [ ] At least one commit should mention `Fixes #<issue number>` _if relevant_

