### PR TITLE
Add CodeCov token to upload coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
       with:
         files: build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml
         fail_ci_if_error: true
+        token: ${{secrets.CODECOV_TOKEN}}
 
   #
   # Android build job


### PR DESCRIPTION
We already had this secret configured in our settings, but didn't supply it to the actual GitHub action step.