### PR TITLE
Fix license url according to spdx license spec

### DIFF
--- a/gradle/java-publication.gradle
+++ b/gradle/java-publication.gradle
@@ -67,7 +67,7 @@ publishing {
                 licenses {
                     license {
                         name = 'MIT'
-                        url = 'https://github.com/mockito/mockito/blob/main/LICENSE'
+                        url = 'https://opensource.org/licenses/MIT'
                         distribution = 'repo'
                     }
                 }


### PR DESCRIPTION
Somewhat of a follow-up of https://github.com/mockito/mockito/pull/3134 😅 Sorry ✌️ 

The reasining behind this PR is the same as https://github.com/mockito/mockito/pull/3134.
But this time it fixes the URL to the license.
Since mockito uses the standard MIT license without any modifications it should point to the "original"/"trusted"/"well known" license url, so that other plugins or tools can rely on this and make sure that mockito is using the original MIT license without any modifications 👍 

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [ ] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [ ] The pull request follows coding style
 - [ ] Mention `Fixes #<issue number>` in the description _if relevant_
 - [ ] At least one commit should mention `Fixes #<issue number>` _if relevant_

