### PR TITLE
Fixes issue #1917

### DIFF
--- a/src/main/java/org/mockito/internal/util/reflection/FieldInitializer.java
+++ b/src/main/java/org/mockito/internal/util/reflection/FieldInitializer.java
@@ -9,14 +9,8 @@ import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.internal.util.MockUtil;
 import org.mockito.plugins.MemberAccessor;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Modifier;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
+import java.lang.reflect.*;
+import java.util.*;
 
 import static java.lang.reflect.Modifier.isStatic;
 

--- a/src/main/java/org/mockito/internal/util/reflection/FieldInitializer.java
+++ b/src/main/java/org/mockito/internal/util/reflection/FieldInitializer.java
@@ -165,6 +165,7 @@ public class FieldInitializer {
          * @return The argument instances to be given to the constructor, should not be null.
          */
         Object[] resolveTypeInstances(Class<?>... argTypes);
+        Object[] resolveTypeInstancesGeneric(HashMap<String, Type> hashMap, Type[] types);
     }
 
     private interface ConstructorInstantiator {
@@ -284,9 +285,17 @@ public class FieldInitializer {
 
         @Override
         public FieldInitializationReport instantiate() {
+            Field[] fields = testClass.getClass().getDeclaredFields();
+            HashMap<String, Type> hashmap = new HashMap<>();
+
+            for (Field field : fields) {
+                hashmap.put(field.getName(), field.getGenericType());
+            }
             final MemberAccessor accessor = Plugins.getMemberAccessor();
             Constructor<?> constructor = biggestConstructor(field.getType());
-            final Object[] args = argResolver.resolveTypeInstances(constructor.getParameterTypes());
+            final Object[] args = argResolver.resolveTypeInstancesGeneric(
+                hashmap, constructor.getGenericParameterTypes());
+           //final Object[] args = argResolver.resolveTypeInstances(constructor.getParameterTypes());
             try {
                 Object newFieldInstance = accessor.newInstance(constructor, args);
                 accessor.set(field, testClass, newFieldInstance);

--- a/src/test/java/org/mockito/internal/configuration/injection/InjectionFourHashmapsWithDifferentTypeParameterTest.java
+++ b/src/test/java/org/mockito/internal/configuration/injection/InjectionFourHashmapsWithDifferentTypeParameterTest.java
@@ -1,0 +1,66 @@
+package org.mockito.internal.configuration.injection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InjectionFourHashmapsWithDifferentTypeParameterTest {
+    public static class TwoListsTest {
+        private final HashMap<String, String> hashmap1;
+        private final HashMap<String, Integer> hashmap2;
+        private final HashMap<Float, Integer> hashmap3;
+        private final HashMap<Float, Float> hashmap4;
+
+        public TwoListsTest(
+            HashMap<String, String> hashmap1, HashMap<String, Integer> hashmap2, HashMap<Float, Integer> hashmap3, HashMap<Float, Float> hashmap4) {
+            this.hashmap1 = hashmap1;
+            this.hashmap2 = hashmap2;
+            this.hashmap3 = hashmap3;
+            this.hashmap4 = hashmap4;
+        }
+
+        public HashMap<String, String> getHashmap1() {
+            return hashmap1;
+        }
+
+        public HashMap<String, Integer> getHashmap2() {
+            return hashmap2;
+        }
+
+        public HashMap<Float, Integer> getHashmap3() {
+            return hashmap3;
+        }
+
+        public HashMap<Float, Float> getHashmap4() {
+            return hashmap4;
+        }
+    }
+
+    @Mock(strictness = Mock.Strictness.LENIENT)
+    HashMap<String, String> mockhashmap1;
+
+    @Mock(strictness = Mock.Strictness.LENIENT)
+    HashMap<String, Integer> mockhashmap2;
+
+    @Mock(strictness = Mock.Strictness.LENIENT)
+    HashMap<Float, Float> mockhashmap4;
+    @Mock(strictness = Mock.Strictness.LENIENT)
+    HashMap<Float, Integer> mockhashmap3;
+
+    @InjectMocks
+    TwoListsTest productionClass;
+    @Test
+    public void test() {
+        assertEquals("mockhashmap1", productionClass.getHashmap1().toString());
+        assertEquals("mockhashmap2", productionClass.getHashmap2().toString());
+        assertEquals("mockhashmap3", productionClass.getHashmap3().toString());
+        assertEquals("mockhashmap4", productionClass.getHashmap4().toString());
+    }
+}

--- a/src/test/java/org/mockito/internal/configuration/injection/InjectionTwoListsWithDifferentTypeParameterTest.java
+++ b/src/test/java/org/mockito/internal/configuration/injection/InjectionTwoListsWithDifferentTypeParameterTest.java
@@ -1,0 +1,46 @@
+package org.mockito.internal.configuration.injection;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InjectionTwoListsWithDifferentTypeParameterTest {
+    public static class TwoListsTest {
+        private final List<Integer> integerList;
+        private final List<String> stringList;
+
+        TwoListsTest(List<String> argumentStringList, List<Integer> argumentIntegerList) {
+            this.stringList = argumentStringList;
+            this.integerList = argumentIntegerList;
+        }
+
+        public List<Integer> getIntegerList() {
+            return integerList;
+        }
+
+        public List<String> getStringList() {
+            return stringList;
+        }
+    }
+    @InjectMocks
+    TwoListsTest productionClass;
+
+    @Mock(strictness = Mock.Strictness.LENIENT)
+    List<Integer> mockIntegerList;
+
+    @Mock(strictness = Mock.Strictness.LENIENT)
+    List<String> mockStringList;
+    @Test
+    public void test() {
+        System.out.println(productionClass.getIntegerList());
+        System.out.println(productionClass.getStringList());
+        assertEquals("mockIntegerList", productionClass.getIntegerList().toString());
+        assertEquals("mockStringList", productionClass.getStringList().toString());
+    }
+}

--- a/src/test/java/org/mockito/internal/util/reflection/FieldInitializerTest.java
+++ b/src/test/java/org/mockito/internal/util/reflection/FieldInitializerTest.java
@@ -17,6 +17,8 @@ import static org.mockito.Mockito.mock;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Type;
+import java.util.HashMap;
 
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -198,7 +200,7 @@ public class FieldInitializerTest {
         ConstructorArgumentResolver resolver =
                 given(
                                 mock(ConstructorArgumentResolver.class)
-                                        .resolveTypeInstances(any(Class.class)))
+                                        .resolveTypeInstancesGeneric(any(HashMap.class), any(Type[].class)))
                         .willReturn(new Object[] {null})
                         .getMock();
 

--- a/src/test/java/org/mockito/internal/util/reflection/ParameterizedConstructorInstantiatorTest.java
+++ b/src/test/java/org/mockito/internal/util/reflection/ParameterizedConstructorInstantiatorTest.java
@@ -7,11 +7,14 @@ package org.mockito.internal.util.reflection;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Observer;
 import java.util.Set;
@@ -73,7 +76,7 @@ public class ParameterizedConstructorInstantiatorTest {
     public void should_instantiate_type_if_resolver_provide_matching_types() throws Exception {
         Observer observer = mock(Observer.class);
         Map map = mock(Map.class);
-        given(resolver.resolveTypeInstances(ArgumentMatchers.any(Class[].class)))
+        given(resolver.resolveTypeInstancesGeneric(any(HashMap.class), any(Type[].class)))
                 .willReturn(new Object[] {observer, map});
 
         new ParameterizedConstructorInstantiator(this, field("withMultipleConstructor"), resolver)
@@ -104,7 +107,7 @@ public class ParameterizedConstructorInstantiatorTest {
 
     @Test
     public void should_report_failure_if_constructor_throws_exception() throws Exception {
-        given(resolver.resolveTypeInstances(ArgumentMatchers.<Class<?>[]>any()))
+        given(resolver.resolveTypeInstancesGeneric(any(HashMap.class), any(Type[].class)))
                 .willReturn(new Object[] {null});
 
         try {
@@ -120,7 +123,7 @@ public class ParameterizedConstructorInstantiatorTest {
     @Test
     public void should_instantiate_type_with_vararg_constructor() throws Exception {
         Observer[] vararg = new Observer[] {};
-        given(resolver.resolveTypeInstances(ArgumentMatchers.any(Class[].class)))
+        given(resolver.resolveTypeInstancesGeneric(any(HashMap.class), any(Type[].class)))
                 .willReturn(new Object[] {"", vararg});
 
         new ParameterizedConstructorInstantiator(this, field("withVarargConstructor"), resolver)


### PR DESCRIPTION
<!-- Hey,
Thanks for the contribution, this is awesome.
As you may have read, project members have somehow an opinionated view on what and how should be
Mockito, e.g. we don't want mockito to be a feature bloat.
There may be a thorough review, with feedback -> code change loop.
-->
<!--
If you have a suggestion for this template you can fix it in the .github/PULL_REQUEST_TEMPLATE.md file
-->
Fixes #1917 where Mockito cannot differentiate injection between classes with different type parameters. Instead of passing 
constructor.getParameterTypes() to argResolver it passes constructor.getGenericParameterTypes() in order to properly compare the Type Parameters of the objects that are being injected. Also added tests to ensure Mockito is injecting mocks as intended and corrected tests that used the original resolveTypeInstances() vs the new resolveTypeInstancesGeneric()


## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [ ] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

