### PR TITLE
Handle Termux in InlineDelegateByteBuddyMockMaker.java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,8 @@ dependencies {
     implementation libraries.objenesis
 
     testImplementation libraries.assertj
+    testImplementation libraries.junitJupiterApi
+    testImplementation libraries.junitJupiterParams
 
     testUtil sourceSets.test.output
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -10,6 +10,7 @@ versions.errorprone = '2.23.0'
 
 libraries.junit4 = 'junit:junit:4.13.2'
 libraries.junitJupiterApi = "org.junit.jupiter:junit-jupiter-api:${versions.junitJupiter}"
+libraries.junitJupiterParams = "org.junit.jupiter:junit-jupiter-params:${versions.junitJupiter}"
 libraries.junitPlatformLauncher = 'org.junit.platform:junit-platform-launcher:1.10.0'
 libraries.junitJupiterEngine = "org.junit.jupiter:junit-jupiter-engine:${versions.junitJupiter}"
 libraries.junitVintageEngine = "org.junit.vintage:junit-vintage-engine:${versions.junitJupiter}"

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
@@ -207,17 +207,7 @@ class InlineDelegateByteBuddyMockMaker
     InlineDelegateByteBuddyMockMaker() {
         if (INITIALIZATION_ERROR != null) {
             String detail;
-
-            boolean isNativeAndroid = System.getProperty("java.specification.vendor", "")
-                    .toLowerCase()
-                    .contains("android");
-
-            // Termux can run any JVM, such as Oracle, but may still fail to instrument the
-            // JVM correctly, so it is worth detecting this as well.
-            boolean isTermuxAndroid = System.getProperty("java.home", "")
-                    .contains("/com.termux/");
-            
-            if (isNativeAndroid || isTermuxAndroid) {
+            if (PlatformUtils.isAndroidPlatform() || PlatformUtils.isProbablyTermuxEnvironment()) {
                 detail =
                         "It appears as if you are trying to run this mock maker on Android which does not support the instrumentation API.";
             } else {

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
@@ -207,9 +207,17 @@ class InlineDelegateByteBuddyMockMaker
     InlineDelegateByteBuddyMockMaker() {
         if (INITIALIZATION_ERROR != null) {
             String detail;
-            if (System.getProperty("java.specification.vendor", "")
+
+            boolean isNativeAndroid = System.getProperty("java.specification.vendor", "")
                     .toLowerCase()
-                    .contains("android")) {
+                    .contains("android");
+
+            // Termux can run any JVM, such as Oracle, but may still fail to instrument the
+            // JVM correctly, so it is worth detecting this as well.
+            boolean isTermuxAndroid = System.getProperty("java.home", "")
+                    .contains("/com.termux/");
+            
+            if (isNativeAndroid || isTermuxAndroid) {
                 detail =
                         "It appears as if you are trying to run this mock maker on Android which does not support the instrumentation API.";
             } else {

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/PlatformUtils.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/PlatformUtils.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.creation.bytebuddy;
+
+/**
+ * Helpers for various platform detection mechanisms related to the ByteBuddy mock maker.
+ *
+ * @author Ashley Scopes
+ */
+final class PlatformUtils {
+    private PlatformUtils() {
+        // Static-only class.
+    }
+
+    static boolean isAndroidPlatform() {
+        return System.getProperty("java.specification.vendor", "")
+                .toLowerCase()
+                .contains("android");
+    }
+
+    static boolean isProbablyTermuxEnvironment() {
+        boolean isLinux = System.getProperty("os.name", "").equalsIgnoreCase("linux");
+        boolean isInTermuxData =
+                System.getProperty("java.home", "").toLowerCase().contains("/com.termux/");
+        return isLinux && isInTermuxData;
+    }
+}

--- a/src/test/java/org/mockito/internal/creation/bytebuddy/PlatformUtilsTest.java
+++ b/src/test/java/org/mockito/internal/creation/bytebuddy/PlatformUtilsTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2023 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.creation.bytebuddy;
+
+import java.util.Properties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Ashley Scopes
+ */
+@Isolated("modifies system properties temporarily")
+class PlatformUtilsTest {
+    Properties globalProperties;
+
+    @BeforeEach
+    void setUp() {
+        globalProperties = new Properties();
+        globalProperties.putAll(System.getProperties());
+        System.getProperties().clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.getProperties().clear();
+        System.getProperties().putAll(globalProperties);
+    }
+
+    @CsvSource(
+            value = {
+                "java.specification.vendor, expected result",
+                "                  android,            true",
+                "                  AnDrOId,            true",
+                "             anythingElse,           false",
+                "                         ,           false",
+            },
+            useHeadersInDisplayName = true)
+    @ParameterizedTest
+    void isAndroidPlatform_returns_expected_value(String vendor, boolean result) {
+        // Given
+        setProperty("java.specification.vendor", vendor);
+
+        // Then
+        assertThat(PlatformUtils.isAndroidPlatform()).isEqualTo(result);
+    }
+
+    @CsvSource(
+            value = {
+                "      os.name,                      java.home, expected result",
+                "        linux, /data/data/com.termux/whatever,            true",
+                "        linux,    /foo/bar/com.termux/somedir,            true",
+                "        LINUX, /data/data/com.termux/whatever,            true",
+                "        Linux,    /foo/bar/com.termux/somedir,            true",
+                "Mac OS X 13.0,    /foo/bar/com.termux/somedir,           false",
+                "   Windows 10,    /foo/bar/com.termux/somedir,           false",
+                "         OS/2,    /foo/bar/com.termux/somedir,           false",
+                "        Linux,                /usr/share/java,           false",
+                "             ,                               ,           false",
+                "          foo,                               ,           false",
+                "             ,                            foo,           false",
+                "        linux,                               ,           false",
+                "             , /data/data/com.termux/whatever,           false",
+            },
+            useHeadersInDisplayName = true)
+    @ParameterizedTest
+    void isProbablyTermuxEnvironment_returns_expected_value(
+            String os, String javaHome, boolean result) {
+        // Given
+        setProperty("os.name", os);
+        setProperty("java.home", javaHome);
+
+        // Then
+        assertThat(PlatformUtils.isProbablyTermuxEnvironment()).isEqualTo(result);
+    }
+
+    static void setProperty(String name, String value) {
+        if (value == null) {
+            System.clearProperty(name);
+        } else {
+            System.setProperty(name, value);
+        }
+    }
+}


### PR DESCRIPTION
Termux on Android can run any JVM, so we cannot rely on the vendor here to determine if we are in Termux. Nonetheless, ByteBuddy can fail to instrument correctly on this platform, so it is worth showing a meaningful error message in this scenario.

## Changes

- Implement checks for Termux in InlineDelegateByteBuddyMockMaker
- Implement unit tests for the ByteBuddy platform conditions
- Extract the ByteBuddy platform conditions to a separate utility class
  to enable unit testing them separately. This also enables adding additional
  checks in the future without making the InlineDelegateByteBuddyMockMaker
  much more complicated.
- Added dependency at test time for junit-jupiter-params to enable writing
  parameterized unit tests.

## Existing behaviour:

```
$ jshell
Oct 24, 2023 7:50:27 AM java.util.prefs.FileSystemPreferences$1 run
INFO: Created user preferences directory.
|  Welcome to JShell -- Version 17-internal
|  For an introduction type: /help intro

jshell> System.getProperty("java.specification.vendor")
$1 ==> "Oracle Corporation"

jshell> System.getProperty("os.name")
$2 ==> "Linux"

jshell> System.getProperty("java.home")
$3 ==> "/data/data/com.termux/files/usr/opt/openjdk"

$ uname -a
Linux localhost 5.4.210-qgki-g809b0fd981e4 #1 SMP PREEMPT Thu Aug 24 22:38:41 CST 2023 aarch64 Android
```

```
$ ./mvnw clean test
...
[INFO] Stack trace
[INFO] java.lang.IllegalStateException: Could not initialize plugin: interface org.mockito.plugins.MockMaker (alternate: null)
        at org.mockito.internal.configuration.plugins.PluginLoader$1.invoke(PluginLoader.java:84)
        at jdk.proxy2/jdk.proxy2.$Proxy23.createStaticMock(Unknown Source)
        at org.mockito.internal.util.MockUtil.createStaticMock(MockUtil.java:202)
        at org.mockito.internal.MockitoCore.mockStatic(MockitoCore.java:134)
        at org.mockito.Mockito.mockStatic(Mockito.java:2325)
        at org.mockito.internal.configuration.MockAnnotationProcessor.processAnnotationForMock(MockAnnotationProcessor.java:69)
        at org.mockito.internal.configuration.MockAnnotationProcessor.process(MockAnnotationProcessor.java:28)
        at org.mockito.internal.configuration.MockAnnotationProcessor.process(MockAnnotationProcessor.java:25)
        at org.mockito.internal.configuration.IndependentAnnotationEngine.createMockFor(IndependentAnnotationEngine.java:44)
        at org.mockito.internal.configuration.IndependentAnnotationEngine.process(IndependentAnnotationEngine.java:72)
        at org.mockito.internal.configuration.InjectingAnnotationEngine.processIndependentAnnotations(InjectingAnnotationEngine.java:62)
        at org.mockito.internal.configuration.InjectingAnnotationEngine.process(InjectingAnnotationEngine.java:47)
        at org.mockito.MockitoAnnotations.openMocks(MockitoAnnotations.java:81)
        at org.mockito.internal.framework.DefaultMockitoSession.<init>(DefaultMockitoSession.java:43)
        at org.mockito.internal.session.DefaultMockitoSessionBuilder.startMocking(DefaultMockitoSessionBuilder.java:83)
        at org.mockito.junit.jupiter.MockitoExtension.beforeEach(MockitoExtension.java:159)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
        Suppressed: java.lang.NullPointerException: Cannot invoke "java.util.Set.forEach(java.util.function.Consumer)" because the return value of "org.junit.jupiter.api.extension.ExtensionContext$Store.remove(Object, java.lang.Class)" is null
                at org.mockito.junit.jupiter.MockitoExtension.afterEach(MockitoExtension.java:190)
                ... 2 more
Caused by: java.lang.IllegalStateException: Internal problem occurred, please report it. Mockito is unable to load the default implementation of class that is a part of Mockito distribution. Failed to load interface org.mockito.plugins.MockMaker
        at org.mockito.internal.configuration.plugins.DefaultMockitoPlugins.create(DefaultMockitoPlugins.java:105)
        at org.mockito.internal.configuration.plugins.DefaultMockitoPlugins.getDefaultPlugin(DefaultMockitoPlugins.java:79)
        at org.mockito.internal.configuration.plugins.PluginLoader.loadPlugin(PluginLoader.java:75)
        at org.mockito.internal.configuration.plugins.PluginLoader.loadPlugin(PluginLoader.java:50)
        at org.mockito.internal.configuration.plugins.PluginRegistry.<init>(PluginRegistry.java:27)
        at org.mockito.internal.configuration.plugins.Plugins.<clinit>(Plugins.java:22)
        at org.mockito.internal.MockitoCore.<clinit>(MockitoCore.java:73)
        at org.mockito.Mockito.<clinit>(Mockito.java:1683)
        at org.mockito.junit.jupiter.MockitoExtension.beforeEach(MockitoExtension.java:155)
        ... 2 more
Caused by: java.lang.reflect.InvocationTargetException
        at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
        at org.mockito.internal.configuration.plugins.DefaultMockitoPlugins.create(DefaultMockitoPlugins.java:103)
        ... 10 more
Caused by: org.mockito.exceptions.base.MockitoInitializationException:
Could not initialize inline Byte Buddy mock maker.

It appears as if your JDK does not supply a working agent attachment mechanism.
Java               : 17
JVM vendor name    : Oracle Corporation
JVM vendor version : 17-internal+0-adhoc..src
JVM name           : OpenJDK 64-Bit Server VM
JVM version        : 17-internal+0-adhoc..src
JVM info           : mixed mode
OS name            : Linux
OS version         : 5.4.210-qgki-g809b0fd981e4

        at org.mockito.internal.creation.bytebuddy.InlineDelegateByteBuddyMockMaker.<init>(InlineDelegateByteBuddyMockMaker.java:244)
        at org.mockito.internal.creation.bytebuddy.InlineByteBuddyMockMaker.<init>(InlineByteBuddyMockMaker.java:23)
        ... 13 more
Caused by: java.lang.IllegalStateException: Could not self-attach to current VM using external process
        at net.bytebuddy.agent.ByteBuddyAgent.installExternal(ByteBuddyAgent.java:706)
        at net.bytebuddy.agent.ByteBuddyAgent.install(ByteBuddyAgent.java:636)
        at net.bytebuddy.agent.ByteBuddyAgent.install(ByteBuddyAgent.java:616)
        at net.bytebuddy.agent.ByteBuddyAgent.install(ByteBuddyAgent.java:568)
        at net.bytebuddy.agent.ByteBuddyAgent.install(ByteBuddyAgent.java:545)
        at org.mockito.internal.creation.bytebuddy.InlineDelegateByteBuddyMockMaker.<clinit>(InlineDelegateByteBuddyMockMaker.java:115)
        ... 14 more
```
