### PR TITLE
Fixes #3061 : Deprecated mockedTypeIsInconsistentWithDelegatedInstance()

### DIFF
--- a/src/main/java/org/mockito/internal/exceptions/Reporter.java
+++ b/src/main/java/org/mockito/internal/exceptions/Reporter.java
@@ -925,6 +925,12 @@ public class Reporter {
         return details.getCause().getMessage();
     }
 
+    /**
+     * Exception is no longer required. To mock with a delegate of a different type, use delgatesTo().
+     *
+     * @deprecated
+     */
+    @Deprecated
     public static MockitoException mockedTypeIsInconsistentWithDelegatedInstanceType(
             Class<?> mockedType, Object delegatedInstance) {
         return new MockitoException(


### PR DESCRIPTION
This PR resolves issue #3061.

Initially I thought it would be possible to replace the delegatedInstance() reference. However, investigating the origins of the mockTypeIsInconsistentWithDelegatedInstance exception, it seems to me that the exception is not needed. It is only thrown in the validateDelegatedInstance method, and this method is never called anywhere in the codebase.  Thus, the exception can be deprecated. 

This will avoid any further confusion with the delegatedInstance() reference. 

This is my first ever pull request, so any feedback is greatly appreciated. 

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

