### PR TITLE
Fixes #3160 : Fix interference between spies when spying on records.

### DIFF
--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
@@ -218,7 +218,7 @@ class InlineDelegateByteBuddyMockMaker
     private final DetachedThreadLocal<Map<Class<?>, BiConsumer<Object, MockedConstruction.Context>>>
             mockedConstruction = new DetachedThreadLocal<>(DetachedThreadLocal.Cleaner.MANUAL);
 
-    private final ThreadLocal<Boolean> mockitoConstruction = ThreadLocal.withInitial(() -> false);
+    private final ThreadLocal<Class<?>> currentMocking = ThreadLocal.withInitial(() -> null);
 
     private final ThreadLocal<Object> currentSpied = new ThreadLocal<>();
 
@@ -272,7 +272,9 @@ class InlineDelegateByteBuddyMockMaker
                 type -> {
                     if (isSuspended.get()) {
                         return false;
-                    } else if (mockitoConstruction.get() || currentConstruction.get() != null) {
+                    } else if ((currentMocking.get() != null
+                                    && type.isAssignableFrom(currentMocking.get()))
+                            || currentConstruction.get() != null) {
                         return true;
                     }
                     Map<Class<?>, ?> interceptors = mockedConstruction.get();
@@ -290,7 +292,7 @@ class InlineDelegateByteBuddyMockMaker
                 };
         ConstructionCallback onConstruction =
                 (type, object, arguments, parameterTypeNames) -> {
-                    if (mockitoConstruction.get()) {
+                    if (currentMocking.get() != null) {
                         Object spy = currentSpied.get();
                         if (spy == null) {
                             return null;
@@ -647,11 +649,11 @@ class InlineDelegateByteBuddyMockMaker
                     accessor.newInstance(
                             selected,
                             callback -> {
-                                mockitoConstruction.set(true);
+                                currentMocking.set(cls);
                                 try {
                                     return callback.newInstance();
                                 } finally {
-                                    mockitoConstruction.set(false);
+                                    currentMocking.remove();
                                 }
                             },
                             arguments);

--- a/subprojects/java21/src/test/java/org/mockito/java21/RecordTest.java
+++ b/subprojects/java21/src/test/java/org/mockito/java21/RecordTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.java21;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+
+import java.util.List;
+
+import org.junit.Test;
+
+public class RecordTest {
+
+    @Test
+    public void given_list_is_already_spied__when_spying_record__then_record_fields_are_correctly_populated() {
+        var ignored = spy(List.of());
+
+        record MyRecord(String name) {
+        }
+        MyRecord spiedRecord = spy(new MyRecord("something"));
+
+        assertThat(spiedRecord.name()).isEqualTo("something");
+    }
+}


### PR DESCRIPTION
This fixes #3160. This is a bug where spied records end up having all their fields null. Here's a reproducer of the bug:

```java
@Test
void myTest() {
    spy(List.of("something"));

    record MyRecord(String name) {}
    MyRecord spiedRecord = spy(new MyRecord("something"));
    assertEquals("something", spiedRecord.name()); // fails because spiedRecord.name() is null
}
```

The issue only occurs when spying records if `AbstractCollection` (or one of its children) is also spied. This is why this reproducer passes if the first line is commented out.

The problem happens because all superclasses and interfaces of `java.util.ImmutableCollections.List12` (the implementation returned by `List.of()` are transformed by `ByteBuddyAgent` and `InlineDelegateByteBuddyMockMaker` (see `InlineBytecodeGenerator::triggerRetransformation`. However, one of the superclasses, `AbstractCollection`, happens to also be used by `MethodHandle`, and when it does, Mockito trips over itself and its fallback strategy also fails for records.

In other words, in the process of constructing a record for spying, `InstrumentationMemberAccessor::newInstance` calls `MethodHandle::invokeWithArguments`, which uses a collection. Since the `AbstractCollection` class was instrumented during the earlier spy creation, the construction is intercepted and calls `isMockConstruction` (in `InlineDelegateByteBuddyMockMaker`). Since the `mockitoConstruction` boolean is `true`, because there is indeed an ongoing mock construction, Mockito thinks that the current constructor `AbstractCollection()` is the correct constructor to implement, and `isMockConstruction` returns `true`. `onConstruction` then does one last check that the type of the constructor matches the object to spy, and when it doesn't, it throws an exception (`InlineDelegateByteBuddyMockMaker` line 287).

Mockito then considers that the spy creation has failed and falls back on creating a mock and then copying fields from the object to spy to the newly created mock (`MockUtil::createMock`). This strategy fails for records, because their fields cannot be set by `MethodHandles::unreflectSetter` (see the javadoc on the method), as opposed to classes, where even final fields can be set. This failure is then ignored, and fields are left uninitialized (see `LenientCopyTool::copyValues`). The interference betwen spies at the root of this issue also occurs for classes, but because the fallback can successfully copy the fields, the issue probably went unnoticed.

**Testing**: I was unable to add a test for this, because the language level is set to 11, before records existed. All existing tests are still passing, though, and the reproducer above fails on the master branch but passes on mine.
