### PR TITLE
Fixes #3179 : Add module for Java 21 tests.

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,7 +22,8 @@ include(
     "osgi-test",
     "bom",
     "errorprone",
-    "programmatic-test"
+    "programmatic-test",
+    "java21"
 )
 
 // https://developer.android.com/studio/command-line/variables#envar

--- a/subprojects/java21/java21.gradle
+++ b/subprojects/java21/java21.gradle
@@ -1,0 +1,24 @@
+apply from: "$rootDir/gradle/dependencies.gradle"
+apply from: "$rootDir/gradle/java-test.gradle"
+
+description = "Test suite for Java 21 Mockito"
+
+dependencies {
+    implementation project.rootProject
+    testImplementation libraries.junit4
+    testImplementation libraries.assertj
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+tasks.named('test') {
+    if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21)) {
+        enabled = false
+    }
+}


### PR DESCRIPTION
This PR adds a Java 21 module to be used for testing.

The current version of Gradle (8.4) doesn't yet support running on Java 21, but it does support compiling and testing using Java 21 through the use of toolchains ([source](https://docs.gradle.org/8.4/release-notes.html#java-21)). 8.5 will support running Java 21 ([source](https://docs.gradle.org/8.5-rc-3/release-notes.html#java-21)), so the toolchain block can be removed then.

The test source directory is currently empty, apart from a `.gitkeep` file, but as soon as this PR is merged, it can be used for the tests from https://github.com/mockito/mockito/pull/3173 and https://github.com/mockito/mockito/pull/3167.

There are no tests yet, but I did test the module by adding my test from https://github.com/mockito/mockito/pull/3173 (see top of that PR's description). The tests are ignored when running using Java 11, and correctly fail/pass when using Java 21.