### PR TITLE
Fixes #3745: add MockTracking option to enforce strictness on instantiated mocks

### DIFF
--- a/mockito-core/src/main/java/module-info.java
+++ b/mockito-core/src/main/java/module-info.java
@@ -38,6 +38,10 @@ module org.mockito {
             org.mockito.junit.jupiter;
     exports org.mockito.internal.configuration.plugins to
             org.mockito.junit.jupiter;
+    exports org.mockito.internal.framework to
+            org.mockito.junit.jupiter;
+    exports org.mockito.internal.junit to
+            org.mockito.junit.jupiter;
     exports org.mockito.internal.session to
             org.mockito.junit.jupiter;
     exports org.mockito.internal.util to

--- a/mockito-extensions/mockito-junit-jupiter/src/main/java/org/mockito/junit/jupiter/MockTracking.java
+++ b/mockito-extensions/mockito-junit-jupiter/src/main/java/org/mockito/junit/jupiter/MockTracking.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.junit.jupiter;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+
+/**
+ * Controls which mocks the {@link MockitoExtension} attaches to the {@link org.mockito.MockitoSession}
+ * for strictness reporting (e.g. unused stubbings, strict stubs).
+ *
+ * @see MockitoSettings#mockTracking()
+ * @since 5.21.0
+ */
+public enum MockTracking {
+
+    /**
+     * Default: only mocks created from {@link Mock @Mock}, {@link Spy @Spy} annotated fields and
+     * parameters are tracked by the session.
+     * <p>
+     * Mocks instantiated manually (e.g. via {@link Mockito#mock(Class)}) are <strong>not</strong>
+     * registered with the session. This matches Mockito's historical behavior.
+     */
+    ANNOTATED,
+
+    /**
+     * In addition to {@link #ANNOTATED}, the extension scans the declared fields of every test
+     * instance (and its superclasses up to {@link Object}) after annotation processing. Any
+     * non-annotated field whose value is a Mockito mock is registered with the session so that
+     * strictness rules (such as detecting unused stubbings) apply to it as well.
+     * <p>
+     * Use this mode when your tests assign mocks to {@code final} fields via
+     * {@link Mockito#mock(Class)} or {@link Mockito#mock()} and you still want the session to
+     * detect over-stubbing on them.
+     */
+    ANNOTATED_AND_INSTANTIATED
+}

--- a/mockito-extensions/mockito-junit-jupiter/src/main/java/org/mockito/junit/jupiter/MockitoExtension.java
+++ b/mockito-extensions/mockito-junit-jupiter/src/main/java/org/mockito/junit/jupiter/MockitoExtension.java
@@ -7,6 +7,7 @@ package org.mockito.junit.jupiter;
 import static org.junit.jupiter.api.extension.ExtensionContext.Namespace.create;
 import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
 
+import java.lang.reflect.Field;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -19,15 +20,21 @@ import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoSession;
 import org.mockito.ScopedMock;
+import org.mockito.Spy;
 import org.mockito.internal.configuration.plugins.Plugins;
+import org.mockito.internal.framework.DefaultMockitoSession;
+import org.mockito.internal.junit.UniversalTestListener;
 import org.mockito.internal.session.MockitoSessionLoggerAdapter;
+import org.mockito.internal.util.MockUtil;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.junit.jupiter.resolver.CaptorParameterResolver;
 import org.mockito.junit.jupiter.resolver.CompositeParameterResolver;
 import org.mockito.junit.jupiter.resolver.MockParameterResolver;
+import org.mockito.mock.MockCreationSettings;
 import org.mockito.quality.Strictness;
 
 /**
@@ -114,6 +121,27 @@ import org.mockito.quality.Strictness;
  *      }
  * }
  * </code></pre>
+ *
+ * <h2>Tracking manually-instantiated mocks</h2>
+ *
+ * By default the extension only tracks mocks created from {@link Mock @Mock} / {@link Spy @Spy}
+ * annotations or parameters. To also enforce strictness on mocks instantiated directly via
+ * {@link Mockito#mock(Class)} (typically assigned to {@code final} fields), set
+ * {@link MockitoSettings#mockTracking()} to {@link MockTracking#ANNOTATED_AND_INSTANTIATED}:
+ *
+ * <pre class="code"><code class="java">
+ * <b>&#064;MockitoSettings(mockTracking = MockTracking.ANNOTATED_AND_INSTANTIATED)</b>
+ * public class ExampleTest {
+ *
+ *     private final Service service = Mockito.mock(Service.class);
+ *     private final Api api = new Api(service);
+ *
+ *     &#064;Test
+ *     public void shouldDoSomething() {
+ *         // over-stubbing on `service` will now be reported by the session
+ *     }
+ * }
+ * </code></pre>
  */
 public class MockitoExtension implements BeforeEachCallback, AfterEachCallback, ParameterResolver {
 
@@ -121,18 +149,23 @@ public class MockitoExtension implements BeforeEachCallback, AfterEachCallback, 
 
     private static final String SESSION = "session", MOCKS = "mocks";
 
+    private static final Field SESSION_LISTENER_FIELD = resolveSessionListenerField();
+
     private final Strictness strictness;
+
+    private final MockTracking mockTracking;
 
     private final ParameterResolver parameterResolver;
 
     // This constructor is invoked by JUnit Jupiter via reflection or ServiceLoader
     @SuppressWarnings("unused")
     public MockitoExtension() {
-        this(Strictness.STRICT_STUBS);
+        this(Strictness.STRICT_STUBS, MockTracking.ANNOTATED);
     }
 
-    private MockitoExtension(Strictness strictness) {
+    private MockitoExtension(Strictness strictness, MockTracking mockTracking) {
         this.strictness = strictness;
+        this.mockTracking = mockTracking;
         this.parameterResolver =
                 new CompositeParameterResolver(
                         new MockParameterResolver(), new CaptorParameterResolver());
@@ -147,10 +180,10 @@ public class MockitoExtension implements BeforeEachCallback, AfterEachCallback, 
     public void beforeEach(final ExtensionContext context) {
         List<Object> testInstances = context.getRequiredTestInstances().getAllInstances();
 
-        Strictness actualStrictness =
-                this.retrieveAnnotationFromTestClasses(context)
-                        .map(MockitoSettings::strictness)
-                        .orElse(strictness);
+        Optional<MockitoSettings> settings = this.retrieveAnnotationFromTestClasses(context);
+        Strictness actualStrictness = settings.map(MockitoSettings::strictness).orElse(strictness);
+        MockTracking actualTracking =
+                settings.map(MockitoSettings::mockTracking).orElse(mockTracking);
 
         MockitoSession session =
                 Mockito.mockitoSession()
@@ -158,6 +191,10 @@ public class MockitoExtension implements BeforeEachCallback, AfterEachCallback, 
                         .strictness(actualStrictness)
                         .logger(new MockitoSessionLoggerAdapter(Plugins.getMockitoLogger()))
                         .startMocking();
+
+        if (actualTracking == MockTracking.ANNOTATED_AND_INSTANTIATED) {
+            registerInstantiatedMocks(session, testInstances);
+        }
 
         context.getStore(MOCKITO).put(MOCKS, new HashSet<>());
         context.getStore(MOCKITO).put(SESSION, session);
@@ -179,6 +216,66 @@ public class MockitoExtension implements BeforeEachCallback, AfterEachCallback, 
         } while (annotation.isEmpty() && currentContext != context.getRoot());
 
         return annotation;
+    }
+
+    /**
+     * Scans every test instance (and its superclasses up to {@link Object}) for fields whose
+     * value is a Mockito mock, and registers them with the session's listener so that strictness
+     * checks (e.g. detecting unused stubbings) apply to them. Fields annotated with
+     * {@link Mock @Mock} or {@link Spy @Spy} are skipped — they were already registered when
+     * the session called {@code initMocks}.
+     */
+    private static void registerInstantiatedMocks(
+            MockitoSession session, List<Object> testInstances) {
+        UniversalTestListener listener = sessionListener(session);
+        for (Object instance : testInstances) {
+            Class<?> currentClass = instance.getClass();
+            while (currentClass != null && currentClass != Object.class) {
+                for (Field field : currentClass.getDeclaredFields()) {
+                    if (field.isAnnotationPresent(Mock.class)
+                            || field.isAnnotationPresent(Spy.class)) {
+                        continue;
+                    }
+                    Object value = readFieldValue(field, instance);
+                    if (MockUtil.isMock(value)) {
+                        MockCreationSettings<?> mockSettings = MockUtil.getMockSettings(value);
+                        listener.onMockCreated(value, mockSettings);
+                    }
+                }
+                currentClass = currentClass.getSuperclass();
+            }
+        }
+    }
+
+    private static Object readFieldValue(Field field, Object instance) {
+        try {
+            field.setAccessible(true);
+            return field.get(instance);
+        } catch (ReflectiveOperationException e) {
+            return null;
+        }
+    }
+
+    private static UniversalTestListener sessionListener(MockitoSession session) {
+        try {
+            return (UniversalTestListener) SESSION_LISTENER_FIELD.get(session);
+        } catch (IllegalAccessException e) {
+            throw new IllegalStateException(
+                    "Unable to read listener from MockitoSession; Mockito internals have changed.",
+                    e);
+        }
+    }
+
+    private static Field resolveSessionListenerField() {
+        try {
+            Field field = DefaultMockitoSession.class.getDeclaredField("listener");
+            field.setAccessible(true);
+            return field;
+        } catch (NoSuchFieldException e) {
+            throw new IllegalStateException(
+                    "Unable to locate DefaultMockitoSession.listener; Mockito internals have changed.",
+                    e);
+        }
     }
 
     /**

--- a/mockito-extensions/mockito-junit-jupiter/src/main/java/org/mockito/junit/jupiter/MockitoSettings.java
+++ b/mockito-extensions/mockito-junit-jupiter/src/main/java/org/mockito/junit/jupiter/MockitoSettings.java
@@ -25,4 +25,13 @@ public @interface MockitoSettings {
      * @return The strictness to configure, by default {@link Strictness#STRICT_STUBS}
      */
     Strictness strictness() default Strictness.STRICT_STUBS;
+
+    /**
+     * Controls which mocks the extension attaches to the session for strictness reporting.
+     * Defaults to {@link MockTracking#ANNOTATED} for backward compatibility.
+     *
+     * @return The mock tracking mode, by default {@link MockTracking#ANNOTATED}
+     * @since 5.21.0
+     */
+    MockTracking mockTracking() default MockTracking.ANNOTATED;
 }

--- a/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/MockTrackingTest.java
+++ b/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/MockTrackingTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2026 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage;
+
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+import org.mockito.Mock;
+import org.mockito.exceptions.misusing.UnnecessaryStubbingException;
+import org.mockito.junit.jupiter.MockTracking;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies the behavior of {@link MockTracking}, in particular
+ * {@link MockTracking#ANNOTATED_AND_INSTANTIATED} which extends strictness reporting to mocks
+ * that are instantiated manually via {@link org.mockito.Mockito#mock(Class)} and assigned to
+ * test fields without an {@link Mock @Mock} annotation.
+ */
+class MockTrackingTest {
+
+    @ExtendWith(MockitoExtension.class)
+    static class DefaultTrackingIgnoresInstantiatedMock {
+
+        private final Function<Integer, String> instantiated = mock();
+
+        @Test
+        void over_stubbing_on_instantiated_mock_is_not_reported_by_default() {
+            when(instantiated.apply(1)).thenReturn("one");
+            // No call on `instantiated` — would be flagged as unused stubbing if tracked.
+        }
+    }
+
+    @Test
+    void by_default_instantiated_mocks_are_not_tracked() {
+        TestExecutionResult result =
+                invokeTestClassAndRetrieveMethodResult(DefaultTrackingIgnoresInstantiatedMock.class);
+
+        assertSuccessful(result);
+    }
+
+    @MockitoSettings(mockTracking = MockTracking.ANNOTATED_AND_INSTANTIATED)
+    static class FullTrackingDetectsOverStubbing {
+
+        private final Function<Integer, String> instantiated = mock();
+
+        @Test
+        void over_stubbing_on_instantiated_mock_should_be_reported() {
+            when(instantiated.apply(1)).thenReturn("one");
+        }
+    }
+
+    @Test
+    void instantiated_mocks_are_tracked_under_annotated_and_instantiated_mode() {
+        TestExecutionResult result =
+                invokeTestClassAndRetrieveMethodResult(FullTrackingDetectsOverStubbing.class);
+
+        assertStubbingDetected(result);
+    }
+
+    @MockitoSettings(mockTracking = MockTracking.ANNOTATED_AND_INSTANTIATED)
+    static class FullTrackingStillAllowsUsedStubs {
+
+        private final Function<Integer, String> instantiated = mock();
+
+        @Test
+        void used_stubs_should_not_be_reported() {
+            when(instantiated.apply(1)).thenReturn("one");
+            assertThat(instantiated.apply(1)).isEqualTo("one");
+        }
+
+    }
+    @Test
+    void used_stubbings_on_instantiated_mocks_do_not_fail_under_annotated_and_instantiated() {
+        TestExecutionResult result =
+                invokeTestClassAndRetrieveMethodResult(FullTrackingStillAllowsUsedStubs.class);
+
+        assertSuccessful(result);
+    }
+
+    @MockitoSettings(mockTracking = MockTracking.ANNOTATED_AND_INSTANTIATED)
+    static class FullTrackingHandlesAnnotatedMocksWithoutDoubleRegistration {
+
+
+        @Mock private Function<Integer, String> annotated;
+
+        @Test
+        void annotated_mock_over_stubbing_is_still_reported() {
+            when(annotated.apply(1)).thenReturn("one");
+        }
+    }
+
+    @Test
+    void annotated_mocks_remain_tracked_exactly_once_under_full_tracking() {
+        TestExecutionResult result =
+                invokeTestClassAndRetrieveMethodResult(
+                        FullTrackingHandlesAnnotatedMocksWithoutDoubleRegistration.class);
+
+        assertStubbingDetected(result);
+    }
+
+    abstract static class BaseWithInstantiatedMock {
+        final Function<Integer, String> inheritedMock = mock();
+    }
+
+    @MockitoSettings(mockTracking = MockTracking.ANNOTATED_AND_INSTANTIATED)
+    static class FullTrackingScansSuperclassFields extends BaseWithInstantiatedMock {
+
+        @Test
+        void over_stubbing_on_inherited_instantiated_mock_should_be_reported() {
+            when(inheritedMock.apply(1)).thenReturn("one");
+        }
+    }
+
+    @Test
+    void instantiated_mocks_in_superclasses_are_tracked() {
+        TestExecutionResult result =
+                invokeTestClassAndRetrieveMethodResult(FullTrackingScansSuperclassFields.class);
+
+        assertStubbingDetected(result);
+    }
+
+    private TestExecutionResult invokeTestClassAndRetrieveMethodResult(Class<?> clazz) {
+        LauncherDiscoveryRequest request =
+                LauncherDiscoveryRequestBuilder.request().selectors(selectClass(clazz)).build();
+
+        Launcher launcher = LauncherFactory.create();
+
+        final TestExecutionResult[] result = new TestExecutionResult[1];
+
+        launcher.registerTestExecutionListeners(
+                new TestExecutionListener() {
+                    @Override
+                    public void executionFinished(
+                            TestIdentifier testIdentifier,
+                            TestExecutionResult testExecutionResult) {
+                        if (testIdentifier.getDisplayName().endsWith("()")) {
+                            result[0] = testExecutionResult;
+                        }
+                    }
+                });
+
+        launcher.execute(request);
+
+        return result[0];
+    }
+
+    private static void assertSuccessful(TestExecutionResult result) {
+        assertThat(result.getStatus()).isEqualTo(TestExecutionResult.Status.SUCCESSFUL);
+    }
+
+    private static void assertStubbingDetected(TestExecutionResult result) {
+        assertThat(result.getStatus()).isEqualTo(TestExecutionResult.Status.FAILED);
+        assertThat(result.getThrowable())
+            .get()
+            .isInstanceOf(UnnecessaryStubbingException.class);
+    }
+}


### PR DESCRIPTION
Fixes #3745.

## What

Adds a `MockTracking` enum on `@MockitoSettings` that controls which mocks the `MockitoExtension` attaches to the underlying `MockitoSession` for strictness reporting.

```java
public enum MockTracking {
    ANNOTATED,                 // default — current behavior
    ANNOTATED_AND_INSTANTIATED // also track mocks held by non-@Mock/@Spy fields
}
```

Usage:

```java
@MockitoSettings(mockTracking = MockTracking.ANNOTATED_AND_INSTANTIATED)
class ExampleTest {
    private final Service service = mock();
    private final Api api = new Api(service);

    @Test
    void shouldDoSomething() {
        // Over-stubbing on `service` is now reported by the session.
    }
}
```

## Why

Tests that assign mocks to `final` fields (a common pattern in code bases where teams prefer constructor injection / final fields) bypass the `@Mock` annotation path. As a result, `MockitoExtension` does not register those mocks with the session listener, so strictness rules — most notably `UnnecessaryStubbingException` — do not trigger for them. The issue #3745 has a reproducer.

## How

When `ANNOTATED_AND_INSTANTIATED` is selected, the extension — after `initMocks(...)` — walks the declared fields of every test instance (and its superclasses up to `Object`). For every field that:

- is not annotated with `@Mock` or `@Spy` (already processed by `initMocks`), and
- holds a value where `MockUtil.isMock(...)` is `true`,

it registers the mock with the session's `UniversalTestListener`, passing the mock's real `MockCreationSettings` so both unused-stubbing detection and stubbing-mismatch reporting apply.

## Backward compatibility

The default is `MockTracking.ANNOTATED`, which preserves the historical behavior. Existing test suites are unaffected unless they explicitly opt in via `@MockitoSettings(mockTracking = MockTracking.ANNOTATED_AND_INSTANTIATED)`.

## Module exports

`mockito-core`'s `module-info` is updated to export `org.mockito.internal.framework` and `org.mockito.internal.junit` to `org.mockito.junit.jupiter` — needed so the extension can read the session's listener via reflection. Both packages were already accessible via other internal exports; this just opens the two specific packages the extension touches.

## Tests

New `MockTrackingTest` covers:

- Default mode does **not** flag over-stubbing on a manually-instantiated mock (backward-compat).
- `ANNOTATED_AND_INSTANTIATED` flags over-stubbing on a manually-instantiated mock.
- Used stubs on instantiated mocks still pass under `ANNOTATED_AND_INSTANTIATED`.
- `@Mock` fields are not double-registered when `ANNOTATED_AND_INSTANTIATED` is selected.
- Instantiated mocks declared in a superclass are tracked.

## Checklist

- [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
- [x] PR is motivated (fixes #3745 — context in the issue)
- [x] Includes a usage example
- [x] No new runtime dependencies
- [ ] Meaningful commit history
- [x] Follows coding style
- [x] Mentions `Fixes #3745`
- [x] Commit message mentions `Fixes #3745`