### PR TITLE
Remove shipkit workaround for generateChangelog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ buildscript {
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:3.1.0'
 
         classpath "io.github.gradle-nexus:publish-plugin:2.0.0-rc-1"
-        // TODO check if https://github.com/shipkit/shipkit-changelog/issues/103 is fixed, and remove workaround in shipkit.gradle.
         classpath 'org.shipkit:shipkit-changelog:2.0.1'
         classpath 'org.shipkit:shipkit-auto-version:2.0.2'
 

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -6,10 +6,6 @@ tasks.named('generateChangelog') {
     previousRevision = project.ext.'shipkit-auto-version.previous-tag'
     githubToken = System.getenv('GITHUB_TOKEN')
     repository = 'mockito/mockito'
-    // Workarounds for https://github.com/shipkit/shipkit-changelog/issues/103
-    doNotTrackState("GenerateChangelogTask tracks the entire repo, which results is locking problems hashing the .gradle folder.")
-    // GenerateChangelogTask uses the entire repo as input, which means it needs to "depend on" all other tasks' outputs.
-    mustRunAfter(allprojects.collectMany { it.tasks }.grep { it.path != ":generateChangelog" && it.path != ":githubRelease" })
 }
 
 tasks.named("githubRelease") {


### PR DESCRIPTION
 * Follow-up on https://github.com/mockito/mockito/pull/3245
Looks like the TODO wasn't big enough at https://github.com/mockito/mockito/pull/3245/files#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7R13
 * Revert workaround for https://github.com/shipkit/shipkit-changelog/issues/103
 * Reverts part of https://github.com/mockito/mockito/pull/3053

## Testing
Same as #3053

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [ ] Mention `Fixes #<issue number>` in the description _if relevant_
 - [ ] At least one commit should mention `Fixes #<issue number>` _if relevant_

