### PR TITLE
Use kvm on ubuntu instead of macos to run Android tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,10 +133,7 @@ jobs:
       with:
         arch: x86_64
         api-level: ${{ matrix.android-api }}
-        # Workaround for https://issuetracker.google.com/issues/267458959
-        target: ${{ matrix.android-api >= 32 && 'google_apis' || 'default' }}
-        # Workaround for https://github.com/ReactiveCircus/android-emulator-runner/issues/160, but newer version.
-        emulator-build: 9322596 # 31.3.14.0 got it via `emulator -version`
+        target: default
         # Override default "-no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim"
         # See emulator manual for reference: https://developer.android.com/studio/run/emulator-commandline
         emulator-options: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,11 +105,9 @@ jobs:
 
     # Definition of the build matrix
     strategy:
-      fail-fast: false
       matrix:
         # Minimum supported and maximum available.
         android-api: [ 26, 33 ]
-        stress-test: [ 1,2,3,4,5,6,7,8,9,10 ]
 
     # All build steps
     steps:
@@ -175,7 +173,7 @@ jobs:
       if: success() || failure()
       uses: actions/upload-artifact@v4
       with:
-        name: androidTest-results-${{ matrix.android-api }}-${{ matrix.stress-test }}
+        name: androidTest-results-${{ matrix.android-api }}
         path: |
           ${{ github.workspace }}/subprojects/androidTest/build/reports/androidTests/connected/**
           ${{ github.workspace }}/emulator.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,9 +105,11 @@ jobs:
 
     # Definition of the build matrix
     strategy:
+      fail-fast: false
       matrix:
         # Minimum supported and maximum available.
         android-api: [ 26, 33 ]
+        stress-test: [ 1,2,3,4,5,6,7,8,9,10 ]
 
     # All build steps
     steps:
@@ -173,7 +175,7 @@ jobs:
       if: success() || failure()
       uses: actions/upload-artifact@v4
       with:
-        name: androidTest-results-${{ matrix.android-api }}
+        name: androidTest-results-${{ matrix.android-api }}-${{ matrix.stress-test }}
         path: |
           ${{ github.workspace }}/subprojects/androidTest/build/reports/androidTests/connected/**
           ${{ github.workspace }}/emulator.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,13 +122,13 @@ jobs:
         distribution: 'zulu'
         java-version: 17
 
-    - name: "Enable KVM."
+    - name: 3. Enable KVM.
       run: |
         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
         sudo udevadm control --reload-rules
         sudo udevadm trigger --name-match=kvm
 
-    - name: 3. Run Android tests on Android API level ${{ matrix.android-api }}
+    - name: 4. Run Android tests on Android API level ${{ matrix.android-api }}
       uses: reactivecircus/android-emulator-runner@v2
       with:
         arch: x86_64
@@ -172,7 +172,7 @@ jobs:
           # Make sure the step fails if the tests failed.
           exit $(cat gradle.exit)
 
-    - name: 4. Upload artifact "androidTest-results-${{ matrix.android-api }}"
+    - name: 5. Upload artifact "androidTest-results-${{ matrix.android-api }}"
       if: success() || failure()
       uses: actions/upload-artifact@v4
       with:
@@ -183,7 +183,7 @@ jobs:
           ${{ github.workspace }}/emulator-startup.log
 
     # :androidTest:connectedCheck (which depends on :androidTest:createDebugAndroidTestCoverageReport) already generated coverage report.
-    - name: 5. Upload coverage report
+    - name: 6. Upload coverage report
       uses: codecov/codecov-action@v3
       with:
         files: subprojects/androidTest/build/reports/coverage/androidTest/debug/connected/report.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
   # Android build job
   #
   android:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
     timeout-minutes: 30
 
@@ -121,6 +121,12 @@ jobs:
       with:
         distribution: 'zulu'
         java-version: 17
+
+    - name: "Enable KVM."
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
 
     - name: 3. Run Android tests on Android API level ${{ matrix.android-api }}
       uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,6 @@ jobs:
       with:
         arch: x86_64
         api-level: ${{ matrix.android-api }}
-        target: default
         # Override default "-no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim"
         # See emulator manual for reference: https://developer.android.com/studio/run/emulator-commandline
         emulator-options: >


### PR DESCRIPTION
See https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners

Might fix help with flaky runs (https://github.com/mockito/mockito/issues/2892), proof: https://github.com/mockito/mockito/actions/runs/7678518487/job/20928495438
Let's try and merge this, and later revert the workaround for boot if necessary.

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [ ] Mention `Fixes #<issue number>` in the description _if relevant_
 - [ ] At least one commit should mention `Fixes #<issue number>` _if relevant_

