### PR TITLE
Fixes #3286 : Mockito.only() points to the wanted call as unwanted if it is the first being calledIssue3286

### DIFF
--- a/src/main/java/org/mockito/internal/verification/Only.java
+++ b/src/main/java/org/mockito/internal/verification/Only.java
@@ -26,6 +26,7 @@ public class Only implements VerificationMode {
         List<Invocation> invocations = data.getAllInvocations();
         List<Invocation> chunk = findInvocations(invocations, target);
         if (invocations.size() != 1 && !chunk.isEmpty()) {
+            markVerified(chunk.get(0), target);
             Invocation unverified = findFirstUnverified(invocations);
             throw noMoreInteractionsWanted(unverified, (List) invocations);
         }

--- a/src/main/java/org/mockito/internal/verification/Only.java
+++ b/src/main/java/org/mockito/internal/verification/Only.java
@@ -25,7 +25,7 @@ public class Only implements VerificationMode {
         MatchableInvocation target = data.getTarget();
         List<Invocation> invocations = data.getAllInvocations();
         List<Invocation> chunk = findInvocations(invocations, target);
-        if(!chunk.isEmpty()) {
+        if (!chunk.isEmpty()) {
             markVerified(chunk.get(0), target);
         }
         if (invocations.size() != 1 && !chunk.isEmpty()) {

--- a/src/main/java/org/mockito/internal/verification/Only.java
+++ b/src/main/java/org/mockito/internal/verification/Only.java
@@ -25,15 +25,16 @@ public class Only implements VerificationMode {
         MatchableInvocation target = data.getTarget();
         List<Invocation> invocations = data.getAllInvocations();
         List<Invocation> chunk = findInvocations(invocations, target);
-        if (invocations.size() != 1 && !chunk.isEmpty()) {
+        if(!chunk.isEmpty()) {
             markVerified(chunk.get(0), target);
+        }
+        if (invocations.size() != 1 && !chunk.isEmpty()) {
             Invocation unverified = findFirstUnverified(invocations);
             throw noMoreInteractionsWanted(unverified, (List) invocations);
         }
         if (invocations.size() != 1 || chunk.isEmpty()) {
             throw wantedButNotInvoked(target);
         }
-        markVerified(chunk.get(0), target);
     }
 
     @Override

--- a/src/test/java/org/mockito/internal/verification/OnlyTest.java
+++ b/src/test/java/org/mockito/internal/verification/OnlyTest.java
@@ -23,8 +23,7 @@ import org.mockitoutil.TestBase;
 
 public class OnlyTest extends TestBase {
 
-    @Mock
-    IMethods mock;
+    @Mock IMethods mock;
 
     Only only = new Only();
 

--- a/src/test/java/org/mockito/internal/verification/OnlyTest.java
+++ b/src/test/java/org/mockito/internal/verification/OnlyTest.java
@@ -10,28 +10,35 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Test;
-import org.mockito.exceptions.base.MockitoAssertionError;
+import org.mockito.Mock;
+import org.mockito.exceptions.verification.NoInteractionsWanted;
+import org.mockito.exceptions.verification.WantedButNotInvoked;
 import org.mockito.internal.invocation.InvocationBuilder;
 import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockito.internal.verification.api.VerificationData;
 import org.mockito.invocation.Invocation;
 import org.mockito.invocation.MatchableInvocation;
+import org.mockitousage.IMethods;
+import org.mockitoutil.TestBase;
 
-public class OnlyTest {
+public class OnlyTest extends TestBase {
+
+    @Mock
+    IMethods mock;
 
     Only only = new Only();
 
-    public class VerificationDataStub implements VerificationData {
-        private final Invocation invocation;
+    public static class VerificationDataStub implements VerificationData {
+        private final Invocation[] invocations;
         private final InvocationMatcher wanted;
 
-        public VerificationDataStub(InvocationMatcher wanted, Invocation invocation) {
-            this.invocation = invocation;
+        public VerificationDataStub(InvocationMatcher wanted, Invocation... invocations) {
+            this.invocations = invocations;
             this.wanted = wanted;
         }
 
         public List<Invocation> getAllInvocations() {
-            return Arrays.asList(invocation);
+            return Arrays.asList(invocations);
         }
 
         @Override
@@ -45,7 +52,7 @@ public class OnlyTest {
     }
 
     @Test
-    public void shouldMarkAsVerified() {
+    public void shouldMarkAsVerifiedWhenAssertionSucceded() {
         // given
         Invocation invocation = new InvocationBuilder().toInvocation();
         assertFalse(invocation.isVerified());
@@ -58,7 +65,7 @@ public class OnlyTest {
     }
 
     @Test
-    public void shouldNotMarkAsVerifiedWhenAssertionFailed() {
+    public void shouldNotMarkAsVerifiedWhenWantedButNotInvoked() {
         // given
         Invocation invocation = new InvocationBuilder().toInvocation();
         assertFalse(invocation.isVerified());
@@ -69,10 +76,32 @@ public class OnlyTest {
                     new VerificationDataStub(
                             new InvocationBuilder().toInvocationMatcher(), invocation));
             fail();
-        } catch (MockitoAssertionError e) {
+        } catch (WantedButNotInvoked e) {
         }
 
         // then
         assertFalse(invocation.isVerified());
+    }
+
+    @Test
+    public void shouldMarkWantedOnlyAsVerified() {
+
+        // given
+        InvocationBuilder invocationBuilder = new InvocationBuilder();
+        Invocation wanted = invocationBuilder.mock(mock).simpleMethod().toInvocation();
+        Invocation different = new InvocationBuilder().mock(mock).differentMethod().toInvocation();
+
+        // when
+        try {
+            only.verify(
+                    new VerificationDataStub(
+                            invocationBuilder.toInvocationMatcher(), wanted, different));
+            fail();
+        } catch (NoInteractionsWanted e) {
+        }
+
+        // then
+        assertTrue(wanted.isVerified());
+        assertFalse(different.isVerified());
     }
 }


### PR DESCRIPTION
Description and example is here: **https://github.com/mockito/mockito/issues/3286**

Is was planning to add third commit ( https://github.com/PiotrPrzybylak/mockito/commit/5fe1060ebe12d0eed2469199958981cc4d472c25 ) that replaces code in Only with calls to other verifiers, but I will do it in other PR since it breaks some tests for now:

```
public class Only implements VerificationMode {

    private final Times once = new Times(1);

    private final NoMoreInteractions noMoreInteractions = new NoMoreInteractions();

    @Override
    public void verify(VerificationData data) {
        once.verify(data);
        noMoreInteractions.verify(data);
    }

    @Override
    public String toString() {
        return "Wanted invocations count: 1 and no other method invoked";
    }
}

```

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

