### PR TITLE
Update codecov-action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
         --scan
 
     - name: 8. Upload coverage report
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         files: build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml
         fail_ci_if_error: true
@@ -180,7 +180,7 @@ jobs:
 
     # :androidTest:connectedCheck (which depends on :androidTest:createDebugAndroidTestCoverageReport) already generated coverage report.
     - name: 6. Upload coverage report
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         files: subprojects/androidTest/build/reports/coverage/androidTest/debug/connected/report.xml
         fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,10 +90,11 @@ jobs:
 
     - name: 8. Upload coverage report
       uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         files: build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml
         fail_ci_if_error: true
-        token: ${{secrets.CODECOV_TOKEN}}
 
   #
   # Android build job
@@ -181,6 +182,8 @@ jobs:
     # :androidTest:connectedCheck (which depends on :androidTest:createDebugAndroidTestCoverageReport) already generated coverage report.
     - name: 6. Upload coverage report
       uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         files: subprojects/androidTest/build/reports/coverage/androidTest/debug/connected/report.xml
         fail_ci_if_error: true


### PR DESCRIPTION
To ensure we can configure a Dependabot secret so that all Dependabot PRs pass CI again. Right now, they are failing since the token is not passed to CI runs that are not coming from maintainers/owners of Mockito.