### PR TITLE
Fixes #3331 : Fix `AdditionalMatchers.and()` and `AdditionalMatchers.or()` not to swap the order of matchers

### DIFF
--- a/src/main/java/org/mockito/internal/progress/ArgumentMatcherStorageImpl.java
+++ b/src/main/java/org/mockito/internal/progress/ArgumentMatcherStorageImpl.java
@@ -42,8 +42,8 @@ public class ArgumentMatcherStorageImpl implements ArgumentMatcherStorage {
     public void reportAnd() {
         assertStateFor("And(?)", TWO_SUB_MATCHERS);
 
-        ArgumentMatcher<?> m1 = popMatcher();
         ArgumentMatcher<?> m2 = popMatcher();
+        ArgumentMatcher<?> m1 = popMatcher();
 
         reportMatcher(new And(m1, m2));
     }
@@ -52,8 +52,8 @@ public class ArgumentMatcherStorageImpl implements ArgumentMatcherStorage {
     public void reportOr() {
         assertStateFor("Or(?)", TWO_SUB_MATCHERS);
 
-        ArgumentMatcher<?> m1 = popMatcher();
         ArgumentMatcher<?> m2 = popMatcher();
+        ArgumentMatcher<?> m1 = popMatcher();
 
         reportMatcher(new Or(m1, m2));
     }

--- a/src/test/java/org/mockitousage/matchers/AdditionalMatcherTest.java
+++ b/src/test/java/org/mockitousage/matchers/AdditionalMatcherTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage.matchers;
+
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.AdditionalMatchers.and;
+import static org.mockito.AdditionalMatchers.or;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AdditionalMatcherTest {
+
+    interface Foo {
+        int doSomeThing(Object param);
+    }
+
+    @Test
+    public void shouldMatchArgumentsSequentiallyWithAnd() {
+        Foo foo = mock(Foo.class);
+
+        when(foo.doSomeThing(and(any(String.class), argThat(String::isEmpty)))).thenReturn(1);
+
+        assertNotEquals(foo.doSomeThing(1), 1);
+    }
+
+    @Test
+    public void shouldMatchArgumentsSequentiallyWithOr() {
+        Foo foo = mock(Foo.class);
+
+        when(foo.doSomeThing(
+                        or(any(Integer.class), and(any(Object.class), argThat(String::isEmpty)))))
+                .thenReturn(1);
+
+        assertEquals(foo.doSomeThing(1), 1);
+    }
+}


### PR DESCRIPTION
related issue: #3331

### Motivation:
- On #3331, we found that AdditionalMatchers.and() and or() swap matcher order

### Modification:
- Changed the assignment order of `popMatcher()` results.

### Result:
- Now, AdditionalMatchers.and() and or() not swap matcher order
- Close #3331

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_