### PR TITLE
Fixes #3237: Fix NullPointerException in Only.verify

### DIFF
--- a/src/main/java/org/mockito/internal/verification/Only.java
+++ b/src/main/java/org/mockito/internal/verification/Only.java
@@ -30,7 +30,9 @@ public class Only implements VerificationMode {
         }
         if (invocations.size() != 1 && !chunk.isEmpty()) {
             Invocation unverified = findFirstUnverified(invocations);
-            throw noMoreInteractionsWanted(unverified, (List) invocations);
+            if (unverified != null) {
+                throw noMoreInteractionsWanted(unverified, (List) invocations);
+            }
         }
         if (invocations.size() != 1 || chunk.isEmpty()) {
             throw wantedButNotInvoked(target);

--- a/src/test/java/org/mockito/internal/verification/OnlyTest.java
+++ b/src/test/java/org/mockito/internal/verification/OnlyTest.java
@@ -103,4 +103,34 @@ public class OnlyTest extends TestBase {
         assertTrue(wanted.isVerified());
         assertFalse(different.isVerified());
     }
+
+    @Test
+    public void shouldMarkMultipleInvocationAsVerified() {
+
+        // given
+        InvocationBuilder invocationBuilder = new InvocationBuilder();
+        Invocation wanted = invocationBuilder.mock(mock).simpleMethod().toInvocation();
+        Invocation different = invocationBuilder.mock(mock).differentMethod().toInvocation();
+
+        // when
+        try {
+            only.verify(
+                    new VerificationDataStub(
+                            invocationBuilder.toInvocationMatcher(), wanted, different));
+            fail();
+        } catch (NoInteractionsWanted e) {
+        }
+
+        try {
+            only.verify(
+                    new VerificationDataStub(
+                            invocationBuilder.toInvocationMatcher(), different, wanted));
+            fail();
+        } catch (WantedButNotInvoked e) {
+        }
+
+        // then
+        assertTrue(wanted.isVerified());
+        assertTrue(different.isVerified());
+    }
 }


### PR DESCRIPTION
## Motivation
In the latest version of mockito-core (5.9.0), the `Only.verify` method throws a `NullPointerException` when it attempts to call `Reporter.noMoreInteractionsWanted` with a null argument. This occurs because the method `InvocationsFinder.findFirstUnverified` can return null, but this is not handled properly in `Only.verify`.

This fixes #3237 

## Changes
- Added a null check for the result of `InvocationsFinder.findFirstUnverified` in `Only.verify`. If the result is null, `Reporter.noMoreInteractionsWanted` is not called.

## Checklist

 - [v] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [v] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [v] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [v] Avoid other runtime dependencies
 - [v] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [v] The pull request follows coding style
 - [v] Mention `Fixes #<issue number>` in the description _if relevant_
 - [v] At least one commit should mention `Fixes #<issue number>` _if relevant_

