### PR TITLE
ci: add .m2 dependencies cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
       with:
         distribution: 'zulu'
         java-version: 17
+        cache: 'gradle'
 
     - name: 3. Validate Gradle wrapper
       if: matrix.java == 11 && matrix.entry.mock-maker == 'mock-maker-default' # SINGLE-MATRIX-JOB
@@ -122,6 +123,7 @@ jobs:
       with:
         distribution: 'zulu'
         java-version: 17
+        cache: 'gradle'
 
     - name: 3. Enable KVM.
       run: |
@@ -214,6 +216,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 21
+          cache: 'gradle'
 
       - name: 3. Build and release
         run: >


### PR DESCRIPTION
<!-- Hey,
Thanks for the contribution, this is awesome.
As you may have read, project members have somehow an opinionated view on what and how should be
Mockito, e.g. we don't want mockito to be a feature bloat.
There may be a thorough review, with feedback -> code change loop.
-->
<!--
If you have a suggestion for this template you can fix it in the .github/PULL_REQUEST_TEMPLATE.md file
-->
## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [ ] Mention `Fixes #<issue number>` in the description _if relevant_
 - [ ] At least one commit should mention `Fixes #<issue number>` _if relevant_

## Description

This pull request addresses an inefficiency in the current CI workflow. By adding a cache to the `setup-java` action, the CI process no longer needs to download ~530 MB of cacheable dependencies on every commit. This change not only reduces the load on external repositories like Maven Central but also significantly speeds up the build time.

## Reference:

https://www.sonatype.com/blog/maven-central-and-the-tragedy-of-the-commons
https://github.com/actions/setup-java?tab=readme-ov-file#caching-packages-dependencies
