### PR TITLE
Allow for installing a Java agent within the Mockito jar, without exposing Byte Buddy's attach mechanism.

### DIFF
--- a/gradle/mockito-core/inline-mock.gradle
+++ b/gradle/mockito-core/inline-mock.gradle
@@ -17,4 +17,8 @@ sourceSets.main {
 tasks.named("jar", Jar) {
     exclude("org/mockito/internal/creation/bytebuddy/inject/package-info.class")
     exclude("org/mockito/internal/creation/bytebuddy/inject/MockMethodDispatcher.class")
+    manifest {
+        attributes 'Premain-Class': 'org.mockito.internal.PremainAttach'
+        attributes 'Can-Retransform-Classes': 'true'
+    }
 }

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -194,7 +194,7 @@ import java.util.function.Function;
  *
  * To add Mockito as an agent to Maven's surefire plugin, the following configuration is needed:
  *
- * <pre class="code"><code>
+ * <pre class="code"><code class="xml">
  * &lt;plugin&gt;
  *     &lt;groupId&gt;org.apache.maven.plugins&lt;/groupId&gt;
  *     &lt;artifactId&gt;maven-dependency-plugin&lt;/artifactId&gt;

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -180,7 +180,7 @@ import java.util.function.Function;
  * as an argument to the executing JVM. To enable this in Gradle, the following example adds Mockito to all test
  * tasks:
  *
- * <pre class="code"><code<code class="kotlin">
+ * <pre class="code"><code class="kotlin">
  * val mockitoAgent = configurations.create("mockitoAgent")
  * dependencies {
  *     mockitoAgent(libs.mockito)

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -169,7 +169,7 @@ import java.util.function.Function;
  * <p>
  * For more information about inline mock making, see <a href="#39">section 39</a>.
  *
- * <h3 id="0.2">0.2. <a class="meaningful_link" href="#mockito-instrumentation" name="mockito-instrumentation">Explicitly setting up instrumentation for inline mocking (Java 21+)</a></h3>
+ * <h3 id="0.3">0.3. <a class="meaningful_link" href="#mockito-instrumentation" name="mockito-instrumentation">Explicitly setting up instrumentation for inline mocking (Java 21+)</a></h3>
  *
  * Starting from Java 21, the <a href="https://openjdk.org/jeps/451">JDK restricts the ability of libraries
  * to attach a Java agent to their own JVM</a>. As a result, the inline-mock-maker might not be able

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -171,9 +171,9 @@ import java.util.function.Function;
  *
  * <h3 id="0.2">0.2. <a class="meaningful_link" href="#mockito-instrumentation" name="mockito-instrumentation">Explicitly setting up instrumentation for inline mocking (Java 21+)</a></h3>
  *
- * Starting from Java 21, the JDK restricts the ability of libraries to attach a Java agent to their own JVM.
- * As a result, the inline-mock-maker might not be able to function without an explicit setup to enable
- * instrumentation, and the JVM will always display a warning.
+ * Starting from Java 21, the <a href="https://openjdk.org/jeps/451">JDK restricts the ability of libraries
+ * to attach a Java agent to their own JVM</a>. As a result, the inline-mock-maker might not be able
+ * to function without an explicit setup to enable instrumentation, and the JVM will always display a warning.
  *
  * <p>
  * To explicitly attach Mockito during test execution, the library's jar file needs to be specified as `-javaagent`

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -180,7 +180,7 @@ import java.util.function.Function;
  * as an argument to the executing JVM. To enable this in Gradle, the following example adds Mockito to all test
  * tasks:
  *
- * <pre class="code"><code>
+ * <pre class="code"><code<code class="kotlin">
  * val mockitoAgent = configurations.create("mockitoAgent")
  * dependencies {
  *     mockitoAgent(libs.mockito)

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -60,6 +60,7 @@ import java.util.function.Function;
  *      <a href="#0">0. Migrating to Mockito 2</a><br/>
  *      <a href="#0.1">0.1 Mockito Android support</a><br/>
  *      <a href="#0.2">0.2 Configuration-free inline mock making</a><br/>
+ *      <a href="#0.3">0.3 Explicitly enabling instrumentation for inline mocking (Java 21+)</a><br/>
  *      <a href="#1">1. Let's verify some behaviour! </a><br/>
  *      <a href="#2">2. How about some stubbing? </a><br/>
  *      <a href="#3">3. Argument matchers </a><br/>
@@ -167,6 +168,52 @@ import java.util.function.Function;
  *
  * <p>
  * For more information about inline mock making, see <a href="#39">section 39</a>.
+ *
+ * <h3 id="0.2">0.2. <a class="meaningful_link" href="#mockito-instrumentation" name="mockito-instrumentation">Explicitly setting up instrumentation for inline mocking (Java 21+)</a></h3>
+ *
+ * Starting from Java 21, the JDK restricts the ability of libraries to attach a Java agent to their own JVM.
+ * As a result, the inline-mock-maker might not be able to function without an explicit setup to enable
+ * instrumentation, and the JVM will always display a warning.
+ *
+ * <p>
+ * To explicitly attach Mockito during test execution, the library's jar file needs to be specified as `-javaagent`
+ * as an argument to the executing JVM. To enable this in Gradle, the following example adds Mockito to all test
+ * tasks:
+ *
+ * <pre class="code"><code>
+ * val mockitoAgent = configurations.create("mockitoAgent")
+ * dependencies {
+ *     mockitoAgent(libs.mockito)
+ * }
+ * tasks {
+ *     test {
+ *         jvmArgs("-javaagent:${mockitoAgent.asPath}")
+ *     }
+ * }
+ * </code></pre>
+ *
+ * To add Mockito as an agent to Maven's surefire plugin, the following configuration is needed:
+ *
+ * <pre class="code"><code>
+ * &lt;plugin&gt;
+ *     &lt;groupId&gt;org.apache.maven.plugins&lt;/groupId&gt;
+ *     &lt;artifactId&gt;maven-dependency-plugin&lt;/artifactId&gt;
+ *     &lt;executions&gt;
+ *         &lt;execution&gt;
+ *             &lt;goals&gt;
+ *                 &lt;goal&gt;properties&lt;/goal&gt;
+ *             &lt;/goals&gt;
+ *         &lt;/execution&gt;
+ *     &lt;/executions&gt;
+ * &lt;/plugin&gt;
+ * &lt;plugin&gt;
+ *     &lt;groupId&gt;org.apache.maven.plugins&lt;/groupId&gt;
+ *     &lt;artifactId&gt;maven-surefire-plugin&lt;/artifactId&gt;
+ *     &lt;configuration&gt;
+ *         &lt;argLine&gt;@{argLine} -javaagent:${org.mockito:mockito-core:jar}&lt;/argLine&gt;
+ *     &lt;/configuration&gt;
+ * &lt;/plugin&gt;
+ * </code></pre>
  *
  * <h3 id="1">1. <a class="meaningful_link" href="#verification" name="verification">Let's verify some behaviour!</a></h3>
  *

--- a/src/main/java/org/mockito/internal/PremainAttach.java
+++ b/src/main/java/org/mockito/internal/PremainAttach.java
@@ -10,7 +10,7 @@ import java.lang.instrument.Instrumentation;
  * Allows users to specify Mockito as a Java agent where the {@link Instrumentation}
  * instance is stored for use by the inline mock maker.
  *
- * The <a href="https://openjdk.org/jeps/451">JET 451</a>, delivered with JDK 21,
+ * The <a href="https://openjdk.org/jeps/451">JEP 451</a>, delivered with JDK 21,
  * is the first milestone to disallow dynamic loading of by default which will happen
  * in a future version of the JDK.
  */

--- a/src/main/java/org/mockito/internal/PremainAttach.java
+++ b/src/main/java/org/mockito/internal/PremainAttach.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal;
+
+import java.lang.instrument.Instrumentation;
+
+/**
+ * Allows users to specify Mockito as a Java agent where the {@link Instrumentation}
+ * instance is stored for use by the inline mock maker.
+ */
+public class PremainAttach {
+
+    private static volatile Instrumentation instrumentation;
+
+    public static void premain(String arg, Instrumentation instrumentation) {
+        if (PremainAttach.instrumentation != null) {
+            return;
+        }
+        PremainAttach.instrumentation = instrumentation;
+    }
+
+    public static Instrumentation getInstrumentation() {
+        return instrumentation;
+    }
+}

--- a/src/main/java/org/mockito/internal/PremainAttach.java
+++ b/src/main/java/org/mockito/internal/PremainAttach.java
@@ -27,10 +27,9 @@ public class PremainAttach {
 
     public static Instrumentation getInstrumentation() {
         // A Java agent is always added to the system class loader. If Mockito is executed from a
-        // different class
-        // loader we need to make sure to resolve the instrumentation instance from there, or fail
-        // the resolution,
-        // if this class does not exist on the system class loader.
+        // different class loader we need to make sure to resolve the instrumentation instance
+        // from there, or fail the resolution, if this class does not exist on the system class
+        // loader.
         ClassLoader systemClassLoader = ClassLoader.getSystemClassLoader();
         if (PremainAttach.class.getClassLoader() == systemClassLoader) {
             return instrumentation;

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
@@ -173,8 +173,6 @@ class InlineDelegateByteBuddyMockMaker
                         while ((length = inputStream.read(buffer)) != -1) {
                             outputStream.write(buffer, 0, length);
                         }
-                    } finally {
-                        inputStream.close();
                     }
                     outputStream.closeEntry();
                 }

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
@@ -11,6 +11,7 @@ import org.mockito.creation.instance.Instantiator;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.exceptions.base.MockitoInitializationException;
 import org.mockito.exceptions.misusing.MockitoConfigurationException;
+import org.mockito.internal.PremainAttach;
 import org.mockito.internal.SuppressSignatureCheck;
 import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.internal.creation.instance.ConstructorInstantiator;
@@ -108,103 +109,111 @@ class InlineDelegateByteBuddyMockMaker
     private static final Throwable INITIALIZATION_ERROR;
 
     static {
-        Instrumentation instrumentation;
-        Throwable initializationError = null;
+        Instrumentation instrumentation = PremainAttach.getInstrumentation();
+        if (instrumentation != null && instrumentation.isRetransformClassesSupported()) {
+            INSTRUMENTATION = instrumentation;
+            INITIALIZATION_ERROR = null;
+        } else {
+            Throwable initializationError = null;
 
-        // ByteBuddy internally may attempt to fork a subprocess. In Java 11 and Java 19, the Java
-        // process class observes the os.name system property to determine the OS and thus determine
-        // how to fork a new process. If the user is stubbing System properties, they may clear
-        // the existing System properties, which will cause this to fail. This is very much an
-        // implementation detail, but it will result in Mockito failing to load with an error that
-        // is not overly clear, so let's attempt to detect this issue ahead of time instead.
-        if (System.getProperty("os.name") == null) {
-            throw new IllegalStateException(
-                    join(
-                            "The Byte Buddy agent cannot be loaded.",
-                            "",
-                            "To initialise the Byte Buddy agent, a subprocess may need to be created. To do this, the JVM requires "
-                                    + "knowledge of the 'os.name' System property in most JRE implementations. This property is not present, "
-                                    + "which means this operation will fail to complete. Please first make sure you are not clearing this "
-                                    + "property anywhere, and failing that, raise a bug with your JVM vendor."));
-        }
-
-        try {
-            try {
-                instrumentation = ByteBuddyAgent.install();
-                if (!instrumentation.isRetransformClassesSupported()) {
-                    throw new IllegalStateException(
-                            join(
-                                    "Byte Buddy requires retransformation for creating inline mocks. This feature is unavailable on the current VM.",
-                                    "",
-                                    "You cannot use this mock maker on this VM"));
-                }
-                File boot = File.createTempFile("mockitoboot", ".jar");
-                boot.deleteOnExit();
-                JarOutputStream outputStream = new JarOutputStream(new FileOutputStream(boot));
-                try {
-                    String source =
-                            "org/mockito/internal/creation/bytebuddy/inject/MockMethodDispatcher";
-                    InputStream inputStream =
-                            InlineDelegateByteBuddyMockMaker.class
-                                    .getClassLoader()
-                                    .getResourceAsStream(source + ".raw");
-                    if (inputStream == null) {
-                        throw new IllegalStateException(
-                                join(
-                                        "The MockMethodDispatcher class file is not locatable: "
-                                                + source
-                                                + ".raw",
-                                        "",
-                                        "The class loader responsible for looking up the resource: "
-                                                + InlineDelegateByteBuddyMockMaker.class
-                                                        .getClassLoader()));
-                    }
-                    outputStream.putNextEntry(new JarEntry(source + ".class"));
-                    try {
-                        int length;
-                        byte[] buffer = new byte[1024];
-                        while ((length = inputStream.read(buffer)) != -1) {
-                            outputStream.write(buffer, 0, length);
-                        }
-                    } finally {
-                        inputStream.close();
-                    }
-                    outputStream.closeEntry();
-                } finally {
-                    outputStream.close();
-                }
-                try (JarFile jarfile = new JarFile(boot)) {
-                    instrumentation.appendToBootstrapClassLoaderSearch(jarfile);
-                }
-                try {
-                    Class.forName(
-                            "org.mockito.internal.creation.bytebuddy.inject.MockMethodDispatcher",
-                            false,
-                            null);
-                } catch (ClassNotFoundException cnfe) {
-                    throw new IllegalStateException(
-                            join(
-                                    "Mockito failed to inject the MockMethodDispatcher class into the bootstrap class loader",
-                                    "",
-                                    "It seems like your current VM does not support the instrumentation API correctly."),
-                            cnfe);
-                }
-            } catch (IOException ioe) {
+            // ByteBuddy internally may attempt to fork a subprocess. In Java 11 and Java 19, the
+            // Java
+            // process class observes the os.name system property to determine the OS and thus
+            // determine
+            // how to fork a new process. If the user is stubbing System properties, they may clear
+            // the existing System properties, which will cause this to fail. This is very much an
+            // implementation detail, but it will result in Mockito failing to load with an error
+            // that
+            // is not overly clear, so let's attempt to detect this issue ahead of time instead.
+            if (System.getProperty("os.name") == null) {
                 throw new IllegalStateException(
                         join(
-                                "Mockito could not self-attach a Java agent to the current VM. This feature is required for inline mocking.",
-                                "This error occured due to an I/O error during the creation of this agent: "
-                                        + ioe,
+                                "The Byte Buddy agent cannot be loaded.",
                                 "",
-                                "Potentially, the current VM does not support the instrumentation API correctly"),
-                        ioe);
+                                "To initialise the Byte Buddy agent, a subprocess may need to be created. To do this, the JVM requires "
+                                        + "knowledge of the 'os.name' System property in most JRE implementations. This property is not present, "
+                                        + "which means this operation will fail to complete. Please first make sure you are not clearing this "
+                                        + "property anywhere, and failing that, raise a bug with your JVM vendor."));
             }
-        } catch (Throwable throwable) {
-            instrumentation = null;
-            initializationError = throwable;
+
+            try {
+                try {
+                    instrumentation = ByteBuddyAgent.install();
+                    if (!instrumentation.isRetransformClassesSupported()) {
+                        throw new IllegalStateException(
+                                join(
+                                        "Byte Buddy requires retransformation for creating inline mocks. This feature is unavailable on the current VM.",
+                                        "",
+                                        "You cannot use this mock maker on this VM"));
+                    }
+                    File boot = File.createTempFile("mockitoboot", ".jar");
+                    boot.deleteOnExit();
+                    JarOutputStream outputStream = new JarOutputStream(new FileOutputStream(boot));
+                    try {
+                        String source =
+                                "org/mockito/internal/creation/bytebuddy/inject/MockMethodDispatcher";
+                        InputStream inputStream =
+                                InlineDelegateByteBuddyMockMaker.class
+                                        .getClassLoader()
+                                        .getResourceAsStream(source + ".raw");
+                        if (inputStream == null) {
+                            throw new IllegalStateException(
+                                    join(
+                                            "The MockMethodDispatcher class file is not locatable: "
+                                                    + source
+                                                    + ".raw",
+                                            "",
+                                            "The class loader responsible for looking up the resource: "
+                                                    + InlineDelegateByteBuddyMockMaker.class
+                                                            .getClassLoader()));
+                        }
+                        outputStream.putNextEntry(new JarEntry(source + ".class"));
+                        try {
+                            int length;
+                            byte[] buffer = new byte[1024];
+                            while ((length = inputStream.read(buffer)) != -1) {
+                                outputStream.write(buffer, 0, length);
+                            }
+                        } finally {
+                            inputStream.close();
+                        }
+                        outputStream.closeEntry();
+                    } finally {
+                        outputStream.close();
+                    }
+                    try (JarFile jarfile = new JarFile(boot)) {
+                        instrumentation.appendToBootstrapClassLoaderSearch(jarfile);
+                    }
+                    try {
+                        Class.forName(
+                                "org.mockito.internal.creation.bytebuddy.inject.MockMethodDispatcher",
+                                false,
+                                null);
+                    } catch (ClassNotFoundException cnfe) {
+                        throw new IllegalStateException(
+                                join(
+                                        "Mockito failed to inject the MockMethodDispatcher class into the bootstrap class loader",
+                                        "",
+                                        "It seems like your current VM does not support the instrumentation API correctly."),
+                                cnfe);
+                    }
+                } catch (IOException ioe) {
+                    throw new IllegalStateException(
+                            join(
+                                    "Mockito could not self-attach a Java agent to the current VM. This feature is required for inline mocking.",
+                                    "This error occured due to an I/O error during the creation of this agent: "
+                                            + ioe,
+                                    "",
+                                    "Potentially, the current VM does not support the instrumentation API correctly"),
+                            ioe);
+                }
+            } catch (Throwable throwable) {
+                instrumentation = null;
+                initializationError = throwable;
+            }
+            INSTRUMENTATION = instrumentation;
+            INITIALIZATION_ERROR = initializationError;
         }
-        INSTRUMENTATION = instrumentation;
-        INITIALIZATION_ERROR = initializationError;
     }
 
     private final BytecodeGenerator bytecodeGenerator;

--- a/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
@@ -4,6 +4,7 @@
  */
 package org.mockito.internal.creation.bytebuddy;
 
+import net.bytebuddy.ClassFileVersion;
 import net.bytebuddy.agent.ByteBuddyAgent;
 import org.mockito.MockedConstruction;
 import org.mockito.creation.instance.InstantiationException;
@@ -136,6 +137,13 @@ class InlineDelegateByteBuddyMockMaker
             try {
                 instrumentation = PremainAttach.getInstrumentation();
                 if (instrumentation == null) {
+                    if (ClassFileVersion.ofThisVm().isAtLeast(ClassFileVersion.JAVA_V21)) {
+                        System.out.println(
+                                "Mockito is currently self-attaching to enable the inline-mock-maker. This "
+                                        + "will no longer work in future releases of the JDK. Please add Mockito as an agent to your "
+                                        + "build what is described in Mockito's documentation: "
+                                        + "https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#0.3");
+                    }
                     instrumentation = ByteBuddyAgent.install();
                 }
                 if (!instrumentation.isRetransformClassesSupported()) {

--- a/src/main/java/org/mockito/internal/util/reflection/InstrumentationMemberAccessor.java
+++ b/src/main/java/org/mockito/internal/util/reflection/InstrumentationMemberAccessor.java
@@ -5,6 +5,7 @@
 package org.mockito.internal.util.reflection;
 
 import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.ClassFileVersion;
 import net.bytebuddy.agent.ByteBuddyAgent;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import net.bytebuddy.implementation.MethodCall;
@@ -49,6 +50,13 @@ class InstrumentationMemberAccessor implements MemberAccessor {
         try {
             instrumentation = PremainAttach.getInstrumentation();
             if (instrumentation == null) {
+                if (ClassFileVersion.ofThisVm().isAtLeast(ClassFileVersion.JAVA_V21)) {
+                    System.out.println(
+                            "Mockito is currently self-attaching to enable the inline-mock-maker. This "
+                                    + "will no longer work in future releases of the JDK. Please add Mockito as an agent to your "
+                                    + "build what is described in Mockito's documentation: "
+                                    + "https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#0.3");
+                }
                 instrumentation = ByteBuddyAgent.install();
             }
             if (!instrumentation.isRetransformClassesSupported()) {


### PR DESCRIPTION
A Java agent can also be attached directly to Mockito, what is also more clean as it will not affect other libraries that use Byte Buddy. Also, this does not require exposing the underlying Byte Buddy version and contains this logic within Mockito.

Currently, the build does not seem to retain the two additional manifest entries. Might it be that this is overridden by the bundle plugin for OSGi?