### PR TITLE
fix: gradle mockitoAgent configuration should not be transitive

### DIFF
--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -176,20 +176,31 @@ import java.util.function.Function;
  * to function without an explicit setup to enable instrumentation, and the JVM will always display a warning.
  *
  * <p>
- * To explicitly attach Mockito during test execution, the library's jar file needs to be specified as `-javaagent`
+ * To explicitly attach Mockito during test execution, the library's jar file needs to be specified as <code>-javaagent</code>
  * as an argument to the executing JVM. To enable this in Gradle, the following example adds Mockito to all test
  * tasks:
  *
  * <pre class="code"><code class="kotlin">
  * val mockitoAgent = configurations.create("mockitoAgent")
  * dependencies {
- *     mockitoAgent(libs.mockito)
+ *     testImplementation(libs.mockito)
+ *     mockitoAgent(libs.mockito) { isTransitive = false }
  * }
  * tasks {
  *     test {
  *         jvmArgs("-javaagent:${mockitoAgent.asPath}")
  *     }
  * }
+ * </code></pre>
+ *
+ * Supposing <code>Mockito</code> is declared in the version catalog as the following
+ *
+ * <pre class="code"><code class="toml">
+ * [versions]
+ * mockito = "5.14.0"
+ *
+ * [libraries]
+ * mockito = { module = "org.mockito:mockito-core", version.ref = "mockito" }
  * </code></pre>
  *
  * To add Mockito as an agent to Maven's surefire plugin, the following configuration is needed:


### PR DESCRIPTION
Fix the documentation for the gradle configuration. Before, the documentation I suggested was working for single jar agents, but `mockito-core` has some transitive dependencies, so they need to be removed ; they will be looked up on the classpath where mockito is already defined.

```kotlin
val mockitoAgent = configurations.create("mockitoAgent")
dependencies {
    testImplementation(libs.mockito) // all mockito and transitive dependencies are there
    mockitoAgent(libs.mockito) { isTransitive = false } // only mockito-core
}
tasks {
    test {
        jvmArgs("-javaagent:${mockitoAgent.asPath}")
    }
}
```

See #3037 
Follow up to #3437

<!-- Hey,
Thanks for the contribution, this is awesome.
As you may have read, project members have somehow an opinionated view on what and how should be
Mockito, e.g. we don't want mockito to be a feature bloat.
There may be a thorough review, with feedback -> code change loop.
-->
<!--
If you have a suggestion for this template you can fix it in the .github/PULL_REQUEST_TEMPLATE.md file
-->
## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

