### PR TITLE
Fix #3466 nexus publishing configuration

### DIFF
--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -19,6 +19,9 @@ tasks.named("githubRelease") {
 
 apply plugin: 'io.github.gradle-nexus.publish-plugin'
 nexusPublishing {
+    packageGroup = "org.mockito"
+    repositoryDescription = provider { "Mockito " + project.version }
+
     repositories {
         if (System.getenv('NEXUS_TOKEN_PWD')) {
             sonatype {


### PR DESCRIPTION
Our shipkit config relies on the nexusPublishing plugin ; by moving the core of mockito sources to `mockito-core` (#3446 / #3453) some convention configurations were lost, in particular the packaging group which seems to be used to retrieve the Sonatype OSSRH staging repository.

```
 Execution failed for task ':initializeSonatypeStagingRepository'.
> Failed to find staging profile for package group: 
```

Indeed looking at publish plugin extension, we can see the `project.group` is used. The group was set by `gradle/java-library.gradle` when it was applied to the root project (where was mockito sources), since this was moved to `mockito-core`, thus `java-library.gradle` script was not anymore applied on the root project.

https://github.com/gradle-nexus/publish-plugin/blob/v2.0.0-rc-1/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishExtension.kt#L38-L40

nexusPublishing config changes
```diff
  apply plugin: 'io.github.gradle-nexus.publish-plugin'
  nexusPublishing {
+     packageGroup = "or.mockito"
      // ...
  }
```




<!-- Hey,
Thanks for the contribution, this is awesome.
As you may have read, project members have somehow an opinionated view on what and how should be
Mockito, e.g. we don't want mockito to be a feature bloat.
There may be a thorough review, with feedback -> code change loop.
-->
<!--
If you have a suggestion for this template you can fix it in the .github/PULL_REQUEST_TEMPLATE.md file
-->
## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

