### PR TITLE
Fixes #3469: Prevent NPEs for Disabled Mocks

### DIFF
--- a/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
@@ -532,7 +532,11 @@ class InlineDelegateByteBuddyMockMaker
                 entry.remove(mock);
             }
         } else {
-            mocks.remove(mock);
+            mocks.put(
+                    mock,
+                    new MockMethodInterceptor(
+                            DisabledMockHandler.HANDLER,
+                            DisabledMockHandler.HANDLER.getMockSettings()));
         }
     }
 
@@ -541,8 +545,7 @@ class InlineDelegateByteBuddyMockMaker
         mockedStatics.getBackingMap().clear();
 
         for (Entry<Object, MockMethodInterceptor> entry : mocks) {
-            MockCreationSettings settings = entry.getValue().getMockHandler().getMockSettings();
-            entry.setValue(new MockMethodInterceptor(DisabledMockHandler.HANDLER, settings));
+            clearMock(entry.getKey());
         }
     }
 

--- a/mockito-core/src/main/java/org/mockito/internal/framework/DisabledMockHandler.java
+++ b/mockito-core/src/main/java/org/mockito/internal/framework/DisabledMockHandler.java
@@ -9,7 +9,19 @@ import org.mockito.exceptions.misusing.DisabledMockException;
 import org.mockito.invocation.Invocation;
 import org.mockito.invocation.InvocationContainer;
 import org.mockito.invocation.MockHandler;
+import org.mockito.listeners.InvocationListener;
+import org.mockito.listeners.StubbingLookupListener;
+import org.mockito.listeners.VerificationStartedListener;
 import org.mockito.mock.MockCreationSettings;
+import org.mockito.mock.MockName;
+import org.mockito.mock.MockType;
+import org.mockito.mock.SerializableMode;
+import org.mockito.quality.Strictness;
+import org.mockito.stubbing.Answer;
+import java.io.Serializable;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Throws {@link DisabledMockException} when a mock is accessed after it has been disabled by
@@ -29,11 +41,120 @@ public class DisabledMockHandler implements MockHandler {
 
     @Override
     public MockCreationSettings getMockSettings() {
-        return null;
+        return DisabledMockCreationSettings.INSTANCE;
     }
 
     @Override
     public InvocationContainer getInvocationContainer() {
         return null;
+    }
+
+    private static class DisabledMockCreationSettings
+            implements Serializable, MockCreationSettings {
+        private static DisabledMockCreationSettings INSTANCE = new DisabledMockCreationSettings();
+
+        private DisabledMockCreationSettings() {
+            // USE INSTANCE
+        }
+
+        @Override
+        public Class getTypeToMock() {
+            throw new DisabledMockException();
+        }
+
+        @Override
+        public Type getGenericTypeToMock() {
+            throw new DisabledMockException();
+        }
+
+        @Override
+        public Set<Class<?>> getExtraInterfaces() {
+            throw new DisabledMockException();
+        }
+
+        @Override
+        public MockName getMockName() {
+            throw new DisabledMockException();
+        }
+
+        @Override
+        public Answer<?> getDefaultAnswer() {
+            throw new DisabledMockException();
+        }
+
+        @Override
+        public Object getSpiedInstance() {
+            throw new DisabledMockException();
+        }
+
+        @Override
+        public boolean isSerializable() {
+            throw new DisabledMockException();
+        }
+
+        @Override
+        public SerializableMode getSerializableMode() {
+            throw new DisabledMockException();
+        }
+
+        @Override
+        public boolean isStubOnly() {
+            throw new DisabledMockException();
+        }
+
+        @Override
+        public boolean isStripAnnotations() {
+            throw new DisabledMockException();
+        }
+
+        @Override
+        public List<StubbingLookupListener> getStubbingLookupListeners() {
+            throw new DisabledMockException();
+        }
+
+        @Override
+        public List<InvocationListener> getInvocationListeners() {
+            throw new DisabledMockException();
+        }
+
+        @Override
+        public List<VerificationStartedListener> getVerificationStartedListeners() {
+            throw new DisabledMockException();
+        }
+
+        @Override
+        public boolean isUsingConstructor() {
+            throw new DisabledMockException();
+        }
+
+        @Override
+        public Object[] getConstructorArgs() {
+            throw new DisabledMockException();
+        }
+
+        @Override
+        public Object getOuterClassInstance() {
+            throw new DisabledMockException();
+        }
+
+        @Override
+        public boolean isLenient() {
+            throw new DisabledMockException();
+        }
+
+        @Override
+        public Strictness getStrictness() {
+            throw new DisabledMockException();
+        }
+
+        @Override
+        public String getMockMaker() {
+            throw new DisabledMockException();
+        }
+
+        @Override
+        public MockType getMockType() {
+            throw new DisabledMockException();
+        }
     }
 }

--- a/mockito-core/src/test/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMakerTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMakerTest.java
@@ -495,7 +495,7 @@ public class InlineDelegateByteBuddyMockMakerTest
         mockMaker.clearMock(proxy);
 
         // then
-        assertThat(mockMaker.getHandler(proxy)).isNull();
+        assertThat(mockMaker.getHandler(proxy)).isEqualTo(DisabledMockHandler.HANDLER);
     }
 
     @Test

--- a/mockito-core/src/test/java/org/mockito/internal/framework/DefaultMockitoFrameworkTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/framework/DefaultMockitoFrameworkTest.java
@@ -6,7 +6,7 @@ package org.mockito.internal.framework;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.any;
@@ -211,6 +211,26 @@ public class DefaultMockitoFrameworkTest extends TestBase {
     }
 
     @Test
+    public void behavior_after_clear_inline_mocks_is_mock() {
+        // clearing mocks only works with inline mocking
+        assumeTrue(Plugins.getMockMaker() instanceof InlineMockMaker);
+
+        PersonWithName obj = mock(PersonWithName.class);
+        when(obj.getMyName()).thenReturn("Bob");
+        assertEquals("Bob", obj.getMyName());
+        assertTrue(mockingDetails(obj).isMock());
+
+        framework.clearInlineMocks();
+
+        try {
+            mockingDetails(obj).isMock();
+        } catch (DisabledMockException e) {
+            return;
+        }
+        Assert.fail("Should have thrown DisabledMockException");
+    }
+
+    @Test
     public void clears_mock() {
         // clearing mocks only works with inline mocking
         assumeTrue(Plugins.getMockMaker() instanceof InlineMockMaker);
@@ -225,8 +245,26 @@ public class DefaultMockitoFrameworkTest extends TestBase {
         framework.clearInlineMock(list1);
 
         // then
-        assertFalse(mockingDetails(list1).isMock());
+        assertThrows(DisabledMockException.class, () -> mockingDetails(list1).isMock());
         assertTrue(mockingDetails(list2).isMock());
+    }
+
+    @Test
+    public void clears_mocks() {
+        // clearing mocks only works with inline mocking
+        assumeTrue(Plugins.getMockMaker() instanceof InlineMockMaker);
+
+        // given
+        List list1 = mock(List.class);
+        assertTrue(mockingDetails(list1).isMock());
+        List list2 = mock(List.class);
+        assertTrue(mockingDetails(list2).isMock());
+
+        framework.clearInlineMocks();
+
+        // then
+        assertThrows(DisabledMockException.class, () -> mockingDetails(list1).isMock());
+        assertThrows(DisabledMockException.class, () -> mockingDetails(list2).isMock());
     }
 
     private static class MyListener implements MockitoListener {}


### PR DESCRIPTION
This change makes a couple of changes surronding the the clearMock and clearMock apis.
1. All disabled mocks gets the INSTANCE of DisabledMockCreationSettings. This prevents any NPEs from attempting to access the MockCreationSettings, but will throw a MockDisabledException if attempting to actually read the settings. This will block calls such as: isMock(), etc.
2. This change syncs the logic between the clearMocks() and clearMock() logic to make the customer experience the same whether you are attempting to clear all mocks or just and individual mock.

These changes are being made mainly to introduce some more consistent behavior for mocks that have been cleared. Currently, the user experience is less than desirable to have NPEs be tripped depending on which clear method was called on the mock. Additionally, I think this disabling approach brings the design more in-line with some of the documentation about the behavior of a cleared mock. 

## Checklist

 - [X] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [X] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [X] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [X ] Avoid other runtime dependencies
 - [X] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [X] The pull request follows coding style
 - [X] Mention `Fixes #<issue number>` in the description _if relevant_
 - [X] At least one commit should mention `Fixes #<issue number>` _if relevant_

