### PR TITLE
Bump errorprone from 2.23.0 to 2.35.1 v2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 bytebuddy = "1.15.8"
-errorprone = "2.23.0"
+errorprone = "2.35.1"
 junit4 = "4.13.2"
 junit-jupiter = "5.11.3"
 junit-platform = "1.11.3"

--- a/mockito-core/src/test/java/org/mockito/internal/util/collections/HashCodeAndEqualsSafeSetTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/util/collections/HashCodeAndEqualsSafeSetTest.java
@@ -133,7 +133,7 @@ public class HashCodeAndEqualsSafeSetTest {
     @Test
     public void isEqualToItself() {
         HashCodeAndEqualsSafeSet set = HashCodeAndEqualsSafeSet.of(mock1);
-        assertThat(set).isEqualTo(set);
+        assertThat(set.equals(set)).isTrue();
     }
 
     @Test

--- a/mockito-core/src/test/java/org/mockitousage/basicapi/ReplacingObjectMethodsTest.java
+++ b/mockito-core/src/test/java/org/mockitousage/basicapi/ReplacingObjectMethodsTest.java
@@ -33,7 +33,7 @@ public class ReplacingObjectMethodsTest extends TestBase {
         Object mock = Mockito.mock(ObjectMethodsOverridden.class);
         Object otherMock = Mockito.mock(ObjectMethodsOverridden.class);
 
-        assertThat(mock).isEqualTo(mock);
+        assertThat(mock.equals(mock)).isTrue();
         assertThat(mock).isNotEqualTo(otherMock);
         assertThat(mock.hashCode()).isNotEqualTo(otherMock.hashCode());
 
@@ -45,7 +45,7 @@ public class ReplacingObjectMethodsTest extends TestBase {
         Object mock = Mockito.mock(ObjectMethodsOverriddenSubclass.class);
         Object otherMock = Mockito.mock(ObjectMethodsOverriddenSubclass.class);
 
-        assertThat(mock).isEqualTo(mock);
+        assertThat(mock.equals(mock)).isTrue();
         assertThat(mock).isNotEqualTo(otherMock);
         assertThat(mock.hashCode()).isNotEqualTo(otherMock.hashCode());
 

--- a/mockito-extensions/mockito-errorprone/build.gradle
+++ b/mockito-extensions/mockito-errorprone/build.gradle
@@ -4,6 +4,12 @@ plugins {
 
 description = "ErrorProne plugins for Mockito"
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
 dependencies {
     compileOnly libs.autoservice
     annotationProcessor libs.autoservice
@@ -33,6 +39,8 @@ tasks.withType(JavaCompile).configureEach {
     options.compilerArgs << "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"
     options.compilerArgs << "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED"
     options.compilerArgs << "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
+    options.compilerArgs << "--source" << "11"
+    options.compilerArgs << "--target" << "11"
 }
 
 tasks.withType(Javadoc).configureEach {


### PR DESCRIPTION
- Replaced `assertThat(set).isEqualTo(set)` with `assertThat(set.equals(set)).isTrue()` in order to explicitly verify reflexivity and avoid triggering ErrorProne's SelfAssertion warning. 

- Fixes #3493 
<!-- Hey,
Thanks for the contribution, this is awesome.
As you may have read, project members have somehow an opinionated view on what and how should be
Mockito, e.g. we don't want mockito to be a feature bloat.
There may be a thorough review, with feedback -> code change loop.
-->
<!--
If you have a suggestion for this template you can fix it in the .github/PULL_REQUEST_TEMPLATE.md file
-->
## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

