### PR TITLE
Mockito fails with JVM internal error when mocking class clinit does not find a transitive dependency

### DIFF
--- a/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
@@ -234,12 +234,16 @@ public class InlineBytecodeGenerator implements BytecodeGenerator, ClassFileTran
     private static void assureInitialization(Class<?> type) {
         try {
             Class.forName(type.getName(), true, type.getClassLoader());
-        } catch (ExceptionInInitializerError e) {
+        } catch (Error error) {
+            Throwable ex = error;
+            if (ex instanceof ExceptionInInitializerError) {
+                ex = ((ExceptionInInitializerError) ex).getException();
+            }
             throw new MockitoException(
                     "Cannot instrument "
                             + type
                             + " because it or one of its supertypes could not be initialized",
-                    e.getException());
+                    ex);
         } catch (Throwable ignored) {
         }
     }

--- a/mockito-core/src/test/java/org/mockitousage/bugs/creation/MockClassWithMissingStaticDepTest.java
+++ b/mockito-core/src/test/java/org/mockitousage/bugs/creation/MockClassWithMissingStaticDepTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2024 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage.bugs.creation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.exceptions.base.MockitoException;
+
+// See Issue #3498
+public class MockClassWithMissingStaticDepTest {
+
+    @Test
+    public void shouldNotSwallowClinitErrorOfClassToMock() {
+        try {
+            @SuppressWarnings("unused")
+            var unused = Mockito.mock(ClassWithErrorInClassInit.class);
+
+            fail();
+        } catch (MockitoException e) {
+            var cause = e.getCause();
+            assertThat(cause).isInstanceOf(MockitoException.class);
+            assertThat(cause.getMessage())
+                    .isEqualTo(
+                            "Cannot instrument class org.mockitousage.bugs.creation.MockClassWithMissingStaticDepTest$ClassWithErrorInClassInit because it or one of its supertypes could not be initialized");
+
+            var cause2 = cause.getCause();
+            assertThat(cause2).isInstanceOf(NoClassDefFoundError.class);
+            assertThat(cause2.getMessage())
+                    .isEqualTo("Simulate missing transitive dependency used in class init.");
+        } catch (NoClassDefFoundError ex) {
+            // Note: mock-maker-subclass will throw the NoClassDefFoundError as is
+            assertThat(ex.getMessage())
+                    .isEqualTo("Simulate missing transitive dependency used in class init.");
+        }
+    }
+
+    private static class ClassWithErrorInClassInit {
+        static {
+            //noinspection ConstantValue
+            if (true) {
+                throw new NoClassDefFoundError(
+                        "Simulate missing transitive dependency used in class init.");
+            }
+        }
+    }
+
+    @Test
+    public void shouldNotSwallowClinitExceptionOfClassToMock() {
+        try {
+            @SuppressWarnings("unused")
+            var unused = Mockito.mock(ClassWithExceptionInClassInit.class);
+
+            fail();
+        } catch (MockitoException e) {
+            var cause = e.getCause();
+            assertThat(cause).isInstanceOf(MockitoException.class);
+            assertThat(cause.getMessage())
+                    .isEqualTo(
+                            "Cannot instrument class org.mockitousage.bugs.creation.MockClassWithMissingStaticDepTest$ClassWithExceptionInClassInit because it or one of its supertypes could not be initialized");
+
+            var cause2 = cause.getCause();
+            assertThat(cause2).isInstanceOf(IllegalStateException.class);
+            assertThat(cause2.getMessage()).isEqualTo("Exception in class init.");
+        } catch (ExceptionInInitializerError ex) {
+            // Note: mock-maker-subclass will throw the ExceptionInInitializerError as is
+            var cause = ex.getCause();
+            assertThat(cause).isInstanceOf(IllegalStateException.class);
+            assertThat(cause.getMessage()).isEqualTo("Exception in class init.");
+        }
+    }
+
+    private static class ClassWithExceptionInClassInit {
+        static {
+            //noinspection ConstantValue
+            if (true) {
+                throw new IllegalStateException("Exception in class init.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Mockito now throws Errors occurred during class initialization to callers instead of swallowing it, and the JVM reporting an obscure exception.

Fixes #3498

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [ ] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [ ] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

