### PR TITLE
Feature/thread lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
         --scan
 
     - name: 8. Upload coverage report
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v4
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
@@ -182,7 +182,7 @@ jobs:
 
     # :mockito-integration-tests:android-tests:connectedCheck (which depends on :mockito-integration-tests:android-tests:createDebugAndroidTestCoverageReport) already generated coverage report.
     - name: 6. Upload coverage report
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v4
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:

--- a/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java
@@ -60,7 +60,6 @@ import org.mockito.internal.invocation.mockref.MockWeakReference;
 import org.mockito.internal.util.concurrent.DetachedThreadLocal;
 import org.mockito.internal.util.concurrent.WeakConcurrentMap;
 import org.mockito.plugins.MemberAccessor;
-import java.util.Optional;
 
 public class MockMethodAdvice extends MockMethodDispatcher {
 
@@ -120,18 +119,20 @@ public class MockMethodAdvice extends MockMethodDispatcher {
     }
 
     @Override
-    public Optional<Callable<?>> handle(Object instance, Method origin, Object[] arguments) throws Throwable {
+    public Callable<?> handle(Object instance, Method origin, Object[] arguments) throws Throwable {
         MockMethodInterceptor interceptor = interceptors.get(instance);
         if (interceptor == null) {
-            return Optional.empty();
+            return null;
         }
-        RealMethod realMethod = (instance instanceof Serializable)
-            ? new SerializableRealMethodCall(identifier, origin, instance, arguments)
-            : new RealMethodCall(selfCallInfo, origin, instance, arguments);
-        
-        return Optional.of(new ReturnValueWrapper(
-            interceptor.doIntercept(instance, origin, arguments, realMethod, LocationFactory.create(true))
-        ));
+        RealMethod realMethod;
+        if (instance instanceof Serializable) {
+            realMethod = new SerializableRealMethodCall(identifier, origin, instance, arguments);
+        } else {
+            realMethod = new RealMethodCall(selfCallInfo, origin, instance, arguments);
+        }
+        return new ReturnValueWrapper(
+                interceptor.doIntercept(
+                        instance, origin, arguments, realMethod, LocationFactory.create(true)));
     }
 
     @Override


### PR DESCRIPTION
This PR refactors the ThreadVerifiesContinuouslyInteractingMockTest class to improve thread safety by adding a ReentrantLock around critical sections. The goal is to ensure that interactions with the mock object are safe and consistent when accessed from multiple threads, preventing race conditions and improving the reliability of the test in a multithreaded environment.