### PR TITLE
Amend grammar in warning for Java 21 implicit agent attachment

### DIFF
--- a/mockito-core/src/main/java/org/mockito/internal/PremainAttachAccess.java
+++ b/mockito-core/src/main/java/org/mockito/internal/PremainAttachAccess.java
@@ -42,7 +42,7 @@ public class PremainAttachAccess {
                 System.err.println(
                         "Mockito is currently self-attaching to enable the inline-mock-maker. This "
                                 + "will no longer work in future releases of the JDK. Please add Mockito as an agent to your "
-                                + "build what is described in Mockito's documentation: "
+                                + "build as described in Mockito's documentation: "
                                 + "https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#0.3");
             }
             // Attempt to dynamically attach, as a last resort.


### PR DESCRIPTION
This fixes the JDK 21 warning for implicit agent attachment to flow more clearly.

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

