### PR TITLE
Fix javadoc publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
           ./gradlew
           githubRelease
           publishToSonatype
-          closeAndReleaseStagingRepository
+          closeAndReleaseStagingRepositories
           releaseSummary
           --stacktrace
         env:

--- a/buildSrc/src/main/kotlin/mockito.javadoc-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/mockito.javadoc-conventions.gradle.kts
@@ -17,17 +17,13 @@ tasks.named<Javadoc>("javadoc") {
 
     // For more details on the format
     // see https://docs.oracle.com/en/java/javase/21/javadoc/javadoc.html
-
-    source = project.sourceSets["main"].allJava
-
     options {
         title = mockitoJavadocExtension.title.get()
-        destinationDirectory = project.layout.buildDirectory.dir("javadoc").get().asFile
         encoding = "UTF-8"
 
         if (this is StandardJavadocDocletOptions) {
             addBooleanOption("-allow-script-in-comments", true)
-            addFileOption("-add-stylesheet", file("$javadocConfigDir/resources/mockito-theme.css"))
+            addFileOption("-add-stylesheet", project.file("$javadocConfigDir/resources/mockito-theme.css"))
             addStringOption("Xwerror", "-quiet")
             charSet = "UTF-8"
             docEncoding = "UTF-8"
@@ -56,12 +52,12 @@ tasks.named<Javadoc>("javadoc") {
         }
         memberLevel = JavadocMemberLevel.PROTECTED
         outputLevel = JavadocOutputLevel.QUIET
+    }
 
-        doLast {
-            copy {
-                from("$javadocConfigDir/resources")
-                into(project.layout.buildDirectory.dir("javadoc"))
-            }
+    doLast {
+        copy {
+            from("$javadocConfigDir/resources")
+            into(destinationDir!!)
         }
     }
 }

--- a/buildSrc/src/main/kotlin/mockito.javadoc-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/mockito.javadoc-conventions.gradle.kts
@@ -15,6 +15,8 @@ tasks.named<Javadoc>("javadoc") {
     inputs.dir(javadocConfigDir)
     description = "Creates javadoc html for ${project.name}."
 
+    exclude("**/internal/**")
+
     // For more details on the format
     // see https://docs.oracle.com/en/java/javase/21/javadoc/javadoc.html
     options {

--- a/buildSrc/src/main/kotlin/mockito.publication-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/mockito.publication-conventions.gradle.kts
@@ -98,7 +98,6 @@ plugins.withType<JavaLibraryPlugin>().configureEach {
     }
 
     val javadocJar by tasks.registering(Jar::class) {
-        onlyIf { tasks.named<Javadoc>("javadoc").get().isEnabled }
         archiveClassifier.set("javadoc")
         from(tasks.named("javadoc"))
         with(licenseSpec)
@@ -106,9 +105,7 @@ plugins.withType<JavaLibraryPlugin>().configureEach {
 
     project.artifacts {
         archives(sourcesJar)
-        if (javadocJar.get().isEnabled) {
-            archives(javadocJar)
-        }
+        archives(javadocJar)
     }
 
     tasks.named("jar", Jar::class) {
@@ -121,9 +118,7 @@ plugins.withType<JavaLibraryPlugin>().configureEach {
             register<MavenPublication>("mockitoLibrary") {
                 from(components["java"])
                 artifact(sourcesJar)
-                if (javadocJar.get().didWork) {
-                    artifact(javadocJar)
-                }
+                artifact(javadocJar)
 
                 pom {
                     // Gradle does not write 'jar' packaging to the pom (unlike other packaging types).

--- a/buildSrc/src/main/kotlin/mockito.publication-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/mockito.publication-conventions.gradle.kts
@@ -9,6 +9,8 @@ plugins {
 // enforce the same group for all published artifacts
 group = "org.mockito"
 
+val localRepoForTesting = rootProject.layout.buildDirectory.dir("repo")
+
 // generic publication conventions
 publishing {
     publications {
@@ -58,9 +60,15 @@ publishing {
 
     //useful for testing - running "publish" will create artifacts/pom in a local dir
     repositories {
-        maven(uri(rootProject.layout.buildDirectory.dir("repo"))) {
+        maven(uri(localRepoForTesting)) {
             name = "local"
         }
+    }
+}
+
+tasks.clean {
+    doLast {
+        delete(localRepoForTesting)
     }
 }
 

--- a/buildSrc/src/main/kotlin/mockito.root.releasing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/mockito.root.releasing-conventions.gradle.kts
@@ -7,8 +7,8 @@ plugins {
 }
 
 val isSnapshot = version.toString().endsWith("SNAPSHOT")
-val githubTokenProvider = providers.environmentVariable("GITHUB_TOKEN")
-val githubShaProvider = providers.environmentVariable("GITHUB_SHA")
+val githubTokenProvider = providers.environmentVariable("GITHUB_TOKEN").orElse("")
+val githubShaProvider = providers.environmentVariable("GITHUB_SHA").orElse("")
 val mockitoRepository = "mockito/mockito"
 
 tasks {

--- a/mockito-core/build.gradle.kts
+++ b/mockito-core/build.gradle.kts
@@ -24,6 +24,13 @@ configurations {
     }
 }
 
+// Disables publishing test fixtures:
+// https://docs.gradle.org/current/userguide/java_testing.html#ex-disable-publishing-of-test-fixtures-variants
+with(components["java"] as AdhocComponentWithVariants) {
+    withVariantsFromConfiguration(configurations.testFixturesApiElements.get()) { skip() }
+    withVariantsFromConfiguration(configurations.testFixturesRuntimeElements.get()) { skip() }
+}
+
 dependencies {
     api(libs.bytebuddy)
     api(libs.bytebuddy.agent)


### PR DESCRIPTION
This PR should fix the javadoc publication issues noticed in #3542

<details><summary>listing of published artifacts</summary>

```shell
$ tree build/repo/org/mockito

build/repo/org/mockito/
├── mockito-android
│   ├── 5.15.2-SNAPSHOT
│   │   ├── maven-metadata.xml
│   │   ├── maven-metadata.xml.md5
│   │   ├── maven-metadata.xml.sha1
│   │   ├── maven-metadata.xml.sha256
│   │   ├── maven-metadata.xml.sha512
│   │   ├── mockito-android-5.15.2-20250102.102747-1-sources.jar
│   │   ├── mockito-android-5.15.2-20250102.102747-1-sources.jar.md5
│   │   ├── mockito-android-5.15.2-20250102.102747-1-sources.jar.sha1
│   │   ├── mockito-android-5.15.2-20250102.102747-1-sources.jar.sha256
│   │   ├── mockito-android-5.15.2-20250102.102747-1-sources.jar.sha512
│   │   ├── mockito-android-5.15.2-20250102.102747-1.jar
│   │   ├── mockito-android-5.15.2-20250102.102747-1.jar.md5
│   │   ├── mockito-android-5.15.2-20250102.102747-1.jar.sha1
│   │   ├── mockito-android-5.15.2-20250102.102747-1.jar.sha256
│   │   ├── mockito-android-5.15.2-20250102.102747-1.jar.sha512
│   │   ├── mockito-android-5.15.2-20250102.102747-1.pom
│   │   ├── mockito-android-5.15.2-20250102.102747-1.pom.md5
│   │   ├── mockito-android-5.15.2-20250102.102747-1.pom.sha1
│   │   ├── mockito-android-5.15.2-20250102.102747-1.pom.sha256
│   │   ├── mockito-android-5.15.2-20250102.102747-1.pom.sha512
│   │   ├── mockito-android-5.15.2-20250102.102938-2-javadoc.jar
│   │   ├── mockito-android-5.15.2-20250102.102938-2-javadoc.jar.md5
│   │   ├── mockito-android-5.15.2-20250102.102938-2-javadoc.jar.sha1
│   │   ├── mockito-android-5.15.2-20250102.102938-2-javadoc.jar.sha256
│   │   ├── mockito-android-5.15.2-20250102.102938-2-javadoc.jar.sha512
│   │   ├── mockito-android-5.15.2-20250102.102938-2-sources.jar
│   │   ├── mockito-android-5.15.2-20250102.102938-2-sources.jar.md5
│   │   ├── mockito-android-5.15.2-20250102.102938-2-sources.jar.sha1
│   │   ├── mockito-android-5.15.2-20250102.102938-2-sources.jar.sha256
│   │   ├── mockito-android-5.15.2-20250102.102938-2-sources.jar.sha512
│   │   ├── mockito-android-5.15.2-20250102.102938-2.jar
│   │   ├── mockito-android-5.15.2-20250102.102938-2.jar.md5
│   │   ├── mockito-android-5.15.2-20250102.102938-2.jar.sha1
│   │   ├── mockito-android-5.15.2-20250102.102938-2.jar.sha256
│   │   ├── mockito-android-5.15.2-20250102.102938-2.jar.sha512
│   │   ├── mockito-android-5.15.2-20250102.102938-2.pom
│   │   ├── mockito-android-5.15.2-20250102.102938-2.pom.md5
│   │   ├── mockito-android-5.15.2-20250102.102938-2.pom.sha1
│   │   ├── mockito-android-5.15.2-20250102.102938-2.pom.sha256
│   │   ├── mockito-android-5.15.2-20250102.102938-2.pom.sha512
│   │   ├── mockito-android-5.15.2-20250102.104306-3-javadoc.jar
│   │   ├── mockito-android-5.15.2-20250102.104306-3-javadoc.jar.md5
│   │   ├── mockito-android-5.15.2-20250102.104306-3-javadoc.jar.sha1
│   │   ├── mockito-android-5.15.2-20250102.104306-3-javadoc.jar.sha256
│   │   ├── mockito-android-5.15.2-20250102.104306-3-javadoc.jar.sha512
│   │   ├── mockito-android-5.15.2-20250102.104306-3-sources.jar
│   │   ├── mockito-android-5.15.2-20250102.104306-3-sources.jar.md5
│   │   ├── mockito-android-5.15.2-20250102.104306-3-sources.jar.sha1
│   │   ├── mockito-android-5.15.2-20250102.104306-3-sources.jar.sha256
│   │   ├── mockito-android-5.15.2-20250102.104306-3-sources.jar.sha512
│   │   ├── mockito-android-5.15.2-20250102.104306-3.jar
│   │   ├── mockito-android-5.15.2-20250102.104306-3.jar.md5
│   │   ├── mockito-android-5.15.2-20250102.104306-3.jar.sha1
│   │   ├── mockito-android-5.15.2-20250102.104306-3.jar.sha256
│   │   ├── mockito-android-5.15.2-20250102.104306-3.jar.sha512
│   │   ├── mockito-android-5.15.2-20250102.104306-3.pom
│   │   ├── mockito-android-5.15.2-20250102.104306-3.pom.md5
│   │   ├── mockito-android-5.15.2-20250102.104306-3.pom.sha1
│   │   ├── mockito-android-5.15.2-20250102.104306-3.pom.sha256
│   │   └── mockito-android-5.15.2-20250102.104306-3.pom.sha512
│   ├── maven-metadata.xml
│   ├── maven-metadata.xml.md5
│   ├── maven-metadata.xml.sha1
│   ├── maven-metadata.xml.sha256
│   └── maven-metadata.xml.sha512
├── mockito-bom
│   ├── 5.15.2-SNAPSHOT
│   │   ├── maven-metadata.xml
│   │   ├── maven-metadata.xml.md5
│   │   ├── maven-metadata.xml.sha1
│   │   ├── maven-metadata.xml.sha256
│   │   ├── maven-metadata.xml.sha512
│   │   ├── mockito-bom-5.15.2-20250102.101809-1.pom
│   │   ├── mockito-bom-5.15.2-20250102.101809-1.pom.md5
│   │   ├── mockito-bom-5.15.2-20250102.101809-1.pom.sha1
│   │   ├── mockito-bom-5.15.2-20250102.101809-1.pom.sha256
│   │   ├── mockito-bom-5.15.2-20250102.101809-1.pom.sha512
│   │   ├── mockito-bom-5.15.2-20250102.102747-2.pom
│   │   ├── mockito-bom-5.15.2-20250102.102747-2.pom.md5
│   │   ├── mockito-bom-5.15.2-20250102.102747-2.pom.sha1
│   │   ├── mockito-bom-5.15.2-20250102.102747-2.pom.sha256
│   │   ├── mockito-bom-5.15.2-20250102.102747-2.pom.sha512
│   │   ├── mockito-bom-5.15.2-20250102.102938-3.pom
│   │   ├── mockito-bom-5.15.2-20250102.102938-3.pom.md5
│   │   ├── mockito-bom-5.15.2-20250102.102938-3.pom.sha1
│   │   ├── mockito-bom-5.15.2-20250102.102938-3.pom.sha256
│   │   ├── mockito-bom-5.15.2-20250102.102938-3.pom.sha512
│   │   ├── mockito-bom-5.15.2-20250102.104306-4.pom
│   │   ├── mockito-bom-5.15.2-20250102.104306-4.pom.md5
│   │   ├── mockito-bom-5.15.2-20250102.104306-4.pom.sha1
│   │   ├── mockito-bom-5.15.2-20250102.104306-4.pom.sha256
│   │   └── mockito-bom-5.15.2-20250102.104306-4.pom.sha512
│   ├── maven-metadata.xml
│   ├── maven-metadata.xml.md5
│   ├── maven-metadata.xml.sha1
│   ├── maven-metadata.xml.sha256
│   └── maven-metadata.xml.sha512
├── mockito-core
│   ├── 5.15.2-SNAPSHOT
│   │   ├── maven-metadata.xml
│   │   ├── maven-metadata.xml.md5
│   │   ├── maven-metadata.xml.sha1
│   │   ├── maven-metadata.xml.sha256
│   │   ├── maven-metadata.xml.sha512
│   │   ├── mockito-core-5.15.2-20250102.102747-1-sources.jar
│   │   ├── mockito-core-5.15.2-20250102.102747-1-sources.jar.md5
│   │   ├── mockito-core-5.15.2-20250102.102747-1-sources.jar.sha1
│   │   ├── mockito-core-5.15.2-20250102.102747-1-sources.jar.sha256
│   │   ├── mockito-core-5.15.2-20250102.102747-1-sources.jar.sha512
│   │   ├── mockito-core-5.15.2-20250102.102747-1.jar
│   │   ├── mockito-core-5.15.2-20250102.102747-1.jar.md5
│   │   ├── mockito-core-5.15.2-20250102.102747-1.jar.sha1
│   │   ├── mockito-core-5.15.2-20250102.102747-1.jar.sha256
│   │   ├── mockito-core-5.15.2-20250102.102747-1.jar.sha512
│   │   ├── mockito-core-5.15.2-20250102.102747-1.pom
│   │   ├── mockito-core-5.15.2-20250102.102747-1.pom.md5
│   │   ├── mockito-core-5.15.2-20250102.102747-1.pom.sha1
│   │   ├── mockito-core-5.15.2-20250102.102747-1.pom.sha256
│   │   ├── mockito-core-5.15.2-20250102.102747-1.pom.sha512
│   │   ├── mockito-core-5.15.2-20250102.102938-2-javadoc.jar
│   │   ├── mockito-core-5.15.2-20250102.102938-2-javadoc.jar.md5
│   │   ├── mockito-core-5.15.2-20250102.102938-2-javadoc.jar.sha1
│   │   ├── mockito-core-5.15.2-20250102.102938-2-javadoc.jar.sha256
│   │   ├── mockito-core-5.15.2-20250102.102938-2-javadoc.jar.sha512
│   │   ├── mockito-core-5.15.2-20250102.102938-2-sources.jar
│   │   ├── mockito-core-5.15.2-20250102.102938-2-sources.jar.md5
│   │   ├── mockito-core-5.15.2-20250102.102938-2-sources.jar.sha1
│   │   ├── mockito-core-5.15.2-20250102.102938-2-sources.jar.sha256
│   │   ├── mockito-core-5.15.2-20250102.102938-2-sources.jar.sha512
│   │   ├── mockito-core-5.15.2-20250102.102938-2.jar
│   │   ├── mockito-core-5.15.2-20250102.102938-2.jar.md5
│   │   ├── mockito-core-5.15.2-20250102.102938-2.jar.sha1
│   │   ├── mockito-core-5.15.2-20250102.102938-2.jar.sha256
│   │   ├── mockito-core-5.15.2-20250102.102938-2.jar.sha512
│   │   ├── mockito-core-5.15.2-20250102.102938-2.pom
│   │   ├── mockito-core-5.15.2-20250102.102938-2.pom.md5
│   │   ├── mockito-core-5.15.2-20250102.102938-2.pom.sha1
│   │   ├── mockito-core-5.15.2-20250102.102938-2.pom.sha256
│   │   ├── mockito-core-5.15.2-20250102.102938-2.pom.sha512
│   │   ├── mockito-core-5.15.2-20250102.104306-3-javadoc.jar
│   │   ├── mockito-core-5.15.2-20250102.104306-3-javadoc.jar.md5
│   │   ├── mockito-core-5.15.2-20250102.104306-3-javadoc.jar.sha1
│   │   ├── mockito-core-5.15.2-20250102.104306-3-javadoc.jar.sha256
│   │   ├── mockito-core-5.15.2-20250102.104306-3-javadoc.jar.sha512
│   │   ├── mockito-core-5.15.2-20250102.104306-3-sources.jar
│   │   ├── mockito-core-5.15.2-20250102.104306-3-sources.jar.md5
│   │   ├── mockito-core-5.15.2-20250102.104306-3-sources.jar.sha1
│   │   ├── mockito-core-5.15.2-20250102.104306-3-sources.jar.sha256
│   │   ├── mockito-core-5.15.2-20250102.104306-3-sources.jar.sha512
│   │   ├── mockito-core-5.15.2-20250102.104306-3.jar
│   │   ├── mockito-core-5.15.2-20250102.104306-3.jar.md5
│   │   ├── mockito-core-5.15.2-20250102.104306-3.jar.sha1
│   │   ├── mockito-core-5.15.2-20250102.104306-3.jar.sha256
│   │   ├── mockito-core-5.15.2-20250102.104306-3.jar.sha512
│   │   ├── mockito-core-5.15.2-20250102.104306-3.pom
│   │   ├── mockito-core-5.15.2-20250102.104306-3.pom.md5
│   │   ├── mockito-core-5.15.2-20250102.104306-3.pom.sha1
│   │   ├── mockito-core-5.15.2-20250102.104306-3.pom.sha256
│   │   └── mockito-core-5.15.2-20250102.104306-3.pom.sha512
│   ├── maven-metadata.xml
│   ├── maven-metadata.xml.md5
│   ├── maven-metadata.xml.sha1
│   ├── maven-metadata.xml.sha256
│   └── maven-metadata.xml.sha512
├── mockito-errorprone
│   ├── 5.15.2-SNAPSHOT
│   │   ├── maven-metadata.xml
│   │   ├── maven-metadata.xml.md5
│   │   ├── maven-metadata.xml.sha1
│   │   ├── maven-metadata.xml.sha256
│   │   ├── maven-metadata.xml.sha512
│   │   ├── mockito-errorprone-5.15.2-20250102.102747-1-sources.jar
│   │   ├── mockito-errorprone-5.15.2-20250102.102747-1-sources.jar.md5
│   │   ├── mockito-errorprone-5.15.2-20250102.102747-1-sources.jar.sha1
│   │   ├── mockito-errorprone-5.15.2-20250102.102747-1-sources.jar.sha256
│   │   ├── mockito-errorprone-5.15.2-20250102.102747-1-sources.jar.sha512
│   │   ├── mockito-errorprone-5.15.2-20250102.102747-1.jar
│   │   ├── mockito-errorprone-5.15.2-20250102.102747-1.jar.md5
│   │   ├── mockito-errorprone-5.15.2-20250102.102747-1.jar.sha1
│   │   ├── mockito-errorprone-5.15.2-20250102.102747-1.jar.sha256
│   │   ├── mockito-errorprone-5.15.2-20250102.102747-1.jar.sha512
│   │   ├── mockito-errorprone-5.15.2-20250102.102747-1.pom
│   │   ├── mockito-errorprone-5.15.2-20250102.102747-1.pom.md5
│   │   ├── mockito-errorprone-5.15.2-20250102.102747-1.pom.sha1
│   │   ├── mockito-errorprone-5.15.2-20250102.102747-1.pom.sha256
│   │   ├── mockito-errorprone-5.15.2-20250102.102747-1.pom.sha512
│   │   ├── mockito-errorprone-5.15.2-20250102.102938-2-javadoc.jar
│   │   ├── mockito-errorprone-5.15.2-20250102.102938-2-javadoc.jar.md5
│   │   ├── mockito-errorprone-5.15.2-20250102.102938-2-javadoc.jar.sha1
│   │   ├── mockito-errorprone-5.15.2-20250102.102938-2-javadoc.jar.sha256
│   │   ├── mockito-errorprone-5.15.2-20250102.102938-2-javadoc.jar.sha512
│   │   ├── mockito-errorprone-5.15.2-20250102.102938-2-sources.jar
│   │   ├── mockito-errorprone-5.15.2-20250102.102938-2-sources.jar.md5
│   │   ├── mockito-errorprone-5.15.2-20250102.102938-2-sources.jar.sha1
│   │   ├── mockito-errorprone-5.15.2-20250102.102938-2-sources.jar.sha256
│   │   ├── mockito-errorprone-5.15.2-20250102.102938-2-sources.jar.sha512
│   │   ├── mockito-errorprone-5.15.2-20250102.102938-2.jar
│   │   ├── mockito-errorprone-5.15.2-20250102.102938-2.jar.md5
│   │   ├── mockito-errorprone-5.15.2-20250102.102938-2.jar.sha1
│   │   ├── mockito-errorprone-5.15.2-20250102.102938-2.jar.sha256
│   │   ├── mockito-errorprone-5.15.2-20250102.102938-2.jar.sha512
│   │   ├── mockito-errorprone-5.15.2-20250102.102938-2.pom
│   │   ├── mockito-errorprone-5.15.2-20250102.102938-2.pom.md5
│   │   ├── mockito-errorprone-5.15.2-20250102.102938-2.pom.sha1
│   │   ├── mockito-errorprone-5.15.2-20250102.102938-2.pom.sha256
│   │   ├── mockito-errorprone-5.15.2-20250102.102938-2.pom.sha512
│   │   ├── mockito-errorprone-5.15.2-20250102.104306-3-javadoc.jar
│   │   ├── mockito-errorprone-5.15.2-20250102.104306-3-javadoc.jar.md5
│   │   ├── mockito-errorprone-5.15.2-20250102.104306-3-javadoc.jar.sha1
│   │   ├── mockito-errorprone-5.15.2-20250102.104306-3-javadoc.jar.sha256
│   │   ├── mockito-errorprone-5.15.2-20250102.104306-3-javadoc.jar.sha512
│   │   ├── mockito-errorprone-5.15.2-20250102.104306-3-sources.jar
│   │   ├── mockito-errorprone-5.15.2-20250102.104306-3-sources.jar.md5
│   │   ├── mockito-errorprone-5.15.2-20250102.104306-3-sources.jar.sha1
│   │   ├── mockito-errorprone-5.15.2-20250102.104306-3-sources.jar.sha256
│   │   ├── mockito-errorprone-5.15.2-20250102.104306-3-sources.jar.sha512
│   │   ├── mockito-errorprone-5.15.2-20250102.104306-3.jar
│   │   ├── mockito-errorprone-5.15.2-20250102.104306-3.jar.md5
│   │   ├── mockito-errorprone-5.15.2-20250102.104306-3.jar.sha1
│   │   ├── mockito-errorprone-5.15.2-20250102.104306-3.jar.sha256
│   │   ├── mockito-errorprone-5.15.2-20250102.104306-3.jar.sha512
│   │   ├── mockito-errorprone-5.15.2-20250102.104306-3.pom
│   │   ├── mockito-errorprone-5.15.2-20250102.104306-3.pom.md5
│   │   ├── mockito-errorprone-5.15.2-20250102.104306-3.pom.sha1
│   │   ├── mockito-errorprone-5.15.2-20250102.104306-3.pom.sha256
│   │   └── mockito-errorprone-5.15.2-20250102.104306-3.pom.sha512
│   ├── maven-metadata.xml
│   ├── maven-metadata.xml.md5
│   ├── maven-metadata.xml.sha1
│   ├── maven-metadata.xml.sha256
│   └── maven-metadata.xml.sha512
├── mockito-junit-jupiter
│   ├── 5.15.2-SNAPSHOT
│   │   ├── maven-metadata.xml
│   │   ├── maven-metadata.xml.md5
│   │   ├── maven-metadata.xml.sha1
│   │   ├── maven-metadata.xml.sha256
│   │   ├── maven-metadata.xml.sha512
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102747-1-sources.jar
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102747-1-sources.jar.md5
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102747-1-sources.jar.sha1
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102747-1-sources.jar.sha256
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102747-1-sources.jar.sha512
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102747-1.jar
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102747-1.jar.md5
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102747-1.jar.sha1
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102747-1.jar.sha256
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102747-1.jar.sha512
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102747-1.pom
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102747-1.pom.md5
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102747-1.pom.sha1
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102747-1.pom.sha256
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102747-1.pom.sha512
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102938-2-javadoc.jar
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102938-2-javadoc.jar.md5
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102938-2-javadoc.jar.sha1
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102938-2-javadoc.jar.sha256
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102938-2-javadoc.jar.sha512
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102938-2-sources.jar
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102938-2-sources.jar.md5
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102938-2-sources.jar.sha1
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102938-2-sources.jar.sha256
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102938-2-sources.jar.sha512
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102938-2.jar
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102938-2.jar.md5
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102938-2.jar.sha1
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102938-2.jar.sha256
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102938-2.jar.sha512
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102938-2.pom
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102938-2.pom.md5
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102938-2.pom.sha1
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102938-2.pom.sha256
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.102938-2.pom.sha512
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.104306-3-javadoc.jar
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.104306-3-javadoc.jar.md5
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.104306-3-javadoc.jar.sha1
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.104306-3-javadoc.jar.sha256
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.104306-3-javadoc.jar.sha512
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.104306-3-sources.jar
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.104306-3-sources.jar.md5
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.104306-3-sources.jar.sha1
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.104306-3-sources.jar.sha256
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.104306-3-sources.jar.sha512
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.104306-3.jar
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.104306-3.jar.md5
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.104306-3.jar.sha1
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.104306-3.jar.sha256
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.104306-3.jar.sha512
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.104306-3.pom
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.104306-3.pom.md5
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.104306-3.pom.sha1
│   │   ├── mockito-junit-jupiter-5.15.2-20250102.104306-3.pom.sha256
│   │   └── mockito-junit-jupiter-5.15.2-20250102.104306-3.pom.sha512
│   ├── maven-metadata.xml
│   ├── maven-metadata.xml.md5
│   ├── maven-metadata.xml.sha1
│   ├── maven-metadata.xml.sha256
│   └── maven-metadata.xml.sha512
├── mockito-proxy
│   ├── 5.15.2-SNAPSHOT
│   │   ├── maven-metadata.xml
│   │   ├── maven-metadata.xml.md5
│   │   ├── maven-metadata.xml.sha1
│   │   ├── maven-metadata.xml.sha256
│   │   ├── maven-metadata.xml.sha512
│   │   ├── mockito-proxy-5.15.2-20250102.102747-1-sources.jar
│   │   ├── mockito-proxy-5.15.2-20250102.102747-1-sources.jar.md5
│   │   ├── mockito-proxy-5.15.2-20250102.102747-1-sources.jar.sha1
│   │   ├── mockito-proxy-5.15.2-20250102.102747-1-sources.jar.sha256
│   │   ├── mockito-proxy-5.15.2-20250102.102747-1-sources.jar.sha512
│   │   ├── mockito-proxy-5.15.2-20250102.102747-1.jar
│   │   ├── mockito-proxy-5.15.2-20250102.102747-1.jar.md5
│   │   ├── mockito-proxy-5.15.2-20250102.102747-1.jar.sha1
│   │   ├── mockito-proxy-5.15.2-20250102.102747-1.jar.sha256
│   │   ├── mockito-proxy-5.15.2-20250102.102747-1.jar.sha512
│   │   ├── mockito-proxy-5.15.2-20250102.102747-1.pom
│   │   ├── mockito-proxy-5.15.2-20250102.102747-1.pom.md5
│   │   ├── mockito-proxy-5.15.2-20250102.102747-1.pom.sha1
│   │   ├── mockito-proxy-5.15.2-20250102.102747-1.pom.sha256
│   │   ├── mockito-proxy-5.15.2-20250102.102747-1.pom.sha512
│   │   ├── mockito-proxy-5.15.2-20250102.102938-2-javadoc.jar
│   │   ├── mockito-proxy-5.15.2-20250102.102938-2-javadoc.jar.md5
│   │   ├── mockito-proxy-5.15.2-20250102.102938-2-javadoc.jar.sha1
│   │   ├── mockito-proxy-5.15.2-20250102.102938-2-javadoc.jar.sha256
│   │   ├── mockito-proxy-5.15.2-20250102.102938-2-javadoc.jar.sha512
│   │   ├── mockito-proxy-5.15.2-20250102.102938-2-sources.jar
│   │   ├── mockito-proxy-5.15.2-20250102.102938-2-sources.jar.md5
│   │   ├── mockito-proxy-5.15.2-20250102.102938-2-sources.jar.sha1
│   │   ├── mockito-proxy-5.15.2-20250102.102938-2-sources.jar.sha256
│   │   ├── mockito-proxy-5.15.2-20250102.102938-2-sources.jar.sha512
│   │   ├── mockito-proxy-5.15.2-20250102.102938-2.jar
│   │   ├── mockito-proxy-5.15.2-20250102.102938-2.jar.md5
│   │   ├── mockito-proxy-5.15.2-20250102.102938-2.jar.sha1
│   │   ├── mockito-proxy-5.15.2-20250102.102938-2.jar.sha256
│   │   ├── mockito-proxy-5.15.2-20250102.102938-2.jar.sha512
│   │   ├── mockito-proxy-5.15.2-20250102.102938-2.pom
│   │   ├── mockito-proxy-5.15.2-20250102.102938-2.pom.md5
│   │   ├── mockito-proxy-5.15.2-20250102.102938-2.pom.sha1
│   │   ├── mockito-proxy-5.15.2-20250102.102938-2.pom.sha256
│   │   ├── mockito-proxy-5.15.2-20250102.102938-2.pom.sha512
│   │   ├── mockito-proxy-5.15.2-20250102.104306-3-javadoc.jar
│   │   ├── mockito-proxy-5.15.2-20250102.104306-3-javadoc.jar.md5
│   │   ├── mockito-proxy-5.15.2-20250102.104306-3-javadoc.jar.sha1
│   │   ├── mockito-proxy-5.15.2-20250102.104306-3-javadoc.jar.sha256
│   │   ├── mockito-proxy-5.15.2-20250102.104306-3-javadoc.jar.sha512
│   │   ├── mockito-proxy-5.15.2-20250102.104306-3-sources.jar
│   │   ├── mockito-proxy-5.15.2-20250102.104306-3-sources.jar.md5
│   │   ├── mockito-proxy-5.15.2-20250102.104306-3-sources.jar.sha1
│   │   ├── mockito-proxy-5.15.2-20250102.104306-3-sources.jar.sha256
│   │   ├── mockito-proxy-5.15.2-20250102.104306-3-sources.jar.sha512
│   │   ├── mockito-proxy-5.15.2-20250102.104306-3.jar
│   │   ├── mockito-proxy-5.15.2-20250102.104306-3.jar.md5
│   │   ├── mockito-proxy-5.15.2-20250102.104306-3.jar.sha1
│   │   ├── mockito-proxy-5.15.2-20250102.104306-3.jar.sha256
│   │   ├── mockito-proxy-5.15.2-20250102.104306-3.jar.sha512
│   │   ├── mockito-proxy-5.15.2-20250102.104306-3.pom
│   │   ├── mockito-proxy-5.15.2-20250102.104306-3.pom.md5
│   │   ├── mockito-proxy-5.15.2-20250102.104306-3.pom.sha1
│   │   ├── mockito-proxy-5.15.2-20250102.104306-3.pom.sha256
│   │   └── mockito-proxy-5.15.2-20250102.104306-3.pom.sha512
│   ├── maven-metadata.xml
│   ├── maven-metadata.xml.md5
│   ├── maven-metadata.xml.sha1
│   ├── maven-metadata.xml.sha256
│   └── maven-metadata.xml.sha512
└── mockito-subclass
    ├── 5.15.2-SNAPSHOT
    │   ├── maven-metadata.xml
    │   ├── maven-metadata.xml.md5
    │   ├── maven-metadata.xml.sha1
    │   ├── maven-metadata.xml.sha256
    │   ├── maven-metadata.xml.sha512
    │   ├── mockito-subclass-5.15.2-20250102.102747-1-sources.jar
    │   ├── mockito-subclass-5.15.2-20250102.102747-1-sources.jar.md5
    │   ├── mockito-subclass-5.15.2-20250102.102747-1-sources.jar.sha1
    │   ├── mockito-subclass-5.15.2-20250102.102747-1-sources.jar.sha256
    │   ├── mockito-subclass-5.15.2-20250102.102747-1-sources.jar.sha512
    │   ├── mockito-subclass-5.15.2-20250102.102747-1.jar
    │   ├── mockito-subclass-5.15.2-20250102.102747-1.jar.md5
    │   ├── mockito-subclass-5.15.2-20250102.102747-1.jar.sha1
    │   ├── mockito-subclass-5.15.2-20250102.102747-1.jar.sha256
    │   ├── mockito-subclass-5.15.2-20250102.102747-1.jar.sha512
    │   ├── mockito-subclass-5.15.2-20250102.102747-1.pom
    │   ├── mockito-subclass-5.15.2-20250102.102747-1.pom.md5
    │   ├── mockito-subclass-5.15.2-20250102.102747-1.pom.sha1
    │   ├── mockito-subclass-5.15.2-20250102.102747-1.pom.sha256
    │   ├── mockito-subclass-5.15.2-20250102.102747-1.pom.sha512
    │   ├── mockito-subclass-5.15.2-20250102.102938-2-javadoc.jar
    │   ├── mockito-subclass-5.15.2-20250102.102938-2-javadoc.jar.md5
    │   ├── mockito-subclass-5.15.2-20250102.102938-2-javadoc.jar.sha1
    │   ├── mockito-subclass-5.15.2-20250102.102938-2-javadoc.jar.sha256
    │   ├── mockito-subclass-5.15.2-20250102.102938-2-javadoc.jar.sha512
    │   ├── mockito-subclass-5.15.2-20250102.102938-2-sources.jar
    │   ├── mockito-subclass-5.15.2-20250102.102938-2-sources.jar.md5
    │   ├── mockito-subclass-5.15.2-20250102.102938-2-sources.jar.sha1
    │   ├── mockito-subclass-5.15.2-20250102.102938-2-sources.jar.sha256
    │   ├── mockito-subclass-5.15.2-20250102.102938-2-sources.jar.sha512
    │   ├── mockito-subclass-5.15.2-20250102.102938-2.jar
    │   ├── mockito-subclass-5.15.2-20250102.102938-2.jar.md5
    │   ├── mockito-subclass-5.15.2-20250102.102938-2.jar.sha1
    │   ├── mockito-subclass-5.15.2-20250102.102938-2.jar.sha256
    │   ├── mockito-subclass-5.15.2-20250102.102938-2.jar.sha512
    │   ├── mockito-subclass-5.15.2-20250102.102938-2.pom
    │   ├── mockito-subclass-5.15.2-20250102.102938-2.pom.md5
    │   ├── mockito-subclass-5.15.2-20250102.102938-2.pom.sha1
    │   ├── mockito-subclass-5.15.2-20250102.102938-2.pom.sha256
    │   ├── mockito-subclass-5.15.2-20250102.102938-2.pom.sha512
    │   ├── mockito-subclass-5.15.2-20250102.104306-3-javadoc.jar
    │   ├── mockito-subclass-5.15.2-20250102.104306-3-javadoc.jar.md5
    │   ├── mockito-subclass-5.15.2-20250102.104306-3-javadoc.jar.sha1
    │   ├── mockito-subclass-5.15.2-20250102.104306-3-javadoc.jar.sha256
    │   ├── mockito-subclass-5.15.2-20250102.104306-3-javadoc.jar.sha512
    │   ├── mockito-subclass-5.15.2-20250102.104306-3-sources.jar
    │   ├── mockito-subclass-5.15.2-20250102.104306-3-sources.jar.md5
    │   ├── mockito-subclass-5.15.2-20250102.104306-3-sources.jar.sha1
    │   ├── mockito-subclass-5.15.2-20250102.104306-3-sources.jar.sha256
    │   ├── mockito-subclass-5.15.2-20250102.104306-3-sources.jar.sha512
    │   ├── mockito-subclass-5.15.2-20250102.104306-3.jar
    │   ├── mockito-subclass-5.15.2-20250102.104306-3.jar.md5
    │   ├── mockito-subclass-5.15.2-20250102.104306-3.jar.sha1
    │   ├── mockito-subclass-5.15.2-20250102.104306-3.jar.sha256
    │   ├── mockito-subclass-5.15.2-20250102.104306-3.jar.sha512
    │   ├── mockito-subclass-5.15.2-20250102.104306-3.pom
    │   ├── mockito-subclass-5.15.2-20250102.104306-3.pom.md5
    │   ├── mockito-subclass-5.15.2-20250102.104306-3.pom.sha1
    │   ├── mockito-subclass-5.15.2-20250102.104306-3.pom.sha256
    │   └── mockito-subclass-5.15.2-20250102.104306-3.pom.sha512
    ├── maven-metadata.xml
    ├── maven-metadata.xml.md5
    ├── maven-metadata.xml.sha1
    ├── maven-metadata.xml.sha256
    └── maven-metadata.xml.sha512

15 directories, 420 files
```

</details>

<details><summary>Listing of published mockito-core javadoc artifact</summary>

```shell
$ unzip -Z1 build/repo/org/mockito/mockito-core/5.15.2-SNAPSHOT/mockito-core-5.15.2-20250102.104306-3-javadoc.jar | tree --fromfile -L1
.
├── LICENSE
├── META-INF
├── allclasses-index.html
├── allpackages-index.html
├── constant-values.html
├── deprecated-list.html
├── element-list
├── favicon.ico
├── help-doc.html
├── index-files
├── index.html
├── jquery-ui.overrides.css
├── legal
├── member-search-index.js
├── mockito-theme.css
├── module-search-index.js
├── org
├── overview-summary.html
├── overview-tree.html
├── package-search-index.js
├── resources
├── script-dir
├── script.js
├── search.js
├── serialized-form.html
├── stylesheet.css
├── tag-search-index.js
└── type-search-index.js

7 directories, 22 files
```

</details>

<details><summary>Listing of published mockito-junit-jupiter javadoc artifact</summary>

```shell
$ unzip -Z1 build/repo/org/mockito/mockito-junit-jupiter/5.15.2-SNAPSHOT/mockito-junit-jupiter-5.15.2-20250102.104306-3-javadoc.jar| tree --fromfile -L1
.
├── LICENSE
├── META-INF
├── allclasses-index.html
├── allpackages-index.html
├── element-list
├── favicon.ico
├── help-doc.html
├── index-files
├── index.html
├── jquery-ui.overrides.css
├── legal
├── member-search-index.js
├── mockito-theme.css
├── module-search-index.js
├── org
├── overview-summary.html
├── overview-tree.html
├── package-search-index.js
├── resources
├── script-dir
├── script.js
├── search.js
├── stylesheet.css
├── tag-search-index.js
└── type-search-index.js

7 directories, 19 files
```

</details>


## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

