### PR TITLE
Fixes #3584 Improve Gradle Kotlin documentation to add agent instead of overwriting the jvmArgs

### DIFF
--- a/mockito-core/src/main/java/org/mockito/Mockito.java
+++ b/mockito-core/src/main/java/org/mockito/Mockito.java
@@ -191,7 +191,7 @@ import java.util.function.Function;
  * }
  * tasks {
  *     test {
- *         jvmArgs("-javaagent:${mockitoAgent.asPath}")
+ *         jvmArgs.add("-javaagent:${mockitoAgent.asPath}")
  *     }
  * }
  * </code></pre>


### PR DESCRIPTION
As per #3584, current documentation recommend to set the jvmArg in the gradle.build.kts extract. This overwrites the value of jvmArgs. This, for example, prevents to run the coverage from IntelliJ. 
With this improved version, the agent is added to the jvmArgs, leaving the existing ones untouched.
