### PR TITLE
API for MockSettings for Spies

### DIFF
--- a/mockito-core/src/main/java/org/mockito/Mockito.java
+++ b/mockito-core/src/main/java/org/mockito/Mockito.java
@@ -2277,13 +2277,24 @@ public class Mockito extends ArgumentMatchers {
      * @return a spy of the real object
      */
     public static <T> T spy(T object) {
+        return spy(object, withSettings());
+    }
+
+    /**
+     * Please refer to the documentation of {@link #spy(Object)}.
+     *
+     * @param object to spy on
+     * @param mockSettings additional mock settings
+     * @return a spy of the real object
+     */
+    public static <T> T spy(T object, MockSettings mockSettings) {
         if (MockUtil.isMock(object)) {
             throw new IllegalArgumentException(
                     "Please don't pass mock here. Spy is not allowed on mock.");
         }
         return MOCKITO_CORE.mock(
                 (Class<T>) object.getClass(),
-                withSettings().spiedInstance(object).defaultAnswer(CALLS_REAL_METHODS));
+                mockSettings.spiedInstance(object).defaultAnswer(CALLS_REAL_METHODS));
     }
 
     /**

--- a/mockito-core/src/main/java/org/mockito/Mockito.java
+++ b/mockito-core/src/main/java/org/mockito/Mockito.java
@@ -2286,6 +2286,7 @@ public class Mockito extends ArgumentMatchers {
      * @param object to spy on
      * @param mockSettings additional mock settings
      * @return a spy of the real object
+     * @since 5.16.0
      */
     public static <T> T spy(T object, MockSettings mockSettings) {
         if (MockUtil.isMock(object)) {

--- a/mockito-core/src/test/java/org/mockito/MockitoTest.java
+++ b/mockito-core/src/test/java/org/mockito/MockitoTest.java
@@ -240,4 +240,20 @@ public class MockitoTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageStartingWith("Please don't pass any values here");
     }
+
+    @Test
+    public void spyMethodWithSettingsAppliesTheSettings() {
+        InvocationListener invocationListener = Mockito.mock(InvocationListener.class);
+
+        Object spy =
+                Mockito.spy(
+                        new Object(),
+                        Mockito.withSettings()
+                                .invocationListeners(invocationListener));
+
+        Mockito.doReturn("my string representation").when(spy).toString();
+        assertThat(spy).hasToString("my string representation");
+        Mockito.verify(invocationListener, times(2)).reportInvocation(ArgumentMatchers.any());
+    }
+
 }


### PR DESCRIPTION
Implementation for https://github.com/mockito/mockito/issues/3586.
Adds API to pass on MockSettings for Spies to add i.e. your own invocation listeners and manipulate the behavior accordingly. Similar method for Mocks already exists.

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_