### PR TITLE
Adjust inline mocking snippet to allow task relocatability

### DIFF
--- a/mockito-core/src/main/java/org/mockito/Mockito.java
+++ b/mockito-core/src/main/java/org/mockito/Mockito.java
@@ -181,7 +181,7 @@ import java.util.function.Function;
  * <p>
  * To explicitly attach Mockito during test execution, the library's jar file needs to be specified as <code>-javaagent</code>
  * as an argument to the executing JVM. To enable this in Gradle, the following example adds Mockito to all test
- * tasks using <strong>Kotlin DSL</strong>:
+ * tasks using <strong>Kotlin DSL</strong>. Using a <code>CommandLineArgumentProvider</code> ensures task relocatability as recommended <a href="https://docs.gradle.org/current/userguide/caching_java_projects.html#dealing_with_file_paths">there</a>:
  *
  * <pre class="code"><code class="kotlin">
  * val mockitoAgent = configurations.create("mockitoAgent")
@@ -191,8 +191,18 @@ import java.util.function.Function;
  * }
  * tasks {
  *     test {
- *         jvmArgs.add("-javaagent:${mockitoAgent.asPath}")
+ *         jvmArgumentProviders.add(
+ *             objects.newInstance&lt;JavaAgentArgumentProvider&gt;().apply {
+ *                 classpath.from(mockitoAgent)
+ *             }
+ *         )
  *     }
+ * }
+ * abstract class JavaAgentArgumentProvider : CommandLineArgumentProvider {
+ *     {@literal @}get:Classpath
+ *     abstract val classpath: ConfigurableFileCollection
+ *
+ *     override fun asArguments() = listOf("-javaagent:${classpath.singleFile.absolutePath}")
  * }
  * </code></pre>
  *
@@ -203,13 +213,28 @@ import java.util.function.Function;
  *     mockitoAgent
  * }
  * dependencies {
+ *     testImplementation(libs.mockito)
  *     mockitoAgent(libs.mockito) {
  *         transitive = false
  *     }
  * }
  * tasks {
  *     test {
- *         jvmArgs += "-javaagent:${configurations.mockitoAgent.asPath}"
+ *         jvmArgumentProviders.add(
+ *             objects.newInstance(JavaAgentArgumentProvider).tap {
+ *                 classpath.from(configurations.mockitoAgent)
+ *             }
+ *         )
+ *     }
+ * }
+ *
+ * abstract class JavaAgentArgumentProvider implements CommandLineArgumentProvider {
+ *     {@literal @}Classpath
+ *     abstract ConfigurableFileCollection getClasspath()
+ *
+ *     {@literal @}Override
+ *     Iterable&lt;String&gt; asArguments() {
+ *         ["-javaagent:${classpath.singleFile.absolutePath}"]
  *     }
  * }
  * </code></pre>

--- a/mockito-core/src/main/java/org/mockito/Mockito.java
+++ b/mockito-core/src/main/java/org/mockito/Mockito.java
@@ -181,7 +181,7 @@ import java.util.function.Function;
  * <p>
  * To explicitly attach Mockito during test execution, the library's jar file needs to be specified as <code>-javaagent</code>
  * as an argument to the executing JVM. To enable this in Gradle, the following example adds Mockito to all test
- * tasks using <strong>Kotlin DSL</strong>. Using a <code>CommandLineArgumentProvider</code> ensures task relocatability as recommended <a href="https://docs.gradle.org/current/userguide/caching_java_projects.html#dealing_with_file_paths">there</a>:
+ * tasks using <strong>Kotlin DSL</strong>. Although omitted for simplicity, using a <code>CommandLineArgumentProvider</code> is recommended by Gradle to ensure task relocatability (<a href="https://docs.gradle.org/current/userguide/caching_java_projects.html#dealing_with_file_paths">documentation</a>):
  *
  * <pre class="code"><code class="kotlin">
  * val mockitoAgent = configurations.create("mockitoAgent")
@@ -191,18 +191,8 @@ import java.util.function.Function;
  * }
  * tasks {
  *     test {
- *         jvmArgumentProviders.add(
- *             objects.newInstance&lt;JavaAgentArgumentProvider&gt;().apply {
- *                 classpath.from(mockitoAgent)
- *             }
- *         )
+ *         jvmArgs.add("-javaagent:${mockitoAgent.asPath}")
  *     }
- * }
- * abstract class JavaAgentArgumentProvider : CommandLineArgumentProvider {
- *     {@literal @}get:Classpath
- *     abstract val classpath: ConfigurableFileCollection
- *
- *     override fun asArguments() = listOf("-javaagent:${classpath.singleFile.absolutePath}")
  * }
  * </code></pre>
  *
@@ -220,21 +210,7 @@ import java.util.function.Function;
  * }
  * tasks {
  *     test {
- *         jvmArgumentProviders.add(
- *             objects.newInstance(JavaAgentArgumentProvider).tap {
- *                 classpath.from(configurations.mockitoAgent)
- *             }
- *         )
- *     }
- * }
- *
- * abstract class JavaAgentArgumentProvider implements CommandLineArgumentProvider {
- *     {@literal @}Classpath
- *     abstract ConfigurableFileCollection getClasspath()
- *
- *     {@literal @}Override
- *     Iterable&lt;String&gt; asArguments() {
- *         ["-javaagent:${classpath.singleFile.absolutePath}"]
+ *         jvmArgs += "-javaagent:${configurations.mockitoAgent.asPath}"
  *     }
  * }
  * </code></pre>


### PR DESCRIPTION
## Issue
Inline mocking configuration snippet for Gradle should allow task relocatability

## Fix
Use a `CommandLineArgumentProvider`

Fixes https://github.com/mockito/mockito/issues/3605

## Checklist

 - [X] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [X] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [X] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [X] Avoid other runtime dependencies
 - [X] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [X] The pull request follows coding style
 - [X] Mention `Fixes #<issue number>` in the description _if relevant_
 - [X] At least one commit should mention `Fixes #<issue number>` _if relevant_

