### PR TITLE
Remove Arrays.asList from critical stubbing path in GenericMetadataSu…

### DIFF
--- a/mockito-core/src/main/java/org/mockito/internal/util/reflection/GenericMetadataSupport.java
+++ b/mockito-core/src/main/java/org/mockito/internal/util/reflection/GenericMetadataSupport.java
@@ -91,7 +91,7 @@ public abstract class GenericMetadataSupport {
 
             Class<?> rawType = extractRawTypeOf(typeToRegister);
             typesToRegister.add(rawType.getGenericSuperclass());
-            typesToRegister.addAll(Arrays.asList(rawType.getGenericInterfaces()));
+            Collections.addAll(typesToRegister, rawType.getGenericInterfaces());
         }
     }
 


### PR DESCRIPTION
…pport

On Android, the implementation of java.util.Arrays.ArrayList.toArray has a non-trivial implementation that ends up calling into android.os.Process.myUid().

Consequently, attempting to stub static methods in android.os.Process with doReturn will end up calling into myUid() before the stubbing completes, triggering an infinite recursion.

To work around that, replace the addAll(asList(...)) call with Collections.addAll. As an added benefit this avoids an array copy.

This upstreams https://r.android.com/3500336.

<!-- Hey,
Thanks for the contribution, this is awesome.
As you may have read, project members have somehow an opinionated view on what and how should be
Mockito, e.g. we don't want mockito to be a feature bloat.
There may be a thorough review, with feedback -> code change loop.
-->
<!--
If you have a suggestion for this template you can fix it in the .github/PULL_REQUEST_TEMPLATE.md file
-->
## Checklist

 - [X] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [X] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [X] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [X] Avoid other runtime dependencies
 - [X] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [X] The pull request follows coding style
 - [ ] Mention `Fixes #<issue number>` in the description _if relevant_
 - [ ] At least one commit should mention `Fixes #<issue number>` _if relevant_

