### PR TITLE
Fixes #3615 : broken links to javadoc.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ publish a new minor or patch version to Maven Central. For release automation we
 [Shipkit library](http://shipkit.org), [Gradle Nexus Publish Plugin](https://github.com/gradle-nexus/publish-plugin).
 Fully automated releases are awesome, and you should do that for your libraries, too!
 See the [latest release notes](https://github.com/mockito/mockito/releases/)
-and [latest documentation](https://javadoc.io/page/org.mockito/mockito-core/latest/org/mockito/Mockito.html). Docs in
+and [latest documentation](https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html). Docs in
 javadoc.io are available 24h after release. Read also
 about [semantic versioning in Mockito](https://github.com/mockito/mockito/wiki/Semantic-Versioning).
 

--- a/mockito-core/src/main/java/org/mockito/Mockito.java
+++ b/mockito-core/src/main/java/org/mockito/Mockito.java
@@ -1609,7 +1609,7 @@ import java.util.function.Function;
  * <h3 id="45">45. <a class="meaningful_link" href="#junit5_mockito" name="junit5_mockito">New JUnit Jupiter (JUnit5+) extension</a></h3>
  *
  * For integration with JUnit Jupiter (JUnit5+), use the `org.mockito:mockito-junit-jupiter` artifact.
- * For more information about the usage of the integration, see <a href="https://javadoc.io/doc/org.mockito/mockito-junit-jupiter/latest/org/mockito/junit/jupiter/MockitoExtension.html">the JavaDoc of <code>MockitoExtension</code></a>.
+ * For more information about the usage of the integration, see <a href="https://javadoc.io/doc/org.mockito/mockito-junit-jupiter/latest/org.mockito.junit.jupiter/org/mockito/junit/jupiter/MockitoExtension.html">the JavaDoc of <code>MockitoExtension</code></a>.
  *
  * <h3 id="46">46. <a class="meaningful_link" href="#mockito_lenient" name="mockito_lenient">
  *       New <code>Mockito.lenient()</code> and <code>MockSettings.lenient()</code> methods (Since 2.20.0)</a></h3>

--- a/mockito-core/src/main/java/org/mockito/internal/PremainAttachAccess.java
+++ b/mockito-core/src/main/java/org/mockito/internal/PremainAttachAccess.java
@@ -73,7 +73,7 @@ public class PremainAttachAccess {
                             "Mockito is currently self-attaching to enable the inline-mock-maker. This "
                                     + "will no longer work in future releases of the JDK. Please add Mockito as an agent to your "
                                     + "build as described in Mockito's documentation: "
-                                    + "https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#0.3");
+                                    + "https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3");
                 }
             }
             // Attempt to dynamically attach, as a last resort.

--- a/mockito-core/src/main/java/org/mockito/junit/MockitoJUnit.java
+++ b/mockito-core/src/main/java/org/mockito/junit/MockitoJUnit.java
@@ -16,7 +16,7 @@ import org.mockito.quality.Strictness;
  * <li>
  *     <ul>JUnit Rules - see {@link MockitoRule}</ul>
  *     <ul>JUnit runners - see {@link MockitoJUnitRunner}</ul>
- *     <ul><a href="http://javadoc.io/doc/org.mockito/mockito-junit-jupiter/latest/org/mockito/junit/jupiter/MockitoExtension.html">JUnit Jupiter extension</a></ul>
+ *     <ul><a href="https://javadoc.io/doc/org.mockito/mockito-junit-jupiter/latest/org.mockito.junit.jupiter/org/mockito/junit/jupiter/MockitoExtension.html">JUnit Jupiter extension</a></ul>
  * </li>
  *
  * @since 1.10.17

--- a/mockito-extensions/mockito-android/src/main/java/org/mockito/android/internal/creation/AndroidByteBuddyMockMaker.java
+++ b/mockito-extensions/mockito-android/src/main/java/org/mockito/android/internal/creation/AndroidByteBuddyMockMaker.java
@@ -30,7 +30,7 @@ public class AndroidByteBuddyMockMaker implements MockMaker {
                                     "The Android mock maker was disabled. You should only include the latter in your 'androidTestCompile' configuration",
                                     "If disabling was a mistake, you can set the 'org.mockito.mock.android' property to 'true' to override this detection.",
                                     "",
-                                    "Visit https://javadoc.io/page/org.mockito/mockito-core/latest/org/mockito/Mockito.html#0.1 for more information"));
+                                    "Visit https://javadoc.io/page/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.1 for more information"));
             delegate = new SubclassByteBuddyMockMaker();
         }
     }


### PR DESCRIPTION
<!-- Hey,
Thanks for the contribution, this is awesome.
As you may have read, project members have somehow an opinionated view on what and how should be
Mockito, e.g. we don't want mockito to be a feature bloat.
There may be a thorough review, with feedback -> code change loop.
-->
<!--
If you have a suggestion for this template you can fix it in the .github/PULL_REQUEST_TEMPLATE.md file
-->
## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

I noticed this warning when I added Mockito to a project:
```
Mockito is currently self-attaching to enable the inline-mock-maker. This will no longer work in future releases of the JDK. Please add Mockito as an agent to your build as described in Mockito's documentation: https://javadoc.io/doc/org.
mockito/mockito-core/latest/org/mockito/Mockito.html#0.3
WARNING: A Java agent has been loaded dynamically (/home/jqno/.m2/repository/net/bytebuddy/byte-buddy-agent/1.15.11/byte-buddy-agent-1.15.11.jar)
WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
WARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information
WARNING: Dynamic loading of agents will be disallowed by default in a future release
```
Unfortunately, the link doesn't work because it should include the module name, which it doesn't. The correct link would be https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3

I found a few other such instances while grepping the codebase for javadoc.io.