### PR TITLE
Fixes #3171: Fall back to Throwable Location strategy on Android

### DIFF
--- a/mockito-core/src/main/java/org/mockito/internal/debugging/LocationFactory.java
+++ b/mockito-core/src/main/java/org/mockito/internal/debugging/LocationFactory.java
@@ -4,6 +4,8 @@
  */
 package org.mockito.internal.debugging;
 
+import org.mockito.internal.util.AndroidPlatform;
+import org.mockito.internal.util.Platform;
 import org.mockito.invocation.Location;
 
 public final class LocationFactory {
@@ -24,6 +26,9 @@ public final class LocationFactory {
     }
 
     private static Factory createLocationFactory() {
+        if (Platform.isAndroid() && !AndroidPlatform.isStackWalkerUsable()) {
+            return new Java8LocationFactory();
+        }
         try {
             // On some platforms, like Android, the StackWalker APIs may not be
             // available, in this case we have to fallback to Java 8 style of stack

--- a/mockito-core/src/main/java/org/mockito/internal/util/AndroidPlatform.java
+++ b/mockito-core/src/main/java/org/mockito/internal/util/AndroidPlatform.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.util;
+
+public class AndroidPlatform {
+
+    private static int getSdkInt() {
+        try {
+            return Class.forName("android.os.Build$VERSION").getField("SDK_INT").getInt(null);
+        } catch (ReflectiveOperationException e) {
+            return 0;
+        }
+    }
+
+    private static int getExtensionVersion(int sdk) {
+        try {
+            return (int)
+                    Class.forName("android.os.ext.SdkExtensions")
+                            .getMethod("getExtensionVersion", int.class)
+                            .invoke(null, sdk);
+        } catch (ReflectiveOperationException e) {
+            return 0;
+        }
+    }
+
+    public static boolean isStackWalkerUsable() {
+        // StackWalker on Android had a bug that is fixed in Android Baklava (36)
+        // or SDK extension train M2025-05 (17) and later. See https://r.android.com/3548340.
+        return getSdkInt() >= 36 || getSdkInt() >= 31 && getExtensionVersion(31) >= 17;
+    }
+}

--- a/mockito-integration-tests/android-tests/src/androidTest/java/org/mockitousage/androidtest/AaaMustRunFirstLocationTests.kt
+++ b/mockito-integration-tests/android-tests/src/androidTest/java/org/mockitousage/androidtest/AaaMustRunFirstLocationTests.kt
@@ -1,0 +1,26 @@
+package org.mockitousage.androidtest
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.withSettings
+import org.mockito.internal.creation.proxy.ProxyMockMaker
+
+@RunWith(AndroidJUnit4::class)
+class AaaMustRunFirstLocationTests {
+
+    /**
+     *  Regression test for https://github.com/mockito/mockito/issues/3171 and
+     *  https://github.com/linkedin/dexmaker/issues/190.
+     *
+     *  Bug only triggers if the first time LocationImpl is used is with ProxyMockMaker, therefore
+     *  this test must be the first to run.
+     */
+    @Test
+    fun mockAndUseInterfaceWithProxyMockMaker() {
+        val basicInterface = mock(BasicInterface::class.java,
+            withSettings().mockMaker(ProxyMockMaker::class.java.name))
+        basicInterface.interfaceMethod()
+    }
+}


### PR DESCRIPTION
Works around an Android Runtime bug where StackWalker would fail to traverse the stack if a stack frame involves java.lang.Proxy.

Disables StackWalker for Android versions that do not yet include the fix in https://r.android.com/3548340.

This issue was also reported as https://github.com/linkedin/dexmaker/issues/190.

Change-Id: I5b81e552666924302971ee8b84e63865281674dc

<!-- Hey,
Thanks for the contribution, this is awesome.
As you may have read, project members have somehow an opinionated view on what and how should be
Mockito, e.g. we don't want mockito to be a feature bloat.
There may be a thorough review, with feedback -> code change loop.
-->
<!--
If you have a suggestion for this template you can fix it in the .github/PULL_REQUEST_TEMPLATE.md file
-->
## Checklist

 - [X] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [X] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [ ] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [X] Avoid other runtime dependencies
 - [X] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [X] The pull request follows coding style
 - [X] Mention `Fixes #<issue number>` in the description _if relevant_
 - [X] At least one commit should mention `Fixes #<issue number>` _if relevant_

