### PR TITLE
Fixes #3622: MockitoExtension fails cleanup when aborted before setup

### DIFF
--- a/mockito-extensions/mockito-junit-jupiter/src/main/java/org/mockito/junit/jupiter/MockitoExtension.java
+++ b/mockito-extensions/mockito-junit-jupiter/src/main/java/org/mockito/junit/jupiter/MockitoExtension.java
@@ -189,12 +189,16 @@ public class MockitoExtension implements BeforeEachCallback, AfterEachCallback, 
     @Override
     @SuppressWarnings("unchecked")
     public void afterEach(ExtensionContext context) {
-        context.getStore(MOCKITO)
-                .remove(MOCKS, Set.class)
-                .forEach(mock -> ((ScopedMock) mock).closeOnDemand());
-        context.getStore(MOCKITO)
-                .remove(SESSION, MockitoSession.class)
-                .finishMocking(context.getExecutionException().orElse(null));
+        ExtensionContext.Store store = context.getStore(MOCKITO);
+
+        Optional.ofNullable(store.remove(MOCKS, Set.class))
+                .ifPresent(mocks -> mocks.forEach(mock -> ((ScopedMock) mock).closeOnDemand()));
+
+        Optional.ofNullable(store.remove(SESSION, MockitoSession.class))
+                .ifPresent(
+                        session ->
+                                session.finishMocking(
+                                        context.getExecutionException().orElse(null)));
     }
 
     @Override

--- a/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/JunitJupiterSkippedTest.java
+++ b/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/JunitJupiterSkippedTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2018 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opentest4j.TestAbortedException;
+
+class JunitJupiterSkippedTest {
+    @Nested
+    class NestedSkipBeforeEachMockito {
+        @Test
+        @ExtendWith({SkipTestBeforeEachExtension.class, MockitoExtension.class})
+        void should_handle_skip_in_before_each() {}
+
+        @Test
+        @ExtendWith({MockitoExtension.class, SkipTestBeforeEachExtension.class})
+        void should_handle_skip_after_before_each() {}
+
+        @Test
+        @ExtendWith(MockitoExtension.class)
+        void should_handle_skip_in_test() {
+            skipTest();
+        }
+    }
+
+    @Nested
+    @ExtendWith({SkipTestBeforeAllExtension.class, MockitoExtension.class})
+    class NestedSkipBeforeAllSkipThenMockito {
+        @Test
+        void should_handle_skip_in_before_all() {}
+    }
+
+    @Nested
+    @ExtendWith({MockitoExtension.class, SkipTestBeforeAllExtension.class})
+    class NestedSkipBeforeAllMockitoThenSkip {
+        @Test
+        void should_handle_skip_in_before_all() {}
+    }
+
+    private static class SkipTestBeforeEachExtension implements BeforeEachCallback {
+        @Override
+        public void beforeEach(ExtensionContext context) {
+            skipTest();
+        }
+    }
+
+    private static class SkipTestBeforeAllExtension implements BeforeAllCallback {
+        @Override
+        public void beforeAll(ExtensionContext context) {
+            skipTest();
+        }
+    }
+
+    private static void skipTest() {
+        throw new TestAbortedException("Skipped test");
+    }
+}


### PR DESCRIPTION
Fixes #3622: MockitoExtension fails cleanup when aborted before setup

In Junit, extensions can throw `org.opentest4j.TestAbortedException` which will abort any subsequent setup steps while afterEach will still run.

When MockitoExtension is declared after a beforeEach extension that skips, mockito's beforeEach will not be executed but it's afterEach will causing an exception:
```
java.lang.NullPointerException: Cannot invoke "java.util.Set.forEach(java.util.function.Consumer)" because the return value of "org.junit.jupiter.api.extension.ExtensionContext$Store.remove(Object, java.lang.Class)" is null

	at org.mockito.junit.jupiter.MockitoExtension.afterEach(MockitoExtension.java:194)
...
```

e.g.

```java
    @Test
    @ExtendWith({SkipTestBeforeEachExtension.class, MockitoExtension.class})
    void should_handle_skip_in_before_each() {
    }

    private static class SkipTestBeforeEachExtension implements BeforeEachCallback {
        @Override
        public void beforeEach(ExtensionContext context) {
            throw new TestAbortedException("Skipped test");
        }
    }
```

## Checklist
 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should mention `Fixes #<issue number>` _if relevant_

