### PR TITLE
Clarify structure of commit messages

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,7 +14,7 @@
 
 ## Pull request criteria
 
-* **At least one commit message** in the PR starts with `Fixes #id : ` where `id` is an [issue tracker](https://github.com/mockito/mockito/issues) id. This allows automated release notes generation. Also GitHub will track the issue and [close it](https://github.com/blog/1386-closing-issues-via-commit-messages) when the PR is merged.
+* **At least one commit message** in the PR ends with `Fixes #id` where `id` is an [issue tracker](https://github.com/mockito/mockito/issues) id. This allows automated release notes generation. Also GitHub will track the issue and [close it](https://github.com/blog/1386-closing-issues-via-commit-messages) when the PR is merged.
 * Use `@since` tags for new public APIs
 * Include tests
 * Document public APIs with examples
@@ -42,13 +42,25 @@ Things we pay attention in a PR :
 * On pull requests, please document the change, what it brings, what is the benefit.
 * **Clean commit history** in the topic branch in your fork of the repository, even during review. That means that commits are _rebased_ and _squashed_ if necessary, so that each commit clearly changes one things and there are no extraneous fix-ups.
 
-  For that matter it's possible to commit [_semantic_ changes](https://lemike-de.tumblr.com/post/79041908218/semantic-commits). _Tests are an asset, so is history_.
+  _Tests are an asset, so is history_.
 
-  _Example gratia_:
+  _Example gratia_ (based on https://cbea.ms/git-commit/):
 
   ```
-  Fixes #73 : The new feature
-  Fixes #73 : Refactors this part of Mockito to make feature possible
+  Enable feature X to do Y
+
+  Include some background information here.
+
+  Fixes #73
+  ```
+
+  ```
+  Fix bug B with feature A
+
+  Include some background information here.
+  Add example scenario/context.
+
+  Fixes #73
   ```
 
 * In the code, always test your feature / change, in unit tests and in our `acceptance test suite` located in `org.mockitousage`. Older tests will be migrated when a test is modified.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,4 @@
-<!-- Hey,
-Thanks for the contribution, this is awesome.
-As you may have read, project members have somehow an opinionated view on what and how should be
-Mockito, e.g. we don't want mockito to be a feature bloat.
-There may be a thorough review, with feedback -> code change loop.
--->
-<!--
-If you have a suggestion for this template you can fix it in the .github/PULL_REQUEST_TEMPLATE.md file
--->
+
 ## Checklist
 
  - [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
@@ -16,7 +8,6 @@ If you have a suggestion for this template you can fix it in the .github/PULL_RE
  - [ ] Avoid other runtime dependencies
  - [ ] Meaningful commit history ; intention is important please rebase your commit history so that each
        commit is meaningful and help the people that will explore a change in 2 years
- - [ ] The pull request follows coding style
+ - [ ] The pull request follows coding style (run `./gradlew spotlessApply` for auto-formatting)
  - [ ] Mention `Fixes #<issue number>` in the description _if relevant_
- - [ ] At least one commit should mention `Fixes #<issue number>` _if relevant_
-
+ - [ ] At least one commit should end with `Fixes #<issue number>` _if relevant_


### PR DESCRIPTION
Since I have been merging most of the community contributions, I realized that I continuously rewrite commit messages with regards to the `Fixes #id` notation.

Therefore, update the contribution guidelines to clarify that the fixes part should come at the end (as to not clutter the message). Also, link to the commit guide that I usually refer to, which also clarifies that the commit title should start with a verb.