### PR TITLE
Make vararg checks Scala friendly (for mockito-scala)

### DIFF
--- a/mockito-core/src/main/java/org/mockito/internal/invocation/MatcherApplicationStrategy.java
+++ b/mockito-core/src/main/java/org/mockito/internal/invocation/MatcherApplicationStrategy.java
@@ -59,10 +59,11 @@ public class MatcherApplicationStrategy {
     public boolean forEachMatcherAndArgument(ArgumentMatcherAction action) {
         final boolean isJavaVarargs =
                 invocation.getMethod().isVarArgs()
-                        && lastMatcherType().stream()
-                                .anyMatch(
+                        && lastMatcherType()
+                                .map(
                                         matcherType ->
-                                                lastParameterType().isAssignableFrom(matcherType));
+                                                lastParameterType().isAssignableFrom(matcherType))
+                                .orElse(false);
 
         // For mockito-scala,
         // we can consider this to be a vararg only if the number of raw arguments is different
@@ -71,14 +72,15 @@ public class MatcherApplicationStrategy {
         // parameter can be in any position.
         final boolean isScalaVararg =
                 invocation.getRawArguments().length != invocation.getArguments().length
-                        && optionalClass("scala.collection.Seq").stream()
-                                .anyMatch(
+                        && optionalClass("scala.collection.Seq")
+                                .map(
                                         seqClass ->
                                                 Arrays.stream(
                                                                 invocation
                                                                         .getMethod()
                                                                         .getParameterTypes())
-                                                        .anyMatch(seqClass::isAssignableFrom));
+                                                        .anyMatch(seqClass::isAssignableFrom))
+                                .orElse(false);
 
         final boolean isVararg = isJavaVarargs || isScalaVararg;
 

--- a/mockito-core/src/main/java/org/mockito/internal/invocation/MatcherApplicationStrategy.java
+++ b/mockito-core/src/main/java/org/mockito/internal/invocation/MatcherApplicationStrategy.java
@@ -121,7 +121,7 @@ public class MatcherApplicationStrategy {
         return parameterTypes[parameterTypes.length - 1];
     }
 
-    private Optional<Class<?>> optionalClass(String className) {
+    Optional<Class<?>> optionalClass(String className) {
         try {
             return Optional.of(Class.forName(className));
         } catch (ClassNotFoundException e) {

--- a/mockito-core/src/test/java/org/mockito/internal/invocation/MatcherApplicationStrategyTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/invocation/MatcherApplicationStrategyTest.java
@@ -7,13 +7,21 @@ package org.mockito.internal.invocation;
 import static java.util.Arrays.asList;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 import static org.mockito.internal.invocation.MatcherApplicationStrategy.getMatcherApplicationStrategyFor;
 import static org.mockito.internal.matchers.Any.ANY;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -116,6 +124,21 @@ public class MatcherApplicationStrategyTest extends TestBase {
 
         // then
         assertTrue(match);
+    }
+
+    @Test
+    public void shouldNotMatchVarargsWithNoMatchers() {
+        // given
+        invocation = varargs("1", "2");
+        matchers = asList();
+        // when
+        boolean match =
+                getMatcherApplicationStrategyFor(invocation, matchers)
+                        .forEachMatcherAndArgument(recordAction);
+
+        // then
+        assertFalse("Should not match when matchers list is empty", match);
+        recordAction.assertIsEmpty();
     }
 
     @Test
@@ -237,6 +260,72 @@ public class MatcherApplicationStrategyTest extends TestBase {
 
         // then
         recordAction.assertContainsExactly(any);
+    }
+
+    // Helper interface to mock Scala Seq
+    private interface MockScalaSeq {}
+
+    @Test
+    public void shouldDetectScalaVarargsProperly() throws Exception {
+        // Create a mock Invocation that simulates Scala varargs behavior
+        Invocation mockInvocation = mock(Invocation.class);
+
+        // Create a mock method with our fake Scala Seq parameter in the middle,
+        // corresponding to `def method(a: String)(b: String*)(c: String)`
+        Method mockMethod = mock(Method.class);
+        when(mockMethod.getParameterTypes())
+                .thenReturn(new Class<?>[] {String.class, MockScalaSeq.class, String.class});
+        when(mockMethod.getParameterCount()).thenReturn(3);
+        when(mockMethod.getGenericParameterTypes())
+                .thenReturn(
+                        new java.lang.reflect.Type[] {
+                            String.class, MockScalaSeq.class, String.class
+                        });
+        when(mockMethod.getName()).thenReturn("mockMethod");
+        when(mockMethod.isVarArgs()).thenReturn(false); // Scala varargs are not Java varargs
+
+        // Set up the invocation to return different lengths for raw vs processed arguments
+        when(mockInvocation.getMethod()).thenReturn(mockMethod);
+        when(mockInvocation.getRawArguments()).thenReturn(new Object[] {new Object[] {"1", "2"}});
+        when(mockInvocation.getArguments()).thenReturn(new Object[] {"1", "2"}); // Different length
+
+        // Set up matchers
+        List<ArgumentMatcher<?>> matchers = asList(new Equals("1"), new Equals("2"));
+
+        // Create a strategy with spied optionalClass method to force Scala detection
+        MatcherApplicationStrategy spyStrategy =
+                spy(getMatcherApplicationStrategyFor(mockInvocation, matchers));
+
+        // Mock the optionalClass method behavior to simulate Scala presence
+        doReturn(Optional.of(MockScalaSeq.class))
+                .when(spyStrategy)
+                .optionalClass(eq("scala.collection.Seq"));
+
+        // When: Test the strategy
+        boolean match = spyStrategy.forEachMatcherAndArgument(recordAction);
+
+        // Then: Assert the match was successful
+        assertTrue("Failed to match Scala varargs pattern", match);
+        recordAction.assertContainsExactly(new Equals("1"), new Equals("2"));
+    }
+
+    @Test
+    public void shouldLoadExistingClasses() {
+        MatcherApplicationStrategy strategy =
+                getMatcherApplicationStrategyFor(varargs("1"), List.of(new Equals("1")));
+
+        Optional<?> result = strategy.optionalClass("java.lang.String");
+        assertTrue(result.isPresent());
+        assertEquals(String.class, result.get());
+    }
+
+    @Test
+    public void shouldReturnEmptyLoadingNonExistingClasses() {
+        MatcherApplicationStrategy strategy =
+                getMatcherApplicationStrategyFor(varargs("1"), List.of(new Equals("1")));
+
+        Optional<?> result = strategy.optionalClass("non.existing.ClassClass");
+        assertFalse(result.isPresent());
     }
 
     private static class IntMatcher extends BaseMatcher<Integer> {

--- a/mockito-core/src/test/java/org/mockito/internal/invocation/MatcherApplicationStrategyTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/invocation/MatcherApplicationStrategyTest.java
@@ -265,27 +265,24 @@ public class MatcherApplicationStrategyTest extends TestBase {
     // Helper interface to mock Scala Seq
     private interface MockScalaSeq {}
 
+    private static class TestScalaClass {
+        @SuppressWarnings("unused")
+        // corresponds to Scala method like `def testMethod(a: String)(b: String*)(c: String)`
+        public void testMethod(String a, MockScalaSeq b, String c) {}
+    }
+
     @Test
     public void shouldDetectScalaVarargsProperly() throws Exception {
         // Create a mock Invocation that simulates Scala varargs behavior
         Invocation mockInvocation = mock(Invocation.class);
 
-        // Create a mock method with our fake Scala Seq parameter in the middle,
-        // corresponding to `def method(a: String)(b: String*)(c: String)`
-        Method mockMethod = mock(Method.class);
-        when(mockMethod.getParameterTypes())
-                .thenReturn(new Class<?>[] {String.class, MockScalaSeq.class, String.class});
-        when(mockMethod.getParameterCount()).thenReturn(3);
-        when(mockMethod.getGenericParameterTypes())
-                .thenReturn(
-                        new java.lang.reflect.Type[] {
-                            String.class, MockScalaSeq.class, String.class
-                        });
-        when(mockMethod.getName()).thenReturn("mockMethod");
-        when(mockMethod.isVarArgs()).thenReturn(false); // Scala varargs are not Java varargs
+        // The method to be tested
+        Method testMethod =
+                TestScalaClass.class.getDeclaredMethod(
+                        "testMethod", String.class, MockScalaSeq.class, String.class);
 
         // Set up the invocation to return different lengths for raw vs processed arguments
-        when(mockInvocation.getMethod()).thenReturn(mockMethod);
+        when(mockInvocation.getMethod()).thenReturn(testMethod);
         when(mockInvocation.getRawArguments()).thenReturn(new Object[] {new Object[] {"1", "2"}});
         when(mockInvocation.getArguments()).thenReturn(new Object[] {"1", "2"}); // Different length
 


### PR DESCRIPTION
## Motivation
changes in #2807 and other work on varargs made mockito-scala not being able to upgrade mockito-core to 4.10+ as Scala varargs are represented a bit differently.
This PR adds support for default Scala varargs encoding. This and several other minor changes will allow us to upgrade mockito-core in mockito-scala project. Which will fix/close or make it possible to proceed with fixes for
-  https://github.com/mockito/mockito-scala/issues/556    
- https://github.com/mockito/mockito-scala/issues/520
- https://github.com/mockito/mockito-scala/issues/515
- https://github.com/mockito/mockito-scala/pull/517
- https://github.com/mockito/mockito-scala/pull/482

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [ ] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style (run `./gradlew spotlessApply` for auto-formatting)
 - [ ] Mention `Fixes #<issue number>` in the description _if relevant_
 - [ ] At least one commit should end with `Fixes #<issue number>` _if relevant_
