### PR TITLE
Correct Junit docs link

### DIFF
--- a/mockito-extensions/mockito-junit-jupiter/build.gradle.kts
+++ b/mockito-extensions/mockito-junit-jupiter/build.gradle.kts
@@ -93,7 +93,7 @@ tasks {
         if (JavaVersion.current() >= JavaVersion.VERSION_18) {
             javadocDocletOptions {
                 addStringOption("-link-modularity-mismatch", "info")
-                links("https://junit.org/junit5/docs/${libs.versions.junit.jupiter.get()}/api/")
+                links("https://docs.junit.org/${libs.versions.junit.jupiter.get()}/api/")
             }
         } else {
             logger.info("Javadoc tool below 18, links to JUnit Jupiter javadocs was not added.")


### PR DESCRIPTION
Closes gh-3667

The result I tested on local machine

![image](https://github.com/user-attachments/assets/34b229ab-a3cd-46a4-9e66-1d122f37bf7e)
