### PR TITLE
Only run release after both Java and Android tests have finished

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,10 @@ permissions:
   contents: read
 
 jobs:
-
   #
   # Main build job
   #
-  build:
+  java:
     runs-on: ubuntu-latest
     if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
 
@@ -196,7 +195,7 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    needs: [build] # build job must pass before we can release
+    needs: [java, android] # both build jobs must pass before we can release
 
     if: github.event_name == 'push'
         && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))


### PR DESCRIPTION
Otherwise we would publish, even if the Android job would fail.
Historically the Android jobs were flaky, but recently they have
been stable. Therefore, we can comfortably block releases on
Android (in case we have unfortunate regressions).