### PR TITLE
Test: reproduce issue with mocking generic array return type (S[])

### DIFF
--- a/mockito-core/src/test/java/org/mockito/bugs/GenericArrayMockingTest.java
+++ b/mockito-core/src/test/java/org/mockito/bugs/GenericArrayMockingTest.java
@@ -1,0 +1,40 @@
+package org.mockito.bugs;
+
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
+
+public class GenericArrayMockingTest {
+
+    public abstract static class DaService<T, S> {
+        public S doSmth(T o, Class<S> clazz) {
+            try {
+                return clazz.newInstance();
+            } catch (InstantiationException | IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public abstract static class HttpDaService<T, S> extends DaService<T, S[]> {}
+
+    public static class HttpDaServiceImpl extends HttpDaService<Object, Object> {}
+
+    @Mock
+    HttpDaServiceImpl daService;
+
+    public GenericArrayMockingTest() {
+        MockitoAnnotations.openMocks(this); // Initializes @Mock
+    }
+
+    @Test
+    public void when_doSmth_thenReturnObjectsArray() {
+        when(daService.doSmth(any(), any())).thenReturn(new Object[4]);
+        Object[] result = daService.doSmth(new Object(), Object[].class);
+        assertEquals(4, result.length);
+    }
+}
+


### PR DESCRIPTION
This PR adds a failing test to reproduce issue #3690.

The issue occurs when attempting to mock a method that returns a generic array type like `S[]`. Due to how generics are resolved, Mockito throws a `MockitoException: Raw extraction not supported for : 'S[]'`.

### Test Case
The test adds a class hierarchy:
- `DaService<T, S>` with method `S doSmth(T, Class<S>)`
- `HttpDaService<T, S>` extends `DaService<T, S[]>`
- `HttpDaServiceImpl` extends `HttpDaService<Object, Object>`

The test attempts:
```java
when(daService.doSmth(any(), any())).thenReturn(new Object[4]);

