### PR TITLE
Raw type used on MockCreationListener changed to generic type

### DIFF
--- a/mockito-core/src/main/java/org/mockito/internal/junit/MismatchReportingTestListener.java
+++ b/mockito-core/src/main/java/org/mockito/internal/junit/MismatchReportingTestListener.java
@@ -14,7 +14,7 @@ import org.mockito.plugins.MockitoLogger;
 /**
  * Reports stubbing argument mismatches to the supplied logger
  */
-public class MismatchReportingTestListener implements MockitoTestListener {
+public class MismatchReportingTestListener<T> implements MockitoTestListener<T> {
 
     private final MockitoLogger logger;
     private List<Object> mocks = new LinkedList<>();
@@ -36,13 +36,13 @@ public class MismatchReportingTestListener implements MockitoTestListener {
             // print unused stubbings only when test succeeds to avoid reporting multiple problems
             // and confusing users
             new ArgMismatchFinder()
-                    .getStubbingArgMismatches(createdMocks)
-                    .format(event.getTestName(), logger);
+                .getStubbingArgMismatches(createdMocks)
+                .format(event.getTestName(), logger);
         }
     }
 
     @Override
-    public void onMockCreated(Object mock, MockCreationSettings settings) {
+    public void onMockCreated(Object mock, MockCreationSettings<T> settings) {
         this.mocks.add(mock);
     }
 }

--- a/mockito-core/src/main/java/org/mockito/internal/junit/MockitoTestListener.java
+++ b/mockito-core/src/main/java/org/mockito/internal/junit/MockitoTestListener.java
@@ -11,6 +11,6 @@ import org.mockito.listeners.MockCreationListener;
  * If we ever want to expose this type publicly, it should not extend MockCreationListener
  * because we want our listeners to be single-method interfaces for easier use and evolution.
  */
-public interface MockitoTestListener extends MockCreationListener {
+public interface MockitoTestListener<T> extends MockCreationListener<T> {
     void testFinished(TestFinishedEvent event);
 }

--- a/mockito-core/src/main/java/org/mockito/internal/junit/NoOpTestListener.java
+++ b/mockito-core/src/main/java/org/mockito/internal/junit/NoOpTestListener.java
@@ -6,11 +6,11 @@ package org.mockito.internal.junit;
 
 import org.mockito.mock.MockCreationSettings;
 
-public class NoOpTestListener implements MockitoTestListener {
+public class NoOpTestListener<T> implements MockitoTestListener<T> {
 
     @Override
     public void testFinished(TestFinishedEvent event) {}
 
     @Override
-    public void onMockCreated(Object mock, MockCreationSettings settings) {}
+    public void onMockCreated(Object mock, MockCreationSettings<T> settings) {}
 }

--- a/mockito-core/src/main/java/org/mockito/internal/junit/StrictStubsRunnerTestListener.java
+++ b/mockito-core/src/main/java/org/mockito/internal/junit/StrictStubsRunnerTestListener.java
@@ -10,16 +10,16 @@ import org.mockito.quality.Strictness;
 /**
  * Fails early when mismatched arguments used for stubbing
  */
-public class StrictStubsRunnerTestListener implements MockitoTestListener {
+public class StrictStubsRunnerTestListener<T> implements MockitoTestListener<T> {
 
     private final DefaultStubbingLookupListener stubbingLookupListener =
-            new DefaultStubbingLookupListener(Strictness.STRICT_STUBS);
+        new DefaultStubbingLookupListener(Strictness.STRICT_STUBS);
 
     @Override
     public void testFinished(TestFinishedEvent event) {}
 
     @Override
-    public void onMockCreated(Object mock, MockCreationSettings settings) {
+    public void onMockCreated(Object mock, MockCreationSettings<T> settings) {
         // It is not ideal that we modify the state of MockCreationSettings object
         // MockCreationSettings is intended to be an immutable view of the creation settings
         // However, we our previous listeners work this way and it hasn't backfired.

--- a/mockito-core/src/main/java/org/mockito/internal/junit/UnnecessaryStubbingsReporter.java
+++ b/mockito-core/src/main/java/org/mockito/internal/junit/UnnecessaryStubbingsReporter.java
@@ -19,28 +19,28 @@ import org.mockito.mock.MockCreationSettings;
 /**
  * Reports unnecessary stubbings
  */
-public class UnnecessaryStubbingsReporter implements MockCreationListener {
+public class UnnecessaryStubbingsReporter<T> implements MockCreationListener<T> {
 
-    private final List<Object> mocks = new LinkedList<Object>();
+    private final List<Object> mocks = new LinkedList<>();
 
     public void validateUnusedStubs(Class<?> testClass, RunNotifier notifier) {
         Collection<Invocation> unused =
-                new UnusedStubbingsFinder().getUnusedStubbingsByLocation(mocks);
+            new UnusedStubbingsFinder().getUnusedStubbingsByLocation(mocks);
         if (unused.isEmpty()) {
             return; // whoa!!! All stubbings were used!
         }
 
         // Oups, there are unused stubbings
         Description unnecessaryStubbings =
-                Description.createTestDescription(testClass, "unnecessary Mockito stubbings");
+            Description.createTestDescription(testClass, "unnecessary Mockito stubbings");
         notifier.fireTestFailure(
-                new Failure(
-                        unnecessaryStubbings,
-                        Reporter.formatUnncessaryStubbingException(testClass, unused)));
+            new Failure(
+                unnecessaryStubbings,
+                Reporter.formatUnncessaryStubbingException(testClass, unused)));
     }
 
     @Override
-    public void onMockCreated(Object mock, MockCreationSettings settings) {
+    public void onMockCreated(Object mock, MockCreationSettings<T> settings) {
         mocks.add(mock);
     }
 }

--- a/mockito-core/src/main/java/org/mockito/listeners/MockCreationListener.java
+++ b/mockito-core/src/main/java/org/mockito/listeners/MockCreationListener.java
@@ -10,7 +10,7 @@ import org.mockito.mock.MockCreationSettings;
  * Notified when mock object is created.
  * For more information on listeners see {@link org.mockito.MockitoFramework#addListener(MockitoListener)}.
  */
-public interface MockCreationListener extends MockitoListener {
+public interface MockCreationListener<T> extends MockitoListener {
 
     /**
      * Mock object was just created.
@@ -18,7 +18,7 @@ public interface MockCreationListener extends MockitoListener {
      * @param mock created mock object
      * @param settings the settings used for creation
      */
-    void onMockCreated(Object mock, MockCreationSettings settings);
+    void onMockCreated(Object mock, MockCreationSettings<T> settings);
 
     /**
      * Static mock object was just created.
@@ -26,5 +26,5 @@ public interface MockCreationListener extends MockitoListener {
      * @param mock the type being mocked
      * @param settings the settings used for creation
      */
-    default void onStaticMockCreated(Class<?> mock, MockCreationSettings settings) {}
+    default void onStaticMockCreated(Class<?> mock, MockCreationSettings<T> settings) {}
 }


### PR DESCRIPTION
Fixes #3700, so external projects implementing `MockCreationListener` does no longer get a raw types warning they do not have control over, by using generic type T.
I did see more classes using raw type when using `MockCreationSettings` class, but this will at least remove the warning from projects using the `MockCreationListener`.

When using the XXX implementation should now use generic type, instead of raw type:

```
public class NoOpTestListener<T> implements MockitoTestListener<T> {

    @Override
    public void testFinished(TestFinishedEvent event) {}

    @Override
    public void onMockCreated(Object mock, MockCreationSettings<T> settings) {}
}
```
Instead of 
```
public class NoOpTestListener implements MockitoTestListener {

    @Override
    public void testFinished(TestFinishedEvent event) {}

    @Override
    public void onMockCreated(Object mock, MockCreationSettings settings) {}
}
```

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style (run `./gradlew spotlessApply` for auto-formatting)
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should end with `Fixes #<issue number>` _if relevant_
