### PR TITLE
build: Allow overriding 'Created-By' for reproducible builds

### DIFF
--- a/buildSrc/src/main/kotlin/mockito.java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/mockito.java-library-conventions.gradle.kts
@@ -33,4 +33,14 @@ tasks {
             unix("rw-r--r--") // 0644
         }
     }
+
+    withType<Jar>().configureEach {
+        manifest {
+            val createdByProperty = project.findProperty("manifest.createdBy") as? String
+            attributes(
+                "Created-By" to (createdByProperty
+                    ?: "${System.getProperty("java.version")} (${System.getProperty("java.vendor")})")
+            )
+        }
+    }
 }


### PR DESCRIPTION
### Summary

This pull request resolves issue #3563 by allowing the `Created-By` entry in the JAR manifest to be overridden via a Gradle property. This is a crucial step towards enabling fully reproducible builds for Mockito.

### Key Changes

- Modified `mockito.java-library-conventions.gradle.kts` to check for a `-Pmanifest.createdBy` Gradle property.
- If the property is present, its value is used for the `Created-By` manifest attribute.
- If not, the build defaults to the existing behavior, using the current JVM's version and vendor.

### Manual Verification

As this change affects the build process itself, I have manually verified the two primary scenarios.

The verification focuses on the `mockito-core` module as a representative sample. Since the change was made in the `mockito.java-library-conventions` plugin using `tasks.withType<Jar>()`, this logic is guaranteed by Gradle to be applied to all modules that produce a JAR file. Therefore, a successful test on one core module is sufficient to confirm the correctness of the implementation for the entire project.

An automated test was not added at this stage, but I'm happy to add one if the maintainers deem it necessary.

---

**Scenario 1: Default Behavior (No Property)**

Verifies that the manifest falls back to the default JVM information when no property is provided.

- **Command:**
  ```bash
  ./gradlew clean :mockito-core:jar && unzip -p mockito-core/build/libs/mockito-core-*.jar META-INF/MANIFEST.MF

- **Output:**
  ```text
  Manifest-Version: 1.0
  Bundle-License: MIT
  Bundle-ManifestVersion: 2
  Bundle-Name: Mockito Mock Library for Java. Core bundle requires Byte 
   Buddy and Objenesis.
  Bundle-SymbolicName: org.mockito.mockito-core
  Bundle-Version: 5.18.1.SNAPSHOT
  Can-Retransform-Classes: true
  Created-By: 21.0.7 (Microsoft)
  ...

**Scenario 2: Overridden Behavior (Property Injected)**

Verifies that the manifest uses the value from the Gradle property when provided.

- **Command:**
  ```bash
  ./gradlew clean :mockito-core:jar -Pmanifest.createdBy="21.0.5 (Azul Systems, Inc.)" && unzip -p mockito-core/build/libs/mockito-core-*.jar META-INF/MANIFEST.MF

- **Output:**
  ```text
  Manifest-Version: 1.0
  Bundle-License: MIT
  Bundle-ManifestVersion: 2
  Bundle-Name: Mockito Mock Library for Java. Core bundle requires Byte 
   Buddy and Objenesis.
  Bundle-SymbolicName: org.mockito.mockito-core
  Bundle-Version: 5.18.1.SNAPSHOT
  Can-Retransform-Classes: true
  Created-By: 21.0.5 (Azul Systems, Inc.)
  ...