### PR TITLE
feat: Add support for JDK21 Sequenced Collections.

### DIFF
--- a/mockito-core/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValues.java
+++ b/mockito-core/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValues.java
@@ -19,6 +19,7 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
@@ -50,6 +51,9 @@ import org.mockito.stubbing.Answer;
  * </li>
  * <li>
  * Returns empty collection for collection-returning methods (works for most commonly used collection types)
+ * </li>
+ * <li>
+ * Returns empty sequenced collections for Java 21+ SequencedCollection, SequencedSet, and SequencedMap interfaces
  * </li>
  * <li>
  * Returns description of mock for toString() method
@@ -104,6 +108,12 @@ public class ReturnsEmptyValues implements Answer<Object>, Serializable {
     }
 
     Object returnValueFor(Class<?> type) {
+        Object sequencedCollection = returnValueForSequencedCollection(type);
+
+        if (sequencedCollection != null) {
+            return sequencedCollection;
+        }
+
         if (Primitives.isPrimitiveOrWrapper(type)) {
             return Primitives.defaultValue(type);
             // new instances are used instead of Collections.emptyList(), etc.
@@ -155,6 +165,20 @@ public class ReturnsEmptyValues implements Answer<Object>, Serializable {
         // Let's not care about the rest of collections.
 
         return returnCommonEmptyValueFor(type);
+    }
+
+    private Object returnValueForSequencedCollection(Class<?> type) {
+        String typeName = type.getName();
+
+        if (Objects.equals("java.util.SequencedCollection", typeName)) {
+            return new ArrayList<>();
+        } else if (Objects.equals("java.util.SequencedSet", typeName)) {
+            return new LinkedHashSet<>();
+        } else if (Objects.equals("java.util.SequencedMap", typeName)) {
+            return new LinkedHashMap<>();
+        }
+
+        return null;
     }
 
     /**

--- a/mockito-core/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValuesTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValuesTest.java
@@ -176,6 +176,33 @@ public class ReturnsEmptyValuesTest extends TestBase {
         assertEquals("seconds of empty " + fqcn, 0L, seconds);
     }
 
+    @Test
+    public void should_return_empty_sequenced_collection_on_java21() throws Exception {
+        Class<?> sequencedCollectionClass = getClassOrSkipTest("java.util.SequencedCollection");
+        Object result = values.returnValueFor(sequencedCollectionClass);
+        assertNotNull("SequencedCollection should return non-null value", result);
+        assertTrue("Should return empty collection", ((Collection<?>) result).isEmpty());
+        assertTrue("Should return ArrayList instance", result instanceof ArrayList);
+    }
+
+    @Test
+    public void should_return_empty_sequenced_set_on_java21() throws Exception {
+        Class<?> sequencedSetClass = getClassOrSkipTest("java.util.SequencedSet");
+        Object result = values.returnValueFor(sequencedSetClass);
+        assertNotNull("SequencedSet should return non-null value", result);
+        assertTrue("Should return empty set", ((Set<?>) result).isEmpty());
+        assertTrue("Should return LinkedHashSet instance", result instanceof LinkedHashSet);
+    }
+
+    @Test
+    public void should_return_empty_sequenced_map_on_java21() throws Exception {
+        Class<?> sequencedMapClass = getClassOrSkipTest("java.util.SequencedMap");
+        Object result = values.returnValueFor(sequencedMapClass);
+        assertNotNull("SequencedMap should return non-null value", result);
+        assertTrue("Should return empty map", ((Map<?, ?>) result).isEmpty());
+        assertTrue("Should return LinkedHashMap instance", result instanceof LinkedHashMap);
+    }
+
     /**
      * Tries to load the given class. If the class is not found, the complete test is skipped.
      */


### PR DESCRIPTION
This PR resolves issue #3659 by adding support for JDK 21's Sequenced Collections.

Description

JEP 431 introduced new SequencedCollection, SequencedSet, and SequencedMap interfaces in JDK 21. When a mock method with one of these return types was unstubbed, Mockito would previously return null instead of an empty collection.

Implementation Details

To address this while maintaining Java 11 compatibility, ReturnsEmptyValues has been updated. The key changes are:

A new private method, returnValueForSequencedCollection, was introduced to handle the reflection-based checks in isolation.

```java
private Object returnValueForSequencedCollection(Class<?> type) {
    String typeName = type.getName();
    if ("java.util.SequencedCollection".equals(typeName)) {
        return new ArrayList<>();
    } else if ("java.util.SequencedSet".equals(typeName)) {
        return new LinkedHashSet<>();
    } else if ("java.util.SequencedMap".equals(typeName)) {
        return new LinkedHashMap<>();
    }
    // Return null to allow other checks to proceed.
    return null;
}
```


This method is called at the beginning of returnValueFor to prioritize these special version-specific checks.

```java
Object returnValueFor(Class<?> type) {
    // 1. Handle special Sequenced Collections first.
    Object sequencedCollection = returnValueForSequencedCollection(type);
    if (sequencedCollection != null) {
        return sequencedCollection;
    }

    // ... rest of the code
```
Fixes #3659


## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style (run `./gradlew spotlessApply` for auto-formatting)
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should end with `Fixes #<issue number>` _if relevant_
