### PR TITLE
test: Use Assume.assumeThat for SequencedCollection tests

### DIFF
--- a/mockito-core/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValuesTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValuesTest.java
@@ -4,14 +4,13 @@
  */
 package org.mockito.internal.stubbing.defaultanswers;
 
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 import static org.junit.Assume.assumeThat;
 import static org.mockito.Mockito.mock;
 
 import java.util.*;
 
-import org.junit.Assume;
 import org.junit.Test;
 import org.mockito.invocation.Invocation;
 import org.mockitoutil.TestBase;
@@ -113,9 +112,11 @@ public class ReturnsEmptyValuesTest extends TestBase {
 
     private void verify_empty_Optional_is_returned(String streamFqcn, String optionalFqcn)
             throws Exception {
-        Class<?> streamType = getClassOrSkipTest(streamFqcn);
-
         // given
+        assumeThat("JDK 8+ required for Optional", isJavaVersionAtLeast(8), is(true));
+
+        Class<?> streamType = Class.forName(streamFqcn);
+
         Object stream = mock(streamType);
         Object optional = streamType.getMethod("findAny").invoke(stream);
         assertNotNull(optional);
@@ -152,7 +153,9 @@ public class ReturnsEmptyValuesTest extends TestBase {
 
     private void verify_empty_Stream_is_returned(String streamFqcn) throws Exception {
         // given
-        Class<?> streamType = getClassOrSkipTest(streamFqcn);
+        assumeThat("JDK 8+ required for Stream", isJavaVersionAtLeast(8), is(true));
+
+        Class<?> streamType = Class.forName(streamFqcn);
 
         // when
         Object stream = values.returnValueFor(streamType);
@@ -165,8 +168,9 @@ public class ReturnsEmptyValuesTest extends TestBase {
     @Test
     public void should_return_empty_duration() throws Exception {
         // given
+        assumeThat("JDK 8+ required for Duration", isJavaVersionAtLeast(8), is(true));
         final String fqcn = "java.time.Duration";
-        final Class<?> durationClass = getClassOrSkipTest(fqcn);
+        Class<?> durationClass = Class.forName(fqcn);
 
         // when
         final Object duration = values.returnValueFor(durationClass);
@@ -180,17 +184,9 @@ public class ReturnsEmptyValuesTest extends TestBase {
 
     @Test
     public void should_return_empty_sequenced_collection() throws Exception {
-        Class<?> sequencedCollectionClass;
-        try {
-            sequencedCollectionClass = Class.forName("java.util.SequencedCollection");
-        } catch (ClassNotFoundException e) {
-            sequencedCollectionClass = null;
-        }
+        assumeThat("JDK 21+ required for SequencedCollection", isJavaVersionAtLeast(21), is(true));
 
-        assumeThat(
-                "SequencedCollection not available on this JVM",
-                sequencedCollectionClass,
-                notNullValue());
+        Class<?> sequencedCollectionClass = Class.forName("java.util.SequencedCollection");
 
         Object result = values.returnValueFor(sequencedCollectionClass);
         assertNotNull("SequencedCollection should return non-null value", result);
@@ -200,14 +196,9 @@ public class ReturnsEmptyValuesTest extends TestBase {
 
     @Test
     public void should_return_empty_sequenced_set() throws Exception {
-        Class<?> sequencedSetClass;
-        try {
-            sequencedSetClass = Class.forName("java.util.SequencedSet");
-        } catch (ClassNotFoundException e) {
-            sequencedSetClass = null;
-        }
+        assumeThat("JDK 21+ required for SequencedSet", isJavaVersionAtLeast(21), is(true));
 
-        assumeThat("SequencedSet not available on this JVM", sequencedSetClass, notNullValue());
+        Class<?> sequencedSetClass = Class.forName("java.util.SequencedSet");
 
         Object result = values.returnValueFor(sequencedSetClass);
         assertNotNull("SequencedSet should return non-null value", result);
@@ -217,14 +208,9 @@ public class ReturnsEmptyValuesTest extends TestBase {
 
     @Test
     public void should_return_empty_sequenced_map() throws Exception {
-        Class<?> sequencedMapClass;
-        try {
-            sequencedMapClass = Class.forName("java.util.SequencedMap");
-        } catch (ClassNotFoundException e) {
-            sequencedMapClass = null;
-        }
+        assumeThat("JDK 21+ required for SequencedMap", isJavaVersionAtLeast(21), is(true));
 
-        assumeThat("SequencedMap not available on this JVM", sequencedMapClass, notNullValue());
+        Class<?> sequencedMapClass = Class.forName("java.util.SequencedMap");
 
         Object result = values.returnValueFor(sequencedMapClass);
         assertNotNull("SequencedMap should return non-null value", result);
@@ -233,14 +219,12 @@ public class ReturnsEmptyValuesTest extends TestBase {
     }
 
     /**
-     * Tries to load the given class. If the class is not found, the complete test is skipped.
+     * Checks if the current Java version is at least the specified version.
      */
-    private Class<?> getClassOrSkipTest(String className) {
-        try {
-            return Class.forName(className);
-        } catch (ClassNotFoundException e) {
-            Assume.assumeNoException("JVM does not support " + className, e);
-            return null;
-        }
+    private boolean isJavaVersionAtLeast(int majorVersion) {
+        String javaVersion = System.getProperty("java.version");
+        String[] versionParts = javaVersion.split("\\.");
+        int currentMajorVersion = Integer.parseInt(versionParts[0]);
+        return currentMajorVersion >= majorVersion;
     }
 }

--- a/mockito-core/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValuesTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValuesTest.java
@@ -4,7 +4,9 @@
  */
 package org.mockito.internal.stubbing.defaultanswers;
 
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.*;
+import static org.junit.Assume.assumeThat;
 import static org.mockito.Mockito.mock;
 
 import java.util.*;
@@ -177,8 +179,19 @@ public class ReturnsEmptyValuesTest extends TestBase {
     }
 
     @Test
-    public void should_return_empty_sequenced_collection_on_java21() throws Exception {
-        Class<?> sequencedCollectionClass = getClassOrSkipTest("java.util.SequencedCollection");
+    public void should_return_empty_sequenced_collection() throws Exception {
+        Class<?> sequencedCollectionClass;
+        try {
+            sequencedCollectionClass = Class.forName("java.util.SequencedCollection");
+        } catch (ClassNotFoundException e) {
+            sequencedCollectionClass = null;
+        }
+
+        assumeThat(
+                "SequencedCollection not available on this JVM",
+                sequencedCollectionClass,
+                notNullValue());
+
         Object result = values.returnValueFor(sequencedCollectionClass);
         assertNotNull("SequencedCollection should return non-null value", result);
         assertTrue("Should return empty collection", ((Collection<?>) result).isEmpty());
@@ -186,8 +199,16 @@ public class ReturnsEmptyValuesTest extends TestBase {
     }
 
     @Test
-    public void should_return_empty_sequenced_set_on_java21() throws Exception {
-        Class<?> sequencedSetClass = getClassOrSkipTest("java.util.SequencedSet");
+    public void should_return_empty_sequenced_set() throws Exception {
+        Class<?> sequencedSetClass;
+        try {
+            sequencedSetClass = Class.forName("java.util.SequencedSet");
+        } catch (ClassNotFoundException e) {
+            sequencedSetClass = null;
+        }
+
+        assumeThat("SequencedSet not available on this JVM", sequencedSetClass, notNullValue());
+
         Object result = values.returnValueFor(sequencedSetClass);
         assertNotNull("SequencedSet should return non-null value", result);
         assertTrue("Should return empty set", ((Set<?>) result).isEmpty());
@@ -195,8 +216,16 @@ public class ReturnsEmptyValuesTest extends TestBase {
     }
 
     @Test
-    public void should_return_empty_sequenced_map_on_java21() throws Exception {
-        Class<?> sequencedMapClass = getClassOrSkipTest("java.util.SequencedMap");
+    public void should_return_empty_sequenced_map() throws Exception {
+        Class<?> sequencedMapClass;
+        try {
+            sequencedMapClass = Class.forName("java.util.SequencedMap");
+        } catch (ClassNotFoundException e) {
+            sequencedMapClass = null;
+        }
+
+        assumeThat("SequencedMap not available on this JVM", sequencedMapClass, notNullValue());
+
         Object result = values.returnValueFor(sequencedMapClass);
         assertNotNull("SequencedMap should return non-null value", result);
         assertTrue("Should return empty map", ((Map<?, ?>) result).isEmpty());


### PR DESCRIPTION
This is a follow-up to the discussion in PR #3708

### Description
As suggested by @TimvdLippe in the original PR, this change refactors the test for JDK 21's `SequencedCollection` to use the project's standard `Assume.assumeThat` utility for conditional execution.

The previous implementation used a custom helper method `getClassOrSkipTest` to check for the presence of the class.
This PR replaces that logic with an explicit check for the Java version, ensuring the test only runs on JDK 21 or newer.

### Key Changes 
- Replaced the `getClassOrSkipTest` call with an `Assume.assumeThat` check on the Java version.


## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style (run `./gradlew spotlessApply` for auto-formatting)
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should end with `Fixes #<issue number>` _if relevant_
