### PR TITLE
Fixes #3709: Add GraalVM nativeTest test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,8 +208,11 @@ jobs:
         distribution: "graalvm"
         cache: gradle
 
-    - name: 3. Run GraalVM native tests
-      run: ./gradlew :mockito-integration-tests:graalvm-tests:nativeTest --stacktrace --scan
+    - name: 3. Run GraalVM native tests with metadata
+      run: ./gradlew :mockito-integration-tests:graalvm-tests:nativeTestWithMetadata --stacktrace --scan
+
+    - name: 4. Verify GraalVM metadata generation
+      run: test -f mockito-integration-tests/graalvm-tests/src/test/resources/META-INF/native-image/org.mockito/graalvm-tests/reflect-config.json
 
   #
   # Release job, only for pushes to the main development branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,43 +214,43 @@ jobs:
   #
   # Release job, only for pushes to the main development branch
   #
-  release:
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    needs: [java, android, graalvm] # all build jobs must pass before we can release
+  # release:
+  #   permissions:
+  #     contents: write
+  #   runs-on: ubuntu-latest
+  #   needs: [java, android, graalvm] # all build jobs must pass before we can release
 
-    if: github.event_name == 'push'
-        && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
-        && github.repository == 'mockito/mockito'
-        && !contains(toJSON(github.event.commits.*.message), '[skip release]')
+  #   if: github.event_name == 'push'
+  #       && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+  #       && github.repository == 'mockito/mockito'
+  #       && !contains(toJSON(github.event.commits.*.message), '[skip release]')
 
-    steps:
+  #   steps:
 
-      - name: 1. Check out code
-        uses: actions/checkout@v5 # https://github.com/actions/checkout
-        with:
-          fetch-depth: '0' # https://github.com/shipkit/shipkit-changelog#fetch-depth-on-ci
+  #     - name: 1. Check out code
+  #       uses: actions/checkout@v5 # https://github.com/actions/checkout
+  #       with:
+  #         fetch-depth: '0' # https://github.com/shipkit/shipkit-changelog#fetch-depth-on-ci
 
-      - name: 2. Set up Java for running Gradle build
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu'
-          java-version: 21
-          cache: 'gradle'
+  #     - name: 2. Set up Java for running Gradle build
+  #       uses: actions/setup-java@v4
+  #       with:
+  #         distribution: 'zulu'
+  #         java-version: 21
+  #         cache: 'gradle'
 
-      - name: 3. Build and release
-        run: >
-          ./gradlew
-          githubRelease
-          publishToSonatype
-          closeAndReleaseStagingRepositories
-          releaseSummary
-          --info
-          --stacktrace
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          NEXUS_TOKEN_USER: ${{secrets.NEXUS_TOKEN_USER}}
-          NEXUS_TOKEN_PWD: ${{secrets.NEXUS_TOKEN_PWD}}
-          PGP_KEY: ${{secrets.PGP_KEY}}
-          PGP_PWD: ${{secrets.PGP_PWD}}
+  #     - name: 3. Build and release
+  #       run: >
+  #         ./gradlew
+  #         githubRelease
+  #         publishToSonatype
+  #         closeAndReleaseStagingRepositories
+  #         releaseSummary
+  #         --info
+  #         --stacktrace
+  #       env:
+  #         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+  #         NEXUS_TOKEN_USER: ${{secrets.NEXUS_TOKEN_USER}}
+  #         NEXUS_TOKEN_PWD: ${{secrets.NEXUS_TOKEN_PWD}}
+  #         PGP_KEY: ${{secrets.PGP_KEY}}
+  #         PGP_PWD: ${{secrets.PGP_PWD}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,16 @@ jobs:
       run: ./gradlew :mockito-integration-tests:graalvm-tests:nativeTestWithMetadata --stacktrace --scan
 
     - name: 4. Verify GraalVM metadata generation
-      run: test -f mockito-integration-tests/graalvm-tests/src/test/resources/META-INF/native-image/org.mockito/graalvm-tests/reflect-config.json
+      run: |
+        REFLECT_CONFIG="mockito-integration-tests/graalvm-tests/src/test/resources/META-INF/native-image/org.mockito/graalvm-tests/reflect-config.json"
+        test -f "$REFLECT_CONFIG" || {
+          echo "reflect-config.json not found at $REFLECT_CONFIG"
+          exit 1
+        }
+        grep -q "org\.mockito\.internal\.creation\.bytebuddy\.codegen\.DummyObject\$MockitoMock" "$REFLECT_CONFIG" || {
+          echo "DummyObject mock not found in reflect-config.json"
+          exit 1
+        }
 
   #
   # Release job, only for pushes to the main development branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
         cache: gradle
 
     - name: 3. Run GraalVM native tests with metadata
-      run: ./gradlew :mockito-integration-tests:graalvm-tests:nativeTestWithMetadata --stacktrace --scan
+      run: ./gradlew :mockito-integration-tests:graalvm-tests:nativeTest -PenableGraalTracingAgent --stacktrace --scan
 
     - name: 4. Verify GraalVM metadata generation
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,172 +21,195 @@ jobs:
   #
   # Main build job
   #
-  java:
+  # java:
+  #   runs-on: ubuntu-latest
+  #   if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
+
+  #   # Definition of the build matrix
+  #   strategy:
+  #     matrix:
+  #       java: [11, 17, 21]
+  #       entry:
+  #         - { mock-maker: 'mock-maker-default', member-accessor: 'member-accessor-default' }
+  #         - { mock-maker: 'mock-maker-inline', member-accessor: 'member-accessor-module' }
+  #         - { mock-maker: 'mock-maker-subclass', member-accessor: 'member-accessor-module' }
+  #         - { mock-maker: 'mock-maker-subclass', member-accessor: 'member-accessor-reflection' }
+  #         - { mock-maker: 'mock-maker-inline', member-accessor: 'member-accessor-reflection' }
+
+  #   # All build steps
+  #   # SINGLE-MATRIX-JOB means that the step does not need to be executed on every job in the matrix
+  #   steps:
+
+  #   - name: 1. Check out code
+  #     uses: actions/checkout@v5 # https://github.com/actions/checkout
+  #     with:
+  #       fetch-depth: '0' # https://github.com/shipkit/shipkit-changelog#fetch-depth-on-ci
+
+  #   - name: 2. Set up Java for running Gradle build
+  #     uses: actions/setup-java@v4
+  #     with:
+  #       distribution: 'zulu'
+  #       java-version: 17
+  #       cache: 'gradle'
+
+  #   - name: 3. Validate Gradle wrapper
+  #     if: matrix.java == 11 && matrix.entry.mock-maker == 'mock-maker-default' # SINGLE-MATRIX-JOB
+  #     uses: gradle/actions/wrapper-validation@v4 # https://github.com/gradle/wrapper-validation-action
+
+  #   - name: 4. Build and check reproducibility of artifacts (single job only)
+  #     if: matrix.java == 11 && matrix.entry.mock-maker == 'mock-maker-default' # SINGLE-MATRIX-JOB
+  #     run: ./check_reproducibility.sh
+
+  #   - name: 5. Spotless check (single job only). Run './gradlew spotlessApply' locally if this job fails.
+  #     if: matrix.java == 11 && matrix.entry.mock-maker == 'mock-maker-default' # SINGLE-MATRIX-JOB
+  #     run: >
+  #       ./gradlew
+  #       spotlessCheck
+  #       --stacktrace
+  #       --scan
+
+  #   - name: 6. Build on Java ${{ matrix.java }} with ${{ matrix.entry.mock-maker }} and ${{ matrix.entry.member-accessor }}
+  #     run: >
+  #       ./gradlew
+  #       -Pmockito.test.java=${{ matrix.java }}
+  #       build
+  #       --stacktrace
+  #       --scan
+  #     env:
+  #       MOCK_MAKER: ${{ matrix.entry.mock-maker }}
+  #       MEMBER_ACCESSOR: ${{ matrix.entry.member-accessor }}
+
+  #   - name: 7. Generate coverage report
+  #     run: >
+  #       ./gradlew
+  #       -Pmockito.test.java=${{ matrix.java }}
+  #       coverageReport
+  #       --stacktrace
+  #       --scan
+
+  #   - name: 8. Upload coverage report
+  #     uses: codecov/codecov-action@v5
+  #     env:
+  #       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  #     with:
+  #       files: mockito-core/build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml
+  #       fail_ci_if_error: true
+
+  # #
+  # # Android build job
+  # #
+  # android:
+  #   runs-on: ubuntu-latest
+  #   if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
+  #   timeout-minutes: 30
+
+  #   # Definition of the build matrix
+  #   strategy:
+  #     matrix:
+  #       # Minimum supported and maximum available.
+  #       android-api: [ 26, 33 ]
+
+  #   # All build steps
+  #   steps:
+  #   - name: 1. Check out code
+  #     uses: actions/checkout@v5
+  #     with:
+  #       fetch-depth: '0' # https://github.com/shipkit/shipkit-changelog#fetch-depth-on-ci
+
+  #   - name: 2. Set up Java for running Gradle build
+  #     uses: actions/setup-java@v4
+  #     with:
+  #       distribution: 'zulu'
+  #       java-version: 17
+  #       cache: 'gradle'
+
+  #   - name: 3. Enable KVM.
+  #     run: |
+  #       echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+  #       sudo udevadm control --reload-rules
+  #       sudo udevadm trigger --name-match=kvm
+
+  #   - name: 4. Run Android tests on Android API level ${{ matrix.android-api }}
+  #     uses: reactivecircus/android-emulator-runner@v2
+  #     with:
+  #       arch: x86_64
+  #       api-level: ${{ matrix.android-api }}
+  #       # Override default "-no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim"
+  #       # See emulator manual for reference: https://developer.android.com/studio/run/emulator-commandline
+  #       emulator-options: >
+  #         -no-window
+  #         -gpu swiftshader_indirect
+  #         -no-snapshot
+  #         -noaudio
+  #         -no-boot-anim
+  #         -camera-back none
+  #         -camera-front none
+  #       # See logcat manual for reference: https://developer.android.com/studio/command-line/logcat
+  #       script: |
+  #         # Capture logcat output from "Launch Emulator" to a file.
+  #         adb logcat -d > emulator-startup.log
+  #         # Shorten the logcat output, by truncating at this point, the relevant part is yet to come.
+  #         # Best effort, could fail with "failed to clear the 'main' log",
+  #         # because something is locking logcat, so try a few times, and ignore errors each time.
+  #         adb logcat --clear || true
+  #         adb logcat --clear || true
+  #         adb logcat --clear || true
+  #         # Capture full logcat output to a file.
+  #         adb logcat > emulator.log & echo $! > logcat_file.pid
+  #         # Output instrumentation test logs to the GitHub Actions output.
+  #         adb logcat "*:S MonitoringInstr:V AndroidJUnitRunner:V TestRequestBuilder:V TestExecutor:V TestRunner:V" --format=color & echo $! > logcat_console.pid
+
+  #         echo 0 > gradle.exit # Set a default exit code.
+  #         # Run the actual tests (suppress build failures by saving the exit code).
+  #         ./gradlew :mockito-integration-tests:android-tests:connectedCheck --no-daemon --no-build-cache || echo $? > gradle.exit
+
+  #         # Stop capturing logcat output.
+  #         kill $(cat logcat_file.pid)    || echo "::warning file=.github/workflows/ci.yml::Logcat process $(cat logcat_file.pid) didn't exist."
+  #         kill $(cat logcat_console.pid) || echo "::warning file=.github/workflows/ci.yml::Logcat process $(cat logcat_console.pid) didn't exist."
+  #         # Make sure the step fails if the tests failed.
+  #         exit $(cat gradle.exit)
+
+  #   - name: 5. Upload artifact "android-tests-results-${{ matrix.android-api }}"
+  #     if: success() || failure()
+  #     uses: actions/upload-artifact@v4
+  #     with:
+  #       name: androidTest-results-${{ matrix.android-api }}
+  #       path: |
+  #         ${{ github.workspace }}/mockito-integration-tests/android-tests/build/reports/android-tests/connected/**
+  #         ${{ github.workspace }}/emulator.log
+  #         ${{ github.workspace }}/emulator-startup.log
+
+  #   # :mockito-integration-tests:android-tests:connectedCheck (which depends on :mockito-integration-tests:android-tests:createDebugAndroidTestCoverageReport) already generated coverage report.
+  #   - name: 6. Upload coverage report
+  #     uses: codecov/codecov-action@v5
+  #     env:
+  #       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  #     with:
+  #       files: mockito-integration-tests/android-tests/build/reports/coverage/android-tests/debug/connected/report.xml
+  #       fail_ci_if_error: true
+
+  #
+  # GraalVM native tests job
+  #
+  graalvm:
     runs-on: ubuntu-latest
     if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
 
-    # Definition of the build matrix
-    strategy:
-      matrix:
-        java: [11, 17, 21]
-        entry:
-          - { mock-maker: 'mock-maker-default', member-accessor: 'member-accessor-default' }
-          - { mock-maker: 'mock-maker-inline', member-accessor: 'member-accessor-module' }
-          - { mock-maker: 'mock-maker-subclass', member-accessor: 'member-accessor-module' }
-          - { mock-maker: 'mock-maker-subclass', member-accessor: 'member-accessor-reflection' }
-          - { mock-maker: 'mock-maker-inline', member-accessor: 'member-accessor-reflection' }
-
-    # All build steps
-    # SINGLE-MATRIX-JOB means that the step does not need to be executed on every job in the matrix
-    steps:
-
-    - name: 1. Check out code
-      uses: actions/checkout@v5 # https://github.com/actions/checkout
-      with:
-        fetch-depth: '0' # https://github.com/shipkit/shipkit-changelog#fetch-depth-on-ci
-
-    - name: 2. Set up Java for running Gradle build
-      uses: actions/setup-java@v4
-      with:
-        distribution: 'zulu'
-        java-version: 17
-        cache: 'gradle'
-
-    - name: 3. Validate Gradle wrapper
-      if: matrix.java == 11 && matrix.entry.mock-maker == 'mock-maker-default' # SINGLE-MATRIX-JOB
-      uses: gradle/actions/wrapper-validation@v4 # https://github.com/gradle/wrapper-validation-action
-
-    - name: 4. Build and check reproducibility of artifacts (single job only)
-      if: matrix.java == 11 && matrix.entry.mock-maker == 'mock-maker-default' # SINGLE-MATRIX-JOB
-      run: ./check_reproducibility.sh
-
-    - name: 5. Spotless check (single job only). Run './gradlew spotlessApply' locally if this job fails.
-      if: matrix.java == 11 && matrix.entry.mock-maker == 'mock-maker-default' # SINGLE-MATRIX-JOB
-      run: >
-        ./gradlew
-        spotlessCheck
-        --stacktrace
-        --scan
-
-    - name: 6. Build on Java ${{ matrix.java }} with ${{ matrix.entry.mock-maker }} and ${{ matrix.entry.member-accessor }}
-      run: >
-        ./gradlew
-        -Pmockito.test.java=${{ matrix.java }}
-        build
-        --stacktrace
-        --scan
-      env:
-        MOCK_MAKER: ${{ matrix.entry.mock-maker }}
-        MEMBER_ACCESSOR: ${{ matrix.entry.member-accessor }}
-
-    - name: 7. Generate coverage report
-      run: >
-        ./gradlew
-        -Pmockito.test.java=${{ matrix.java }}
-        coverageReport
-        --stacktrace
-        --scan
-
-    - name: 8. Upload coverage report
-      uses: codecov/codecov-action@v5
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      with:
-        files: mockito-core/build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml
-        fail_ci_if_error: true
-
-  #
-  # Android build job
-  #
-  android:
-    runs-on: ubuntu-latest
-    if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
-    timeout-minutes: 30
-
-    # Definition of the build matrix
-    strategy:
-      matrix:
-        # Minimum supported and maximum available.
-        android-api: [ 26, 33 ]
-
-    # All build steps
     steps:
     - name: 1. Check out code
       uses: actions/checkout@v5
       with:
-        fetch-depth: '0' # https://github.com/shipkit/shipkit-changelog#fetch-depth-on-ci
+        fetch-depth: '0'
 
-    - name: 2. Set up Java for running Gradle build
-      uses: actions/setup-java@v4
+    - name: 2. Setup GraalVM
+      uses: graalvm/setup-graalvm@7f488cf82a3629ee755e4e97342c01d6bed318fa
       with:
-        distribution: 'zulu'
-        java-version: 17
-        cache: 'gradle'
+        java-version: "21"
+        distribution: "graalvm"
+        cache: gradle
 
-    - name: 3. Enable KVM.
-      run: |
-        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-        sudo udevadm control --reload-rules
-        sudo udevadm trigger --name-match=kvm
-
-    - name: 4. Run Android tests on Android API level ${{ matrix.android-api }}
-      uses: reactivecircus/android-emulator-runner@v2
-      with:
-        arch: x86_64
-        api-level: ${{ matrix.android-api }}
-        # Override default "-no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim"
-        # See emulator manual for reference: https://developer.android.com/studio/run/emulator-commandline
-        emulator-options: >
-          -no-window
-          -gpu swiftshader_indirect
-          -no-snapshot
-          -noaudio
-          -no-boot-anim
-          -camera-back none
-          -camera-front none
-        # See logcat manual for reference: https://developer.android.com/studio/command-line/logcat
-        script: |
-          # Capture logcat output from "Launch Emulator" to a file.
-          adb logcat -d > emulator-startup.log
-          # Shorten the logcat output, by truncating at this point, the relevant part is yet to come.
-          # Best effort, could fail with "failed to clear the 'main' log",
-          # because something is locking logcat, so try a few times, and ignore errors each time.
-          adb logcat --clear || true
-          adb logcat --clear || true
-          adb logcat --clear || true
-          # Capture full logcat output to a file.
-          adb logcat > emulator.log & echo $! > logcat_file.pid
-          # Output instrumentation test logs to the GitHub Actions output.
-          adb logcat "*:S MonitoringInstr:V AndroidJUnitRunner:V TestRequestBuilder:V TestExecutor:V TestRunner:V" --format=color & echo $! > logcat_console.pid
-
-          echo 0 > gradle.exit # Set a default exit code.
-          # Run the actual tests (suppress build failures by saving the exit code).
-          ./gradlew :mockito-integration-tests:android-tests:connectedCheck --no-daemon --no-build-cache || echo $? > gradle.exit
-
-          # Stop capturing logcat output.
-          kill $(cat logcat_file.pid)    || echo "::warning file=.github/workflows/ci.yml::Logcat process $(cat logcat_file.pid) didn't exist."
-          kill $(cat logcat_console.pid) || echo "::warning file=.github/workflows/ci.yml::Logcat process $(cat logcat_console.pid) didn't exist."
-          # Make sure the step fails if the tests failed.
-          exit $(cat gradle.exit)
-
-    - name: 5. Upload artifact "android-tests-results-${{ matrix.android-api }}"
-      if: success() || failure()
-      uses: actions/upload-artifact@v4
-      with:
-        name: androidTest-results-${{ matrix.android-api }}
-        path: |
-          ${{ github.workspace }}/mockito-integration-tests/android-tests/build/reports/android-tests/connected/**
-          ${{ github.workspace }}/emulator.log
-          ${{ github.workspace }}/emulator-startup.log
-
-    # :mockito-integration-tests:android-tests:connectedCheck (which depends on :mockito-integration-tests:android-tests:createDebugAndroidTestCoverageReport) already generated coverage report.
-    - name: 6. Upload coverage report
-      uses: codecov/codecov-action@v5
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      with:
-        files: mockito-integration-tests/android-tests/build/reports/coverage/android-tests/debug/connected/report.xml
-        fail_ci_if_error: true
+    - name: 3. Run GraalVM native tests
+      run: ./gradlew :mockito-integration-tests:graalvm-tests:nativeTest --stacktrace --scan
 
   #
   # Release job, only for pushes to the main development branch
@@ -195,7 +218,7 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    needs: [java, android] # both build jobs must pass before we can release
+    needs: [java, android, graalvm] # all build jobs must pass before we can release
 
     if: github.event_name == 'push'
         && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,14 +202,14 @@ jobs:
         fetch-depth: '0'
 
     - name: 2. Setup GraalVM
-      uses: graalvm/setup-graalvm@7f488cf82a3629ee755e4e97342c01d6bed318fa
+      uses: graalvm/setup-graalvm@v1.3.5
       with:
         java-version: "21"
         distribution: "graalvm"
         cache: gradle
 
     - name: 3. Run GraalVM native tests with metadata
-      run: ./gradlew :mockito-integration-tests:graalvm-tests:nativeTest -PenableGraalTracingAgent --stacktrace --scan
+      run: ./gradlew :mockito-integration-tests:graalvm-tests:nativeTest -PenableGraalTracingAgent --scan
 
     - name: 4. Verify GraalVM metadata generation
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,172 +21,172 @@ jobs:
   #
   # Main build job
   #
-  # java:
-  #   runs-on: ubuntu-latest
-  #   if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
+  java:
+    runs-on: ubuntu-latest
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
 
-  #   # Definition of the build matrix
-  #   strategy:
-  #     matrix:
-  #       java: [11, 17, 21]
-  #       entry:
-  #         - { mock-maker: 'mock-maker-default', member-accessor: 'member-accessor-default' }
-  #         - { mock-maker: 'mock-maker-inline', member-accessor: 'member-accessor-module' }
-  #         - { mock-maker: 'mock-maker-subclass', member-accessor: 'member-accessor-module' }
-  #         - { mock-maker: 'mock-maker-subclass', member-accessor: 'member-accessor-reflection' }
-  #         - { mock-maker: 'mock-maker-inline', member-accessor: 'member-accessor-reflection' }
+    # Definition of the build matrix
+    strategy:
+      matrix:
+        java: [11, 17, 21]
+        entry:
+          - { mock-maker: 'mock-maker-default', member-accessor: 'member-accessor-default' }
+          - { mock-maker: 'mock-maker-inline', member-accessor: 'member-accessor-module' }
+          - { mock-maker: 'mock-maker-subclass', member-accessor: 'member-accessor-module' }
+          - { mock-maker: 'mock-maker-subclass', member-accessor: 'member-accessor-reflection' }
+          - { mock-maker: 'mock-maker-inline', member-accessor: 'member-accessor-reflection' }
 
-  #   # All build steps
-  #   # SINGLE-MATRIX-JOB means that the step does not need to be executed on every job in the matrix
-  #   steps:
+    # All build steps
+    # SINGLE-MATRIX-JOB means that the step does not need to be executed on every job in the matrix
+    steps:
 
-  #   - name: 1. Check out code
-  #     uses: actions/checkout@v5 # https://github.com/actions/checkout
-  #     with:
-  #       fetch-depth: '0' # https://github.com/shipkit/shipkit-changelog#fetch-depth-on-ci
+    - name: 1. Check out code
+      uses: actions/checkout@v5 # https://github.com/actions/checkout
+      with:
+        fetch-depth: '0' # https://github.com/shipkit/shipkit-changelog#fetch-depth-on-ci
 
-  #   - name: 2. Set up Java for running Gradle build
-  #     uses: actions/setup-java@v4
-  #     with:
-  #       distribution: 'zulu'
-  #       java-version: 17
-  #       cache: 'gradle'
+    - name: 2. Set up Java for running Gradle build
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'zulu'
+        java-version: 17
+        cache: 'gradle'
 
-  #   - name: 3. Validate Gradle wrapper
-  #     if: matrix.java == 11 && matrix.entry.mock-maker == 'mock-maker-default' # SINGLE-MATRIX-JOB
-  #     uses: gradle/actions/wrapper-validation@v4 # https://github.com/gradle/wrapper-validation-action
+    - name: 3. Validate Gradle wrapper
+      if: matrix.java == 11 && matrix.entry.mock-maker == 'mock-maker-default' # SINGLE-MATRIX-JOB
+      uses: gradle/actions/wrapper-validation@v4 # https://github.com/gradle/wrapper-validation-action
 
-  #   - name: 4. Build and check reproducibility of artifacts (single job only)
-  #     if: matrix.java == 11 && matrix.entry.mock-maker == 'mock-maker-default' # SINGLE-MATRIX-JOB
-  #     run: ./check_reproducibility.sh
+    - name: 4. Build and check reproducibility of artifacts (single job only)
+      if: matrix.java == 11 && matrix.entry.mock-maker == 'mock-maker-default' # SINGLE-MATRIX-JOB
+      run: ./check_reproducibility.sh
 
-  #   - name: 5. Spotless check (single job only). Run './gradlew spotlessApply' locally if this job fails.
-  #     if: matrix.java == 11 && matrix.entry.mock-maker == 'mock-maker-default' # SINGLE-MATRIX-JOB
-  #     run: >
-  #       ./gradlew
-  #       spotlessCheck
-  #       --stacktrace
-  #       --scan
+    - name: 5. Spotless check (single job only). Run './gradlew spotlessApply' locally if this job fails.
+      if: matrix.java == 11 && matrix.entry.mock-maker == 'mock-maker-default' # SINGLE-MATRIX-JOB
+      run: >
+        ./gradlew
+        spotlessCheck
+        --stacktrace
+        --scan
 
-  #   - name: 6. Build on Java ${{ matrix.java }} with ${{ matrix.entry.mock-maker }} and ${{ matrix.entry.member-accessor }}
-  #     run: >
-  #       ./gradlew
-  #       -Pmockito.test.java=${{ matrix.java }}
-  #       build
-  #       --stacktrace
-  #       --scan
-  #     env:
-  #       MOCK_MAKER: ${{ matrix.entry.mock-maker }}
-  #       MEMBER_ACCESSOR: ${{ matrix.entry.member-accessor }}
+    - name: 6. Build on Java ${{ matrix.java }} with ${{ matrix.entry.mock-maker }} and ${{ matrix.entry.member-accessor }}
+      run: >
+        ./gradlew
+        -Pmockito.test.java=${{ matrix.java }}
+        build
+        --stacktrace
+        --scan
+      env:
+        MOCK_MAKER: ${{ matrix.entry.mock-maker }}
+        MEMBER_ACCESSOR: ${{ matrix.entry.member-accessor }}
 
-  #   - name: 7. Generate coverage report
-  #     run: >
-  #       ./gradlew
-  #       -Pmockito.test.java=${{ matrix.java }}
-  #       coverageReport
-  #       --stacktrace
-  #       --scan
+    - name: 7. Generate coverage report
+      run: >
+        ./gradlew
+        -Pmockito.test.java=${{ matrix.java }}
+        coverageReport
+        --stacktrace
+        --scan
 
-  #   - name: 8. Upload coverage report
-  #     uses: codecov/codecov-action@v5
-  #     env:
-  #       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  #     with:
-  #       files: mockito-core/build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml
-  #       fail_ci_if_error: true
+    - name: 8. Upload coverage report
+      uses: codecov/codecov-action@v5
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      with:
+        files: mockito-core/build/reports/jacoco/mockitoCoverage/mockitoCoverage.xml
+        fail_ci_if_error: true
 
-  # #
-  # # Android build job
-  # #
-  # android:
-  #   runs-on: ubuntu-latest
-  #   if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
-  #   timeout-minutes: 30
+  #
+  # Android build job
+  #
+  android:
+    runs-on: ubuntu-latest
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
+    timeout-minutes: 30
 
-  #   # Definition of the build matrix
-  #   strategy:
-  #     matrix:
-  #       # Minimum supported and maximum available.
-  #       android-api: [ 26, 33 ]
+    # Definition of the build matrix
+    strategy:
+      matrix:
+        # Minimum supported and maximum available.
+        android-api: [ 26, 33 ]
 
-  #   # All build steps
-  #   steps:
-  #   - name: 1. Check out code
-  #     uses: actions/checkout@v5
-  #     with:
-  #       fetch-depth: '0' # https://github.com/shipkit/shipkit-changelog#fetch-depth-on-ci
+    # All build steps
+    steps:
+    - name: 1. Check out code
+      uses: actions/checkout@v5
+      with:
+        fetch-depth: '0' # https://github.com/shipkit/shipkit-changelog#fetch-depth-on-ci
 
-  #   - name: 2. Set up Java for running Gradle build
-  #     uses: actions/setup-java@v4
-  #     with:
-  #       distribution: 'zulu'
-  #       java-version: 17
-  #       cache: 'gradle'
+    - name: 2. Set up Java for running Gradle build
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'zulu'
+        java-version: 17
+        cache: 'gradle'
 
-  #   - name: 3. Enable KVM.
-  #     run: |
-  #       echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-  #       sudo udevadm control --reload-rules
-  #       sudo udevadm trigger --name-match=kvm
+    - name: 3. Enable KVM.
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
 
-  #   - name: 4. Run Android tests on Android API level ${{ matrix.android-api }}
-  #     uses: reactivecircus/android-emulator-runner@v2
-  #     with:
-  #       arch: x86_64
-  #       api-level: ${{ matrix.android-api }}
-  #       # Override default "-no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim"
-  #       # See emulator manual for reference: https://developer.android.com/studio/run/emulator-commandline
-  #       emulator-options: >
-  #         -no-window
-  #         -gpu swiftshader_indirect
-  #         -no-snapshot
-  #         -noaudio
-  #         -no-boot-anim
-  #         -camera-back none
-  #         -camera-front none
-  #       # See logcat manual for reference: https://developer.android.com/studio/command-line/logcat
-  #       script: |
-  #         # Capture logcat output from "Launch Emulator" to a file.
-  #         adb logcat -d > emulator-startup.log
-  #         # Shorten the logcat output, by truncating at this point, the relevant part is yet to come.
-  #         # Best effort, could fail with "failed to clear the 'main' log",
-  #         # because something is locking logcat, so try a few times, and ignore errors each time.
-  #         adb logcat --clear || true
-  #         adb logcat --clear || true
-  #         adb logcat --clear || true
-  #         # Capture full logcat output to a file.
-  #         adb logcat > emulator.log & echo $! > logcat_file.pid
-  #         # Output instrumentation test logs to the GitHub Actions output.
-  #         adb logcat "*:S MonitoringInstr:V AndroidJUnitRunner:V TestRequestBuilder:V TestExecutor:V TestRunner:V" --format=color & echo $! > logcat_console.pid
+    - name: 4. Run Android tests on Android API level ${{ matrix.android-api }}
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        arch: x86_64
+        api-level: ${{ matrix.android-api }}
+        # Override default "-no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim"
+        # See emulator manual for reference: https://developer.android.com/studio/run/emulator-commandline
+        emulator-options: >
+          -no-window
+          -gpu swiftshader_indirect
+          -no-snapshot
+          -noaudio
+          -no-boot-anim
+          -camera-back none
+          -camera-front none
+        # See logcat manual for reference: https://developer.android.com/studio/command-line/logcat
+        script: |
+          # Capture logcat output from "Launch Emulator" to a file.
+          adb logcat -d > emulator-startup.log
+          # Shorten the logcat output, by truncating at this point, the relevant part is yet to come.
+          # Best effort, could fail with "failed to clear the 'main' log",
+          # because something is locking logcat, so try a few times, and ignore errors each time.
+          adb logcat --clear || true
+          adb logcat --clear || true
+          adb logcat --clear || true
+          # Capture full logcat output to a file.
+          adb logcat > emulator.log & echo $! > logcat_file.pid
+          # Output instrumentation test logs to the GitHub Actions output.
+          adb logcat "*:S MonitoringInstr:V AndroidJUnitRunner:V TestRequestBuilder:V TestExecutor:V TestRunner:V" --format=color & echo $! > logcat_console.pid
 
-  #         echo 0 > gradle.exit # Set a default exit code.
-  #         # Run the actual tests (suppress build failures by saving the exit code).
-  #         ./gradlew :mockito-integration-tests:android-tests:connectedCheck --no-daemon --no-build-cache || echo $? > gradle.exit
+          echo 0 > gradle.exit # Set a default exit code.
+          # Run the actual tests (suppress build failures by saving the exit code).
+          ./gradlew :mockito-integration-tests:android-tests:connectedCheck --no-daemon --no-build-cache || echo $? > gradle.exit
 
-  #         # Stop capturing logcat output.
-  #         kill $(cat logcat_file.pid)    || echo "::warning file=.github/workflows/ci.yml::Logcat process $(cat logcat_file.pid) didn't exist."
-  #         kill $(cat logcat_console.pid) || echo "::warning file=.github/workflows/ci.yml::Logcat process $(cat logcat_console.pid) didn't exist."
-  #         # Make sure the step fails if the tests failed.
-  #         exit $(cat gradle.exit)
+          # Stop capturing logcat output.
+          kill $(cat logcat_file.pid)    || echo "::warning file=.github/workflows/ci.yml::Logcat process $(cat logcat_file.pid) didn't exist."
+          kill $(cat logcat_console.pid) || echo "::warning file=.github/workflows/ci.yml::Logcat process $(cat logcat_console.pid) didn't exist."
+          # Make sure the step fails if the tests failed.
+          exit $(cat gradle.exit)
 
-  #   - name: 5. Upload artifact "android-tests-results-${{ matrix.android-api }}"
-  #     if: success() || failure()
-  #     uses: actions/upload-artifact@v4
-  #     with:
-  #       name: androidTest-results-${{ matrix.android-api }}
-  #       path: |
-  #         ${{ github.workspace }}/mockito-integration-tests/android-tests/build/reports/android-tests/connected/**
-  #         ${{ github.workspace }}/emulator.log
-  #         ${{ github.workspace }}/emulator-startup.log
+    - name: 5. Upload artifact "android-tests-results-${{ matrix.android-api }}"
+      if: success() || failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: androidTest-results-${{ matrix.android-api }}
+        path: |
+          ${{ github.workspace }}/mockito-integration-tests/android-tests/build/reports/android-tests/connected/**
+          ${{ github.workspace }}/emulator.log
+          ${{ github.workspace }}/emulator-startup.log
 
-  #   # :mockito-integration-tests:android-tests:connectedCheck (which depends on :mockito-integration-tests:android-tests:createDebugAndroidTestCoverageReport) already generated coverage report.
-  #   - name: 6. Upload coverage report
-  #     uses: codecov/codecov-action@v5
-  #     env:
-  #       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  #     with:
-  #       files: mockito-integration-tests/android-tests/build/reports/coverage/android-tests/debug/connected/report.xml
-  #       fail_ci_if_error: true
+    # :mockito-integration-tests:android-tests:connectedCheck (which depends on :mockito-integration-tests:android-tests:createDebugAndroidTestCoverageReport) already generated coverage report.
+    - name: 6. Upload coverage report
+      uses: codecov/codecov-action@v5
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      with:
+        files: mockito-integration-tests/android-tests/build/reports/coverage/android-tests/debug/connected/report.xml
+        fail_ci_if_error: true
 
   #
   # GraalVM native tests job
@@ -226,43 +226,43 @@ jobs:
   #
   # Release job, only for pushes to the main development branch
   #
-  # release:
-  #   permissions:
-  #     contents: write
-  #   runs-on: ubuntu-latest
-  #   needs: [java, android, graalvm] # all build jobs must pass before we can release
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    needs: [java, android, graalvm] # all build jobs must pass before we can release
 
-  #   if: github.event_name == 'push'
-  #       && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
-  #       && github.repository == 'mockito/mockito'
-  #       && !contains(toJSON(github.event.commits.*.message), '[skip release]')
+    if: github.event_name == 'push'
+        && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+        && github.repository == 'mockito/mockito'
+        && !contains(toJSON(github.event.commits.*.message), '[skip release]')
 
-  #   steps:
+    steps:
 
-  #     - name: 1. Check out code
-  #       uses: actions/checkout@v5 # https://github.com/actions/checkout
-  #       with:
-  #         fetch-depth: '0' # https://github.com/shipkit/shipkit-changelog#fetch-depth-on-ci
+      - name: 1. Check out code
+        uses: actions/checkout@v5 # https://github.com/actions/checkout
+        with:
+          fetch-depth: '0' # https://github.com/shipkit/shipkit-changelog#fetch-depth-on-ci
 
-  #     - name: 2. Set up Java for running Gradle build
-  #       uses: actions/setup-java@v4
-  #       with:
-  #         distribution: 'zulu'
-  #         java-version: 21
-  #         cache: 'gradle'
+      - name: 2. Set up Java for running Gradle build
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 21
+          cache: 'gradle'
 
-  #     - name: 3. Build and release
-  #       run: >
-  #         ./gradlew
-  #         githubRelease
-  #         publishToSonatype
-  #         closeAndReleaseStagingRepositories
-  #         releaseSummary
-  #         --info
-  #         --stacktrace
-  #       env:
-  #         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-  #         NEXUS_TOKEN_USER: ${{secrets.NEXUS_TOKEN_USER}}
-  #         NEXUS_TOKEN_PWD: ${{secrets.NEXUS_TOKEN_PWD}}
-  #         PGP_KEY: ${{secrets.PGP_KEY}}
-  #         PGP_PWD: ${{secrets.PGP_PWD}}
+      - name: 3. Build and release
+        run: >
+          ./gradlew
+          githubRelease
+          publishToSonatype
+          closeAndReleaseStagingRepositories
+          releaseSummary
+          --info
+          --stacktrace
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          NEXUS_TOKEN_USER: ${{secrets.NEXUS_TOKEN_USER}}
+          NEXUS_TOKEN_PWD: ${{secrets.NEXUS_TOKEN_PWD}}
+          PGP_KEY: ${{secrets.PGP_KEY}}
+          PGP_PWD: ${{secrets.PGP_PWD}}

--- a/mockito-integration-tests/graalvm-tests/.gitignore
+++ b/mockito-integration-tests/graalvm-tests/.gitignore
@@ -1,0 +1,1 @@
+src/test/resources/META-INF/native-image/org.mockito/graalvm-tests/

--- a/mockito-integration-tests/graalvm-tests/build.gradle.kts
+++ b/mockito-integration-tests/graalvm-tests/build.gradle.kts
@@ -28,8 +28,7 @@ graalvmNative {
     }
 
     agent {
-        // Only enable the tracing agent when the JVM vendor is GraalVM
-        enabled = System.getProperty("java.vendor", "").contains("GraalVM")
+        enabled = project.hasProperty("enableGraalTracingAgent")
         defaultMode = "standard"
 
         metadataCopy {
@@ -43,19 +42,8 @@ graalvmNative {
 tasks {
     test {
         forkEvery = 1
-    }
-
-    register("generateMetadata") {
-        group = "graalvm"
-        description = "Generate GraalVM metadata files by running tests with agent"
-        dependsOn("test")
-        finalizedBy("metadataCopy")
-    }
-
-    register("nativeTestWithMetadata") {
-        group = "graalvm"
-        description = "Run native tests using generated metadata"
-        dependsOn("generateMetadata")
-        finalizedBy("nativeTest")
+        if (project.hasProperty("enableGraalTracingAgent")) {
+            finalizedBy("metadataCopy")
+        }
     }
 }

--- a/mockito-integration-tests/graalvm-tests/build.gradle.kts
+++ b/mockito-integration-tests/graalvm-tests/build.gradle.kts
@@ -1,0 +1,60 @@
+plugins {
+    id("java")
+    id("mockito.test-conventions")
+    id("org.graalvm.buildtools.native") version "0.11.0"
+}
+
+description = "Test suite for exercising subclass mock maker with GraalVM native image"
+
+dependencies {
+    implementation(project(":mockito-core"))
+    implementation(project(":mockito-extensions:mockito-subclass"))
+    testImplementation(libs.junit4)
+    testImplementation(libs.assertj)
+    testImplementation(libs.junit.platform.launcher)
+}
+
+// org.graalvm.buildtools.native:0.11.0 requires Java >=17
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+graalvmNative {
+    binaries {
+        named("test") {
+            buildArgs.addAll("--verbose", "-O0")
+        }
+    }
+
+    agent {
+        enabled = true
+        defaultMode = "standard"
+
+        metadataCopy {
+            inputTaskNames.add("test")
+            outputDirectories.add("src/test/resources/META-INF/native-image/org.mockito/graalvm-tests")
+            mergeWithExisting = false
+        }
+    }
+}
+
+tasks {
+    test {
+        forkEvery = 1
+    }
+
+    register("generateMetadata") {
+        group = "graalvm"
+        description = "Generate GraalVM metadata files by running tests with agent"
+        dependsOn("test")
+        finalizedBy("metadataCopy")
+    }
+
+    register("nativeTestWithMetadata") {
+        group = "graalvm"
+        description = "Run native tests using generated metadata"
+        dependsOn("generateMetadata")
+        finalizedBy("nativeTest")
+    }
+}

--- a/mockito-integration-tests/graalvm-tests/build.gradle.kts
+++ b/mockito-integration-tests/graalvm-tests/build.gradle.kts
@@ -28,7 +28,8 @@ graalvmNative {
     }
 
     agent {
-        enabled = true
+        // Only enable the tracing agent when the JVM vendor is GraalVM
+        enabled = System.getProperty("java.vendor", "").contains("GraalVM")
         defaultMode = "standard"
 
         metadataCopy {

--- a/mockito-integration-tests/graalvm-tests/src/test/java/org/mockito/graalvm/DummyObject.java
+++ b/mockito-integration-tests/graalvm-tests/src/test/java/org/mockito/graalvm/DummyObject.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.graalvm;
+
+public class DummyObject {
+    public String getValue() {
+        return "original";
+    }
+
+    public String processValue(String input) {
+        return "original-" + input;
+    }
+}

--- a/mockito-integration-tests/graalvm-tests/src/test/java/org/mockito/graalvm/DummyObject.java
+++ b/mockito-integration-tests/graalvm-tests/src/test/java/org/mockito/graalvm/DummyObject.java
@@ -8,8 +8,4 @@ public class DummyObject {
     public String getValue() {
         return "original";
     }
-
-    public String processValue(String input) {
-        return "original-" + input;
-    }
 }

--- a/mockito-integration-tests/graalvm-tests/src/test/java/org/mockito/graalvm/GraalVMSubclassMockMakerTest.java
+++ b/mockito-integration-tests/graalvm-tests/src/test/java/org/mockito/graalvm/GraalVMSubclassMockMakerTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.graalvm;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import org.junit.Test;
+
+public final class GraalVMSubclassMockMakerTest {
+
+    @Test
+    public void test_subclass_mock_maker_with_simple_object() {
+        DummyObject dummyMock = mock(DummyObject.class, withSettings());
+
+        when(dummyMock.getValue()).thenReturn("mocked");
+
+        assertEquals("mocked", dummyMock.getValue());
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -45,6 +45,7 @@ include(
     "mockito-integration-tests:osgi-tests",
     "mockito-integration-tests:programmatic-tests",
     "mockito-integration-tests:java-21-tests",
+    "mockito-integration-tests:graalvm-tests",
 )
 
 // https://developer.android.com/studio/command-line/variables#envar


### PR DESCRIPTION
## Description

Adds a test suite using the subclass MockMaker running a simple Mockito test using GraalVM native image. Tested using `21.0.8-graal`.

Run:
```
sdk use java 21.0.8-graal
./gradlew :mockito-integration-tests:graalvm-tests:nativeTestWithMetadata 
```

After merging https://github.com/mockito/mockito/pull/3710 the `reflect-config.json` should include a line similar to this:

```
{
  "name":"org.mockito.internal.creation.bytebuddy.codegen.DummyObject$MockitoMock$je9a223op99200N"
},
```

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style (run `./gradlew spotlessApply` for auto-formatting)
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should end with `Fixes #<issue number>` _if relevant_
