### PR TITLE
Feat: automatically detect class to mock in mockStatic and mockConstruction

### DIFF
--- a/mockito-core/src/main/java/org/mockito/Mockito.java
+++ b/mockito-core/src/main/java/org/mockito/Mockito.java
@@ -2423,6 +2423,107 @@ public class Mockito extends ArgumentMatchers {
     }
 
     /**
+     * Creates a thread-local mock controller for all static methods of the given class or interface.
+     * The returned object's {@link MockedStatic#close()} method must be called upon completing the
+     * test or the mock will remain active on the current thread.
+     * <p>
+     * <b>Note</b>: We recommend against mocking static methods of classes in the standard library or
+     * classes used by custom class loaders used to execute the block with the mocked class. A mock
+     * maker might forbid mocking static methods of know classes that are known to cause problems.
+     * Also, if a static method is a JVM-intrinsic, it cannot typically be mocked even if not
+     * explicitly forbidden.
+     * <p>
+     * See examples in javadoc for {@link Mockito} class
+     *
+     * @param reified don't pass any values to it. It's a trick to detect the class/interface you
+     *                want to mock.
+     * @return mock controller
+     * @since 5.21.0
+     */
+    @SafeVarargs
+    public static <T> MockedStatic<T> mockStatic(T... reified) {
+        return mockStatic(withSettings(), reified);
+    }
+
+    /**
+     * Creates a thread-local mock controller for all static methods of the given class or interface.
+     * The returned object's {@link MockedStatic#close()} method must be called upon completing the
+     * test or the mock will remain active on the current thread.
+     * <p>
+     * <b>Note</b>: We recommend against mocking static methods of classes in the standard library or
+     * classes used by custom class loaders used to execute the block with the mocked class. A mock
+     * maker might forbid mocking static methods of know classes that are known to cause problems.
+     * Also, if a static method is a JVM-intrinsic, it cannot typically be mocked even if not
+     * explicitly forbidden.
+     * <p>
+     * See examples in javadoc for {@link Mockito} class
+     *
+     * @param defaultAnswer the default answer when invoking static methods.
+     * @param reified don't pass any values to it. It's a trick to detect the class/interface you
+     *                want to mock.
+     * @return mock controller
+     * @since 5.21.0
+     */
+    @SafeVarargs
+    public static <T> MockedStatic<T> mockStatic(
+            @SuppressWarnings("rawtypes") Answer defaultAnswer, T... reified) {
+        return mockStatic(withSettings().defaultAnswer(defaultAnswer), reified);
+    }
+
+    /**
+     * Creates a thread-local mock controller for all static methods of the given class or interface.
+     * The returned object's {@link MockedStatic#close()} method must be called upon completing the
+     * test or the mock will remain active on the current thread.
+     * <p>
+     * <b>Note</b>: We recommend against mocking static methods of classes in the standard library or
+     * classes used by custom class loaders used to execute the block with the mocked class. A mock
+     * maker might forbid mocking static methods of know classes that are known to cause problems.
+     * Also, if a static method is a JVM-intrinsic, it cannot typically be mocked even if not
+     * explicitly forbidden.
+     * <p>
+     * See examples in javadoc for {@link Mockito} class
+     *
+     * @param name the name of the mock to use in error messages.
+     * @param reified don't pass any values to it. It's a trick to detect the class/interface you
+     *                want to mock.
+     * @return mock controller
+     * @since 5.21.0
+     */
+    @SafeVarargs
+    public static <T> MockedStatic<T> mockStatic(String name, T... reified) {
+        return mockStatic(withSettings().name(name).defaultAnswer(RETURNS_DEFAULTS), reified);
+    }
+
+    /**
+     * Creates a thread-local mock controller for all static methods of the given class or interface.
+     * The returned object's {@link MockedStatic#close()} method must be called upon completing the
+     * test or the mock will remain active on the current thread.
+     * <p>
+     * <b>Note</b>: We recommend against mocking static methods of classes in the standard library or
+     * classes used by custom class loaders used to execute the block with the mocked class. A mock
+     * maker might forbid mocking static methods of know classes that are known to cause problems.
+     * Also, if a static method is a JVM-intrinsic, it cannot typically be mocked even if not
+     * explicitly forbidden.
+     * <p>
+     * See examples in javadoc for {@link Mockito} class
+     *
+     * @param mockSettings the settings to use where only name and default answer are considered.
+     * @param reified don't pass any values to it. It's a trick to detect the class/interface you
+     *                want to mock.
+     * @return mock controller
+     * @since 5.21.0
+     */
+    @SafeVarargs
+    public static <T> MockedStatic<T> mockStatic(MockSettings mockSettings, T... reified) {
+        if (reified == null || reified.length > 0) {
+            throw new IllegalArgumentException(
+                    "Please don't pass any values here. Java will detect class automagically.");
+        }
+
+        return mockStatic(getClassOf(reified), mockSettings);
+    }
+
+    /**
      * Creates a thread-local mock controller for all constructions of the given class.
      * The returned object's {@link MockedConstruction#close()} method must be called upon completing the
      * test or the mock will remain active on the current thread.
@@ -2552,6 +2653,129 @@ public class Mockito extends ArgumentMatchers {
             Function<MockedConstruction.Context, MockSettings> mockSettingsFactory,
             MockedConstruction.MockInitializer<T> mockInitializer) {
         return MOCKITO_CORE.mockConstruction(classToMock, mockSettingsFactory, mockInitializer);
+    }
+
+    /**
+     * Creates a thread-local mock controller for all constructions of the given class.
+     * The returned object's {@link MockedConstruction#close()} method must be called upon completing the
+     * test or the mock will remain active on the current thread.
+     * <p>
+     * See examples in javadoc for {@link Mockito} class
+     *
+     * @param reified don't pass any values to it. It's a trick to detect the class/interface you
+     *                want to mock.
+     * @return mock controller
+     * @since 5.21.0
+     */
+    @SafeVarargs
+    public static <T> MockedConstruction<T> mockConstruction(T... reified) {
+        return mockConstruction(index -> withSettings(), (mock, context) -> {}, reified);
+    }
+
+    /**
+     * Creates a thread-local mock controller for all constructions of the given class.
+     * The returned object's {@link MockedConstruction#close()} method must be called upon completing the
+     * test or the mock will remain active on the current thread.
+     * <p>
+     * See examples in javadoc for {@link Mockito} class
+     *
+     * @param mockInitializer a callback to prepare the methods on a mock after its instantiation.
+     * @param reified don't pass any values to it. It's a trick to detect the class/interface you
+     *                want to mock.
+     * @return mock controller
+     * @since 5.21.0
+     */
+    @SafeVarargs
+    public static <T> MockedConstruction<T> mockConstruction(
+            MockedConstruction.MockInitializer<T> mockInitializer, T... reified) {
+        return mockConstruction(withSettings(), mockInitializer, reified);
+    }
+
+    /**
+     * Creates a thread-local mock controller for all constructions of the given class.
+     * The returned object's {@link MockedConstruction#close()} method must be called upon completing the
+     * test or the mock will remain active on the current thread.
+     * <p>
+     * See examples in javadoc for {@link Mockito} class
+     *
+     * @param mockSettings the mock settings to use.
+     * @param reified don't pass any values to it. It's a trick to detect the class/interface you
+     *                want to mock.
+     * @return mock controller
+     * @since 5.21.0
+     */
+    @SafeVarargs
+    public static <T> MockedConstruction<T> mockConstruction(
+            MockSettings mockSettings, T... reified) {
+        return mockConstruction(context -> mockSettings, reified);
+    }
+
+    /**
+     * Creates a thread-local mock controller for all constructions of the given class.
+     * The returned object's {@link MockedConstruction#close()} method must be called upon completing the
+     * test or the mock will remain active on the current thread.
+     * <p>
+     * See examples in javadoc for {@link Mockito} class
+     *
+     * @param mockSettingsFactory the mock settings to use.
+     * @param reified don't pass any values to it. It's a trick to detect the class/interface you
+     *                want to mock.
+     * @return mock controller
+     * @since 5.21.0
+     */
+    @SafeVarargs
+    public static <T> MockedConstruction<T> mockConstruction(
+            Function<MockedConstruction.Context, MockSettings> mockSettingsFactory, T... reified) {
+        return mockConstruction(mockSettingsFactory, (mock, context) -> {}, reified);
+    }
+
+    /**
+     * Creates a thread-local mock controller for all constructions of the given class.
+     * The returned object's {@link MockedConstruction#close()} method must be called upon completing the
+     * test or the mock will remain active on the current thread.
+     * <p>
+     * See examples in javadoc for {@link Mockito} class
+     *
+     * @param mockSettings the settings to use.
+     * @param mockInitializer a callback to prepare the methods on a mock after its instantiation.
+     * @param reified don't pass any values to it. It's a trick to detect the class/interface you
+     *                want to mock.
+     * @return mock controller
+     * @since 5.21.0
+     */
+    @SafeVarargs
+    public static <T> MockedConstruction<T> mockConstruction(
+            MockSettings mockSettings,
+            MockedConstruction.MockInitializer<T> mockInitializer,
+            T... reified) {
+        return mockConstruction(index -> mockSettings, mockInitializer, reified);
+    }
+
+    /**
+     * Creates a thread-local mock controller for all constructions of the given class.
+     * The returned object's {@link MockedConstruction#close()} method must be called upon completing the
+     * test or the mock will remain active on the current thread.
+     * <p>
+     * See examples in javadoc for {@link Mockito} class
+     *
+     * @param mockSettingsFactory a function to create settings to use.
+     * @param mockInitializer a callback to prepare the methods on a mock after its instantiation.
+     * @param reified don't pass any values to it. It's a trick to detect the class/interface you
+     *                want to mock.
+     * @return mock controller
+     * @since 5.21.0
+     */
+    @SafeVarargs
+    public static <T> MockedConstruction<T> mockConstruction(
+            Function<MockedConstruction.Context, MockSettings> mockSettingsFactory,
+            MockedConstruction.MockInitializer<T> mockInitializer,
+            T... reified) {
+        if (reified == null || reified.length > 0) {
+            throw new IllegalArgumentException(
+                    "Please don't pass any values here. Java will detect class automagically.");
+        }
+
+        return mockConstruction(getClassOf(reified), mockSettingsFactory, mockInitializer);
     }
 
     /**

--- a/mockito-core/src/test/java/org/mockito/MockitoTest.java
+++ b/mockito-core/src/test/java/org/mockito/MockitoTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.times;
 import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
 
@@ -237,5 +238,197 @@ public class MockitoTest {
                         })
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageStartingWith("Please don't pass any values here");
+    }
+
+    @Test
+    public void ensure_reified_mocked_static_can_be_called_without_parameters() {
+        Assume.assumeThat(Plugins.getMockMaker(), instanceOf(InlineMockMaker.class));
+
+        try (MockedStatic<Dummy> mockedStatic = Mockito.mockStatic()) {
+            mockedStatic.when(Dummy::getValue).thenReturn("stub");
+            assertEquals("stub", Dummy.getValue());
+        }
+    }
+
+    @Test
+    public void ensure_reified_mocked_static_can_be_called_with_default_answer() {
+        Assume.assumeThat(Plugins.getMockMaker(), instanceOf(InlineMockMaker.class));
+
+        try (MockedStatic<Dummy> ignored = Mockito.mockStatic(Answers.CALLS_REAL_METHODS)) {
+            assertEquals("value", Dummy.getValue());
+        }
+    }
+
+    @Test
+    public void ensure_reified_mocked_static_can_be_called_with_name() {
+        Assume.assumeThat(Plugins.getMockMaker(), instanceOf(InlineMockMaker.class));
+
+        try (MockedStatic<Dummy> mockedStatic = Mockito.mockStatic("name")) {
+            assertThatThrownBy(() -> mockedStatic.verify(Dummy::getValue))
+                    .hasMessageContaining("name.getValue()");
+        }
+    }
+
+    @Test
+    public void ensure_reified_mocked_static_can_be_called_with_settings() {
+        Assume.assumeThat(Plugins.getMockMaker(), instanceOf(InlineMockMaker.class));
+        MockSettingsImpl<Dummy> settings = (MockSettingsImpl<Dummy>) Mockito.withSettings();
+
+        try (MockedStatic<Dummy> mockedStatic = Mockito.mockStatic(settings)) {
+            mockedStatic.when(Dummy::getValue).thenReturn("stub");
+            assertEquals("stub", Dummy.getValue());
+        }
+    }
+
+    @Test
+    @SuppressWarnings({"resource", "DataFlowIssue"})
+    public void ensure_reified_mocked_static_should_not_be_called_with_null() {
+        Assume.assumeThat(Plugins.getMockMaker(), instanceOf(InlineMockMaker.class));
+        MockSettingsImpl<Dummy> settings = (MockSettingsImpl<Dummy>) Mockito.withSettings();
+
+        assertThatThrownBy(() -> Mockito.mockStatic(settings, (Dummy[]) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageStartingWith("Please don't pass any values here");
+    }
+
+    @Test
+    @SuppressWarnings({"resource"})
+    public void ensure_reified_mocked_static_should_not_be_called_with_parameters() {
+        Assume.assumeThat(Plugins.getMockMaker(), instanceOf(InlineMockMaker.class));
+        MockSettingsImpl<Dummy> settings = (MockSettingsImpl<Dummy>) Mockito.withSettings();
+
+        assertThatThrownBy(() -> Mockito.mockStatic(settings, new Dummy[] {new Dummy()}))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageStartingWith("Please don't pass any values here");
+    }
+
+    @Test
+    public void ensure_reified_mocked_construction_can_be_called_without_parameters() {
+        Assume.assumeThat(Plugins.getMockMaker(), instanceOf(InlineMockMaker.class));
+
+        try (MockedConstruction<Dummy> mockedConstruction = Mockito.mockConstruction()) {
+            final Dummy dummy = new Dummy();
+            final Dummy constructed = mockedConstruction.constructed().get(0);
+
+            Mockito.when(constructed.getAnswer()).thenReturn(1);
+            assertEquals(1, dummy.getAnswer());
+        }
+    }
+
+    @Test
+    public void ensure_reified_mocked_construction_can_be_called_with_initializer() {
+        Assume.assumeThat(Plugins.getMockMaker(), instanceOf(InlineMockMaker.class));
+
+        try (MockedConstruction<Dummy> ignored =
+                Mockito.mockConstruction(
+                        (mock, context) -> Mockito.when(mock.getAnswer()).thenReturn(1))) {
+            final Dummy dummy = new Dummy();
+
+            assertEquals(1, dummy.getAnswer());
+        }
+    }
+
+    @Test
+    public void ensure_reified_mocked_construction_can_be_called_with_settings() {
+        Assume.assumeThat(Plugins.getMockMaker(), instanceOf(InlineMockMaker.class));
+        MockSettingsImpl<Dummy> settings = (MockSettingsImpl<Dummy>) Mockito.withSettings();
+
+        try (MockedConstruction<Dummy> mockedConstruction = Mockito.mockConstruction(settings)) {
+            final Dummy dummy = new Dummy();
+            final Dummy constructed = mockedConstruction.constructed().get(0);
+
+            Mockito.when(constructed.getAnswer()).thenReturn(1);
+            assertEquals(1, dummy.getAnswer());
+        }
+    }
+
+    @Test
+    public void ensure_reified_mocked_construction_can_be_called_with_settings_factory() {
+        Assume.assumeThat(Plugins.getMockMaker(), instanceOf(InlineMockMaker.class));
+        MockSettingsImpl<Dummy> settings = (MockSettingsImpl<Dummy>) Mockito.withSettings();
+
+        try (MockedConstruction<Dummy> mockedConstruction =
+                Mockito.mockConstruction(context -> settings)) {
+            final Dummy dummy = new Dummy();
+            final Dummy constructed = mockedConstruction.constructed().get(0);
+
+            Mockito.when(constructed.getAnswer()).thenReturn(1);
+            assertEquals(1, dummy.getAnswer());
+        }
+    }
+
+    @Test
+    public void ensure_reified_mocked_construction_can_be_called_with_settings_and_initializer() {
+        Assume.assumeThat(Plugins.getMockMaker(), instanceOf(InlineMockMaker.class));
+        MockSettingsImpl<Dummy> settings = (MockSettingsImpl<Dummy>) Mockito.withSettings();
+
+        try (MockedConstruction<Dummy> ignored =
+                Mockito.mockConstruction(
+                        settings,
+                        (mock, context) -> Mockito.when(mock.getAnswer()).thenReturn(1))) {
+            final Dummy dummy = new Dummy();
+
+            assertEquals(1, dummy.getAnswer());
+        }
+    }
+
+    @Test
+    public void ensure_reified_mocked_construction_can_be_called_with_factory_and_initializer() {
+        Assume.assumeThat(Plugins.getMockMaker(), instanceOf(InlineMockMaker.class));
+        MockSettingsImpl<Dummy> settings = (MockSettingsImpl<Dummy>) Mockito.withSettings();
+
+        try (MockedConstruction<Dummy> ignored =
+                Mockito.mockConstruction(
+                        context -> settings,
+                        (mock, context) -> Mockito.when(mock.getAnswer()).thenReturn(1))) {
+            final Dummy dummy = new Dummy();
+
+            assertEquals(1, dummy.getAnswer());
+        }
+    }
+
+    @Test
+    @SuppressWarnings({"resource", "DataFlowIssue"})
+    public void ensure_reified_mocked_construction_should_not_be_called_with_null() {
+        Assume.assumeThat(Plugins.getMockMaker(), instanceOf(InlineMockMaker.class));
+        MockSettingsImpl<Dummy> settings = (MockSettingsImpl<Dummy>) Mockito.withSettings();
+
+        assertThatThrownBy(
+                        () ->
+                                Mockito.mockConstruction(
+                                        context -> settings,
+                                        (mock, context) ->
+                                                Mockito.when(mock.getAnswer()).thenReturn(1),
+                                        (Dummy[]) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageStartingWith("Please don't pass any values here");
+    }
+
+    @Test
+    @SuppressWarnings({"resource"})
+    public void ensure_reified_mocked_construction_should_not_be_called_with_parameters() {
+        Assume.assumeThat(Plugins.getMockMaker(), instanceOf(InlineMockMaker.class));
+        MockSettingsImpl<Dummy> settings = (MockSettingsImpl<Dummy>) Mockito.withSettings();
+
+        assertThatThrownBy(
+                        () ->
+                                Mockito.mockConstruction(
+                                        context -> settings,
+                                        (mock, context) ->
+                                                Mockito.when(mock.getAnswer()).thenReturn(1),
+                                        new Dummy[] {new Dummy()}))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageStartingWith("Please don't pass any values here");
+    }
+
+    private static final class Dummy {
+
+        public static String getValue() {
+            return "value";
+        }
+
+        public int getAnswer() {
+            return 42;
+        }
     }
 }


### PR DESCRIPTION
As PR #2779 introduced the ability to automatically detect the class to mock for mocks and spies, this commit allows doing the same with `mockStatic` and `mockConstruction`.

Added overloaded reified methods to match all the counterparts that consume an explicit Class literal parameter.

For instance, users can now leverage these:
```java
MockedStatic<SomeClass> mock = mockStatic();
MockedConstruction<SomeClass> mock = mockConstruction();
```
instead of:
```java
MockedStatic<SomeClass> mock = mockStatic(SomeClass.class);
MockedConstruction<SomeClass> mock = mockConstruction(SomeClass.class);
```

The following methods have been added:
* `mockStatic(T...)`
* `mockStatic(Answer, T...)`
* `mockStatic(String, T...)`
* `mockStatic(MockSettings, T...)`
* `mockConstruction(T...)`
* `mockConstruction(MockInitializer, T...)`
* `mockConstruction(MockSettings, T...)`
* `mockConstruction(Function<Context, MockSettings>, T...)`
* `mockConstruction(MockSettings, MockInitializer, T...)`
* `mockConstruction(Function<Context, MockSettings>, MockInitializer, T...)`

Unit tests to cover all the new lines/branches have been added.

The Javadoc of each newly added method is copied from its counterpart that consume an explicit Class literal parameter,
of course documenting the `reified` parameter instead of the class literal one.
As part of the Javadoc, `@since 5.21.0` have been added since `5.20.0` is the current version.

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style (run `./gradlew spotlessApply` for auto-formatting)
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should end with `Fixes #<issue number>` _if relevant_
