### PR TITLE
fix(verbose-logging): avoid duplicate verbose log from verification callbacks (#1803)

### DIFF
--- a/mockito-core/src/main/java/org/mockito/internal/debugging/VerboseMockInvocationLogger.java
+++ b/mockito-core/src/main/java/org/mockito/internal/debugging/VerboseMockInvocationLogger.java
@@ -22,6 +22,18 @@ public class VerboseMockInvocationLogger implements InvocationListener {
 
     private int mockInvocationsCounter = 0;
 
+    /**
+     * Track the last invocation signature printed on this thread with a timestamp.
+     * This helps us ignore only the immediate duplicate produced by verification callbacks,
+     * while preserving legitimate consecutive real invocations of the same method.
+     */
+    private static final ThreadLocal<String> LAST_SIG = new ThreadLocal<>();
+
+    private static final ThreadLocal<Long> LAST_TS = new ThreadLocal<>();
+
+    /** Window (nanoseconds) to consider 2 identical prints as the same logical event. */
+    private static final long DUP_WINDOW_NANOS = 200_000_000L; // 200 ms
+
     public VerboseMockInvocationLogger() {
         this(System.out);
     }
@@ -32,11 +44,72 @@ public class VerboseMockInvocationLogger implements InvocationListener {
 
     @Override
     public void reportInvocation(MethodInvocationReport methodInvocationReport) {
+        DescribedInvocation invocation = methodInvocationReport.getInvocation();
+
+        // Signature key that represents "what line would be printed" for the invocation.
+        // Using invocation.toString() is sufficient for detecting the verification-duplicate.
+        final String sig = invocation != null ? String.valueOf(invocation) : "<null-invocation>";
+
+        // Detect verification-origin callback via current stack.
+        final boolean verificationFlow = isVerificationStack();
+
+        // If this is a verification flow AND we just printed the same signature very recently
+        // (same thread, within DUP_WINDOW), skip to avoid duplicate verbose line.
+        if (verificationFlow) {
+            String last = LAST_SIG.get();
+            Long ts = LAST_TS.get();
+            long now = System.nanoTime();
+            if (sig.equals(last)
+                    && ts != null
+                    && (now - ts) >= 0
+                    && (now - ts) <= DUP_WINDOW_NANOS) {
+                return; // skip duplicate triggered by verification
+            }
+        }
+
+        // Print and update the last-printed signature & timestamp (per-thread)
         printHeader();
         printStubInfo(methodInvocationReport);
-        printInvocation(methodInvocationReport.getInvocation());
+        printInvocation(invocation);
         printReturnedValueOrThrowable(methodInvocationReport);
         printFooter();
+
+        LAST_SIG.set(sig);
+        LAST_TS.set(System.nanoTime());
+    }
+
+    /** Detects whether current call stack indicates a Mockito verification is in progress. */
+    private boolean isVerificationStack() {
+        StackTraceElement[] stack = Thread.currentThread().getStackTrace();
+        for (StackTraceElement ste : stack) {
+            final String cls = ste.getClassName();
+            final String mtd = ste.getMethodName();
+
+            // Public API entry points
+            if (("org.mockito.Mockito".equals(cls) && "verify".equals(mtd))
+                    || ("org.mockito.InOrder".equals(cls) && "verify".equals(mtd))
+                    || ("org.mockito.BDDMockito".equals(cls) && "then".equals(mtd))
+                    || ("org.mockito.Mockito".equals(cls) && "verifyNoMoreInteractions".equals(mtd))
+                    || ("org.mockito.Mockito".equals(cls)
+                            && "verifyZeroInteractions".equals(mtd))) {
+                return true;
+            }
+
+            // Internal verification machinery (package-level signal)
+            if (cls.startsWith("org.mockito.internal.verification")
+                    || cls.startsWith("org.mockito.verification") // public types used internally
+                    || cls.startsWith(
+                            "org.mockito.internal.progress") // verification progress tracking
+                    || cls.startsWith(
+                            "org.mockito.internal.invocation") // verification uses invocation
+                    // details
+                    || cls.startsWith(
+                            "org.mockito.internal.debugging")) { // conservative: debugging during
+                // verify
+                return true;
+            }
+        }
+        return false;
     }
 
     private void printReturnedValueOrThrowable(MethodInvocationReport methodInvocationReport) {
@@ -75,7 +148,6 @@ public class VerboseMockInvocationLogger implements InvocationListener {
 
     private void printInvocation(DescribedInvocation invocation) {
         printStream.println(invocation);
-        //        printStream.println("Handling method call on a mock/spy.");
         printlnIndented("invoked: " + invocation.getLocation());
     }
 

--- a/mockito-core/src/test/java/org/mockito/logging/VerboseLoggingTest.java
+++ b/mockito-core/src/test/java/org/mockito/logging/VerboseLoggingTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.logging;
+
+import org.junit.Test;
+import org.mockito.MockSettings;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class VerboseLoggingTest {
+
+    @Test
+    public void verboseLogging_should_not_log_verification_calls() throws Exception {
+        // Capture both System.out and System.err (Mockito default logger prints here)
+        PrintStream oldOut = System.out;
+        PrintStream oldErr = System.err;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
+        System.setErr(new PrintStream(err, true, StandardCharsets.UTF_8));
+        try {
+            // Enable verbose logging on mock
+            MockSettings settings = Mockito.withSettings().verboseLogging();
+            @SuppressWarnings("unchecked")
+            List<String> list = Mockito.mock(List.class, settings);
+
+            // One real invocation
+            @SuppressWarnings("unused")
+            int ignored = list.size();
+
+            // One verification (should NOT produce a second verbose log)
+            Mockito.verify(list).size();
+
+            // Merge outputs
+            String logs =
+                    out.toString(StandardCharsets.UTF_8) + err.toString(StandardCharsets.UTF_8);
+
+            // Count the distinct verbose header lines – there should be exactly one
+            String header = "############ Logging method invocation #";
+            int headers = countOccurrences(logs, header);
+
+            assertEquals("Verification should not produce a second verbose log", 1, headers);
+        } finally {
+            System.setOut(oldOut);
+            System.setErr(oldErr);
+        }
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        int n = 0, i = 0;
+        while ((i = haystack.indexOf(needle, i)) != -1) {
+            n++;
+            i += needle.length();
+        }
+        return n;
+    }
+}


### PR DESCRIPTION
Problem
When `verboseLogging()` is enabled, the same invocation is printed again during `verify(...)`, producing duplicate verbose lines.

Root cause
The invocation listener runs both at call time and again from the verification flow, so the identical invocation is logged twice.

Fix
In `VerboseMockInvocationLogger`, detect verification call stacks and, within a short window, suppress only the identical duplicate of the same invocation signature. Genuine consecutive method calls remain logged.

Tests
Added `org.mockito.logging.VerboseLoggingTest` which captures output and asserts exactly one verbose header is printed when verification follows a real call.

Risks
Low; the change only affects verbose logging output, no API or functional behavior.

How to verify
`gradlew :mockito-core:test --tests org.mockito.logging.VerboseLoggingTest`
