### PR TITLE
Forbid mocking WeakReference with inline mock maker

### DIFF
--- a/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
@@ -36,6 +36,7 @@ import org.mockito.mock.SerializableMode;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
 import java.lang.instrument.UnmodifiableClassException;
+import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.security.ProtectionDomain;
@@ -65,7 +66,8 @@ public class InlineBytecodeGenerator implements BytecodeGenerator, ClassFileTran
                             Long.class,
                             Float.class,
                             Double.class,
-                            String.class));
+                            String.class,
+                            WeakReference.class));
 
     private final Instrumentation instrumentation;
 

--- a/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
@@ -596,7 +596,7 @@ class InlineDelegateByteBuddyMockMaker
                     return "primitive type";
                 }
                 if (EXCLUDES.contains(type)) {
-                    return "Cannot mock wrapper types, String.class or Class.class";
+                    return "Cannot mock primitive wrapper types, String, Class, or WeakReference";
                 }
                 return "VM does not support modification of given type";
             }

--- a/mockito-core/src/test/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMakerTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMakerTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
+import java.lang.ref.WeakReference;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.regex.Pattern;
@@ -369,7 +370,7 @@ public class InlineDelegateByteBuddyMockMakerTest
     public void should_provide_reason_for_wrapper_class() {
         MockMaker.TypeMockability mockable = mockMaker.isTypeMockable(Integer.class);
         assertThat(mockable.nonMockableReason())
-                .isEqualTo("Cannot mock wrapper types, String.class or Class.class");
+                .isEqualTo("Cannot mock primitive wrapper types, String, Class, or WeakReference");
     }
 
     @Test
@@ -394,7 +395,7 @@ public class InlineDelegateByteBuddyMockMakerTest
         MockMaker.TypeMockability mockable = mockMaker.isTypeMockable(String.class);
         assertThat(mockable.mockable()).isFalse();
         assertThat(mockable.nonMockableReason())
-                .contains("Cannot mock wrapper types, String.class or Class.class");
+                .contains("Cannot mock primitive wrapper types, String, Class, or WeakReference");
     }
 
     @Test
@@ -402,7 +403,15 @@ public class InlineDelegateByteBuddyMockMakerTest
         MockMaker.TypeMockability mockable = mockMaker.isTypeMockable(Class.class);
         assertThat(mockable.mockable()).isFalse();
         assertThat(mockable.nonMockableReason())
-                .contains("Cannot mock wrapper types, String.class or Class.class");
+                .contains("Cannot mock primitive wrapper types, String, Class, or WeakReference");
+    }
+
+    @Test
+    public void is_type_mockable_excludes_WeakReference() {
+        MockMaker.TypeMockability mockable = mockMaker.isTypeMockable(WeakReference.class);
+        assertThat(mockable.mockable()).isFalse();
+        assertThat(mockable.nonMockableReason())
+                .contains("Cannot mock primitive wrapper types, String, Class, or WeakReference");
     }
 
     @Test


### PR DESCRIPTION
Fixes #3758

Possibly we could update the `isMockConstruction` predicate in `InlineDelegateByteBuddyMockMaker` to avoid this recursive trace. But it also seems to reasonable to do this - not allow mocking WeakReference at all. It's a simple type that shouldn't need to be mocked anyway.

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [X] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [X] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [X] Avoid other runtime dependencies
 - [X] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [X] The pull request follows coding style (run `./gradlew spotlessApply` for auto-formatting)
 - [X] Mention `Fixes #<issue number>` in the description _if relevant_
 - [X] At least one commit should end with `Fixes #<issue number>` _if relevant_
