### PR TITLE
Update ErrorProne to 2.45.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 bytebuddy = "1.17.7"
-errorprone = "2.42.0"
+errorprone = "2.45.0"
 jacoco = "0.8.13"
 junit4 = "4.13.2"
 junit-jupiter = "5.13.4"


### PR DESCRIPTION
## Summary

This updates ErrorProne from 2.42.0 to 2.45.0, the latest version available.

**Note:** ErrorProne 2.45.0 requires Java 21+ to run (class file version 65.0). This doesn't affect Mockito's runtime requirements - only the JDK used for compilation needs to be Java 21+.

Fixes #3493

## Checklist

- [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
- [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
- [x] If possible / relevant include an example in the description
- [x] Avoid other runtime dependencies
- [x] Meaningful commit history
- [x] The pull request follows coding style (ran `./gradlew spotlessApply`)
- [x] Mention `Fixes #<issue number>` in the description
- [x] At least one commit should end with `Fixes #<issue number>`