### PR TITLE
Avoid mocking of internal static utilities

### DIFF
--- a/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/InlineBytecodeGenerator.java
@@ -133,7 +133,18 @@ public class InlineBytecodeGenerator implements BytecodeGenerator, ClassFileTran
                                         .bind(MockMethodAdvice.Identifier.class, identifier)
                                         .to(MockMethodAdvice.class))
                         .method(
-                                isStatic().and(not(BytecodeGenerator.isGroovyMethod(true))),
+                                isStatic()
+                                        .and(
+                                                not(
+                                                        isPrivate()
+                                                                .or(
+                                                                        isDeclaredBy(
+                                                                                        nameStartsWith(
+                                                                                                "java."))
+                                                                                .<MethodDescription>
+                                                                                        and(
+                                                                                                isPackagePrivate()))))
+                                        .and(not(BytecodeGenerator.isGroovyMethod(true))),
                                 Advice.withCustomMapping()
                                         .bind(MockMethodAdvice.Identifier.class, identifier)
                                         .to(MockMethodAdvice.ForStatic.class))


### PR DESCRIPTION
Avoids mocking private static methods, as well as package-private static methods of java.* classes, as those are primarily internal utilities that will cause non-intuitive changes of methods. This are not invoked for non-static mocks either. Fixes #3778.

Minor risk: people might have relied on stubbing those internal methods.