### PR TITLE
Fix non-deterministic AssertionError when using MockMakers.SUBCLASS (#3406, #2823)

### DIFF
--- a/mockito-core/src/main/java/org/mockito/internal/util/MockUtil.java
+++ b/mockito-core/src/main/java/org/mockito/internal/util/MockUtil.java
@@ -157,8 +157,10 @@ public class MockUtil {
         for (MockMaker mockMaker : mockMakers.values()) {
             MockHandler<?> handler = mockMaker.getHandler(mock);
             if (handler != null) {
-                assert getMockMaker(handler.getMockSettings().getMockMaker()) == mockMaker;
-                return handler;
+                String mockMakerName = handler.getMockSettings().getMockMaker();
+                if (getMockMaker(mockMakerName) == mockMaker) {
+                    return handler;
+                }
             }
         }
         return null;

--- a/mockito-integration-tests/programmatic-tests/src/test/java/org/mockito/ProgrammaticMockMakerTest.java
+++ b/mockito-integration-tests/programmatic-tests/src/test/java/org/mockito/ProgrammaticMockMakerTest.java
@@ -157,6 +157,17 @@ public final class ProgrammaticMockMakerTest {
                 .hasMessageContaining(InvalidMockMaker.class.getName());
     }
 
+    @Test
+    public void test_interface_after_subclass_mock_maker() {
+        NonFinalClass subClassMock = Mockito.mock(NonFinalClass.class, Mockito.withSettings().mockMaker(MockMakers.SUBCLASS));
+        Mockito.when(subClassMock.someMethod()).thenReturn("1");
+        assertEquals("1", subClassMock.someMethod());
+
+        SomeInterface interfaceMock = Mockito.mock(SomeInterface.class);
+        Mockito.when(interfaceMock.someMethod()).thenReturn("2");
+        assertEquals("2", interfaceMock.someMethod());
+    }
+
     private static final class FinalClass {
         String someMethod() {
             return "ORIGINAL";
@@ -190,6 +201,16 @@ public final class ProgrammaticMockMakerTest {
         Container subContainer() {
             return new Container();
         }
+    }
+
+    private static class NonFinalClass {
+        String someMethod() {
+            return "ORIGINAL";
+        }
+    }
+
+    private interface SomeInterface {
+        String someMethod();
     }
 
     public static class CustomMockMaker extends SubclassByteBuddyMockMaker {


### PR DESCRIPTION
`MockUtil::mockMakers` is a `ConcurrentHashMap` with random iteration order based on identify hash-code of `Class` keys.

```java
    private static final Map<Class<? extends MockMaker>, MockMaker> mockMakers =
            new ConcurrentHashMap<>(
                    Collections.singletonMap(defaultMockMaker.getClass(), defaultMockMaker));
```

Depending on the order the following code in `MockUtil::getMockHandlerOrNull` sometimes throws `AssertionError` after `MockMakers.SUBCLASS` was used:

```java
for (MockMaker mockMaker : mockMakers.values()) {
    MockHandler<?> handler = mockMaker.getHandler(mock);
    if (handler != null) {
        assert getMockMaker(handler.getMockSettings().getMockMaker()) == mockMaker;
        return handler;
    }
}
```

Specifically the following order causes issues:

<img width="1505" height="300" alt="image" src="https://github.com/user-attachments/assets/4e07a96a-b65c-4123-860a-031901ee02cb" />

The problem was previously reported in #3406 and #2823.

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style (run `./gradlew spotlessApply` for auto-formatting)
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should end with `Fixes #<issue number>` _if relevant_
