### PR TITLE
fix: do not mask exception

### DIFF
--- a/mockito-core/src/main/java/org/mockito/internal/exceptions/Reporter.java
+++ b/mockito-core/src/main/java/org/mockito/internal/exceptions/Reporter.java
@@ -14,6 +14,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.mockito.exceptions.base.MockitoAssertionError;
@@ -900,23 +902,40 @@ public class Reporter {
             Field field, Collection<?> mockCandidates) {
         List<String> mockNames =
                 mockCandidates.stream()
+                        .filter(MockUtil::isMock)
                         .map(MockUtil::getMockName)
                         .map(MockName::toString)
                         .collect(Collectors.toList());
-        return new MockitoException(
-                join(
-                        "Mockito couldn't inject mock dependency on field "
-                                + "'"
-                                + field
-                                + "' that is annotated with @InjectMocks in your test, ",
-                        "because there were multiple matching mocks (i.e. "
-                                + "fields annotated with @Mock and having matching type): "
-                                + String.join(", ", mockNames)
-                                + ".",
-                        "If you have multiple fields of same type in your class under test "
-                                + "then consider naming the @Mock fields "
-                                + "identically to the respective class under test's fields, "
-                                + "so Mockito can match them by name."));
+        Set<String> spyClasses =
+                mockCandidates.stream()
+                        .filter(Predicate.not(MockUtil::isMock))
+                        .map(Object::getClass)
+                        .map(Class::toString)
+                        .collect(Collectors.toSet());
+
+        List<String> messageRows =
+                new ArrayList<>(
+                        List.of(
+                                "Mockito couldn't inject mock dependency on field "
+                                        + "'"
+                                        + field
+                                        + "' that is annotated with @InjectMocks in your test, ",
+                                "because there were multiple matching mocks or spies (i.e. "
+                                        + "fields annotated with @Mock or @Spy and having matching type)."));
+
+        if (!mockNames.isEmpty()) {
+            messageRows.add("Mocks:" + String.join(", ", mockNames));
+        }
+        if (!spyClasses.isEmpty()) {
+            messageRows.add("Spies:" + String.join(", ", spyClasses));
+        }
+        messageRows.add(
+                "If you have multiple fields of same type in your class under test "
+                        + "then consider naming the @Mock fields "
+                        + "identically to the respective class under test's fields, "
+                        + "so Mockito can match them by name.");
+
+        return new MockitoException(join("\n", "", messageRows));
     }
 
     private static String exceptionCauseMessageIfAvailable(Exception details) {


### PR DESCRIPTION
Prevent exception to be thrown when generating exception message in moreThanOneMockCandidate. 

Fixes #285 as far as I understand

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style (run `./gradlew spotlessApply` for auto-formatting)
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should end with `Fixes #<issue number>` _if relevant_
