### PR TITLE
Replaces raw generic types with type parameters

### DIFF
--- a/mockito-core/src/main/java/org/mockito/MockingDetails.java
+++ b/mockito-core/src/main/java/org/mockito/MockingDetails.java
@@ -117,7 +117,7 @@ public interface MockingDetails {
      * @return mock handler instance of this mock
      * @since 2.10.0
      */
-    MockHandler getMockHandler();
+    MockHandler<?> getMockHandler();
 
     /**
      * Returns the mock object which is associated with this this instance of {@link MockingDetails}.

--- a/mockito-core/src/main/java/org/mockito/internal/MockedStaticImpl.java
+++ b/mockito-core/src/main/java/org/mockito/internal/MockedStaticImpl.java
@@ -61,7 +61,7 @@ public final class MockedStaticImpl<T> extends ScopedMockImpl<MockMaker.StaticMo
         assertNotClosed();
 
         MockingDetails mockingDetails = Mockito.mockingDetails(control.getType());
-        MockHandler handler = mockingDetails.getMockHandler();
+        MockHandler<?> handler = mockingDetails.getMockHandler();
 
         VerificationStartedNotifier.notifyVerificationStarted(
                 handler.getMockSettings().getVerificationStartedListeners(), mockingDetails);

--- a/mockito-core/src/main/java/org/mockito/internal/MockitoCore.java
+++ b/mockito-core/src/main/java/org/mockito/internal/MockitoCore.java
@@ -158,7 +158,7 @@ public class MockitoCore {
             throw notAMockPassedToVerify(mock.getClass());
         }
         assertNotStubOnlyMock(mock);
-        MockHandler handler = mockingDetails.getMockHandler();
+        MockHandler<?> handler = mockingDetails.getMockHandler();
         mock =
                 (T)
                         VerificationStartedNotifier.notifyVerificationStarted(

--- a/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMaker.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMaker.java
@@ -37,13 +37,13 @@ public class ByteBuddyMockMaker implements ClassCreatingMockMaker {
     }
 
     @Override
-    public <T> T createMock(MockCreationSettings<T> settings, MockHandler handler) {
+    public <T> T createMock(MockCreationSettings<T> settings, MockHandler<T> handler) {
         return subclassByteBuddyMockMaker.createMock(settings, handler);
     }
 
     @Override
     public <T> Optional<T> createSpy(
-            MockCreationSettings<T> settings, MockHandler handler, T object) {
+            MockCreationSettings<T> settings, MockHandler<T> handler, T object) {
         return subclassByteBuddyMockMaker.createSpy(settings, handler, object);
     }
 
@@ -53,12 +53,13 @@ public class ByteBuddyMockMaker implements ClassCreatingMockMaker {
     }
 
     @Override
-    public MockHandler getHandler(Object mock) {
+    public MockHandler<?> getHandler(Object mock) {
         return subclassByteBuddyMockMaker.getHandler(mock);
     }
 
     @Override
-    public void resetMock(Object mock, MockHandler newHandler, MockCreationSettings settings) {
+    public void resetMock(
+            Object mock, MockHandler<?> newHandler, MockCreationSettings<?> settings) {
         subclassByteBuddyMockMaker.resetMock(mock, newHandler, settings);
     }
 
@@ -69,7 +70,7 @@ public class ByteBuddyMockMaker implements ClassCreatingMockMaker {
 
     @Override
     public <T> StaticMockControl<T> createStaticMock(
-            Class<T> type, MockCreationSettings<T> settings, MockHandler handler) {
+            Class<T> type, MockCreationSettings<T> settings, MockHandler<T> handler) {
         return subclassByteBuddyMockMaker.createStaticMock(type, settings, handler);
     }
 

--- a/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
@@ -52,13 +52,13 @@ public class InlineByteBuddyMockMaker
     }
 
     @Override
-    public <T> T createMock(MockCreationSettings<T> settings, MockHandler handler) {
+    public <T> T createMock(MockCreationSettings<T> settings, MockHandler<T> handler) {
         return inlineDelegateByteBuddyMockMaker.createMock(settings, handler);
     }
 
     @Override
     public <T> Optional<T> createSpy(
-            MockCreationSettings<T> settings, MockHandler handler, T instance) {
+            MockCreationSettings<T> settings, MockHandler<T> handler, T instance) {
         return inlineDelegateByteBuddyMockMaker.createSpy(settings, handler, instance);
     }
 
@@ -68,7 +68,8 @@ public class InlineByteBuddyMockMaker
     }
 
     @Override
-    public void resetMock(Object mock, MockHandler newHandler, MockCreationSettings settings) {
+    public void resetMock(
+            Object mock, MockHandler<?> newHandler, MockCreationSettings<?> settings) {
         inlineDelegateByteBuddyMockMaker.resetMock(mock, newHandler, settings);
     }
 
@@ -79,7 +80,7 @@ public class InlineByteBuddyMockMaker
 
     @Override
     public <T> StaticMockControl<T> createStaticMock(
-            Class<T> type, MockCreationSettings<T> settings, MockHandler handler) {
+            Class<T> type, MockCreationSettings<T> settings, MockHandler<T> handler) {
         return inlineDelegateByteBuddyMockMaker.createStaticMock(type, settings, handler);
     }
 
@@ -95,7 +96,7 @@ public class InlineByteBuddyMockMaker
 
     @Override
     public <T> SingletonMockControl<T> createSingletonMock(
-            T instance, MockCreationSettings<T> settings, MockHandler handler) {
+            T instance, MockCreationSettings<T> settings, MockHandler<T> handler) {
         return inlineDelegateByteBuddyMockMaker.createSingletonMock(instance, settings, handler);
     }
 

--- a/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
@@ -368,13 +368,13 @@ class InlineDelegateByteBuddyMockMaker
     }
 
     @Override
-    public <T> T createMock(MockCreationSettings<T> settings, MockHandler handler) {
+    public <T> T createMock(MockCreationSettings<T> settings, MockHandler<T> handler) {
         return doCreateMock(settings, handler, false);
     }
 
     @Override
     public <T> Optional<T> createSpy(
-            MockCreationSettings<T> settings, MockHandler handler, T object) {
+            MockCreationSettings<T> settings, MockHandler<T> handler, T object) {
         if (object == null) {
             throw new MockitoConfigurationException("Spy instance must not be null");
         }
@@ -388,7 +388,7 @@ class InlineDelegateByteBuddyMockMaker
 
     private <T> T doCreateMock(
             MockCreationSettings<T> settings,
-            MockHandler handler,
+            MockHandler<T> handler,
             boolean nullOnNonInlineConstruction) {
         Class<? extends T> type = createMockType(settings);
 
@@ -536,7 +536,8 @@ class InlineDelegateByteBuddyMockMaker
     }
 
     @Override
-    public void resetMock(Object mock, MockHandler newHandler, MockCreationSettings settings) {
+    public void resetMock(
+            Object mock, MockHandler<?> newHandler, MockCreationSettings<?> settings) {
         MockMethodInterceptor mockMethodInterceptor =
                 new MockMethodInterceptor(newHandler, settings);
         if (mock instanceof Class<?>) {
@@ -624,7 +625,7 @@ class InlineDelegateByteBuddyMockMaker
 
     @Override
     public <T> StaticMockControl<T> createStaticMock(
-            Class<T> type, MockCreationSettings<T> settings, MockHandler handler) {
+            Class<T> type, MockCreationSettings<T> settings, MockHandler<T> handler) {
         if (type == ConcurrentHashMap.class) {
             throw new MockitoException(
                     "It is not possible to mock static methods of ConcurrentHashMap "
@@ -684,7 +685,7 @@ class InlineDelegateByteBuddyMockMaker
     @Override
     @SuppressWarnings("unchecked")
     public <T> SingletonMockControl<T> createSingletonMock(
-            T instance, MockCreationSettings<T> settings, MockHandler handler) {
+            T instance, MockCreationSettings<T> settings, MockHandler<T> handler) {
         if (instance.getClass() == ConcurrentHashMap.class) {
             throw new MockitoException(
                     "It is not possible to create a singleton mock of ConcurrentHashMap "

--- a/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassByteBuddyMockMaker.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassByteBuddyMockMaker.java
@@ -41,7 +41,7 @@ public class SubclassByteBuddyMockMaker implements ClassCreatingMockMaker {
     }
 
     @Override
-    public <T> T createMock(MockCreationSettings<T> settings, MockHandler handler) {
+    public <T> T createMock(MockCreationSettings<T> settings, MockHandler<T> handler) {
         Class<? extends T> mockedProxyType = createMockType(settings);
 
         Instantiator instantiator = Plugins.getInstantiatorProvider().getInstantiator(settings);
@@ -146,7 +146,7 @@ public class SubclassByteBuddyMockMaker implements ClassCreatingMockMaker {
     }
 
     @Override
-    public MockHandler getHandler(Object mock) {
+    public MockHandler<?> getHandler(Object mock) {
         if (!(mock instanceof MockAccess)) {
             return null;
         }
@@ -154,7 +154,8 @@ public class SubclassByteBuddyMockMaker implements ClassCreatingMockMaker {
     }
 
     @Override
-    public void resetMock(Object mock, MockHandler newHandler, MockCreationSettings settings) {
+    public void resetMock(
+            Object mock, MockHandler<?> newHandler, MockCreationSettings<?> settings) {
         ((MockAccess) mock).setMockitoInterceptor(new MockMethodInterceptor(newHandler, settings));
     }
 

--- a/mockito-core/src/main/java/org/mockito/internal/creation/proxy/ProxyMockMaker.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/proxy/ProxyMockMaker.java
@@ -33,7 +33,7 @@ public class ProxyMockMaker implements MockMaker {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> T createMock(MockCreationSettings<T> settings, MockHandler handler) {
+    public <T> T createMock(MockCreationSettings<T> settings, MockHandler<T> handler) {
         boolean object = settings.getTypeToMock() == Object.class;
         Class<?>[] ifaces = new Class<?>[settings.getExtraInterfaces().size() + (object ? 0 : 1)];
         int index = 0;
@@ -77,7 +77,7 @@ public class ProxyMockMaker implements MockMaker {
     }
 
     @Override
-    public MockHandler getHandler(Object mock) {
+    public MockHandler<?> getHandler(Object mock) {
         if (!Proxy.isProxyClass(mock.getClass())) {
             return null;
         }
@@ -89,7 +89,8 @@ public class ProxyMockMaker implements MockMaker {
     }
 
     @Override
-    public void resetMock(Object mock, MockHandler newHandler, MockCreationSettings settings) {
+    public void resetMock(
+            Object mock, MockHandler<?> newHandler, MockCreationSettings<?> settings) {
         ((MockInvocationHandler) Proxy.getInvocationHandler(mock)).handler.set(newHandler);
     }
 

--- a/mockito-core/src/main/java/org/mockito/internal/framework/DisabledMockHandler.java
+++ b/mockito-core/src/main/java/org/mockito/internal/framework/DisabledMockHandler.java
@@ -27,8 +27,8 @@ import java.util.Set;
  * Throws {@link DisabledMockException} when a mock is accessed after it has been disabled by
  * {@link MockitoFramework#clearInlineMocks()}.
  */
-public class DisabledMockHandler implements MockHandler {
-    public static MockHandler HANDLER = new DisabledMockHandler();
+public class DisabledMockHandler implements MockHandler<Object> {
+    public static MockHandler<Object> HANDLER = new DisabledMockHandler();
 
     private DisabledMockHandler() {
         // private, use HANDLER instead
@@ -40,7 +40,7 @@ public class DisabledMockHandler implements MockHandler {
     }
 
     @Override
-    public MockCreationSettings getMockSettings() {
+    public MockCreationSettings<Object> getMockSettings() {
         return DisabledMockCreationSettings.INSTANCE;
     }
 
@@ -50,7 +50,7 @@ public class DisabledMockHandler implements MockHandler {
     }
 
     private static class DisabledMockCreationSettings
-            implements Serializable, MockCreationSettings {
+            implements Serializable, MockCreationSettings<Object> {
         private static DisabledMockCreationSettings INSTANCE = new DisabledMockCreationSettings();
 
         private DisabledMockCreationSettings() {
@@ -58,7 +58,7 @@ public class DisabledMockHandler implements MockHandler {
         }
 
         @Override
-        public Class getTypeToMock() {
+        public Class<Object> getTypeToMock() {
             throw new DisabledMockException();
         }
 

--- a/mockito-core/src/main/java/org/mockito/internal/invocation/DefaultInvocationFactory.java
+++ b/mockito-core/src/main/java/org/mockito/internal/invocation/DefaultInvocationFactory.java
@@ -20,9 +20,9 @@ public class DefaultInvocationFactory implements InvocationFactory {
 
     public Invocation createInvocation(
             Object target,
-            MockCreationSettings settings,
+            MockCreationSettings<?> settings,
             Method method,
-            final Callable realMethod,
+            final Callable<?> realMethod,
             Object... args) {
         RealMethod superMethod = new RealMethod.FromCallable(realMethod);
         return createInvocation(target, settings, method, superMethod, args);
@@ -31,9 +31,9 @@ public class DefaultInvocationFactory implements InvocationFactory {
     @Override
     public Invocation createInvocation(
             Object target,
-            MockCreationSettings settings,
+            MockCreationSettings<?> settings,
             Method method,
-            RealMethodBehavior realMethod,
+            RealMethodBehavior<?> realMethod,
             Object... args) {
         RealMethod superMethod = new RealMethod.FromBehavior(realMethod);
         return createInvocation(target, settings, method, superMethod, args);
@@ -41,7 +41,7 @@ public class DefaultInvocationFactory implements InvocationFactory {
 
     private Invocation createInvocation(
             Object target,
-            MockCreationSettings settings,
+            MockCreationSettings<?> settings,
             Method method,
             RealMethod superMethod,
             Object[] args) {
@@ -53,7 +53,7 @@ public class DefaultInvocationFactory implements InvocationFactory {
             Method invokedMethod,
             Object[] arguments,
             RealMethod realMethod,
-            MockCreationSettings settings,
+            MockCreationSettings<?> settings,
             Location location) {
         return new InterceptedInvocation(
                 new MockWeakReference<Object>(mock),
@@ -69,12 +69,13 @@ public class DefaultInvocationFactory implements InvocationFactory {
             Method invokedMethod,
             Object[] arguments,
             RealMethod realMethod,
-            MockCreationSettings settings) {
+            MockCreationSettings<?> settings) {
         return createInvocation(
                 mock, invokedMethod, arguments, realMethod, settings, LocationFactory.create());
     }
 
-    private static MockitoMethod createMockitoMethod(Method method, MockCreationSettings settings) {
+    private static MockitoMethod createMockitoMethod(
+            Method method, MockCreationSettings<?> settings) {
         if (settings.isSerializable()) {
             return new SerializableMethod(method);
         } else {

--- a/mockito-core/src/main/java/org/mockito/internal/invocation/RealMethod.java
+++ b/mockito-core/src/main/java/org/mockito/internal/invocation/RealMethod.java
@@ -34,7 +34,7 @@ public interface RealMethod extends Serializable {
     class FromCallable extends FromBehavior implements RealMethod {
         public FromCallable(final Callable<?> callable) {
             super(
-                    new InvocationFactory.RealMethodBehavior() {
+                    new InvocationFactory.RealMethodBehavior<Object>() {
                         @Override
                         public Object call() throws Throwable {
                             return callable.call();

--- a/mockito-core/src/main/java/org/mockito/internal/listeners/StubbingLookupNotifier.java
+++ b/mockito-core/src/main/java/org/mockito/internal/listeners/StubbingLookupNotifier.java
@@ -36,13 +36,13 @@ public final class StubbingLookupNotifier {
         private final Invocation invocation;
         private final Stubbing stubbing;
         private final Collection<Stubbing> allStubbings;
-        private final MockCreationSettings mockSettings;
+        private final MockCreationSettings<?> mockSettings;
 
         public Event(
                 Invocation invocation,
                 Stubbing stubbing,
                 Collection<Stubbing> allStubbings,
-                MockCreationSettings mockSettings) {
+                MockCreationSettings<?> mockSettings) {
             this.invocation = invocation;
             this.stubbing = stubbing;
             this.allStubbings = allStubbings;
@@ -65,7 +65,7 @@ public final class StubbingLookupNotifier {
         }
 
         @Override
-        public MockCreationSettings getMockSettings() {
+        public MockCreationSettings<?> getMockSettings() {
             return mockSettings;
         }
     }

--- a/mockito-core/src/main/java/org/mockito/internal/listeners/VerificationStartedNotifier.java
+++ b/mockito-core/src/main/java/org/mockito/internal/listeners/VerificationStartedNotifier.java
@@ -5,7 +5,6 @@
 package org.mockito.internal.listeners;
 
 import java.util.List;
-import java.util.Set;
 
 import org.mockito.MockingDetails;
 import org.mockito.Mockito;
@@ -53,7 +52,7 @@ public final class VerificationStartedNotifier {
                                 + ValuePrinter.print(mock)
                                 + ".\n ");
             }
-            MockCreationSettings originalMockSettings =
+            MockCreationSettings<?> originalMockSettings =
                     this.originalMockingDetails.getMockCreationSettings();
             assertCompatibleTypes(mock, originalMockSettings);
             this.mock = mock;
@@ -65,8 +64,8 @@ public final class VerificationStartedNotifier {
         }
     }
 
-    static void assertCompatibleTypes(Object mock, MockCreationSettings originalSettings) {
-        Class originalType = originalSettings.getTypeToMock();
+    static void assertCompatibleTypes(Object mock, MockCreationSettings<?> originalSettings) {
+        Class<?> originalType = originalSettings.getTypeToMock();
         if (!originalType.isInstance(mock)) {
             throw Reporter.methodDoesNotAcceptParameter(
                     "VerificationStartedEvent.setMock",
@@ -79,7 +78,7 @@ public final class VerificationStartedNotifier {
                             + ".\n ");
         }
 
-        for (Class iface : (Set<Class>) originalSettings.getExtraInterfaces()) {
+        for (Class<?> iface : originalSettings.getExtraInterfaces()) {
             if (!iface.isInstance(mock)) {
                 throw Reporter.methodDoesNotAcceptParameter(
                         "VerificationStartedEvent.setMock",

--- a/mockito-core/src/main/java/org/mockito/internal/progress/MockingProgress.java
+++ b/mockito-core/src/main/java/org/mockito/internal/progress/MockingProgress.java
@@ -41,9 +41,9 @@ public interface MockingProgress {
 
     ArgumentMatcherStorage getArgumentMatcherStorage();
 
-    void mockingStarted(Object mock, MockCreationSettings settings);
+    void mockingStarted(Object mock, MockCreationSettings<?> settings);
 
-    void mockingStarted(Class<?> mock, MockCreationSettings settings);
+    void mockingStarted(Class<?> mock, MockCreationSettings<?> settings);
 
     void addListener(MockitoListener listener);
 

--- a/mockito-core/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
+++ b/mockito-core/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
@@ -163,7 +163,7 @@ public class MockingProgressImpl implements MockingProgress {
     }
 
     @Override
-    public void mockingStarted(Object mock, MockCreationSettings settings) {
+    public void mockingStarted(Object mock, MockCreationSettings<?> settings) {
         for (MockitoListener listener : listeners) {
             if (listener instanceof MockCreationListener) {
                 ((MockCreationListener) listener).onMockCreated(mock, settings);
@@ -173,7 +173,7 @@ public class MockingProgressImpl implements MockingProgress {
     }
 
     @Override
-    public void mockingStarted(Class<?> mock, MockCreationSettings settings) {
+    public void mockingStarted(Class<?> mock, MockCreationSettings<?> settings) {
         for (MockitoListener listener : listeners) {
             if (listener instanceof MockCreationListener) {
                 ((MockCreationListener) listener).onStaticMockCreated(mock, settings);

--- a/mockito-core/src/main/java/org/mockito/internal/util/DefaultMockingDetails.java
+++ b/mockito-core/src/main/java/org/mockito/internal/util/DefaultMockingDetails.java
@@ -64,7 +64,7 @@ public class DefaultMockingDetails implements MockingDetails {
     }
 
     @Override
-    public MockHandler getMockHandler() {
+    public MockHandler<?> getMockHandler() {
         return mockHandler();
     }
 

--- a/mockito-core/src/main/java/org/mockito/internal/util/MockUtil.java
+++ b/mockito-core/src/main/java/org/mockito/internal/util/MockUtil.java
@@ -80,7 +80,7 @@ public class MockUtil {
 
     public static <T> T createMock(MockCreationSettings<T> settings) {
         MockMaker mockMaker = getMockMaker(settings.getMockMaker());
-        MockHandler mockHandler = createMockHandler(settings);
+        MockHandler<T> mockHandler = createMockHandler(settings);
 
         Object spiedInstance = settings.getSpiedInstance();
 
@@ -103,16 +103,16 @@ public class MockUtil {
     }
 
     public static void resetMock(Object mock) {
-        MockHandler oldHandler = getMockHandler(mock);
-        MockCreationSettings settings = oldHandler.getMockSettings();
-        MockHandler newHandler = createMockHandler(settings);
+        MockHandler<?> oldHandler = getMockHandler(mock);
+        MockCreationSettings<?> settings = oldHandler.getMockSettings();
+        MockHandler<?> newHandler = createMockHandler(settings);
 
         mock = resolve(mock);
         getMockMaker(settings.getMockMaker()).resetMock(mock, newHandler, settings);
     }
 
     public static MockHandler<?> getMockHandler(Object mock) {
-        MockHandler handler = getMockHandlerOrNull(mock);
+        MockHandler<?> handler = getMockHandlerOrNull(mock);
         if (handler != null) {
             return handler;
         } else {
@@ -187,13 +187,13 @@ public class MockUtil {
     public static void maybeRedefineMockName(Object mock, String newName) {
         MockName mockName = getMockName(mock);
         // TODO SF hacky...
-        MockCreationSettings mockSettings = getMockHandler(mock).getMockSettings();
+        MockCreationSettings<?> mockSettings = getMockHandler(mock).getMockSettings();
         if (mockName.isDefault() && mockSettings instanceof CreationSettings) {
             ((CreationSettings) mockSettings).setMockName(new MockNameImpl(newName));
         }
     }
 
-    public static MockCreationSettings getMockSettings(Object mock) {
+    public static MockCreationSettings<?> getMockSettings(Object mock) {
         return getMockHandler(mock).getMockSettings();
     }
 

--- a/mockito-core/src/main/java/org/mockito/invocation/InvocationFactory.java
+++ b/mockito-core/src/main/java/org/mockito/invocation/InvocationFactory.java
@@ -49,8 +49,8 @@ public interface InvocationFactory {
      */
     Invocation createInvocation(
             Object target,
-            MockCreationSettings settings,
+            MockCreationSettings<?> settings,
             Method method,
-            RealMethodBehavior realMethod,
+            RealMethodBehavior<?> realMethod,
             Object... args);
 }

--- a/mockito-core/src/main/java/org/mockito/listeners/MockCreationListener.java
+++ b/mockito-core/src/main/java/org/mockito/listeners/MockCreationListener.java
@@ -18,7 +18,7 @@ public interface MockCreationListener extends MockitoListener {
      * @param mock created mock object
      * @param settings the settings used for creation
      */
-    void onMockCreated(Object mock, MockCreationSettings settings);
+    void onMockCreated(Object mock, MockCreationSettings<?> settings);
 
     /**
      * Static mock object was just created.
@@ -26,5 +26,5 @@ public interface MockCreationListener extends MockitoListener {
      * @param mock the type being mocked
      * @param settings the settings used for creation
      */
-    default void onStaticMockCreated(Class<?> mock, MockCreationSettings settings) {}
+    default void onStaticMockCreated(Class<?> mock, MockCreationSettings<?> settings) {}
 }

--- a/mockito-core/src/main/java/org/mockito/listeners/StubbingLookupEvent.java
+++ b/mockito-core/src/main/java/org/mockito/listeners/StubbingLookupEvent.java
@@ -39,5 +39,5 @@ public interface StubbingLookupEvent {
      * @return Settings of the mock object that we are invoking
      * @since 2.24.6
      */
-    MockCreationSettings getMockSettings();
+    MockCreationSettings<?> getMockSettings();
 }

--- a/mockito-core/src/main/java/org/mockito/plugins/MockMaker.java
+++ b/mockito-core/src/main/java/org/mockito/plugins/MockMaker.java
@@ -85,7 +85,7 @@ public interface MockMaker {
      * @return The mock instance.
      * @since 1.9.5
      */
-    <T> T createMock(MockCreationSettings<T> settings, MockHandler handler);
+    <T> T createMock(MockCreationSettings<T> settings, MockHandler<T> handler);
 
     /**
      * By implementing this method, a mock maker can optionally support the creation of spies where all fields
@@ -102,7 +102,7 @@ public interface MockMaker {
      * @since 3.5.0
      */
     default <T> Optional<T> createSpy(
-            MockCreationSettings<T> settings, MockHandler handler, T instance) {
+            MockCreationSettings<T> settings, MockHandler<T> handler, T instance) {
         return Optional.empty();
     }
 
@@ -116,7 +116,7 @@ public interface MockMaker {
      *   This means the passed object is not really a Mockito mock.
      * @since 1.9.5
      */
-    MockHandler getHandler(Object mock);
+    MockHandler<?> getHandler(Object mock);
 
     /**
      * Replaces the existing handler on {@code mock} with {@code newHandler}.
@@ -132,7 +132,7 @@ public interface MockMaker {
      * @param settings The mock settings - should you need to access some of the mock creation details.
      * @since 1.9.5
      */
-    void resetMock(Object mock, MockHandler newHandler, MockCreationSettings settings);
+    void resetMock(Object mock, MockHandler<?> newHandler, MockCreationSettings<?> settings);
 
     /**
      * Indicates if the given type can be mocked by this mockmaker.
@@ -164,7 +164,7 @@ public interface MockMaker {
      * @since 3.4.0
      */
     default <T> StaticMockControl<T> createStaticMock(
-            Class<T> type, MockCreationSettings<T> settings, MockHandler handler) {
+            Class<T> type, MockCreationSettings<T> settings, MockHandler<T> handler) {
         throw new MockitoException(
                 join(
                         "The used MockMaker "
@@ -218,7 +218,7 @@ public interface MockMaker {
      * @since 5.22.0
      */
     default <T> SingletonMockControl<T> createSingletonMock(
-            T instance, MockCreationSettings<T> settings, MockHandler handler) {
+            T instance, MockCreationSettings<T> settings, MockHandler<T> handler) {
         throw new MockitoException(
                 join(
                         "The used MockMaker "

--- a/mockito-core/src/test/java/org/mockito/internal/creation/AbstractMockMakerTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/creation/AbstractMockMakerTest.java
@@ -35,8 +35,8 @@ public abstract class AbstractMockMakerTest<MM extends MockMaker, C> {
         C mockOne = mockMaker.createMock(settingsFor(target), dummyHandler());
         C mockTwo = mockMaker.createMock(settingsFor(target), dummyHandler());
 
-        MockHandler handlerOne = mockMaker.getHandler(mockOne);
-        MockHandler handlerTwo = mockMaker.getHandler(mockTwo);
+        MockHandler<?> handlerOne = mockMaker.getHandler(mockOne);
+        MockHandler<?> handlerTwo = mockMaker.getHandler(mockTwo);
 
         assertThat(handlerOne).isNotSameAs(handlerTwo);
     }
@@ -80,8 +80,9 @@ public abstract class AbstractMockMakerTest<MM extends MockMaker, C> {
         return mockSettings;
     }
 
-    protected static MockHandler dummyHandler() {
-        return new DummyMockHandler();
+    @SuppressWarnings("unchecked")
+    protected static <T> MockHandler<T> dummyHandler() {
+        return (MockHandler<T>) new DummyMockHandler();
     }
 
     private static class DummyMockHandler implements MockHandler<Object> {

--- a/mockito-core/src/test/java/org/mockitointegration/DeferMockMakersClassLoadingTest.java
+++ b/mockito-core/src/test/java/org/mockitointegration/DeferMockMakersClassLoadingTest.java
@@ -64,17 +64,18 @@ public class DeferMockMakersClassLoadingTest {
 
     public static class CustomMockMaker implements MockMaker {
         @Override
-        public <T> T createMock(MockCreationSettings<T> settings, MockHandler handler) {
+        public <T> T createMock(MockCreationSettings<T> settings, MockHandler<T> handler) {
             return settings.getTypeToMock().cast(MY_MOCK);
         }
 
         @Override
-        public MockHandler getHandler(Object mock) {
+        public MockHandler<?> getHandler(Object mock) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public void resetMock(Object mock, MockHandler newHandler, MockCreationSettings settings) {
+        public void resetMock(
+                Object mock, MockHandler<?> newHandler, MockCreationSettings<?> settings) {
             throw new UnsupportedOperationException();
         }
 

--- a/mockito-integration-tests/extensions-tests/src/test/java/org/mockitousage/plugins/switcher/MyMockMaker.java
+++ b/mockito-integration-tests/extensions-tests/src/test/java/org/mockitousage/plugins/switcher/MyMockMaker.java
@@ -12,18 +12,19 @@ public class MyMockMaker extends SubclassByteBuddyMockMaker {
 
     static ThreadLocal<Object> explosive = new ThreadLocal<Object>();
 
-    public <T> T createMock(MockCreationSettings<T> settings, MockHandler handler) {
+    public <T> T createMock(MockCreationSettings<T> settings, MockHandler<T> handler) {
         if (explosive.get() != null) {
             throw new RuntimeException(MyMockMaker.class.getName());
         }
         return super.createMock(settings, handler);
     }
 
-    public MockHandler getHandler(Object mock) {
+    public MockHandler<?> getHandler(Object mock) {
         return super.getHandler(mock);
     }
 
-    public void resetMock(Object mock, MockHandler newHandler, MockCreationSettings settings) {
+    public void resetMock(
+            Object mock, MockHandler<?> newHandler, MockCreationSettings<?> settings) {
         super.resetMock(mock, newHandler, settings);
     }
 

--- a/mockito-integration-tests/programmatic-tests/src/test/java/org/mockito/ProgrammaticMockMakerTest.java
+++ b/mockito-integration-tests/programmatic-tests/src/test/java/org/mockito/ProgrammaticMockMakerTest.java
@@ -159,7 +159,9 @@ public final class ProgrammaticMockMakerTest {
 
     @Test
     public void test_interface_after_subclass_mock_maker() {
-        NonFinalClass subClassMock = Mockito.mock(NonFinalClass.class, Mockito.withSettings().mockMaker(MockMakers.SUBCLASS));
+        NonFinalClass subClassMock =
+                Mockito.mock(
+                        NonFinalClass.class, Mockito.withSettings().mockMaker(MockMakers.SUBCLASS));
         Mockito.when(subClassMock.someMethod()).thenReturn("1");
         assertEquals("1", subClassMock.someMethod());
 
@@ -215,7 +217,7 @@ public final class ProgrammaticMockMakerTest {
 
     public static class CustomMockMaker extends SubclassByteBuddyMockMaker {
         @Override
-        public <T> T createMock(MockCreationSettings<T> settings, MockHandler handler) {
+        public <T> T createMock(MockCreationSettings<T> settings, MockHandler<T> handler) {
             throw new RuntimeException("CUSTOM MOCK MAKER");
         }
     }


### PR DESCRIPTION
Eliminates raw type usages of `MockHandler`, `MockCreationSettings`, and `RealMethodBehavior` replacing them with properly parameterized types.

The benefits of the changes are stronger compile-time type safety (although most of the places is not possible and `<?>` is used, for others like `MockHandler<T>` in createMock it makes explicit that the handler is tied to the mock's type). Also, it provides cleaner IDE experience (without raw type warnings).

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style (run `./gradlew spotlessApply` for auto-formatting)
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should end with `Fixes #<issue number>` _if relevant_
