### PR TITLE
Upgrade Android Gradle Plugin to 8.13.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
     strategy:
       matrix:
         # Minimum supported and maximum available.
-        android-api: [ 28, 33 ]
+        android-api: [ 28, 33, 36 ]
 
     # All build steps
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,8 +160,8 @@ jobs:
           adb logcat "*:S MonitoringInstr:V AndroidJUnitRunner:V TestRequestBuilder:V TestExecutor:V TestRunner:V" --format=color & echo $! > logcat_console.pid
 
           echo 0 > gradle.exit # Set a default exit code.
-          # Run the actual tests (suppress build failures by saving the exit code).
-          ./gradlew :mockito-integration-tests:android-tests:connectedCheck --no-daemon --no-build-cache || echo $? > gradle.exit
+          # Run the actual tests and generate coverage report including mockito-core classes.
+          ./gradlew :mockito-integration-tests:android-tests:connectedCheck :mockito-integration-tests:android-tests:createMockitoCoverageReport --no-daemon --no-build-cache || echo $? > gradle.exit
 
           # Stop capturing logcat output.
           kill $(cat logcat_file.pid)    || echo "::warning file=.github/workflows/ci.yml::Logcat process $(cat logcat_file.pid) didn't exist."
@@ -179,13 +179,12 @@ jobs:
           ${{ github.workspace }}/emulator.log
           ${{ github.workspace }}/emulator-startup.log
 
-    # :mockito-integration-tests:android-tests:connectedCheck (which depends on :mockito-integration-tests:android-tests:createDebugAndroidTestCoverageReport) already generated coverage report.
     - name: 6. Upload coverage report
       uses: codecov/codecov-action@v5
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
-        files: mockito-integration-tests/android-tests/build/reports/coverage/android-tests/debug/connected/report.xml
+        files: mockito-integration-tests/android-tests/build/reports/jacoco/createMockitoCoverageReport/createMockitoCoverageReport.xml
         fail_ci_if_error: true
 
   #

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ out
 classes
 .gradletasknamecache
 *.log
+local.properties
 
 # Used to check reproducibility of Mockito jars
 checksums/

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ gradleplugin-aQute-bnd = "7.1.0"
 gradleplugin-errorprone = "4.3.0"
 gradleplugin-spotless = "8.0.0"
 
-gradleplugin-android = "7.4.2"
+gradleplugin-android = "8.13.2"
 
 [libraries]
 android-junit = { module = "androidx.test.ext:junit", version = "1.2.1" }

--- a/mockito-extensions/mockito-android/build.gradle.kts
+++ b/mockito-extensions/mockito-android/build.gradle.kts
@@ -12,6 +12,10 @@ android {
     defaultConfig {
         minSdk = 21
     }
+
+    publishing {
+        singleVariant("release")
+    }
 }
 
 dependencies {

--- a/mockito-integration-tests/android-tests/build.gradle.kts
+++ b/mockito-integration-tests/android-tests/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.android.build.gradle.internal.coverage.JacocoReportTask
-
 // Module-level android configuration.
 // https://developer.android.com/build/migrate-to-catalogs
 
@@ -26,27 +24,6 @@ android {
         debug {
             enableUnitTestCoverage = true
             enableAndroidTestCoverage = true
-        }
-    }
-    afterEvaluate {
-        // Enable coverage of mockito classes which are not part of this module.
-        // Without these added classFileCollection dependencies the coverage data/report is empty.
-        tasks.named<JacocoReportTask>("createDebugAndroidTestCoverageReport") jacocoTask@{
-            // Clear the production code of this module: src/main/java, it has no mockito-user-visible code.
-            classFileCollection.setFrom()
-            rootProject.allprojects currentProject@{
-                plugins.withId("java") {
-                    val sourceSets = this@currentProject.sourceSets
-                    // Mimic org.gradle.testing.jacoco.tasks.JacocoReportBase.sourceSets().
-                    // Not possible to set task.javaSources because it's initialized with setDisallowChanges.
-                    //task.javaSources.add({ [ sourceSets.main.allJava.srcDirs ] })
-                    this@jacocoTask.classFileCollection.from(
-                        sourceSets.named("main").get().output.asFileTree.matching {
-                            exclude("**/internal/util/concurrent/**")
-                        }
-                    )
-                }
-            }
         }
     }
 
@@ -80,8 +57,6 @@ configurations.testImplementation {
 dependencies {
     implementation(libs.kotlin.stdlib)
 
-    // Add :android on the classpath so that AGP's jacoco setup thinks it's "production code to be tested".
-    // Essentially a way to say: tasks.createDebugAndroidTestCoverageReport.classFileCollection.from(project(":android"))
     runtimeOnly(project(":mockito-extensions:mockito-android"))
 
     testImplementation(project(":mockito-core"))
@@ -92,4 +67,40 @@ dependencies {
     androidTestImplementation(libs.android.runner)
     androidTestImplementation(libs.android.junit)
     androidTestImplementation(project(":mockito-extensions:mockito-android"))
+}
+
+// Coverage report that includes mockito-core classes (not just this module's classes).
+// AGP 8+ finalizes JacocoReportTask.classFileCollection, so we use a standard Gradle
+// JacocoReport task instead of modifying the AGP-internal task.
+tasks.register<JacocoReport>("createMockitoCoverageReport") {
+    dependsOn("createDebugAndroidTestCoverageReport")
+    group = "verification"
+    description = "Generates a Jacoco coverage report including mockito-core classes."
+
+    // Use coverage data produced by connected tests
+    executionData.setFrom(
+        fileTree(layout.buildDirectory.dir("outputs/code_coverage/debugAndroidTest/connected")) {
+            include("**/*.ec")
+        }
+    )
+
+    // Include compiled classes from all Java subprojects (mockito-core, etc.)
+    classDirectories.setFrom(
+        rootProject.allprojects.filter { it.plugins.hasPlugin("java") }.map { proj ->
+            proj.sourceSets["main"].output.asFileTree.matching {
+                exclude("**/internal/util/concurrent/**")
+            }
+        }
+    )
+
+    sourceDirectories.setFrom(
+        rootProject.allprojects.filter { it.plugins.hasPlugin("java") }.flatMap { proj ->
+            proj.sourceSets["main"].allJava.srcDirs
+        }
+    )
+
+    reports {
+        html.required.set(true)
+        xml.required.set(true)
+    }
 }


### PR DESCRIPTION
This fixes an issue where the Android integration tests would fail to run on an API 36 emulator due to an AGP compatibility issue.

I verified:
- Android Studio gradle sync succeeds
- `mockito-integration-tests/android-tests` still pass
- publish flow for `mockito-android` still succeeds: `./gradlew :mockito-extensions:mockito-android:publishAllPublicationsToLocalRepository`