### PR TITLE
Fixes #3814 : implement package-level clinit suppression

### DIFF
--- a/mockito-core/src/main/java/org/mockito/Mockito.java
+++ b/mockito-core/src/main/java/org/mockito/Mockito.java
@@ -1830,6 +1830,11 @@ import java.util.function.Function;
  *
  * When Mockito is used as a Java agent ({@code -javaagent}), you can suppress static initializers
  * ({@code <clinit>}) of specific classes via the system property {@code mockito.suppress.clinit}.
+ * The value is a comma-separated list where each entry is either an exact fully-qualified class name
+ * (e.g. {@code com.example.MyClass}) or a package wildcard ending in {@code .*}
+ * (e.g. {@code com.example.*}) that matches the package and all sub-packages.
+ * Only trailing {@code .*} wildcards are supported; middle wildcards like {@code com.*.bar.*} are
+ * <b>not</b> supported.
  * This causes all static fields in those classes to retain their JVM zero-value defaults
  * ({@code null}, {@code 0}, {@code false}, etc.) instead of running the static initialization block.
  *

--- a/mockito-core/src/main/java/org/mockito/internal/PremainAttach.java
+++ b/mockito-core/src/main/java/org/mockito/internal/PremainAttach.java
@@ -7,9 +7,9 @@ package org.mockito.internal;
 import org.mockito.internal.creation.bytebuddy.ClinitSuppressionTransformer;
 
 import java.lang.instrument.Instrumentation;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * Allows users to specify Mockito as a Java agent where the {@link Instrumentation}
@@ -28,10 +28,10 @@ public class PremainAttach {
         if (PremainAttach.instrumentation != null) {
             return;
         }
-        Set<String> classes =
-                parseSuppressClinitProperty(System.getProperty(SUPPRESS_CLINIT_PROPERTY));
-        if (!classes.isEmpty()) {
-            instrumentation.addTransformer(new ClinitSuppressionTransformer(classes), false);
+        Predicate<String> shouldSuppress =
+                buildClinitPredicate(System.getProperty(SUPPRESS_CLINIT_PROPERTY));
+        if (shouldSuppress != null) {
+            instrumentation.addTransformer(new ClinitSuppressionTransformer(shouldSuppress), false);
         }
         PremainAttach.instrumentation = instrumentation;
     }
@@ -41,23 +41,47 @@ public class PremainAttach {
     }
 
     /**
-     * Parses a comma-separated list of class names into a set, trimming whitespace from each
-     * entry and ignoring empty entries.
+     * Parses the {@code mockito.suppress.clinit} property value into a predicate over
+     * fully-qualified class names. The property is a comma-separated list; each entry is
+     * either an exact class name ({@code com.example.MyClass}) or a package wildcard ending
+     * in {@code .*} ({@code com.example.*}) that matches the package and all sub-packages.
+     * Whitespace is trimmed; empty entries are ignored.
      *
      * @param property the property value, may be {@code null}
-     * @return an unmodifiable set of class names
+     * @return the predicate, or {@code null} if no entries are configured
      */
-    static Set<String> parseSuppressClinitProperty(String property) {
+    static Predicate<String> buildClinitPredicate(String property) {
         if (property == null || property.trim().isEmpty()) {
-            return Collections.emptySet();
+            return null;
         }
-        Set<String> result = new HashSet<>();
+        Set<String> classes = new HashSet<>();
+        Set<String> packages = new HashSet<>();
         for (String name : property.split(",")) {
             String trimmed = name.trim();
-            if (!trimmed.isEmpty()) {
-                result.add(trimmed);
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            if (trimmed.endsWith(".*")) {
+                // Drop only the trailing '*' and keep the preceding '.' so that
+                // "com.example." correctly rejects "com.examples.Foo".
+                packages.add(trimmed.substring(0, trimmed.length() - 1));
+            } else {
+                classes.add(trimmed);
             }
         }
-        return Collections.unmodifiableSet(result);
+        if (classes.isEmpty() && packages.isEmpty()) {
+            return null;
+        }
+        return name -> {
+            if (classes.contains(name)) {
+                return true;
+            }
+            for (String prefix : packages) {
+                if (name.startsWith(prefix)) {
+                    return true;
+                }
+            }
+            return false;
+        };
     }
 }

--- a/mockito-core/src/main/java/org/mockito/internal/PremainAttach.java
+++ b/mockito-core/src/main/java/org/mockito/internal/PremainAttach.java
@@ -31,6 +31,10 @@ public class PremainAttach {
         Predicate<String> shouldSuppress =
                 buildClinitPredicate(System.getProperty(SUPPRESS_CLINIT_PROPERTY));
         if (shouldSuppress != null) {
+            System.err.println(
+                    "Suppressing static class initializer for '"
+                            + System.getProperty(SUPPRESS_CLINIT_PROPERTY)
+                            + "' (see mockito.suppress.clinit system property)");
             instrumentation.addTransformer(new ClinitSuppressionTransformer(shouldSuppress), false);
         }
         PremainAttach.instrumentation = instrumentation;

--- a/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/ClinitSuppressionTransformer.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/ClinitSuppressionTransformer.java
@@ -13,16 +13,16 @@ import net.bytebuddy.utility.OpenedClassReader;
 
 import java.lang.instrument.ClassFileTransformer;
 import java.security.ProtectionDomain;
-import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * A {@link ClassFileTransformer} that suppresses static initializers ({@code <clinit>}) for
- * specified classes at class-load time.
+ * classes selected by a predicate at class-load time.
  *
- * <p>When a class is first loaded (not retransformed) and its fully-qualified name appears in the
- * configured set, the transformer replaces the {@code <clinit>} method with an empty method body.
- * This causes all static fields to retain their JVM zero-value defaults ({@code null},
- * {@code 0}, {@code false}, etc.).
+ * <p>When a class is first loaded (not retransformed) and its fully-qualified name is accepted
+ * by the configured {@link Predicate}, the transformer replaces the {@code <clinit>} method
+ * with an empty method body. This causes all static fields to retain their JVM zero-value
+ * defaults ({@code null}, {@code 0}, {@code false}, etc.).
  *
  * <p>This transformer is registered at premain time when the system property
  * {@code mockito.suppress.clinit} is set. See {@link org.mockito.internal.PremainAttach} for
@@ -30,16 +30,16 @@ import java.util.Set;
  */
 public class ClinitSuppressionTransformer implements ClassFileTransformer {
 
-    private final Set<String> classNames;
+    private final Predicate<String> shouldSuppress;
 
     /**
      * Creates a new transformer.
      *
-     * @param classNames fully-qualified class names whose static initializers should be suppressed
-     *     (e.g. {@code "com.example.MyClass"})
+     * @param shouldSuppress predicate that returns {@code true} for fully-qualified class names
+     *     whose static initializers should be suppressed
      */
-    public ClinitSuppressionTransformer(Set<String> classNames) {
-        this.classNames = classNames;
+    public ClinitSuppressionTransformer(Predicate<String> shouldSuppress) {
+        this.shouldSuppress = shouldSuppress;
     }
 
     @Override
@@ -56,7 +56,7 @@ public class ClinitSuppressionTransformer implements ClassFileTransformer {
             return null;
         }
         String dotName = className.replace('/', '.');
-        if (!classNames.contains(dotName)) {
+        if (!shouldSuppress.test(dotName)) {
             return null;
         }
         return suppressClinit(classfileBuffer);

--- a/mockito-core/src/test/java/org/mockito/internal/PremainAttachTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/PremainAttachTest.java
@@ -6,7 +6,7 @@ package org.mockito.internal;
 
 import org.junit.Test;
 
-import java.util.Set;
+import java.util.function.Predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,44 +14,84 @@ public class PremainAttachTest {
 
     @Test
     public void parse_suppress_clinit_property_with_multiple_classes() {
-        Set<String> result =
-                PremainAttach.parseSuppressClinitProperty(
+        Predicate<String> matcher =
+                PremainAttach.buildClinitPredicate(
                         "com.example.ClassA,com.example.ClassB,com.example.ClassC");
 
-        assertThat(result)
-                .containsExactlyInAnyOrder(
-                        "com.example.ClassA", "com.example.ClassB", "com.example.ClassC");
+        assertThat(matcher).isNotNull();
+        assertThat(matcher.test("com.example.ClassA")).isTrue();
+        assertThat(matcher.test("com.example.ClassB")).isTrue();
+        assertThat(matcher.test("com.example.ClassC")).isTrue();
+        assertThat(matcher.test("com.example.Other")).isFalse();
     }
 
     @Test
     public void parse_suppress_clinit_property_with_whitespace_trimming() {
-        Set<String> result =
-                PremainAttach.parseSuppressClinitProperty(
-                        " com.example.ClassA , com.example.ClassB ");
+        Predicate<String> matcher =
+                PremainAttach.buildClinitPredicate(" com.example.ClassA , com.example.ClassB ");
 
-        assertThat(result).containsExactlyInAnyOrder("com.example.ClassA", "com.example.ClassB");
+        assertThat(matcher).isNotNull();
+        assertThat(matcher.test("com.example.ClassA")).isTrue();
+        assertThat(matcher.test("com.example.ClassB")).isTrue();
     }
 
     @Test
     public void parse_suppress_clinit_property_with_one_empty_class() {
-        Set<String> result =
-                PremainAttach.parseSuppressClinitProperty(
-                        " com.example.ClassA , , com.example.ClassB ");
+        Predicate<String> matcher =
+                PremainAttach.buildClinitPredicate(" com.example.ClassA , , com.example.ClassB ");
 
-        assertThat(result).containsExactlyInAnyOrder("com.example.ClassA", "com.example.ClassB");
+        assertThat(matcher).isNotNull();
+        assertThat(matcher.test("com.example.ClassA")).isTrue();
+        assertThat(matcher.test("com.example.ClassB")).isTrue();
     }
 
     @Test
-    public void parse_suppress_clinit_property_returns_empty_when_null() {
-        Set<String> result = PremainAttach.parseSuppressClinitProperty(null);
-
-        assertThat(result).isEmpty();
+    public void parse_suppress_clinit_property_returns_null_when_null() {
+        assertThat(PremainAttach.buildClinitPredicate(null)).isNull();
     }
 
     @Test
-    public void parse_suppress_clinit_property_returns_empty_when_blank() {
-        Set<String> result = PremainAttach.parseSuppressClinitProperty("   ");
+    public void parse_suppress_clinit_property_returns_null_when_blank() {
+        assertThat(PremainAttach.buildClinitPredicate("   ")).isNull();
+    }
 
-        assertThat(result).isEmpty();
+    @Test
+    public void parse_suppress_clinit_property_returns_null_when_only_empty_entries() {
+        assertThat(PremainAttach.buildClinitPredicate(" , , ")).isNull();
+    }
+
+    @Test
+    public void parse_suppress_clinit_property_with_package_wildcard_matches_recursively() {
+        Predicate<String> matcher = PremainAttach.buildClinitPredicate("com.example.*");
+
+        assertThat(matcher).isNotNull();
+        assertThat(matcher.test("com.example.Foo")).isTrue();
+        assertThat(matcher.test("com.example.bar.Baz")).isTrue();
+        assertThat(matcher.test("com.example.a.b.c.Deep")).isTrue();
+    }
+
+    @Test
+    public void parse_suppress_clinit_property_with_package_wildcard_rejects_sibling_packages() {
+        Predicate<String> matcher = PremainAttach.buildClinitPredicate("com.example.*");
+
+        assertThat(matcher).isNotNull();
+        assertThat(matcher.test("com.examples.Foo")).isFalse();
+        assertThat(matcher.test("com.exampleX.Foo")).isFalse();
+        assertThat(matcher.test("org.example.Foo")).isFalse();
+    }
+
+    @Test
+    public void parse_suppress_clinit_property_mixes_classes_and_packages() {
+        Predicate<String> matcher =
+                PremainAttach.buildClinitPredicate(
+                        "com.example.ClassA, com.package.*, com.example.ClassB");
+
+        assertThat(matcher).isNotNull();
+        assertThat(matcher.test("com.example.ClassA")).isTrue();
+        assertThat(matcher.test("com.example.ClassB")).isTrue();
+        assertThat(matcher.test("com.package.Anything")).isTrue();
+        assertThat(matcher.test("com.package.nested.Thing")).isTrue();
+        assertThat(matcher.test("com.example.ClassC")).isFalse();
+        assertThat(matcher.test("com.packages.Other")).isFalse();
     }
 }

--- a/mockito-core/src/test/java/org/mockito/internal/PremainAttachTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/PremainAttachTest.java
@@ -84,14 +84,23 @@ public class PremainAttachTest {
     public void parse_suppress_clinit_property_mixes_classes_and_packages() {
         Predicate<String> matcher =
                 PremainAttach.buildClinitPredicate(
-                        "com.example.ClassA, com.package.*, com.example.ClassB");
+                        "com.example.ClassA, com.pkg.*, com.example.ClassB");
 
         assertThat(matcher).isNotNull();
         assertThat(matcher.test("com.example.ClassA")).isTrue();
         assertThat(matcher.test("com.example.ClassB")).isTrue();
-        assertThat(matcher.test("com.package.Anything")).isTrue();
-        assertThat(matcher.test("com.package.nested.Thing")).isTrue();
+        assertThat(matcher.test("com.pkg.Anything")).isTrue();
+        assertThat(matcher.test("com.pkg.nested.Thing")).isTrue();
         assertThat(matcher.test("com.example.ClassC")).isFalse();
-        assertThat(matcher.test("com.packages.Other")).isFalse();
+        assertThat(matcher.test("com.pkgs.Other")).isFalse();
+    }
+
+    @Test
+    public void parse_suppress_clinit_property_with_middle_wildcard_is_not_supported() {
+        Predicate<String> matcher = PremainAttach.buildClinitPredicate("com.*.bar.*");
+
+        assertThat(matcher).isNotNull();
+        assertThat(matcher.test("com.foo.bar.Foo")).isFalse();
+        assertThat(matcher.test("com.any.bar.Bar")).isFalse();
     }
 }

--- a/mockito-core/src/test/java/org/mockito/internal/creation/bytebuddy/ClinitSuppressionTransformerTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/creation/bytebuddy/ClinitSuppressionTransformerTest.java
@@ -19,9 +19,9 @@ import java.io.ObjectOutputStream;
 import java.io.ObjectStreamClass;
 import java.io.Serializable;
 import java.lang.reflect.Field;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -136,8 +136,8 @@ public class ClinitSuppressionTransformerTest {
 
     @Test
     public void transformer_returns_null_for_non_matching_class() throws IOException {
-        Set<String> names = Collections.singleton("com.example.OtherClass");
-        ClinitSuppressionTransformer transformer = new ClinitSuppressionTransformer(names);
+        Predicate<String> matcher = "com.example.OtherClass"::equals;
+        ClinitSuppressionTransformer transformer = new ClinitSuppressionTransformer(matcher);
 
         byte[] result =
                 transformer.transform(
@@ -152,8 +152,8 @@ public class ClinitSuppressionTransformerTest {
 
     @Test
     public void transformer_returns_null_for_retransformation() throws IOException {
-        Set<String> names = Collections.singleton(WithClinit.class.getName());
-        ClinitSuppressionTransformer transformer = new ClinitSuppressionTransformer(names);
+        Predicate<String> matcher = WithClinit.class.getName()::equals;
+        ClinitSuppressionTransformer transformer = new ClinitSuppressionTransformer(matcher);
 
         byte[] result =
                 transformer.transform(
@@ -168,8 +168,27 @@ public class ClinitSuppressionTransformerTest {
 
     @Test
     public void transformer_suppresses_matching_class_on_initial_load() throws IOException {
-        Set<String> names = Collections.singleton(WithClinit.class.getName());
-        ClinitSuppressionTransformer transformer = new ClinitSuppressionTransformer(names);
+        Predicate<String> matcher = WithClinit.class.getName()::equals;
+        ClinitSuppressionTransformer transformer = new ClinitSuppressionTransformer(matcher);
+
+        byte[] original = readClassBytes(WithClinit.class);
+        byte[] result =
+                transformer.transform(
+                        getClass().getClassLoader(),
+                        WithClinit.class.getName().replace('.', '/'),
+                        null,
+                        null,
+                        original);
+
+        assertThat(result).isNotNull();
+        assertThat(result).isNotEqualTo(original);
+    }
+
+    @Test
+    public void transformer_suppresses_class_matched_by_package_predicate() throws IOException {
+        String packagePrefix = WithClinit.class.getPackage().getName() + ".";
+        Predicate<String> matcher = name -> name.startsWith(packagePrefix);
+        ClinitSuppressionTransformer transformer = new ClinitSuppressionTransformer(matcher);
 
         byte[] original = readClassBytes(WithClinit.class);
         byte[] result =


### PR DESCRIPTION
Fixes #3814 .

With this PR, the `mockito.suppress.clinit` property can accept both an exact class name (e.g., `com.example.MyClass`) or a package wildcard ending in `.*` (e.g., `com.example.*`) that matches the package and all sub-packages.

In addition to unit tests, I've also installed locally and created a simple project using both the features.

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style (run `./gradlew spotlessApply` for auto-formatting)
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should end with `Fixes #<issue number>` _if relevant_
