### PR TITLE
Fixes #3796 Add CheckReturnValue and CanIgnoreReturnValue annotations

### DIFF
--- a/mockito-core/src/main/java/org/mockito/AdditionalMatchers.java
+++ b/mockito-core/src/main/java/org/mockito/AdditionalMatchers.java
@@ -38,6 +38,7 @@ import org.mockito.internal.matchers.LessThan;
  * Scroll down to see all methods - full list of matchers.
  */
 @SuppressWarnings("ALL")
+@CanIgnoreReturnValue
 public final class AdditionalMatchers {
 
     /**

--- a/mockito-core/src/main/java/org/mockito/BDDMockito.java
+++ b/mockito-core/src/main/java/org/mockito/BDDMockito.java
@@ -79,6 +79,7 @@ import org.mockito.verification.VerificationMode;
  * @since 1.8.0
  */
 @SuppressWarnings("unchecked")
+@CanIgnoreReturnValue
 public class BDDMockito extends Mockito {
 
     /**

--- a/mockito-core/src/main/java/org/mockito/CanIgnoreReturnValue.java
+++ b/mockito-core/src/main/java/org/mockito/CanIgnoreReturnValue.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation is not intended to be used by Mockito end-users directly.
+ * Instead, we use it to annotate methods or classes for Static Analysis tools,
+ * including FindBugs and ErrorProne.
+ * <p>These tools can check whether the return value of a method is unnecessarily
+ * ignored. By annotating a method (or a whole class) with {@code @CanIgnoreReturnValue},
+ * we indicate that ignoring the return value of this method is acceptable and
+ * should not trigger a compile-time warning or error.
+ * <p>This annotation is public because we need to use it across multiple packages.
+ */
+@Target({ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE, ElementType.TYPE})
+@Retention(RetentionPolicy.CLASS)
+public @interface CanIgnoreReturnValue {}

--- a/mockito-core/src/main/java/org/mockito/Mock.java
+++ b/mockito-core/src/main/java/org/mockito/Mock.java
@@ -139,6 +139,7 @@ public @interface Mock {
      */
     boolean withoutAnnotations() default false;
 
+    @CanIgnoreReturnValue
     enum Strictness {
 
         /**

--- a/mockito-core/src/main/java/org/mockito/MockSettings.java
+++ b/mockito-core/src/main/java/org/mockito/MockSettings.java
@@ -47,6 +47,7 @@ import org.mockito.stubbing.Answer;
  * Secondly, to enable combining different mock settings without introducing zillions of overloaded mock() methods.
  */
 @NotExtensible
+@CanIgnoreReturnValue
 public interface MockSettings extends Serializable {
 
     /**

--- a/mockito-core/src/main/java/org/mockito/MockitoAnnotations.java
+++ b/mockito-core/src/main/java/org/mockito/MockitoAnnotations.java
@@ -70,6 +70,7 @@ public final class MockitoAnnotations {
      *
      * @return A closable to close when completing any tests in {@code testClass}.
      */
+    @CanIgnoreReturnValue
     public static AutoCloseable openMocks(Object testClass) {
         if (testClass == null) {
             throw new MockitoException(

--- a/mockito-core/src/main/java/org/mockito/MockitoFramework.java
+++ b/mockito-core/src/main/java/org/mockito/MockitoFramework.java
@@ -21,6 +21,7 @@ import org.mockito.plugins.MockitoPlugins;
  * @since 2.1.0
  */
 @NotExtensible
+@CanIgnoreReturnValue
 public interface MockitoFramework {
 
     /**

--- a/mockito-core/src/main/java/org/mockito/configuration/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/configuration/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Mockito configuration utilities.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.configuration;

--- a/mockito-core/src/main/java/org/mockito/exceptions/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/exceptions/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Mockito exceptions utilities
  */
+@org.mockito.CheckReturnValue
 package org.mockito.exceptions;

--- a/mockito-core/src/main/java/org/mockito/hamcrest/MockitoHamcrest.java
+++ b/mockito-core/src/main/java/org/mockito/hamcrest/MockitoHamcrest.java
@@ -10,6 +10,7 @@ import static org.mockito.internal.util.Primitives.defaultValue;
 
 import org.hamcrest.Matcher;
 import org.mockito.ArgumentMatcher;
+import org.mockito.CanIgnoreReturnValue;
 import org.mockito.internal.hamcrest.HamcrestArgumentMatcher;
 
 /**
@@ -74,6 +75,7 @@ public final class MockitoHamcrest {
      * @return <code>null</code> or default value for primitive (0, false, etc.)
      * @since 2.1.0
      */
+    @CanIgnoreReturnValue
     @SuppressWarnings("unchecked")
     public static <T> T argThat(Matcher<T> matcher) {
         reportMatcher(matcher);

--- a/mockito-core/src/main/java/org/mockito/hamcrest/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/hamcrest/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Mockito Hamcrest matcher integration.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.hamcrest;

--- a/mockito-core/src/main/java/org/mockito/internal/configuration/injection/MockInjection.java
+++ b/mockito-core/src/main/java/org/mockito/internal/configuration/injection/MockInjection.java
@@ -4,6 +4,8 @@
  */
 package org.mockito.internal.configuration.injection;
 
+import org.mockito.CanIgnoreReturnValue;
+
 import static org.mockito.internal.util.Checks.checkItemsNotNull;
 import static org.mockito.internal.util.Checks.checkNotNull;
 import static org.mockito.internal.util.collections.Sets.newMockSafeHashSet;
@@ -63,21 +65,25 @@ public final class MockInjection {
             this.fields.addAll(checkItemsNotNull(fields, "fields"));
         }
 
+        @CanIgnoreReturnValue
         public OngoingMockInjection withMocks(Set<Object> mocks) {
             this.mocks.addAll(checkNotNull(mocks, "mocks"));
             return this;
         }
 
+        @CanIgnoreReturnValue
         public OngoingMockInjection tryConstructorInjection() {
             injectionStrategies.thenTry(new ConstructorInjection());
             return this;
         }
 
+        @CanIgnoreReturnValue
         public OngoingMockInjection tryPropertyOrFieldInjection() {
             injectionStrategies.thenTry(new PropertyAndSetterInjection());
             return this;
         }
 
+        @CanIgnoreReturnValue
         public OngoingMockInjection handleSpyAnnotation() {
             postInjectionStrategies.thenTry(new SpyOnInjectedFieldsHandler());
             return this;

--- a/mockito-core/src/main/java/org/mockito/internal/configuration/injection/MockInjectionStrategy.java
+++ b/mockito-core/src/main/java/org/mockito/internal/configuration/injection/MockInjectionStrategy.java
@@ -4,6 +4,7 @@
  */
 package org.mockito.internal.configuration.injection;
 
+import org.mockito.CanIgnoreReturnValue;
 import java.lang.reflect.Field;
 import java.util.Set;
 
@@ -37,6 +38,7 @@ public abstract class MockInjectionStrategy {
      * @param strategy Queued strategy.
      * @return The passed strategy instance to allow chaining.
      */
+    @CanIgnoreReturnValue
     public MockInjectionStrategy thenTry(MockInjectionStrategy strategy) {
         if (nextStrategy != null) {
             nextStrategy.thenTry(strategy);
@@ -64,6 +66,7 @@ public abstract class MockInjectionStrategy {
      * @param mockCandidates A set of mock candidate, that might be injected.
      * @return <code>true</code> if successful, <code>false</code> otherwise.
      */
+    @CanIgnoreReturnValue
     public boolean process(Field onField, Object fieldOwnedBy, Set<Object> mockCandidates) {
         if (processInjection(onField, fieldOwnedBy, mockCandidates)) {
             return true;

--- a/mockito-core/src/main/java/org/mockito/internal/configuration/injection/filter/NameBasedCandidateFilter.java
+++ b/mockito-core/src/main/java/org/mockito/internal/configuration/injection/filter/NameBasedCandidateFilter.java
@@ -4,6 +4,8 @@
  */
 package org.mockito.internal.configuration.injection.filter;
 
+import org.mockito.CheckReturnValue;
+
 import static org.mockito.internal.util.MockUtil.getMockName;
 
 import java.lang.reflect.Field;
@@ -11,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+@CheckReturnValue
 public class NameBasedCandidateFilter implements MockCandidateFilter {
     private final MockCandidateFilter next;
 

--- a/mockito-core/src/main/java/org/mockito/internal/configuration/injection/filter/TerminalMockCandidateFilter.java
+++ b/mockito-core/src/main/java/org/mockito/internal/configuration/injection/filter/TerminalMockCandidateFilter.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.List;
 
+import org.mockito.CheckReturnValue;
 import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.internal.util.reflection.BeanPropertySetter;
 import org.mockito.plugins.MemberAccessor;
@@ -22,6 +23,7 @@ import org.mockito.plugins.MemberAccessor;
  * <li>an {@link OngoingInjector} that will try to inject the candidate trying first the property setter then if not possible try the field access</li>
  * </ul>
  */
+@CheckReturnValue
 public class TerminalMockCandidateFilter implements MockCandidateFilter {
     @Override
     public OngoingInjector filterCandidate(

--- a/mockito-core/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
+++ b/mockito-core/src/main/java/org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java
@@ -17,8 +17,10 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.mockito.CheckReturnValue;
 import org.mockito.internal.util.MockUtil;
 
+@CheckReturnValue
 public class TypeBasedCandidateFilter implements MockCandidateFilter {
 
     private final MockCandidateFilter next;

--- a/mockito-core/src/main/java/org/mockito/internal/configuration/injection/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/configuration/injection/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Mockito injection internals.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal.configuration.injection;

--- a/mockito-core/src/main/java/org/mockito/internal/configuration/injection/scanner/InjectMocksScanner.java
+++ b/mockito-core/src/main/java/org/mockito/internal/configuration/injection/scanner/InjectMocksScanner.java
@@ -12,12 +12,14 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.mockito.Captor;
+import org.mockito.CheckReturnValue;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
 /**
  * Scan field for injection.
  */
+@CheckReturnValue
 public class InjectMocksScanner {
     private final Class<?> clazz;
 

--- a/mockito-core/src/main/java/org/mockito/internal/configuration/injection/scanner/MockScanner.java
+++ b/mockito-core/src/main/java/org/mockito/internal/configuration/injection/scanner/MockScanner.java
@@ -9,6 +9,7 @@ import static org.mockito.internal.util.collections.Sets.newMockSafeHashSet;
 import java.lang.reflect.Field;
 import java.util.Set;
 
+import org.mockito.CheckReturnValue;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.internal.util.MockUtil;
@@ -17,6 +18,7 @@ import org.mockito.internal.util.reflection.FieldReader;
 /**
  * Scan mocks, and prepare them if needed.
  */
+@CheckReturnValue
 public class MockScanner {
     private final Object instance;
     private final Class<?> clazz;

--- a/mockito-core/src/main/java/org/mockito/internal/configuration/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/configuration/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Mockito configuration.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal.configuration;

--- a/mockito-core/src/main/java/org/mockito/internal/configuration/plugins/DefaultMockitoPlugins.java
+++ b/mockito-core/src/main/java/org/mockito/internal/configuration/plugins/DefaultMockitoPlugins.java
@@ -8,7 +8,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
 import org.mockito.MockMakers;
 import org.mockito.internal.util.MockUtil;
 import org.mockito.plugins.AnnotationEngine;

--- a/mockito-core/src/main/java/org/mockito/internal/configuration/plugins/PluginInitializer.java
+++ b/mockito-core/src/main/java/org/mockito/internal/configuration/plugins/PluginInitializer.java
@@ -12,6 +12,7 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Set;
 
+import org.mockito.CanIgnoreReturnValue;
 import org.mockito.internal.util.collections.Iterables;
 import org.mockito.plugins.PluginSwitch;
 
@@ -29,6 +30,7 @@ class PluginInitializer {
      * Equivalent to {@link java.util.ServiceLoader#load} but without requiring
      * Java 6 / Android 2.3 (Gingerbread).
      */
+    @CanIgnoreReturnValue
     public <T> T loadImpl(Class<T> service) {
         ClassLoader loader = Thread.currentThread().getContextClassLoader();
         if (loader == null) {

--- a/mockito-core/src/main/java/org/mockito/internal/configuration/plugins/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/configuration/plugins/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Mockito plugins configuration machinery.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal.configuration.plugins;

--- a/mockito-core/src/main/java/org/mockito/internal/creation/MockSettingsImpl.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/MockSettingsImpl.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.mockito.CanIgnoreReturnValue;
 import org.mockito.MockSettings;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.creation.settings.CreationSettings;
@@ -49,17 +50,20 @@ public class MockSettingsImpl<T> extends CreationSettings<T>
     private Object[] constructorArgs;
 
     @Override
+    @CanIgnoreReturnValue
     public MockSettings serializable() {
         return serializable(SerializableMode.BASIC);
     }
 
     @Override
+    @CanIgnoreReturnValue
     public MockSettings serializable(SerializableMode mode) {
         this.serializableMode = mode;
         return this;
     }
 
     @Override
+    @CanIgnoreReturnValue
     public MockSettings extraInterfaces(Class<?>... extraInterfaces) {
         if (extraInterfaces == null || extraInterfaces.length == 0) {
             throw extraInterfacesRequiresAtLeastOneInterface();
@@ -92,18 +96,21 @@ public class MockSettingsImpl<T> extends CreationSettings<T>
     }
 
     @Override
+    @CanIgnoreReturnValue
     public MockSettings name(String name) {
         this.name = name;
         return this;
     }
 
     @Override
+    @CanIgnoreReturnValue
     public MockSettings spiedInstance(Object spiedInstance) {
         this.spiedInstance = spiedInstance;
         return this;
     }
 
     @Override
+    @CanIgnoreReturnValue
     public MockSettings defaultAnswer(Answer defaultAnswer) {
         this.defaultAnswer = defaultAnswer;
         if (defaultAnswer == null) {
@@ -118,12 +125,14 @@ public class MockSettingsImpl<T> extends CreationSettings<T>
     }
 
     @Override
+    @CanIgnoreReturnValue
     public MockSettingsImpl<T> stubOnly() {
         this.stubOnly = true;
         return this;
     }
 
     @Override
+    @CanIgnoreReturnValue
     public MockSettings useConstructor(Object... constructorArgs) {
         Checks.checkNotNull(
                 constructorArgs,
@@ -135,12 +144,14 @@ public class MockSettingsImpl<T> extends CreationSettings<T>
     }
 
     @Override
+    @CanIgnoreReturnValue
     public MockSettings outerInstance(Object outerClassInstance) {
         this.outerClassInstance = outerClassInstance;
         return this;
     }
 
     @Override
+    @CanIgnoreReturnValue
     public MockSettings withoutAnnotations() {
         stripAnnotations = true;
         return this;
@@ -173,6 +184,7 @@ public class MockSettingsImpl<T> extends CreationSettings<T>
     }
 
     @Override
+    @CanIgnoreReturnValue
     public MockSettings verboseLogging() {
         if (!invocationListenersContainsType(VerboseMockInvocationLogger.class)) {
             invocationListeners(new VerboseMockInvocationLogger());
@@ -181,12 +193,14 @@ public class MockSettingsImpl<T> extends CreationSettings<T>
     }
 
     @Override
+    @CanIgnoreReturnValue
     public MockSettings invocationListeners(InvocationListener... listeners) {
         addListeners(listeners, invocationListeners, "invocationListeners");
         return this;
     }
 
     @Override
+    @CanIgnoreReturnValue
     public MockSettings stubbingLookupListeners(StubbingLookupListener... listeners) {
         addListeners(listeners, stubbingLookupListeners, "stubbingLookupListeners");
         return this;
@@ -208,6 +222,7 @@ public class MockSettingsImpl<T> extends CreationSettings<T>
     }
 
     @Override
+    @CanIgnoreReturnValue
     public MockSettings verificationStartedListeners(VerificationStartedListener... listeners) {
         addListeners(listeners, this.verificationStartedListeners, "verificationStartedListeners");
         return this;
@@ -242,12 +257,14 @@ public class MockSettingsImpl<T> extends CreationSettings<T>
     }
 
     @Override
+    @CanIgnoreReturnValue
     public MockSettings lenient() {
         this.strictness = Strictness.LENIENT;
         return this;
     }
 
     @Override
+    @CanIgnoreReturnValue
     public MockSettings strictness(Strictness strictness) {
         if (strictness == null) {
             throw strictnessDoesNotAcceptNullParameter();
@@ -257,12 +274,14 @@ public class MockSettingsImpl<T> extends CreationSettings<T>
     }
 
     @Override
+    @CanIgnoreReturnValue
     public MockSettings mockMaker(String mockMaker) {
         this.mockMaker = mockMaker;
         return this;
     }
 
     @Override
+    @CanIgnoreReturnValue
     public MockSettings genericTypeToMock(Type genericType) {
         this.genericTypeToMock = genericType;
         return this;

--- a/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMaker.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMaker.java
@@ -4,13 +4,12 @@
  */
 package org.mockito.internal.creation.bytebuddy;
 
+import java.util.Optional;
+import java.util.function.Function;
 import org.mockito.MockedConstruction;
 import org.mockito.internal.exceptions.Reporter;
 import org.mockito.invocation.MockHandler;
 import org.mockito.mock.MockCreationSettings;
-
-import java.util.Optional;
-import java.util.function.Function;
 
 /**
  * ByteBuddy MockMaker.

--- a/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMaker.java
@@ -4,15 +4,14 @@
  */
 package org.mockito.internal.creation.bytebuddy;
 
+import java.util.Optional;
+import java.util.function.Function;
 import org.mockito.MockedConstruction;
 import org.mockito.creation.instance.Instantiator;
 import org.mockito.internal.exceptions.Reporter;
 import org.mockito.invocation.MockHandler;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.plugins.InlineMockMaker;
-
-import java.util.Optional;
-import java.util.function.Function;
 
 public class InlineByteBuddyMockMaker
         implements ClassCreatingMockMaker, InlineMockMaker, Instantiator {

--- a/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
@@ -4,6 +4,33 @@
  */
 package org.mockito.internal.creation.bytebuddy;
 
+import static org.mockito.internal.creation.bytebuddy.InlineBytecodeGenerator.EXCLUDES;
+import static org.mockito.internal.util.StringUtil.join;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.instrument.Instrumentation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.JarOutputStream;
+import org.mockito.CanIgnoreReturnValue;
 import org.mockito.MockedConstruction;
 import org.mockito.creation.instance.InstantiationException;
 import org.mockito.creation.instance.Instantiator;
@@ -25,26 +52,6 @@ import org.mockito.invocation.MockHandler;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.plugins.InlineMockMaker;
 import org.mockito.plugins.MemberAccessor;
-
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.instrument.Instrumentation;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Modifier;
-import java.util.*;
-import java.util.Map.Entry;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.BiConsumer;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
-import java.util.jar.JarOutputStream;
-
-import static org.mockito.internal.creation.bytebuddy.InlineBytecodeGenerator.EXCLUDES;
-import static org.mockito.internal.util.StringUtil.join;
 
 /**
  * Agent and subclass based mock maker.
@@ -429,6 +436,7 @@ class InlineDelegateByteBuddyMockMaker
     }
 
     @Override
+    @CanIgnoreReturnValue
     public <T> Class<? extends T> createMockType(MockCreationSettings<T> settings) {
         try {
             return bytecodeGenerator.mockClass(

--- a/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/access/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/access/package-info.java
@@ -6,4 +6,5 @@
 /**
  * ByteBuddy related stuff used for mock interaction.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal.creation.bytebuddy.access;

--- a/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/codegen/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/codegen/package-info.java
@@ -6,4 +6,5 @@
 /**
  * ByteBuddy package for generated types.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal.creation.bytebuddy.codegen;

--- a/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/inject/MockMethodDispatcher.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/inject/MockMethodDispatcher.java
@@ -4,11 +4,13 @@
  */
 package org.mockito.internal.creation.bytebuddy.inject;
 
+import org.mockito.CheckReturnValue;
 import java.lang.reflect.Method;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+@CheckReturnValue
 public abstract class MockMethodDispatcher {
 
     static {

--- a/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/package-info.java
@@ -6,4 +6,5 @@
 /**
  * ByteBuddy related stuff.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal.creation.bytebuddy;

--- a/mockito-core/src/main/java/org/mockito/internal/creation/instance/ConstructorInstantiator.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/instance/ConstructorInstantiator.java
@@ -12,12 +12,14 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.mockito.CheckReturnValue;
 import org.mockito.creation.instance.InstantiationException;
 import org.mockito.creation.instance.Instantiator;
 import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.internal.util.Primitives;
 import org.mockito.plugins.MemberAccessor;
 
+@CheckReturnValue
 public class ConstructorInstantiator implements Instantiator {
 
     /**

--- a/mockito-core/src/main/java/org/mockito/internal/creation/instance/DefaultInstantiatorProvider.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/instance/DefaultInstantiatorProvider.java
@@ -4,10 +4,12 @@
  */
 package org.mockito.internal.creation.instance;
 
+import org.mockito.CheckReturnValue;
 import org.mockito.creation.instance.Instantiator;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.plugins.InstantiatorProvider2;
 
+@CheckReturnValue
 public class DefaultInstantiatorProvider implements InstantiatorProvider2 {
 
     private static final Instantiator INSTANCE = new ObjenesisInstantiator();

--- a/mockito-core/src/main/java/org/mockito/internal/creation/instance/ObjenesisInstantiator.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/instance/ObjenesisInstantiator.java
@@ -4,10 +4,12 @@
  */
 package org.mockito.internal.creation.instance;
 
+import org.mockito.CheckReturnValue;
 import org.mockito.creation.instance.Instantiator;
 import org.mockito.internal.configuration.GlobalConfiguration;
 import org.objenesis.ObjenesisStd;
 
+@CheckReturnValue
 class ObjenesisInstantiator implements Instantiator {
 
     // TODO: in order to provide decent exception message when objenesis is not found,

--- a/mockito-core/src/main/java/org/mockito/internal/creation/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Mock object creation.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal.creation;

--- a/mockito-core/src/main/java/org/mockito/internal/creation/proxy/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/proxy/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Mock makers based on the {@link java.lang.reflect.Proxy} utility.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal.creation.proxy;

--- a/mockito-core/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
@@ -13,6 +13,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import org.mockito.CanIgnoreReturnValue;
+import org.mockito.CheckReturnValue;
 import org.mockito.listeners.InvocationListener;
 import org.mockito.listeners.StubbingLookupListener;
 import org.mockito.listeners.VerificationStartedListener;
@@ -23,6 +25,7 @@ import org.mockito.mock.SerializableMode;
 import org.mockito.quality.Strictness;
 import org.mockito.stubbing.Answer;
 
+@CheckReturnValue
 public class CreationSettings<T> implements MockCreationSettings<T>, Serializable {
     private static final long serialVersionUID = -6789800638070123629L;
 
@@ -83,11 +86,13 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
         return typeToMock;
     }
 
+    @CanIgnoreReturnValue
     public CreationSettings<T> setTypeToMock(Class<T> typeToMock) {
         this.typeToMock = typeToMock;
         return this;
     }
 
+    @CanIgnoreReturnValue
     public CreationSettings<T> setGenericTypeToMock(Type genericTypeToMock) {
         this.genericTypeToMock = genericTypeToMock;
         return this;
@@ -98,6 +103,7 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
         return extraInterfaces;
     }
 
+    @CanIgnoreReturnValue
     public CreationSettings<T> setExtraInterfaces(Set<Class<?>> extraInterfaces) {
         this.extraInterfaces = extraInterfaces;
         return this;
@@ -122,6 +128,7 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
         return mockName;
     }
 
+    @CanIgnoreReturnValue
     public CreationSettings<T> setMockName(MockName mockName) {
         this.mockName = mockName;
         return this;
@@ -132,6 +139,7 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
         return serializableMode != SerializableMode.NONE;
     }
 
+    @CanIgnoreReturnValue
     public CreationSettings<T> setSerializableMode(SerializableMode serializableMode) {
         this.serializableMode = serializableMode;
         return this;

--- a/mockito-core/src/main/java/org/mockito/internal/creation/util/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/util/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Stuff that does not have a good package yet.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal.creation.util;

--- a/mockito-core/src/main/java/org/mockito/internal/debugging/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/debugging/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Whatever helps in debugging failed tests.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal.debugging;

--- a/mockito-core/src/main/java/org/mockito/internal/exceptions/Reporter.java
+++ b/mockito-core/src/main/java/org/mockito/internal/exceptions/Reporter.java
@@ -16,6 +16,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.mockito.CheckReturnValue;
 import org.mockito.exceptions.base.MockitoAssertionError;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.exceptions.base.MockitoInitializationException;
@@ -69,6 +70,7 @@ import org.mockito.stubbing.Stubbing;
  * Generally, exception messages are full of line breaks to make them easy to
  * read (xunit plugins take only fraction of screen on modern IDEs).
  */
+@CheckReturnValue
 public class Reporter {
 
     private static final String NON_PUBLIC_PARENT =

--- a/mockito-core/src/main/java/org/mockito/internal/exceptions/stacktrace/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/exceptions/stacktrace/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Stack trace filtering / cleaning internal APIs.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal.exceptions.stacktrace;

--- a/mockito-core/src/main/java/org/mockito/internal/exceptions/util/ScenarioPrinter.java
+++ b/mockito-core/src/main/java/org/mockito/internal/exceptions/util/ScenarioPrinter.java
@@ -6,8 +6,10 @@ package org.mockito.internal.exceptions.util;
 
 import java.util.List;
 
+import org.mockito.CheckReturnValue;
 import org.mockito.internal.exceptions.VerificationAwareInvocation;
 
+@CheckReturnValue
 public class ScenarioPrinter {
 
     public String print(List<VerificationAwareInvocation> invocations) {

--- a/mockito-core/src/main/java/org/mockito/internal/framework/DefaultMockitoFramework.java
+++ b/mockito-core/src/main/java/org/mockito/internal/framework/DefaultMockitoFramework.java
@@ -6,6 +6,8 @@ package org.mockito.internal.framework;
 
 import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
 
+import org.mockito.CanIgnoreReturnValue;
+import org.mockito.CheckReturnValue;
 import org.mockito.MockitoFramework;
 import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.internal.invocation.DefaultInvocationFactory;
@@ -16,9 +18,11 @@ import org.mockito.plugins.InlineMockMaker;
 import org.mockito.plugins.MockMaker;
 import org.mockito.plugins.MockitoPlugins;
 
+@CheckReturnValue
 public class DefaultMockitoFramework implements MockitoFramework {
 
     @Override
+    @CanIgnoreReturnValue
     public MockitoFramework addListener(MockitoListener listener) {
         Checks.checkNotNull(listener, "listener");
         mockingProgress().addListener(listener);
@@ -26,6 +30,7 @@ public class DefaultMockitoFramework implements MockitoFramework {
     }
 
     @Override
+    @CanIgnoreReturnValue
     public MockitoFramework removeListener(MockitoListener listener) {
         Checks.checkNotNull(listener, "listener");
         mockingProgress().removeListener(listener);

--- a/mockito-core/src/main/java/org/mockito/internal/framework/DefaultMockitoSession.java
+++ b/mockito-core/src/main/java/org/mockito/internal/framework/DefaultMockitoSession.java
@@ -4,6 +4,7 @@
  */
 package org.mockito.internal.framework;
 
+import org.mockito.CheckReturnValue;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.MockitoSession;
@@ -18,6 +19,7 @@ import org.mockito.quality.Strictness;
 import java.util.ArrayList;
 import java.util.List;
 
+@CheckReturnValue
 public class DefaultMockitoSession implements MockitoSession {
 
     private final String name;

--- a/mockito-core/src/main/java/org/mockito/internal/framework/DisabledMockHandler.java
+++ b/mockito-core/src/main/java/org/mockito/internal/framework/DisabledMockHandler.java
@@ -4,6 +4,7 @@
  */
 package org.mockito.internal.framework;
 
+import org.mockito.CheckReturnValue;
 import org.mockito.MockitoFramework;
 import org.mockito.exceptions.misusing.DisabledMockException;
 import org.mockito.invocation.Invocation;
@@ -27,6 +28,7 @@ import java.util.Set;
  * Throws {@link DisabledMockException} when a mock is accessed after it has been disabled by
  * {@link MockitoFramework#clearInlineMocks()}.
  */
+@CheckReturnValue
 public class DisabledMockHandler implements MockHandler<Object> {
     public static MockHandler<Object> HANDLER = new DisabledMockHandler();
 

--- a/mockito-core/src/main/java/org/mockito/internal/hamcrest/HamcrestArgumentMatcher.java
+++ b/mockito-core/src/main/java/org/mockito/internal/hamcrest/HamcrestArgumentMatcher.java
@@ -7,9 +7,11 @@ package org.mockito.internal.hamcrest;
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
 import org.mockito.ArgumentMatcher;
+import org.mockito.CheckReturnValue;
 
 import static java.util.Objects.requireNonNull;
 
+@CheckReturnValue
 public class HamcrestArgumentMatcher<T> implements ArgumentMatcher<T> {
 
     private final Matcher<T> matcher;

--- a/mockito-core/src/main/java/org/mockito/internal/hamcrest/MatcherGenericTypeExtractor.java
+++ b/mockito-core/src/main/java/org/mockito/internal/hamcrest/MatcherGenericTypeExtractor.java
@@ -8,8 +8,10 @@ import static org.mockito.internal.util.reflection.GenericTypeExtractor.genericT
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Matcher;
+import org.mockito.CheckReturnValue;
 
 /** Extracts generic type of matcher */
+@CheckReturnValue
 public final class MatcherGenericTypeExtractor {
 
     /**

--- a/mockito-core/src/main/java/org/mockito/internal/handler/InvocationNotifierHandler.java
+++ b/mockito-core/src/main/java/org/mockito/internal/handler/InvocationNotifierHandler.java
@@ -7,7 +7,7 @@ package org.mockito.internal.handler;
 import static org.mockito.internal.exceptions.Reporter.invocationListenerThrewException;
 
 import java.util.List;
-
+import org.mockito.CheckReturnValue;
 import org.mockito.invocation.Invocation;
 import org.mockito.invocation.InvocationContainer;
 import org.mockito.invocation.MockHandler;
@@ -18,6 +18,7 @@ import org.mockito.mock.MockCreationSettings;
  * Handler, that call all listeners wanted for this mock, before delegating it
  * to the parameterized handler.
  */
+@CheckReturnValue
 class InvocationNotifierHandler<T> implements MockHandler<T> {
 
     private final List<InvocationListener> invocationListeners;

--- a/mockito-core/src/main/java/org/mockito/internal/handler/MockHandlerFactory.java
+++ b/mockito-core/src/main/java/org/mockito/internal/handler/MockHandlerFactory.java
@@ -4,10 +4,12 @@
  */
 package org.mockito.internal.handler;
 
+import org.mockito.CheckReturnValue;
 import org.mockito.invocation.MockHandler;
 import org.mockito.mock.MockCreationSettings;
 
 /** by Szczepan Faber, created at: 5/21/12 */
+@CheckReturnValue
 public final class MockHandlerFactory {
 
     public static <T> MockHandler<T> createMockHandler(MockCreationSettings<T> settings) {

--- a/mockito-core/src/main/java/org/mockito/internal/handler/MockHandlerImpl.java
+++ b/mockito-core/src/main/java/org/mockito/internal/handler/MockHandlerImpl.java
@@ -7,6 +7,7 @@ package org.mockito.internal.handler;
 import static org.mockito.internal.listeners.StubbingLookupNotifier.notifyStubbedAnswerLookup;
 import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
 
+import org.mockito.CheckReturnValue;
 import org.mockito.internal.creation.settings.CreationSettings;
 import org.mockito.internal.invocation.InvocationMatcher;
 import org.mockito.internal.invocation.MatchersBinder;
@@ -28,6 +29,7 @@ import org.mockito.verification.VerificationMode;
  *
  * @param <T> type of mock object to handle
  */
+@CheckReturnValue
 public class MockHandlerImpl<T> implements MockHandler<T> {
 
     private static final long serialVersionUID = -2917871070982574165L;

--- a/mockito-core/src/main/java/org/mockito/internal/handler/NotifiedMethodInvocationReport.java
+++ b/mockito-core/src/main/java/org/mockito/internal/handler/NotifiedMethodInvocationReport.java
@@ -6,6 +6,7 @@ package org.mockito.internal.handler;
 
 import static org.mockito.internal.matchers.Equality.areEqual;
 
+import org.mockito.CheckReturnValue;
 import org.mockito.invocation.DescribedInvocation;
 import org.mockito.invocation.Invocation;
 import org.mockito.listeners.MethodInvocationReport;
@@ -13,6 +14,7 @@ import org.mockito.listeners.MethodInvocationReport;
 /**
  * Report on a method call
  */
+@CheckReturnValue
 public class NotifiedMethodInvocationReport implements MethodInvocationReport {
     private final Invocation invocation;
     private final Object returnedValue;

--- a/mockito-core/src/main/java/org/mockito/internal/handler/NullResultGuardian.java
+++ b/mockito-core/src/main/java/org/mockito/internal/handler/NullResultGuardian.java
@@ -6,6 +6,7 @@ package org.mockito.internal.handler;
 
 import static org.mockito.internal.util.Primitives.defaultValue;
 
+import org.mockito.CheckReturnValue;
 import org.mockito.invocation.Invocation;
 import org.mockito.invocation.InvocationContainer;
 import org.mockito.invocation.MockHandler;
@@ -16,6 +17,7 @@ import org.mockito.mock.MockCreationSettings;
  *
  * by Szczepan Faber, created at: 5/22/12
  */
+@CheckReturnValue
 class NullResultGuardian<T> implements MockHandler<T> {
 
     private final MockHandler<T> delegate;

--- a/mockito-core/src/main/java/org/mockito/internal/invocation/ArgumentMatcherAction.java
+++ b/mockito-core/src/main/java/org/mockito/internal/invocation/ArgumentMatcherAction.java
@@ -5,7 +5,9 @@
 package org.mockito.internal.invocation;
 
 import org.mockito.ArgumentMatcher;
+import org.mockito.CanIgnoreReturnValue;
 
+@CanIgnoreReturnValue
 public interface ArgumentMatcherAction {
     /**
      * Implementations must apply the given matcher to the argument and return

--- a/mockito-core/src/main/java/org/mockito/internal/invocation/MatcherApplicationStrategy.java
+++ b/mockito-core/src/main/java/org/mockito/internal/invocation/MatcherApplicationStrategy.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.mockito.ArgumentMatcher;
+import org.mockito.CanIgnoreReturnValue;
 import org.mockito.internal.matchers.CapturingMatcher;
 import org.mockito.invocation.Invocation;
 
@@ -56,6 +57,7 @@ public class MatcherApplicationStrategy {
      *         because too many or to few matchers are available.
      *         </ul>
      */
+    @CanIgnoreReturnValue
     public boolean forEachMatcherAndArgument(ArgumentMatcherAction action) {
         final boolean isJavaVarargs =
                 invocation.getMethod().isVarArgs()

--- a/mockito-core/src/main/java/org/mockito/internal/invocation/finder/AllInvocationsFinder.java
+++ b/mockito-core/src/main/java/org/mockito/internal/invocation/finder/AllInvocationsFinder.java
@@ -9,12 +9,14 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import org.mockito.CheckReturnValue;
 import org.mockito.internal.invocation.InvocationComparator;
 import org.mockito.internal.stubbing.StubbingComparator;
 import org.mockito.internal.util.DefaultMockingDetails;
 import org.mockito.invocation.Invocation;
 import org.mockito.stubbing.Stubbing;
 
+@CheckReturnValue
 public class AllInvocationsFinder {
 
     private AllInvocationsFinder() {}

--- a/mockito-core/src/main/java/org/mockito/internal/invocation/finder/VerifiableInvocationsFinder.java
+++ b/mockito-core/src/main/java/org/mockito/internal/invocation/finder/VerifiableInvocationsFinder.java
@@ -7,11 +7,13 @@ package org.mockito.internal.invocation.finder;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.mockito.CheckReturnValue;
 import org.mockito.invocation.Invocation;
 
 /**
  * Author: Szczepan Faber, created at: 4/3/11
  */
+@CheckReturnValue
 public class VerifiableInvocationsFinder {
 
     private VerifiableInvocationsFinder() {}

--- a/mockito-core/src/main/java/org/mockito/internal/invocation/mockref/MockStrongReference.java
+++ b/mockito-core/src/main/java/org/mockito/internal/invocation/mockref/MockStrongReference.java
@@ -4,8 +4,10 @@
  */
 package org.mockito.internal.invocation.mockref;
 
+import org.mockito.CheckReturnValue;
 import java.io.ObjectStreamException;
 
+@CheckReturnValue
 public class MockStrongReference<T> implements MockReference<T> {
 
     private final T ref;

--- a/mockito-core/src/main/java/org/mockito/internal/invocation/mockref/MockWeakReference.java
+++ b/mockito-core/src/main/java/org/mockito/internal/invocation/mockref/MockWeakReference.java
@@ -4,6 +4,7 @@
  */
 package org.mockito.internal.invocation.mockref;
 
+import org.mockito.CheckReturnValue;
 import java.io.ObjectStreamException;
 import java.lang.ref.WeakReference;
 
@@ -11,6 +12,7 @@ import java.lang.ref.WeakReference;
  * A weak reference that is converted into a strong reference when serialized.
  * See {@link MockReference}.
  */
+@CheckReturnValue
 public class MockWeakReference<T> implements MockReference<T> {
 
     private final WeakReference<T> ref;

--- a/mockito-core/src/main/java/org/mockito/internal/invocation/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/invocation/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Invocation machinery and related classes.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal.invocation;

--- a/mockito-core/src/main/java/org/mockito/internal/junit/JUnitRule.java
+++ b/mockito-core/src/main/java/org/mockito/internal/junit/JUnitRule.java
@@ -6,6 +6,7 @@ package org.mockito.internal.junit;
 
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
+import org.mockito.CanIgnoreReturnValue;
 import org.mockito.junit.MockitoRule;
 import org.mockito.plugins.MockitoLogger;
 import org.mockito.quality.Strictness;
@@ -33,6 +34,7 @@ public final class JUnitRule implements MockitoRule {
     }
 
     @Override
+    @CanIgnoreReturnValue
     public MockitoRule strictness(Strictness strictness) {
         sessionStore.setStrictness(strictness);
         return this;

--- a/mockito-core/src/main/java/org/mockito/internal/junit/JUnitTestRule.java
+++ b/mockito-core/src/main/java/org/mockito/internal/junit/JUnitTestRule.java
@@ -6,6 +6,7 @@ package org.mockito.internal.junit;
 
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+import org.mockito.CanIgnoreReturnValue;
 import org.mockito.junit.MockitoTestRule;
 import org.mockito.plugins.MockitoLogger;
 import org.mockito.quality.Strictness;
@@ -31,6 +32,7 @@ public final class JUnitTestRule implements MockitoTestRule {
     }
 
     @Override
+    @CanIgnoreReturnValue
     public MockitoTestRule strictness(Strictness strictness) {
         sessionStore.setStrictness(strictness);
         return this;

--- a/mockito-core/src/main/java/org/mockito/internal/junit/VerificationCollectorImpl.java
+++ b/mockito-core/src/main/java/org/mockito/internal/junit/VerificationCollectorImpl.java
@@ -8,6 +8,7 @@ import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingPro
 
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+import org.mockito.CanIgnoreReturnValue;
 import org.mockito.exceptions.base.MockitoAssertionError;
 import org.mockito.internal.progress.MockingProgressImpl;
 import org.mockito.internal.verification.api.VerificationData;
@@ -62,6 +63,7 @@ public class VerificationCollectorImpl implements VerificationCollector {
     }
 
     @Override
+    @CanIgnoreReturnValue
     public VerificationCollector assertLazily() {
         mockingProgress()
                 .setVerificationStrategy(

--- a/mockito-core/src/main/java/org/mockito/internal/junit/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/junit/package-info.java
@@ -6,4 +6,5 @@
 /**
  * JUnit integration support classes.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal.junit;

--- a/mockito-core/src/main/java/org/mockito/internal/listeners/StubbingLookupNotifier.java
+++ b/mockito-core/src/main/java/org/mockito/internal/listeners/StubbingLookupNotifier.java
@@ -7,6 +7,7 @@ package org.mockito.internal.listeners;
 import java.util.Collection;
 import java.util.List;
 
+import org.mockito.CheckReturnValue;
 import org.mockito.internal.creation.settings.CreationSettings;
 import org.mockito.invocation.Invocation;
 import org.mockito.listeners.StubbingLookupEvent;
@@ -14,6 +15,7 @@ import org.mockito.listeners.StubbingLookupListener;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.stubbing.Stubbing;
 
+@CheckReturnValue
 public final class StubbingLookupNotifier {
 
     public static void notifyStubbedAnswerLookup(

--- a/mockito-core/src/main/java/org/mockito/internal/listeners/VerificationStartedNotifier.java
+++ b/mockito-core/src/main/java/org/mockito/internal/listeners/VerificationStartedNotifier.java
@@ -5,7 +5,8 @@
 package org.mockito.internal.listeners;
 
 import java.util.List;
-
+import org.mockito.CanIgnoreReturnValue;
+import org.mockito.CheckReturnValue;
 import org.mockito.MockingDetails;
 import org.mockito.Mockito;
 import org.mockito.internal.exceptions.Reporter;
@@ -14,8 +15,10 @@ import org.mockito.listeners.VerificationStartedEvent;
 import org.mockito.listeners.VerificationStartedListener;
 import org.mockito.mock.MockCreationSettings;
 
+@CheckReturnValue
 public final class VerificationStartedNotifier {
 
+    @CanIgnoreReturnValue
     public static Object notifyVerificationStarted(
             List<VerificationStartedListener> listeners, MockingDetails originalMockingDetails) {
         if (listeners.isEmpty()) {

--- a/mockito-core/src/main/java/org/mockito/internal/matchers/Any.java
+++ b/mockito-core/src/main/java/org/mockito/internal/matchers/Any.java
@@ -7,12 +7,14 @@ package org.mockito.internal.matchers;
 import java.io.Serializable;
 
 import org.mockito.ArgumentMatcher;
+import org.mockito.CanIgnoreReturnValue;
 
 public class Any implements ArgumentMatcher<Object>, Serializable {
 
     public static final Any ANY = new Any();
 
     @Override
+    @CanIgnoreReturnValue
     public boolean matches(Object actual) {
         return true;
     }

--- a/mockito-core/src/main/java/org/mockito/internal/matchers/apachecommons/EqualsBuilder.java
+++ b/mockito-core/src/main/java/org/mockito/internal/matchers/apachecommons/EqualsBuilder.java
@@ -4,15 +4,15 @@
  */
 package org.mockito.internal.matchers.apachecommons;
 
-import org.mockito.internal.configuration.plugins.Plugins;
-import org.mockito.plugins.MemberAccessor;
-
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.mockito.CanIgnoreReturnValue;
+import org.mockito.internal.configuration.plugins.Plugins;
+import org.mockito.plugins.MemberAccessor;
 
 // Class comes from Apache Commons Lang, added some tiny changes
 /**
@@ -323,6 +323,7 @@ class EqualsBuilder {
      * @return EqualsBuilder - used to chain calls.
      * @since 2.1.0
      */
+    @CanIgnoreReturnValue
     public EqualsBuilder appendSuper(boolean superEquals) {
         isEquals &= superEquals;
         return this;
@@ -338,6 +339,7 @@ class EqualsBuilder {
      * @param rhs  the right hand object
      * @return EqualsBuilder - used to chain calls.
      */
+    @CanIgnoreReturnValue
     public EqualsBuilder append(Object lhs, Object rhs) {
         if (!isEquals) {
             return this;
@@ -397,6 +399,7 @@ class EqualsBuilder {
      *                  the right hand <code>long</code>
      * @return EqualsBuilder - used to chain calls.
      */
+    @CanIgnoreReturnValue
     public EqualsBuilder append(long lhs, long rhs) {
         isEquals &= (lhs == rhs);
         return this;
@@ -409,6 +412,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>int</code>
      * @return EqualsBuilder - used to chain calls.
      */
+    @CanIgnoreReturnValue
     public EqualsBuilder append(int lhs, int rhs) {
         isEquals &= (lhs == rhs);
         return this;
@@ -421,6 +425,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>short</code>
      * @return EqualsBuilder - used to chain calls.
      */
+    @CanIgnoreReturnValue
     public EqualsBuilder append(short lhs, short rhs) {
         isEquals &= (lhs == rhs);
         return this;
@@ -433,6 +438,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>char</code>
      * @return EqualsBuilder - used to chain calls.
      */
+    @CanIgnoreReturnValue
     public EqualsBuilder append(char lhs, char rhs) {
         isEquals &= (lhs == rhs);
         return this;
@@ -445,6 +451,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>byte</code>
      * @return EqualsBuilder - used to chain calls.
      */
+    @CanIgnoreReturnValue
     public EqualsBuilder append(byte lhs, byte rhs) {
         isEquals &= (lhs == rhs);
         return this;
@@ -463,6 +470,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>double</code>
      * @return EqualsBuilder - used to chain calls.
      */
+    @CanIgnoreReturnValue
     public EqualsBuilder append(double lhs, double rhs) {
         if (!isEquals) {
             return this;
@@ -483,6 +491,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>float</code>
      * @return EqualsBuilder - used to chain calls.
      */
+    @CanIgnoreReturnValue
     public EqualsBuilder append(float lhs, float rhs) {
         if (!isEquals) {
             return this;
@@ -497,6 +506,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>boolean</code>
      * @return EqualsBuilder - used to chain calls.
      */
+    @CanIgnoreReturnValue
     public EqualsBuilder append(boolean lhs, boolean rhs) {
         isEquals &= (lhs == rhs);
         return this;
@@ -512,6 +522,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>Object[]</code>
      * @return EqualsBuilder - used to chain calls.
      */
+    @CanIgnoreReturnValue
     public EqualsBuilder append(Object[] lhs, Object[] rhs) {
         if (!isEquals) {
             return this;
@@ -543,6 +554,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>long[]</code>
      * @return EqualsBuilder - used to chain calls.
      */
+    @CanIgnoreReturnValue
     public EqualsBuilder append(long[] lhs, long[] rhs) {
         if (!isEquals) {
             return this;
@@ -574,6 +586,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>int[]</code>
      * @return EqualsBuilder - used to chain calls.
      */
+    @CanIgnoreReturnValue
     public EqualsBuilder append(int[] lhs, int[] rhs) {
         if (!isEquals) {
             return this;
@@ -605,6 +618,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>short[]</code>
      * @return EqualsBuilder - used to chain calls.
      */
+    @CanIgnoreReturnValue
     public EqualsBuilder append(short[] lhs, short[] rhs) {
         if (!isEquals) {
             return this;
@@ -636,6 +650,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>char[]</code>
      * @return EqualsBuilder - used to chain calls.
      */
+    @CanIgnoreReturnValue
     public EqualsBuilder append(char[] lhs, char[] rhs) {
         if (!isEquals) {
             return this;
@@ -667,6 +682,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>byte[]</code>
      * @return EqualsBuilder - used to chain calls.
      */
+    @CanIgnoreReturnValue
     public EqualsBuilder append(byte[] lhs, byte[] rhs) {
         if (!isEquals) {
             return this;
@@ -698,6 +714,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>double[]</code>
      * @return EqualsBuilder - used to chain calls.
      */
+    @CanIgnoreReturnValue
     public EqualsBuilder append(double[] lhs, double[] rhs) {
         if (!isEquals) {
             return this;
@@ -729,6 +746,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>float[]</code>
      * @return EqualsBuilder - used to chain calls.
      */
+    @CanIgnoreReturnValue
     public EqualsBuilder append(float[] lhs, float[] rhs) {
         if (!isEquals) {
             return this;
@@ -760,6 +778,7 @@ class EqualsBuilder {
      * @param rhs  the right hand <code>boolean[]</code>
      * @return EqualsBuilder - used to chain calls.
      */
+    @CanIgnoreReturnValue
     public EqualsBuilder append(boolean[] lhs, boolean[] rhs) {
         if (!isEquals) {
             return this;

--- a/mockito-core/src/main/java/org/mockito/internal/matchers/apachecommons/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/matchers/apachecommons/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Argument matchers that use Apache Commons Lang reflection-equality.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal.matchers.apachecommons;

--- a/mockito-core/src/main/java/org/mockito/internal/matchers/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/matchers/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Argument matchers for verification and stubbing.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal.matchers;

--- a/mockito-core/src/main/java/org/mockito/internal/matchers/text/FormattedText.java
+++ b/mockito-core/src/main/java/org/mockito/internal/matchers/text/FormattedText.java
@@ -4,10 +4,13 @@
  */
 package org.mockito.internal.matchers.text;
 
+import org.mockito.CheckReturnValue;
+
 /**
  * Contains text that has already been formatted
  * and hence it does not need any formatting (like quotes around string, etc.)
  */
+@CheckReturnValue
 class FormattedText {
 
     private final String text;

--- a/mockito-core/src/main/java/org/mockito/internal/matchers/text/MatcherToString.java
+++ b/mockito-core/src/main/java/org/mockito/internal/matchers/text/MatcherToString.java
@@ -10,8 +10,10 @@ import static org.mockito.internal.util.StringUtil.decamelizeMatcherName;
 import java.lang.reflect.Method;
 
 import org.mockito.ArgumentMatcher;
+import org.mockito.CheckReturnValue;
 
 /** Provides better toString() text for matcher that don't have toString() method declared. */
+@CheckReturnValue
 final class MatcherToString {
 
     /**

--- a/mockito-core/src/main/java/org/mockito/internal/matchers/text/MatchersPrinter.java
+++ b/mockito-core/src/main/java/org/mockito/internal/matchers/text/MatchersPrinter.java
@@ -9,10 +9,12 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.mockito.ArgumentMatcher;
+import org.mockito.CheckReturnValue;
 import org.mockito.internal.matchers.ContainsExtraTypeInfo;
 import org.mockito.internal.reporting.PrintSettings;
 
 @SuppressWarnings("unchecked")
+@CheckReturnValue
 public class MatchersPrinter {
 
     public String getArgumentsLine(List<ArgumentMatcher> matchers, PrintSettings printSettings) {

--- a/mockito-core/src/main/java/org/mockito/internal/matchers/text/ValuePrinter.java
+++ b/mockito-core/src/main/java/org/mockito/internal/matchers/text/ValuePrinter.java
@@ -4,6 +4,7 @@
  */
 package org.mockito.internal.matchers.text;
 
+import org.mockito.CheckReturnValue;
 import java.lang.reflect.Array;
 import java.util.Iterator;
 import java.util.Map;
@@ -12,6 +13,7 @@ import java.util.Map;
  * Prints a Java object value in a way humans can read it neatly.
  * Inspired on hamcrest. Used for printing arguments in verification errors.
  */
+@CheckReturnValue
 public class ValuePrinter {
 
     private ValuePrinter() {}

--- a/mockito-core/src/main/java/org/mockito/internal/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/package-info.java
@@ -8,4 +8,5 @@
  *
  * Subject to change at any time without notice.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal;

--- a/mockito-core/src/main/java/org/mockito/internal/progress/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/progress/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Mocking progress stateful classes.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal.progress;

--- a/mockito-core/src/main/java/org/mockito/internal/reporting/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/reporting/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Deals with nicely printing verification errors.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal.reporting;

--- a/mockito-core/src/main/java/org/mockito/internal/runners/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/runners/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Internal classes for runners implementations.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal.runners;

--- a/mockito-core/src/main/java/org/mockito/internal/runners/util/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/runners/util/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Internal utils for runner implementations.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal.runners.util;

--- a/mockito-core/src/main/java/org/mockito/internal/session/DefaultMockitoSessionBuilder.java
+++ b/mockito-core/src/main/java/org/mockito/internal/session/DefaultMockitoSessionBuilder.java
@@ -8,7 +8,8 @@ import static java.util.Collections.emptyList;
 
 import java.util.ArrayList;
 import java.util.List;
-
+import org.mockito.CanIgnoreReturnValue;
+import org.mockito.CheckReturnValue;
 import org.mockito.MockitoSession;
 import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.internal.framework.DefaultMockitoSession;
@@ -17,6 +18,7 @@ import org.mockito.quality.Strictness;
 import org.mockito.session.MockitoSessionBuilder;
 import org.mockito.session.MockitoSessionLogger;
 
+@CheckReturnValue
 public class DefaultMockitoSessionBuilder implements MockitoSessionBuilder {
 
     private final List<Object> testClassInstances = new ArrayList<Object>();
@@ -25,6 +27,7 @@ public class DefaultMockitoSessionBuilder implements MockitoSessionBuilder {
     private MockitoSessionLogger logger;
 
     @Override
+    @CanIgnoreReturnValue
     public MockitoSessionBuilder initMocks(Object testClassInstance) {
         if (testClassInstance != null) {
             this.testClassInstances.add(testClassInstance);
@@ -33,6 +36,7 @@ public class DefaultMockitoSessionBuilder implements MockitoSessionBuilder {
     }
 
     @Override
+    @CanIgnoreReturnValue
     public MockitoSessionBuilder initMocks(Object... testClassInstances) {
         if (testClassInstances != null) {
             for (Object instance : testClassInstances) {
@@ -43,18 +47,21 @@ public class DefaultMockitoSessionBuilder implements MockitoSessionBuilder {
     }
 
     @Override
+    @CanIgnoreReturnValue
     public MockitoSessionBuilder name(String name) {
         this.name = name;
         return this;
     }
 
     @Override
+    @CanIgnoreReturnValue
     public MockitoSessionBuilder strictness(Strictness strictness) {
         this.strictness = strictness;
         return this;
     }
 
     @Override
+    @CanIgnoreReturnValue
     public MockitoSessionBuilder logger(MockitoSessionLogger logger) {
         this.logger = logger;
         return this;

--- a/mockito-core/src/main/java/org/mockito/internal/session/MockitoLoggerAdapter.java
+++ b/mockito-core/src/main/java/org/mockito/internal/session/MockitoLoggerAdapter.java
@@ -4,9 +4,11 @@
  */
 package org.mockito.internal.session;
 
+import org.mockito.CheckReturnValue;
 import org.mockito.plugins.MockitoLogger;
 import org.mockito.session.MockitoSessionLogger;
 
+@CheckReturnValue
 class MockitoLoggerAdapter implements MockitoLogger {
 
     private final MockitoSessionLogger logger;

--- a/mockito-core/src/main/java/org/mockito/internal/session/MockitoSessionLoggerAdapter.java
+++ b/mockito-core/src/main/java/org/mockito/internal/session/MockitoSessionLoggerAdapter.java
@@ -4,9 +4,11 @@
  */
 package org.mockito.internal.session;
 
+import org.mockito.CheckReturnValue;
 import org.mockito.plugins.MockitoLogger;
 import org.mockito.session.MockitoSessionLogger;
 
+@CheckReturnValue
 public class MockitoSessionLoggerAdapter implements MockitoSessionLogger {
 
     private final MockitoLogger logger;

--- a/mockito-core/src/main/java/org/mockito/internal/stubbing/InvocationContainerImpl.java
+++ b/mockito-core/src/main/java/org/mockito/internal/stubbing/InvocationContainerImpl.java
@@ -11,7 +11,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-
+import org.mockito.CanIgnoreReturnValue;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.invocation.StubInfoImpl;
 import org.mockito.internal.verification.DefaultRegisteredInvocations;
@@ -57,6 +57,7 @@ public class InvocationContainerImpl implements InvocationContainer, Serializabl
     }
 
     /** Adds new stubbed answer and returns the invocation matcher the answer was added to. */
+    @CanIgnoreReturnValue
     public StubbedInvocationMatcher addAnswer(
             Answer<?> answer, boolean isConsecutive, Strictness stubbingStrictness) {
         Invocation invocation = invocationForStubbing.getInvocation();

--- a/mockito-core/src/main/java/org/mockito/internal/stubbing/StubberImpl.java
+++ b/mockito-core/src/main/java/org/mockito/internal/stubbing/StubberImpl.java
@@ -14,6 +14,7 @@ import static org.mockito.internal.util.MockUtil.isMock;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.mockito.CanIgnoreReturnValue;
 import org.mockito.internal.stubbing.answers.CallsRealMethods;
 import org.mockito.internal.stubbing.answers.Returns;
 import org.mockito.internal.stubbing.answers.ThrowsException;
@@ -72,6 +73,7 @@ public class StubberImpl implements Stubber {
     }
 
     @Override
+    @CanIgnoreReturnValue
     public Stubber doThrow(Throwable... toBeThrown) {
         if (toBeThrown == null) {
             answers.add(new ThrowsException(null));
@@ -109,18 +111,21 @@ public class StubberImpl implements Stubber {
     }
 
     @Override
+    @CanIgnoreReturnValue
     public Stubber doNothing() {
         answers.add(doesNothing());
         return this;
     }
 
     @Override
+    @CanIgnoreReturnValue
     public Stubber doAnswer(Answer answer) {
         answers.add(answer);
         return this;
     }
 
     @Override
+    @CanIgnoreReturnValue
     public Stubber doCallRealMethod() {
         answers.add(new CallsRealMethods());
         return this;

--- a/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AbstractThrowsException.java
+++ b/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AbstractThrowsException.java
@@ -7,6 +7,7 @@ package org.mockito.internal.stubbing.answers;
 import static org.mockito.internal.exceptions.Reporter.cannotStubWithNullThrowable;
 import static org.mockito.internal.exceptions.Reporter.checkedExceptionInvalid;
 
+import org.mockito.CanIgnoreReturnValue;
 import org.mockito.internal.exceptions.stacktrace.ConditionalStackTraceFilter;
 import org.mockito.internal.util.MockUtil;
 import org.mockito.invocation.InvocationOnMock;
@@ -20,6 +21,7 @@ public abstract class AbstractThrowsException implements Answer<Object>, Validab
     protected abstract Throwable getThrowable();
 
     @Override
+    @CanIgnoreReturnValue
     public Object answer(InvocationOnMock invocation) throws Throwable {
         Throwable throwable = getThrowable();
         if (throwable == null) {

--- a/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Answers for stubbed calls.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal.stubbing.answers;

--- a/mockito-core/src/main/java/org/mockito/internal/stubbing/defaultanswers/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/stubbing/defaultanswers/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Implementations of default Answers.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal.stubbing.defaultanswers;

--- a/mockito-core/src/main/java/org/mockito/internal/stubbing/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/stubbing/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Stubbing logic.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal.stubbing;

--- a/mockito-core/src/main/java/org/mockito/internal/util/Checks.java
+++ b/mockito-core/src/main/java/org/mockito/internal/util/Checks.java
@@ -4,13 +4,17 @@
  */
 package org.mockito.internal.util;
 
+import org.mockito.CanIgnoreReturnValue;
+
 /** Pre-made preconditions */
 public final class Checks {
 
+    @CanIgnoreReturnValue
     public static <T> T checkNotNull(T value, String checkedValue) {
         return checkNotNull(value, checkedValue, null);
     }
 
+    @CanIgnoreReturnValue
     public static <T> T checkNotNull(T value, String checkedValue, String additionalMessage) {
         if (value == null) {
             String message = checkedValue + " should not be null";

--- a/mockito-core/src/main/java/org/mockito/internal/util/MockUtil.java
+++ b/mockito-core/src/main/java/org/mockito/internal/util/MockUtil.java
@@ -4,6 +4,12 @@
  */
 package org.mockito.internal.util;
 
+import static org.mockito.internal.handler.MockHandlerFactory.createMockHandler;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 import org.mockito.MockedConstruction;
 import org.mockito.Mockito;
 import org.mockito.exceptions.misusing.NotAMockException;
@@ -18,13 +24,6 @@ import org.mockito.mock.MockName;
 import org.mockito.plugins.MockMaker;
 import org.mockito.plugins.MockMaker.TypeMockability;
 import org.mockito.plugins.MockResolver;
-
-import java.util.Collections;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
-
-import static org.mockito.internal.handler.MockHandlerFactory.createMockHandler;
 
 @SuppressWarnings("unchecked")
 public class MockUtil {

--- a/mockito-core/src/main/java/org/mockito/internal/util/collections/HashCodeAndEqualsMockWrapper.java
+++ b/mockito-core/src/main/java/org/mockito/internal/util/collections/HashCodeAndEqualsMockWrapper.java
@@ -4,6 +4,7 @@
  */
 package org.mockito.internal.util.collections;
 
+import org.mockito.CheckReturnValue;
 import org.mockito.internal.util.MockUtil;
 
 /**
@@ -24,6 +25,7 @@ import org.mockito.internal.util.MockUtil;
  *
  * @see HashCodeAndEqualsSafeSet
  */
+@CheckReturnValue
 public class HashCodeAndEqualsMockWrapper {
 
     private final Object mockInstance;

--- a/mockito-core/src/main/java/org/mockito/internal/util/collections/HashCodeAndEqualsSafeSet.java
+++ b/mockito-core/src/main/java/org/mockito/internal/util/collections/HashCodeAndEqualsSafeSet.java
@@ -12,6 +12,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
+import org.mockito.CanIgnoreReturnValue;
+import org.mockito.CheckReturnValue;
 import org.mockito.internal.util.Checks;
 
 /**
@@ -29,6 +31,7 @@ import org.mockito.internal.util.Checks;
  *
  * @see HashCodeAndEqualsMockWrapper
  */
+@CheckReturnValue
 public class HashCodeAndEqualsSafeSet implements Set<Object> {
 
     private final HashSet<HashCodeAndEqualsMockWrapper> backingHashSet = new HashSet<>();
@@ -70,11 +73,13 @@ public class HashCodeAndEqualsSafeSet implements Set<Object> {
     }
 
     @Override
+    @CanIgnoreReturnValue
     public boolean add(Object mock) {
         return backingHashSet.add(HashCodeAndEqualsMockWrapper.of(mock));
     }
 
     @Override
+    @CanIgnoreReturnValue
     public boolean remove(Object mock) {
         return backingHashSet.remove(HashCodeAndEqualsMockWrapper.of(mock));
     }
@@ -137,6 +142,7 @@ public class HashCodeAndEqualsSafeSet implements Set<Object> {
     }
 
     @Override
+    @CanIgnoreReturnValue
     public boolean addAll(Collection<?> mocks) {
         return backingHashSet.addAll(asWrappedMocks(mocks));
     }

--- a/mockito-core/src/main/java/org/mockito/internal/util/collections/IdentitySet.java
+++ b/mockito-core/src/main/java/org/mockito/internal/util/collections/IdentitySet.java
@@ -4,9 +4,11 @@
  */
 package org.mockito.internal.util.collections;
 
+import org.mockito.CheckReturnValue;
 import java.util.LinkedList;
 
 @SuppressWarnings("unchecked")
+@CheckReturnValue
 public class IdentitySet {
 
     private final LinkedList list = new LinkedList();

--- a/mockito-core/src/main/java/org/mockito/internal/util/collections/Iterables.java
+++ b/mockito-core/src/main/java/org/mockito/internal/util/collections/Iterables.java
@@ -4,12 +4,14 @@
  */
 package org.mockito.internal.util.collections;
 
+import org.mockito.CheckReturnValue;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.List;
 
 /** Utilities for Iterables */
+@CheckReturnValue
 public final class Iterables {
 
     /**

--- a/mockito-core/src/main/java/org/mockito/internal/util/collections/Sets.java
+++ b/mockito-core/src/main/java/org/mockito/internal/util/collections/Sets.java
@@ -4,11 +4,14 @@
  */
 package org.mockito.internal.util.collections;
 
+import org.mockito.CheckReturnValue;
+
 import static java.util.Arrays.asList;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+@CheckReturnValue
 public abstract class Sets {
     public static Set<Object> newMockSafeHashSet(Iterable<Object> mocks) {
         return HashCodeAndEqualsSafeSet.of(mocks);

--- a/mockito-core/src/main/java/org/mockito/internal/util/collections/WeakIdentityMap.java
+++ b/mockito-core/src/main/java/org/mockito/internal/util/collections/WeakIdentityMap.java
@@ -4,6 +4,8 @@
  */
 package org.mockito.internal.util.collections;
 
+import org.mockito.CanIgnoreReturnValue;
+import org.mockito.CheckReturnValue;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.util.*;
@@ -18,6 +20,7 @@ import java.util.*;
  * lookups. Hash collisions (distinct objects sharing an identity hash code) are resolved by
  * linear scan within the bucket using {@code ==}. Lookups do not allocate.
  */
+@CheckReturnValue
 public class WeakIdentityMap<V> extends AbstractMap<Object, V> {
 
     private final Map<Integer, List<WeakEntry<V>>> delegate = new HashMap<>();
@@ -69,6 +72,7 @@ public class WeakIdentityMap<V> extends AbstractMap<Object, V> {
     }
 
     @Override
+    @CanIgnoreReturnValue
     public V put(Object key, V value) {
         expungeStaleEntries();
         int hash = System.identityHashCode(key);
@@ -91,6 +95,7 @@ public class WeakIdentityMap<V> extends AbstractMap<Object, V> {
     }
 
     @Override
+    @CanIgnoreReturnValue
     public V remove(Object key) {
         expungeStaleEntries();
         int hash = System.identityHashCode(key);

--- a/mockito-core/src/main/java/org/mockito/internal/util/concurrent/DetachedThreadLocal.java
+++ b/mockito-core/src/main/java/org/mockito/internal/util/concurrent/DetachedThreadLocal.java
@@ -4,6 +4,8 @@
  */
 package org.mockito.internal.util.concurrent;
 
+import org.mockito.CheckReturnValue;
+
 /**
  * <p>
  * A detached local that allows for explicit control of setting and removing values from a thread-local
@@ -11,6 +13,7 @@ package org.mockito.internal.util.concurrent;
  * </p>
  * Instances of this class are non-blocking and fully thread safe.
  */
+@CheckReturnValue
 public class DetachedThreadLocal<T> implements Runnable {
 
     final WeakConcurrentMap<Thread, T> map;

--- a/mockito-core/src/main/java/org/mockito/internal/util/io/IOUtil.java
+++ b/mockito-core/src/main/java/org/mockito/internal/util/io/IOUtil.java
@@ -16,12 +16,14 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import org.mockito.CheckReturnValue;
 import org.mockito.exceptions.base.MockitoException;
 
 /**
  * IO utils. A bit of reinventing the wheel but we don't want extra dependencies at this stage and
  * we want to be java.
  */
+@CheckReturnValue
 public final class IOUtil {
 
     /**

--- a/mockito-core/src/main/java/org/mockito/internal/util/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/util/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Static utils
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal.util;

--- a/mockito-core/src/main/java/org/mockito/internal/util/reflection/FieldInitializer.java
+++ b/mockito-core/src/main/java/org/mockito/internal/util/reflection/FieldInitializer.java
@@ -4,10 +4,7 @@
  */
 package org.mockito.internal.util.reflection;
 
-import org.mockito.exceptions.base.MockitoException;
-import org.mockito.internal.configuration.plugins.Plugins;
-import org.mockito.internal.util.MockUtil;
-import org.mockito.plugins.MemberAccessor;
+import static java.lang.reflect.Modifier.isStatic;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -17,8 +14,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-
-import static java.lang.reflect.Modifier.isStatic;
+import org.mockito.CanIgnoreReturnValue;
+import org.mockito.exceptions.base.MockitoException;
+import org.mockito.internal.configuration.plugins.Plugins;
+import org.mockito.internal.util.MockUtil;
+import org.mockito.plugins.MemberAccessor;
 
 /**
  * Initialize a field with type instance if a default constructor can be found.
@@ -45,6 +45,7 @@ public class FieldInitializer {
      * @param fieldOwner Instance of the test.
      * @param field Field to be initialize.
      */
+    @CanIgnoreReturnValue
     public FieldInitializer(Object fieldOwner, Field field) {
         this(fieldOwner, field, new NoArgConstructorInstantiator(fieldOwner, field));
     }
@@ -275,6 +276,7 @@ public class FieldInitializer {
          * Internal, checks are done by FieldInitializer.
          * Fields are assumed to be accessible.
          */
+        @CanIgnoreReturnValue
         ParameterizedConstructorInstantiator(
                 Object testClass, Field field, ConstructorArgumentResolver argumentResolver) {
             this.testClass = testClass;

--- a/mockito-core/src/main/java/org/mockito/internal/util/reflection/InstrumentationMemberAccessor.java
+++ b/mockito-core/src/main/java/org/mockito/internal/util/reflection/InstrumentationMemberAccessor.java
@@ -8,6 +8,7 @@ import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.dynamic.loading.ByteArrayClassLoader;
 import net.bytebuddy.dynamic.loading.InjectionClassLoader;
 import net.bytebuddy.implementation.MethodCall;
+import org.mockito.CanIgnoreReturnValue;
 import org.mockito.exceptions.base.MockitoInitializationException;
 import org.mockito.internal.PremainAttachAccess;
 import org.mockito.internal.SuppressSignatureCheck;
@@ -449,6 +450,7 @@ class InstrumentationMemberAccessor implements MemberAccessor {
         // Used to avoid invoke/invokeExact being exposed to Android where this class should
         // never be loaded. Since the invocation happens from the generated code, the Android
         // build pipeline does not fail.
+        @CanIgnoreReturnValue
         Object invokeWithArguments(MethodHandle handle, Object... arguments) throws Throwable;
     }
 }

--- a/mockito-core/src/main/java/org/mockito/internal/util/reflection/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/util/reflection/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Reflection utilities.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal.util.reflection;

--- a/mockito-core/src/main/java/org/mockito/internal/verification/VerificationModeFactory.java
+++ b/mockito-core/src/main/java/org/mockito/internal/verification/VerificationModeFactory.java
@@ -4,6 +4,7 @@
  */
 package org.mockito.internal.verification;
 
+import org.mockito.CanIgnoreReturnValue;
 import org.mockito.verification.VerificationMode;
 
 public final class VerificationModeFactory {
@@ -12,6 +13,7 @@ public final class VerificationModeFactory {
         return atLeast(1);
     }
 
+    @CanIgnoreReturnValue
     public static VerificationMode atLeast(int minNumberOfInvocations) {
         return new AtLeast(minNumberOfInvocations);
     }

--- a/mockito-core/src/main/java/org/mockito/internal/verification/api/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/verification/api/package-info.java
@@ -6,4 +6,5 @@
 /**
  * This package should be open to public once verification API is fully finished.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal.verification.api;

--- a/mockito-core/src/main/java/org/mockito/internal/verification/argumentmatching/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/verification/argumentmatching/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Deals with matching arguments.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal.verification.argumentmatching;

--- a/mockito-core/src/main/java/org/mockito/internal/verification/checkers/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/verification/checkers/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Verification checkers.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal.verification.checkers;

--- a/mockito-core/src/main/java/org/mockito/internal/verification/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/internal/verification/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Verification logic.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.internal.verification;

--- a/mockito-core/src/main/java/org/mockito/junit/MockitoRule.java
+++ b/mockito-core/src/main/java/org/mockito/junit/MockitoRule.java
@@ -5,6 +5,7 @@
 package org.mockito.junit;
 
 import org.junit.rules.MethodRule;
+import org.mockito.CanIgnoreReturnValue;
 import org.mockito.MockSettings;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -145,5 +146,6 @@ public interface MockitoRule extends MethodRule {
      *
      * @since 2.3.0
      */
+    @CanIgnoreReturnValue
     MockitoRule strictness(Strictness strictness);
 }

--- a/mockito-core/src/main/java/org/mockito/junit/MockitoTestRule.java
+++ b/mockito-core/src/main/java/org/mockito/junit/MockitoTestRule.java
@@ -5,6 +5,7 @@
 package org.mockito.junit;
 
 import org.junit.rules.TestRule;
+import org.mockito.CanIgnoreReturnValue;
 import org.mockito.quality.Strictness;
 
 /**
@@ -27,5 +28,6 @@ public interface MockitoTestRule extends TestRule {
      *
      * @since 3.3.0
      */
+    @CanIgnoreReturnValue
     MockitoTestRule strictness(Strictness strictness);
 }

--- a/mockito-core/src/main/java/org/mockito/junit/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/junit/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Mockito JUnit integration ; rule and runners.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.junit;

--- a/mockito-core/src/main/java/org/mockito/listeners/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/listeners/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Public classes relative to the listener APIs.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.listeners;

--- a/mockito-core/src/main/java/org/mockito/mock/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/mock/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Mock settings related classes.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.mock;

--- a/mockito-core/src/main/java/org/mockito/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/package-info.java
@@ -8,4 +8,5 @@
  *
  * @see org.mockito.Mockito
  */
+@org.mockito.CheckReturnValue
 package org.mockito;

--- a/mockito-core/src/main/java/org/mockito/quality/Strictness.java
+++ b/mockito-core/src/main/java/org/mockito/quality/Strictness.java
@@ -4,6 +4,7 @@
  */
 package org.mockito.quality;
 
+import org.mockito.CanIgnoreReturnValue;
 import org.mockito.MockitoSession;
 import org.mockito.exceptions.misusing.PotentialStubbingProblem;
 import org.mockito.exceptions.misusing.UnnecessaryStubbingException;
@@ -37,6 +38,7 @@ import org.mockito.junit.MockitoRule;
  *
  * @since 2.3.0
  */
+@CanIgnoreReturnValue
 public enum Strictness {
 
     /**

--- a/mockito-core/src/main/java/org/mockito/quality/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/quality/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Mocking quality related classes.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.quality;

--- a/mockito-core/src/main/java/org/mockito/verification/package-info.java
+++ b/mockito-core/src/main/java/org/mockito/verification/package-info.java
@@ -6,4 +6,5 @@
 /**
  * Verification related classes.
  */
+@org.mockito.CheckReturnValue
 package org.mockito.verification;

--- a/mockito-core/src/test/java/org/mockito/MockTest.java
+++ b/mockito-core/src/test/java/org/mockito/MockTest.java
@@ -4,13 +4,13 @@
  */
 package org.mockito;
 
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assume.assumeThat;
+
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assume.assumeThat;
 
 @RunWith(Enclosed.class)
 public class MockTest {

--- a/mockito-core/src/test/java/org/mockito/MockitoTest.java
+++ b/mockito-core/src/test/java/org/mockito/MockitoTest.java
@@ -421,6 +421,7 @@ public class MockitoTest {
                 .hasMessageStartingWith("Please don't pass any values here");
     }
 
+    @CanIgnoreReturnValue
     private static final class Dummy {
 
         public static String getValue() {

--- a/mockito-core/src/test/java/org/mockito/internal/configuration/plugins/PluginLoaderTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/configuration/plugins/PluginLoaderTest.java
@@ -4,6 +4,7 @@
  */
 package org.mockito.internal.configuration.plugins;
 
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.Mockito.never;
@@ -71,13 +72,14 @@ public class PluginLoaderTest {
         willReturn(null).given(initializer).loadImpl(FooPlugin.class);
         willReturn(null).given(initializer).loadImpl(BarPlugin.class);
         FooPlugin expected = new FooPlugin();
-        willReturn(expected).given(plugins).getDefaultPlugin(FooPlugin.class);
+        FooPlugin unused = willReturn(expected).given(plugins).getDefaultPlugin(FooPlugin.class);
 
         // when
         Object plugin = loader.loadPlugin(FooPlugin.class, BarPlugin.class);
 
         // then
         assertSame(expected, plugin);
+        assertNull(unused);
     }
 
     @Test
@@ -133,13 +135,14 @@ public class PluginLoaderTest {
         willReturn(null).given(initializer).loadImpl(Foo.class);
         willReturn(null).given(initializer).loadImpl(FooChildPlugin.class);
         FooChildPlugin expected = new FooChildPlugin();
-        willReturn(expected).given(plugins).getDefaultPlugin(Foo.class);
+        Foo unused = willReturn(expected).given(plugins).getDefaultPlugin(Foo.class);
 
         // when
         Foo plugin = loader.loadPlugin(Foo.class, FooChildPlugin.class);
 
         // then
         assertSame(expected, plugin);
+        assertNull(unused);
     }
 
     @Test
@@ -173,13 +176,15 @@ public class PluginLoaderTest {
         willReturn(null).given(initializer).loadImpl(Foo.class);
         willReturn(null).given(initializer).loadImpl(FooChildPlugin.class);
         FooChildPlugin expected = new FooChildPlugin();
-        willReturn(expected).given(plugins).getDefaultPlugin(FooChildPlugin.class);
+        FooChildPlugin unused =
+                willReturn(expected).given(plugins).getDefaultPlugin(FooChildPlugin.class);
 
         // when
         Foo plugin = loader.loadPlugin(FooChildPlugin.class, Foo.class);
 
         // then
         assertSame(expected, plugin);
+        assertNull(unused);
     }
 
     @Test
@@ -213,13 +218,15 @@ public class PluginLoaderTest {
         willReturn(null).given(initializer).loadImpl(FooBarChildPlugin1.class);
         willReturn(null).given(initializer).loadImpl(FooBarChildPlugin2.class);
         FooBarChildPlugin1 expected = new FooBarChildPlugin1();
-        willReturn(expected).given(plugins).getDefaultPlugin(FooBarChildPlugin1.class);
+        FooBarChildPlugin1 unused =
+                willReturn(expected).given(plugins).getDefaultPlugin(FooBarChildPlugin1.class);
 
         // when
         FooBar plugin = loader.loadPlugin(FooBarChildPlugin1.class, FooBarChildPlugin2.class);
 
         // then
         assertSame(expected, plugin);
+        assertNull(unused);
     }
 
     static class FooPlugin {}

--- a/mockito-core/src/test/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMakerTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/creation/bytebuddy/ByteBuddyMockMakerTest.java
@@ -4,12 +4,15 @@
  */
 package org.mockito.internal.creation.bytebuddy;
 
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.verify;
 
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.internal.creation.settings.CreationSettings;
 import org.mockito.internal.handler.MockHandlerImpl;
+import org.mockito.invocation.MockHandler;
+import org.mockito.plugins.MockMaker.TypeMockability;
 import org.mockitoutil.TestBase;
 
 public class ByteBuddyMockMakerTest extends TestBase {
@@ -23,12 +26,16 @@ public class ByteBuddyMockMakerTest extends TestBase {
         CreationSettings<Object> creationSettings = new CreationSettings<Object>();
         MockHandlerImpl<Object> handler = new MockHandlerImpl<Object>(creationSettings);
 
-        mockMaker.createMockType(creationSettings);
-        mockMaker.createMock(creationSettings, handler);
-        mockMaker.getHandler(this);
-        mockMaker.isTypeMockable(Object.class);
+        Class<?> mockType = mockMaker.createMockType(creationSettings);
+        Object mock = mockMaker.createMock(creationSettings, handler);
+        MockHandler<?> createdHandler = mockMaker.getHandler(this);
+        TypeMockability isTypeMockable = mockMaker.isTypeMockable(Object.class);
         mockMaker.resetMock(this, handler, creationSettings);
 
+        assertNull(mockType);
+        assertNull(mock);
+        assertNull(createdHandler);
+        assertNull(isTypeMockable);
         verify(delegate).createMock(creationSettings, handler);
         verify(delegate).createMockType(creationSettings);
         verify(delegate).getHandler(this);

--- a/mockito-core/src/test/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMakerTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/creation/bytebuddy/InlineByteBuddyMockMakerTest.java
@@ -8,8 +8,13 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.internal.creation.settings.CreationSettings;
 import org.mockito.internal.handler.MockHandlerImpl;
+import org.mockito.invocation.MockHandler;
+import org.mockito.plugins.MockMaker.ConstructionMockControl;
+import org.mockito.plugins.MockMaker.StaticMockControl;
+import org.mockito.plugins.MockMaker.TypeMockability;
 import org.mockitoutil.TestBase;
 
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.verify;
 
 public class InlineByteBuddyMockMakerTest extends TestBase {
@@ -23,17 +28,25 @@ public class InlineByteBuddyMockMakerTest extends TestBase {
         CreationSettings<Object> creationSettings = new CreationSettings<Object>();
         MockHandlerImpl<Object> handler = new MockHandlerImpl<Object>(creationSettings);
 
-        mockMaker.createMockType(creationSettings);
-        mockMaker.createMock(creationSettings, handler);
-        mockMaker.createStaticMock(Object.class, creationSettings, handler);
-        mockMaker.createConstructionMock(Object.class, null, null, null);
-        mockMaker.getHandler(this);
-        mockMaker.isTypeMockable(Object.class);
+        Class<?> mockType = mockMaker.createMockType(creationSettings);
+        Object mock = mockMaker.createMock(creationSettings, handler);
+        StaticMockControl<Object> staticMock =
+                mockMaker.createStaticMock(Object.class, creationSettings, handler);
+        ConstructionMockControl<Object> constructionMock =
+                mockMaker.createConstructionMock(Object.class, null, null, null);
+        MockHandler createdHandler = mockMaker.getHandler(this);
+        TypeMockability isTypeMockable = mockMaker.isTypeMockable(Object.class);
         mockMaker.resetMock(this, handler, creationSettings);
         mockMaker.clearMock(this);
         mockMaker.clearAllMocks();
         mockMaker.clearAllCaches();
 
+        assertNull(mockType);
+        assertNull(mock);
+        assertNull(staticMock);
+        assertNull(constructionMock);
+        assertNull(createdHandler);
+        assertNull(isTypeMockable);
         verify(delegate).createMock(creationSettings, handler);
         verify(delegate).createStaticMock(Object.class, creationSettings, handler);
         verify(delegate).createConstructionMock(Object.class, null, null, null);

--- a/mockito-core/src/test/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMakerTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMakerTest.java
@@ -169,7 +169,7 @@ public class InlineDelegateByteBuddyMockMakerTest
     public void should_throw_exception_redefining_unmodifiable_class() {
         MockCreationSettings settings = settingsFor(int.class);
         try {
-            mockMaker.createMock(settings, new MockHandlerImpl(settings));
+            Object mock = mockMaker.createMock(settings, new MockHandlerImpl(settings));
             fail("Expected a MockitoException");
         } catch (MockitoException e) {
             e.printStackTrace();
@@ -183,7 +183,7 @@ public class InlineDelegateByteBuddyMockMakerTest
         int[] array = new int[5];
         MockCreationSettings<? extends int[]> settings = settingsFor(array.getClass());
         try {
-            mockMaker.createMock(settings, new MockHandlerImpl(settings));
+            int[] mock = mockMaker.createMock(settings, new MockHandlerImpl(settings));
             fail("Expected a MockitoException");
         } catch (MockitoException e) {
             assertThat(e).hasMessageContaining("Arrays cannot be mocked");
@@ -206,7 +206,8 @@ public class InlineDelegateByteBuddyMockMakerTest
                         .setSerializableMode(SerializableMode.BASIC);
 
         try {
-            mockMaker.createMock(settings, new MockHandlerImpl<FinalClass>(settings));
+            FinalClass mock =
+                    mockMaker.createMock(settings, new MockHandlerImpl<FinalClass>(settings));
             fail("Expected a MockitoException");
         } catch (MockitoException e) {
             assertThat(e)
@@ -225,7 +226,8 @@ public class InlineDelegateByteBuddyMockMakerTest
                         .setExtraInterfaces(Sets.<Class<?>>newSet(List.class));
 
         try {
-            mockMaker.createMock(settings, new MockHandlerImpl<FinalClass>(settings));
+            FinalClass mock =
+                    mockMaker.createMock(settings, new MockHandlerImpl<FinalClass>(settings));
             fail("Expected a MockitoException");
         } catch (MockitoException e) {
             assertThat(e)

--- a/mockito-core/src/test/java/org/mockito/internal/framework/DefaultMockitoFrameworkTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/framework/DefaultMockitoFrameworkTest.java
@@ -221,13 +221,10 @@ public class DefaultMockitoFrameworkTest extends TestBase {
         assertTrue(mockingDetails(obj).isMock());
 
         framework.clearInlineMocks();
-
-        try {
-            mockingDetails(obj).isMock();
-        } catch (DisabledMockException e) {
-            return;
-        }
-        Assert.fail("Should have thrown DisabledMockException");
+        Assert.assertThrows(
+                "Should have thrown DisabledMockException",
+                DisabledMockException.class,
+                () -> mockingDetails(obj).isMock());
     }
 
     @Test

--- a/mockito-core/src/test/java/org/mockito/internal/handler/InvocationNotifierHandlerTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/handler/InvocationNotifierHandlerTest.java
@@ -6,6 +6,7 @@ package org.mockito.internal.handler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
@@ -16,6 +17,7 @@ import static org.mockito.Mockito.verify;
 import java.text.ParseException;
 import java.util.ArrayList;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,6 +26,7 @@ import org.mockito.Spy;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.creation.MockSettingsImpl;
 import org.mockito.invocation.Invocation;
+import org.mockito.invocation.InvocationContainer;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.listeners.InvocationListener;
 import org.mockito.listeners.MethodInvocationReport;
@@ -63,13 +66,14 @@ public class InvocationNotifierHandlerTest {
         given(mockHandler.handle(invocation)).willReturn("returned value");
 
         // when
-        notifier.handle(invocation);
+        Object returnedValue = notifier.handle(invocation);
 
         // then
         verify(listener1)
                 .reportInvocation(new NotifiedMethodInvocationReport(invocation, "returned value"));
         verify(listener2)
                 .reportInvocation(new NotifiedMethodInvocationReport(invocation, "returned value"));
+        Assert.assertEquals("returned value", returnedValue);
     }
 
     @Test
@@ -80,7 +84,7 @@ public class InvocationNotifierHandlerTest {
         given(mockHandler.handle(invocation)).willReturn(computedException);
 
         // when
-        notifier.handle(invocation);
+        Object thrownException = notifier.handle(invocation);
 
         // then
         verify(listener1)
@@ -89,6 +93,8 @@ public class InvocationNotifierHandlerTest {
         verify(listener2)
                 .reportInvocation(
                         new NotifiedMethodInvocationReport(invocation, (Object) computedException));
+        Assert.assertNotNull(thrownException);
+        Assert.assertEquals(Exception.class, thrownException.getClass());
     }
 
     @Test
@@ -134,9 +140,11 @@ public class InvocationNotifierHandlerTest {
 
     @Test
     public void should_delegate_all_MockHandlerInterface_to_the_parameterized_MockHandler() {
-        notifier.getInvocationContainer();
-        notifier.getMockSettings();
+        InvocationContainer invocationContainer = notifier.getInvocationContainer();
+        MockCreationSettings<ArrayList<Answer<?>>> mockSettings = notifier.getMockSettings();
 
+        assertNull(invocationContainer);
+        assertNull(mockSettings);
         verify(mockHandler).getInvocationContainer();
         verify(mockHandler).getMockSettings();
     }

--- a/mockito-core/src/test/java/org/mockito/internal/progress/VerificationModeBuilder.java
+++ b/mockito-core/src/test/java/org/mockito/internal/progress/VerificationModeBuilder.java
@@ -4,6 +4,7 @@
  */
 package org.mockito.internal.progress;
 
+import org.mockito.CanIgnoreReturnValue;
 import org.mockito.internal.verification.Times;
 import org.mockito.internal.verification.VerificationModeFactory;
 
@@ -15,6 +16,7 @@ public class VerificationModeBuilder {
         return VerificationModeFactory.times(times);
     }
 
+    @CanIgnoreReturnValue
     public VerificationModeBuilder times(int times) {
         this.times = times;
         return this;

--- a/mockito-core/src/test/java/org/mockito/internal/session/DefaultMockitoSessionBuilderTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/session/DefaultMockitoSessionBuilderTest.java
@@ -113,12 +113,14 @@ public class DefaultMockitoSessionBuilderTest {
 
     @Test
     public void requires_finish_mocking() {
-        new DefaultMockitoSessionBuilder().startMocking();
+        MockitoSession mockitoSession = new DefaultMockitoSessionBuilder().startMocking();
 
+        assertNotNull(mockitoSession);
         ThrowableAssert.assertThat(
                         new Runnable() {
                             public void run() {
-                                new DefaultMockitoSessionBuilder().startMocking();
+                                MockitoSession unused =
+                                        new DefaultMockitoSessionBuilder().startMocking();
                             }
                         })
                 .throwsException(UnfinishedMockingSessionException.class);
@@ -126,12 +128,13 @@ public class DefaultMockitoSessionBuilderTest {
 
     @Test
     public void auto_cleans_dirty_listeners() {
-        new DefaultMockitoSessionBuilder().startMocking();
+        MockitoSession mockitoSession = new DefaultMockitoSessionBuilder().startMocking();
 
         ThrowableAssert.assertThat(
                         new Runnable() {
                             public void run() {
-                                new DefaultMockitoSessionBuilder().startMocking();
+                                MockitoSession unused =
+                                        new DefaultMockitoSessionBuilder().startMocking();
                             }
                         })
                 .throwsException(UnfinishedMockingSessionException.class);

--- a/mockito-core/src/test/java/org/mockito/internal/stubbing/InvocationContainerImplTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/stubbing/InvocationContainerImplTest.java
@@ -58,7 +58,7 @@ public class InvocationContainerImplTest {
                             }
                             c.setInvocationForPotentialStubbing(new InvocationMatcher(invocation));
                             c.addAnswer(new Returns("foo"), null);
-                            c.findAnswerFor(invocation);
+                            StubbedInvocationMatcher ignored = c.findAnswerFor(invocation);
                         }
                     };
             t[i].setUncaughtExceptionHandler(

--- a/mockito-core/src/test/java/org/mockito/internal/stubbing/answers/AnswersWithDelayTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/stubbing/answers/AnswersWithDelayTest.java
@@ -9,7 +9,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.within;
 
 import java.util.Date;
-
 import org.junit.Test;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.invocation.InvocationBuilder;
@@ -60,7 +59,9 @@ public class AnswersWithDelayTest {
         final AnswersWithDelay testSubject = new AnswersWithDelay(sleepyTime, new Returns("value"));
 
         final Date before = new Date();
-        testSubject.answer(new InvocationBuilder().method("oneArg").arg("A").toInvocation());
+        Object ignored =
+                testSubject.answer(
+                        new InvocationBuilder().method("oneArg").arg("A").toInvocation());
         final Date after = new Date();
 
         final long timePassed = after.getTime() - before.getTime();

--- a/mockito-core/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsDeepStubsConcurrentTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/stubbing/defaultanswers/ReturnsDeepStubsConcurrentTest.java
@@ -11,6 +11,7 @@ import java.util.stream.IntStream;
 
 import org.junit.Test;
 import org.mockito.Answers;
+import org.mockito.CanIgnoreReturnValue;
 
 public class ReturnsDeepStubsConcurrentTest {
 
@@ -23,6 +24,7 @@ public class ReturnsDeepStubsConcurrentTest {
         }
     }
 
+    @CanIgnoreReturnValue
     interface Service {
         List<String> doSomething();
     }

--- a/mockito-core/src/test/java/org/mockito/internal/util/SimpleMockitoLogger.java
+++ b/mockito-core/src/test/java/org/mockito/internal/util/SimpleMockitoLogger.java
@@ -4,6 +4,7 @@
  */
 package org.mockito.internal.util;
 
+import org.mockito.CanIgnoreReturnValue;
 import org.mockito.plugins.MockitoLogger;
 
 public class SimpleMockitoLogger implements MockitoLogger {
@@ -22,6 +23,7 @@ public class SimpleMockitoLogger implements MockitoLogger {
         return loggedInfo.length() == 0;
     }
 
+    @CanIgnoreReturnValue
     public SimpleMockitoLogger clear() {
         loggedInfo = new StringBuilder();
         return this;

--- a/mockito-core/src/test/java/org/mockito/internal/util/reflection/FieldInitializerTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/util/reflection/FieldInitializerTest.java
@@ -202,7 +202,8 @@ public class FieldInitializerTest {
                         .willReturn(new Object[] {null})
                         .getMock();
 
-        new FieldInitializer(this, field("noDefaultConstructor"), resolver).initialize();
+        FieldInitializationReport ignored =
+                new FieldInitializer(this, field("noDefaultConstructor"), resolver).initialize();
 
         assertNotNull(noDefaultConstructor);
     }

--- a/mockito-core/src/test/java/org/mockito/internal/util/reflection/ParameterizedConstructorInstantiatorTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/util/reflection/ParameterizedConstructorInstantiatorTest.java
@@ -76,8 +76,10 @@ public class ParameterizedConstructorInstantiatorTest {
         given(resolver.resolveTypeInstances(ArgumentMatchers.any(Class[].class)))
                 .willReturn(new Object[] {observer, map});
 
-        new ParameterizedConstructorInstantiator(this, field("withMultipleConstructor"), resolver)
-                .instantiate();
+        FieldInitializationReport ignored =
+                new ParameterizedConstructorInstantiator(
+                                this, field("withMultipleConstructor"), resolver)
+                        .instantiate();
 
         assertNotNull(withMultipleConstructor);
         assertNotNull(withMultipleConstructor.observer);
@@ -123,8 +125,10 @@ public class ParameterizedConstructorInstantiatorTest {
         given(resolver.resolveTypeInstances(ArgumentMatchers.any(Class[].class)))
                 .willReturn(new Object[] {"", vararg});
 
-        new ParameterizedConstructorInstantiator(this, field("withVarargConstructor"), resolver)
-                .instantiate();
+        FieldInitializationReport ignored =
+                new ParameterizedConstructorInstantiator(
+                                this, field("withVarargConstructor"), resolver)
+                        .instantiate();
 
         assertNotNull(withVarargConstructor);
     }

--- a/mockito-core/src/test/java/org/mockitousage/annotation/SpyInjectionTest.java
+++ b/mockito-core/src/test/java/org/mockitousage/annotation/SpyInjectionTest.java
@@ -27,7 +27,7 @@ public class SpyInjectionTest extends TestBase {
     }
 
     @Test
-    public void shouldDoStuff() throws Exception {
-        MockUtil.isMock(hasSpy.spy);
+    public void shouldDoStuff() {
+        boolean ignored = MockUtil.isMock(hasSpy.spy);
     }
 }


### PR DESCRIPTION
Fixes #3796
It adds annotation `@CanIgnoreReturnValue` which can be used to indicate that return value of a method can be  ignored. Used for static analysis tools such as FindBugs and ErrorProne.

Also adds `@CanIgnoreReturnValue` for methods where return value can be ignored and `@CheckReturnValue` for each `package-info.java` and suitable classes where there isn't this file

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style (run `./gradlew spotlessApply` for auto-formatting)
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should end with `Fixes #<issue number>` _if relevant_
