### PR TITLE
Fixes #3818 : Fix data race in InvocationContainerImpl.invocationForStubbing

### DIFF
--- a/mockito-core/src/main/java/org/mockito/internal/stubbing/InvocationContainerImpl.java
+++ b/mockito-core/src/main/java/org/mockito/internal/stubbing/InvocationContainerImpl.java
@@ -34,7 +34,7 @@ public class InvocationContainerImpl implements InvocationContainer, Serializabl
     private final RegisteredInvocations registeredInvocations;
     private final Strictness mockStrictness;
 
-    private MatchableInvocation invocationForStubbing;
+    private volatile MatchableInvocation invocationForStubbing;
 
     public InvocationContainerImpl(MockCreationSettings<?> mockSettings) {
         this.registeredInvocations = createRegisteredInvocations(mockSettings);


### PR DESCRIPTION
Makes `invocationForStubbing` volatile to ensure thread safety. Fixes [#3818](https://github.com/mockito/mockito/issues/3818).
