### PR TITLE
Add `captorForClass` static alias of `ArgumentCaptor.forClass`

### DIFF
--- a/mockito-core/src/main/java/org/mockito/ArgumentCaptor.java
+++ b/mockito-core/src/main/java/org/mockito/ArgumentCaptor.java
@@ -149,6 +149,34 @@ public class ArgumentCaptor<T> {
     }
 
     /**
+     * Static alias of {@link #forClass(Class)}.
+     * <p>
+     * Intended for use with static imports where the plain {@code forClass} name is
+     * ambiguous or insufficiently expressive. The body delegates to
+     * {@link #forClass(Class)} and behaves identically.
+     * <p>
+     * Example usage:
+     *
+     * <pre class="code"><code class="java">
+     *   import static org.mockito.ArgumentCaptor.captorForClass;
+     *
+     *   ArgumentCaptor&lt;Person&gt; argument = captorForClass(Person.class);
+     *   verify(mock).doSomething(argument.capture());
+     *   assertEquals("John", argument.getValue().getName());
+     * </code></pre>
+     *
+     * @param clazz Type matching the parameter to be captured.
+     * @param <S> Type of clazz
+     * @param <U> Type of object captured by the newly built ArgumentCaptor
+     * @return A new ArgumentCaptor
+     * @see #forClass(Class)
+     * @since 5.24.0
+     */
+    public static <U, S extends U> ArgumentCaptor<U> captorForClass(Class<S> clazz) {
+        return forClass(clazz);
+    }
+
+    /**
      * Build a new <code>ArgumentCaptor</code> by inferring the class type.
      * <p>
      * This enables inferring the generic type of an argument captor without

--- a/mockito-core/src/test/java/org/mockito/ArgumentCaptorTest.java
+++ b/mockito-core/src/test/java/org/mockito/ArgumentCaptorTest.java
@@ -48,6 +48,15 @@ public class ArgumentCaptorTest {
     }
 
     @Test
+    public void captorForClass_returns_captor_equivalent_to_forClass() throws Exception {
+        class Foo {}
+
+        ArgumentCaptor<Foo> captor = ArgumentCaptor.captorForClass(Foo.class);
+        assertThat(captor.getCaptorType()).isEqualTo(Foo.class);
+        assertThat(captor.capture()).isNull();
+    }
+
+    @Test
     public void captor_calls_forClass_with_the_inferred_argument() throws Exception {
         ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.captor();
         assertThat(captor.getCaptorType()).isEqualTo(Map.class);


### PR DESCRIPTION
Introduces ArgumentCaptor.captorForClass(Class) as a thin delegate to ArgumentCaptor.forClass(Class). The new name reads well when statically imported, where the bare forClass(...) reference is ambiguous and does not convey that an ArgumentCaptor is being built.

This follows the same precedent set by Arguments.arguments(...) in JUnit Jupiter, which was added as a more expressive static-import friendly alias of Arguments.of(...).

Example - before, with everything statically imported the construction site is ambiguous:

    import static org.mockito.ArgumentCaptor.forClass;

    final var elementCaptor = forClass(Byte.class); // forClass of what?
    inOrder.verify(subscriber, times(HelloWorld.BYTES)).onNext(elementCaptor.capture());

After:

    import static org.mockito.ArgumentCaptor.captorForClass;

    final var elementCaptor = captorForClass(Byte.class);
    inOrder.verify(subscriber, times(HelloWorld.BYTES)).onNext(elementCaptor.capture());

forClass is preserved unchanged, so existing call sites are not affected. A unit test mirroring the existing forClass coverage is added in ArgumentCaptorTest.

Fixes #3820


Checklist

 - [x] Read the contributing guide
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style (run ./gradlew spotlessApply for auto-formatting)
 - [x] Mention Fixes #<issue number> in the description if relevant
 - [x] At least one commit should end with Fixes #<issue number> if relevant
