### PR TITLE
Improve Gradle agent docs for configuration cache

### DIFF
--- a/mockito-core/src/main/java/org/mockito/Mockito.java
+++ b/mockito-core/src/main/java/org/mockito/Mockito.java
@@ -204,7 +204,7 @@ import java.util.function.Function;
  * <p>
  * To explicitly attach Mockito during test execution, the library's jar file needs to be specified as <code>-javaagent</code>
  * as an argument to the executing JVM. To enable this in Gradle, the following example adds Mockito to all test
- * tasks using <strong>Kotlin DSL</strong>. Although omitted for simplicity, using a <code>CommandLineArgumentProvider</code> is recommended by Gradle to ensure task relocatability (<a href="https://docs.gradle.org/current/userguide/caching_java_projects.html#dealing_with_file_paths">documentation</a>):
+ * tasks using <strong>Kotlin DSL</strong>. Using a <code>CommandLineArgumentProvider</code> is recommended by Gradle to ensure task relocatability (<a href="https://docs.gradle.org/current/userguide/caching_java_projects.html#dealing_with_file_paths">documentation</a>):
  *
  * <pre class="code"><code class="kotlin">
  * val mockitoAgent = configurations.create("mockitoAgent")
@@ -233,7 +233,16 @@ import java.util.function.Function;
  * }
  * tasks {
  *     test {
- *         jvmArgs += "-javaagent:${configurations.mockitoAgent.asPath}"
+ *         jvmArgumentProviders.add(new CommandLineArgumentProvider() {
+ *             @InputFiles
+ *             @PathSensitive(PathSensitivity.RELATIVE)
+ *             FileCollection mockitoAgent = configurations.mockitoAgent
+ *
+ *             @Override
+ *             Iterable<String> asArguments() {
+ *                 ["-javaagent:${mockitoAgent.asPath}"]
+ *             }
+ *         })
  *     }
  * }
  * </code></pre>


### PR DESCRIPTION
## Summary

This updates the Groovy Gradle example for explicitly attaching Mockito as a Java agent to use `CommandLineArgumentProvider`.

The previous example accessed `configurations.mockitoAgent` directly from the test task configuration, which can fail when Gradle configuration cache is enabled. The revised example follows the provider-based pattern suggested in #3822 and keeps the documented setup compatible with configuration-cache usage.

The surrounding wording is also adjusted so it no longer says that `CommandLineArgumentProvider` is omitted from the examples.

Fixes #3822

## Checklist

 - [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style (run `./gradlew spotlessApply` for auto-formatting)
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should end with `Fixes #<issue number>` _if relevant_