### PR TITLE
Add InvocationOnMock.getInvocationCount() for stateful Answers

### DIFF
--- a/mockito-core/src/main/java/org/mockito/Mockito.java
+++ b/mockito-core/src/main/java/org/mockito/Mockito.java
@@ -677,6 +677,21 @@ import java.util.function.Function;
  * System.out.println(mock.someMethod("foo"));
  * </code></pre>
  *
+ * <p>
+ * {@link org.mockito.invocation.InvocationOnMock} also exposes
+ * {@link org.mockito.invocation.InvocationOnMock#getInvocationCount()}, which is useful when the
+ * answer should depend on how many times the same call has already happened &mdash; for example,
+ * failing the first few calls and then returning a value:
+ *
+ * <pre class="code"><code class="java">
+ * when(mock.get("foo")).thenAnswer(invocation -&gt; {
+ *     if (invocation.getInvocationCount() &lt;= 2) {
+ *         throw new RuntimeException("not ready yet");
+ *     }
+ *     return 200;
+ * });
+ * </code></pre>
+ *
  *
  *
  *

--- a/mockito-core/src/main/java/org/mockito/invocation/InvocationOnMock.java
+++ b/mockito-core/src/main/java/org/mockito/invocation/InvocationOnMock.java
@@ -6,7 +6,8 @@ package org.mockito.invocation;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
-
+import java.util.Arrays;
+import org.mockito.Mockito;
 import org.mockito.NotExtensible;
 
 /**
@@ -95,4 +96,51 @@ public interface InvocationOnMock extends Serializable {
      * @throws Throwable in case real method throws
      */
     Object callRealMethod() throws Throwable;
+
+    /**
+     * Returns the number of times this method has been invoked on this mock with the
+     * same arguments, including the current invocation.
+     *
+     * <p>
+     * This is useful when an {@link org.mockito.stubbing.Answer} needs to behave
+     * differently depending on how many times it has been called. For example, to fail
+     * the first few calls and then return a value:
+     *
+     * <pre class="code"><code class="java">
+     * when(mock.get("foo")).thenAnswer(invocation -&gt; {
+     *     if (invocation.getInvocationCount() &lt;= 2) {
+     *         throw new RuntimeException("not ready yet");
+     *     }
+     *     return 200;
+     * });
+     * </code></pre>
+     *
+     * <p>
+     * Counts are scoped to the same mock, the same method, and the same arguments
+     * (compared with {@link java.util.Arrays#deepEquals(Object[], Object[])}). Calls to
+     * other methods, other mocks, or the same method with different arguments are not
+     * included.
+     *
+     * <p>
+     * The current invocation is included in the count, so the first call returns
+     * {@code 1}.
+     *
+     * @return the 1-based count of matching invocations on this mock, including this one
+     * @since 5.x.x
+     */
+    default int getInvocationCount() {
+        return (int)
+                Mockito.mockingDetails(getMock()).getInvocations().stream()
+                        .filter(this::sameMethod)
+                        .filter(this::sameArguments)
+                        .count();
+    }
+
+    private boolean sameMethod(Invocation invocation) {
+        return invocation.getMethod().equals(getMethod());
+    }
+
+    private boolean sameArguments(Invocation invocation) {
+        return Arrays.deepEquals(invocation.getArguments(), getArguments());
+    }
 }

--- a/mockito-core/src/test/java/org/mockitousage/invocation/InvocationOnMockTest.java
+++ b/mockito-core/src/test/java/org/mockitousage/invocation/InvocationOnMockTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage.invocation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+
+public class InvocationOnMockTest {
+
+    @Test
+    public void ensure_that_count_is_one_after_first_call() {
+        Map<String, Integer> mock = mock();
+        when(mock.get("foo")).thenAnswer(InvocationOnMock::getInvocationCount);
+
+        assertThat(mock.get("foo")).isEqualTo(1);
+    }
+
+    @Test
+    public void ensure_that_count_increments_across_calls() {
+        Map<String, Integer> mock = mock();
+        when(mock.get("foo")).thenAnswer(InvocationOnMock::getInvocationCount);
+
+        assertThat(mock.get("foo")).isEqualTo(1);
+        assertThat(mock.get("foo")).isEqualTo(2);
+        assertThat(mock.get("foo")).isEqualTo(3);
+    }
+
+    @Test
+    public void ensure_that_first_n_calls_can_fail_then_return_value() {
+        Map<String, Integer> mock = mock();
+        when(mock.get("foo"))
+                .thenAnswer(
+                        inv -> {
+                            if (inv.getInvocationCount() <= 2) {
+                                throw new RuntimeException("Oupps");
+                            }
+                            return 200;
+                        });
+
+        assertThatThrownBy(() -> mock.get("foo")).hasMessage("Oupps");
+        assertThatThrownBy(() -> mock.get("foo")).hasMessage("Oupps");
+        assertThat(mock.get("foo")).isEqualTo(200);
+    }
+
+    @Test
+    public void ensure_that_counts_are_isolated_per_arguments() {
+        Map<String, Integer> mock = mock();
+        when(mock.get("foo")).thenAnswer(InvocationOnMock::getInvocationCount);
+        when(mock.get("bar")).thenAnswer(InvocationOnMock::getInvocationCount);
+
+        mock.get("foo");
+        mock.get("foo");
+        mock.get("bar");
+
+        assertThat(mock.get("foo")).isEqualTo(3);
+        assertThat(mock.get("bar")).isEqualTo(2);
+    }
+
+    @Test
+    public void ensure_that_counts_are_isolated_per_method() {
+        Map<String, Integer> mock = mock();
+        when(mock.get("foo")).thenAnswer(InvocationOnMock::getInvocationCount);
+        when(mock.put("bar", 2)).thenAnswer(InvocationOnMock::getInvocationCount);
+
+        mock.get("foo");
+        mock.put("bar", 2);
+        mock.put("bar", 2);
+        mock.put("bar", 2);
+
+        assertThat(mock.get("foo")).isEqualTo(2);
+        assertThat(mock.put("bar", 2)).isEqualTo(4);
+    }
+
+    @Test
+    public void ensure_that_counts_are_isolated_per_mock() {
+        Map<String, Integer> firstMock = mock();
+        Map<String, Integer> secondMock = mock();
+        when(firstMock.get("foo")).thenAnswer(InvocationOnMock::getInvocationCount);
+        when(secondMock.get("foo")).thenAnswer(InvocationOnMock::getInvocationCount);
+
+        firstMock.get("foo");
+        firstMock.get("foo");
+
+        assertThat(firstMock.get("foo")).isEqualTo(3);
+        assertThat(secondMock.get("foo")).isEqualTo(1);
+    }
+
+    @Test
+    public void ensure_that_null_arguments_are_supported() {
+        Map<String, Integer> mock = mock();
+        when(mock.get(null)).thenAnswer(InvocationOnMock::getInvocationCount);
+
+        assertThat(mock.get(null)).isEqualTo(1);
+        assertThat(mock.get(null)).isEqualTo(2);
+    }
+
+    @Test
+    public void ensure_that_varargs_methods_are_supported() {
+        List<String> mock = mock();
+        when(mock.toArray(new String[0]))
+                .thenAnswer(inv -> new String[] {String.valueOf(inv.getInvocationCount())});
+
+        assertThat(mock.toArray(new String[0])).containsExactly("1");
+        assertThat(mock.toArray(new String[0])).containsExactly("2");
+    }
+}


### PR DESCRIPTION
Fixes #3824

As discussed in #3824, I raised a PR to add `InvocationOnMock::getInvocationCount` — small addition that lets Answer implementations verify how many times the same call has already happened.

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style (run `./gradlew spotlessApply` for auto-formatting)
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should end with `Fixes #<issue number>` _if relevant_
