### PR TITLE
Fix NotAMockException when using mockSingleton with MockitoJUnit

### DIFF
--- a/mockito-core/src/main/java/org/mockito/internal/MockitoCore.java
+++ b/mockito-core/src/main/java/org/mockito/internal/MockitoCore.java
@@ -102,7 +102,7 @@ public class MockitoCore {
         checkDoNotMockAnnotation(creationSettings);
         MockMaker.SingletonMockControl<T> control = createSingletonMock(instance, creationSettings);
         control.enable();
-        mockingProgress().mockingStarted(instance, creationSettings);
+        mockingProgress().singletonMockingStarted(instance, creationSettings);
         return new MockedSingletonImpl<>(control);
     }
 

--- a/mockito-core/src/main/java/org/mockito/internal/progress/MockingProgress.java
+++ b/mockito-core/src/main/java/org/mockito/internal/progress/MockingProgress.java
@@ -45,6 +45,8 @@ public interface MockingProgress {
 
     void mockingStarted(Class<?> mock, MockCreationSettings<?> settings);
 
+    void singletonMockingStarted(Object mock, MockCreationSettings<?> settings);
+
     void addListener(MockitoListener listener);
 
     void removeListener(MockitoListener listener);

--- a/mockito-core/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
+++ b/mockito-core/src/main/java/org/mockito/internal/progress/MockingProgressImpl.java
@@ -183,6 +183,16 @@ public class MockingProgressImpl implements MockingProgress {
     }
 
     @Override
+    public void singletonMockingStarted(Object mock, MockCreationSettings<?> settings) {
+        for (MockitoListener listener : listeners) {
+            if (listener instanceof MockCreationListener) {
+                ((MockCreationListener) listener).onSingletonMockCreated(mock, settings);
+            }
+        }
+        validateMostStuff();
+    }
+
+    @Override
     public void addListener(MockitoListener listener) {
         addListener(listener, listeners);
     }

--- a/mockito-core/src/main/java/org/mockito/listeners/MockCreationListener.java
+++ b/mockito-core/src/main/java/org/mockito/listeners/MockCreationListener.java
@@ -27,4 +27,12 @@ public interface MockCreationListener extends MockitoListener {
      * @param settings the settings used for creation
      */
     default void onStaticMockCreated(Class<?> mock, MockCreationSettings<?> settings) {}
+
+    /**
+     * Singleton mock was just created.
+     *
+     * @param mock the singleton instance being mocked
+     * @param settings the settings used for creation
+     */
+    default void onSingletonMockCreated(Object mock, MockCreationSettings<?> settings) {}
 }

--- a/mockito-integration-tests/inline-mocks-tests/src/test/java/org/mockitoinline/SingletonMockWithJUnitTest.java
+++ b/mockito-integration-tests/inline-mocks-tests/src/test/java/org/mockitoinline/SingletonMockWithJUnitTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitoinline;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.MockedSingleton;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+// Regression test for issue #3826
+public class SingletonMockWithJUnitTest {
+
+    public enum MyEnum {
+        A
+    }
+
+    @Rule public MockitoRule rule = MockitoJUnit.rule();
+
+    @Test
+    public void mockSingleton_with_MockitoJUnit_should_not_throw_NotAMockException() {
+        try (MockedSingleton<MyEnum> ignored = Mockito.mockSingleton(MyEnum.A)) {}
+    }
+}


### PR DESCRIPTION
Fixes #3826

The cause of this is that `mockSingleton` implementation overloaded the existing `MockingProgress#mockingStarted` callback. When using `MockitoJUnit` rule, `UniversalTestListener` uses this callback to track created mocks. If the scoped singleton mock is closed, then the `testFinished` downstream logic would look up mocking details on the singleton which is no longer a mock leading to this exception.

It was probably a mistake to reuse the `mockingStarted` callback originally - let's mimic the `mockStatic` path which uses its own dedicated callback for reporting created static mocks.

Note that the unused-stubbing detector stuff (used with "strict stubs" strictness) currently does not support static mocks, and it does not support singleton mocks either. That seems okay; a future PR can add support if desired.

_____________________

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style (run `./gradlew spotlessApply` for auto-formatting)
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should end with `Fixes #<issue number>` _if relevant_
