### PR TITLE
Fix clearInlineMocks not de-registering singleton mocks

### DIFF
--- a/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
@@ -581,10 +581,6 @@ class InlineDelegateByteBuddyMockMaker
             for (Map<Class<?>, ?> entry : mockedStatics.getBackingMap().target.values()) {
                 entry.remove(mock);
             }
-        } else if (isRegisteredSingleton(mock)) {
-            for (Map<Object, ?> entry : mockedSingletons.getBackingMap().target.values()) {
-                entry.remove(mock);
-            }
         } else {
             mocks.put(
                     mock,
@@ -592,15 +588,6 @@ class InlineDelegateByteBuddyMockMaker
                             DisabledMockHandler.HANDLER,
                             DisabledMockHandler.HANDLER.getMockSettings()));
         }
-    }
-
-    private boolean isRegisteredSingleton(Object mock) {
-        for (Map<Object, ?> entry : mockedSingletons.getBackingMap().target.values()) {
-            if (entry.containsKey(mock)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     @Override

--- a/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
@@ -581,6 +581,10 @@ class InlineDelegateByteBuddyMockMaker
             for (Map<Class<?>, ?> entry : mockedStatics.getBackingMap().target.values()) {
                 entry.remove(mock);
             }
+        } else if (isRegisteredSingleton(mock)) {
+            for (Map<Object, ?> entry : mockedSingletons.getBackingMap().target.values()) {
+                entry.remove(mock);
+            }
         } else {
             mocks.put(
                     mock,
@@ -590,9 +594,19 @@ class InlineDelegateByteBuddyMockMaker
         }
     }
 
+    private boolean isRegisteredSingleton(Object mock) {
+        for (Map<Object, ?> entry : mockedSingletons.getBackingMap().target.values()) {
+            if (entry.containsKey(mock)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @Override
     public void clearAllMocks() {
         mockedStatics.getBackingMap().clear();
+        mockedSingletons.getBackingMap().clear();
 
         for (Entry<Object, MockMethodInterceptor> entry : mocks) {
             clearMock(entry.getKey());

--- a/mockito-integration-tests/inline-mocks-tests/src/test/java/org/mockitoinline/SingletonMockTest.java
+++ b/mockito-integration-tests/inline-mocks-tests/src/test/java/org/mockitoinline/SingletonMockTest.java
@@ -102,23 +102,6 @@ public final class SingletonMockTest {
         }
     }
 
-    @Test
-    public void testSingletonMockDeregisteredByClearInlineMock() {
-        MyEnum singleton = MyEnum.A;
-
-        // Intentionally do not close the MockedSingleton to simulate a leak.
-        Mockito.mockSingleton(singleton);
-        when(singleton.foo()).thenReturn("bar");
-        assertEquals("bar", singleton.foo());
-
-        Mockito.framework().clearInlineMock(singleton);
-
-        assertEquals("foo", singleton.foo());
-        try (MockedSingleton<MyEnum> ignored = Mockito.mockSingleton(singleton)) {
-            assertNull(singleton.foo());
-        }
-    }
-
     enum MyEnum {
         A {
             @Override

--- a/mockito-integration-tests/inline-mocks-tests/src/test/java/org/mockitoinline/SingletonMockTest.java
+++ b/mockito-integration-tests/inline-mocks-tests/src/test/java/org/mockitoinline/SingletonMockTest.java
@@ -6,7 +6,6 @@ package org.mockitoinline;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNull;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
@@ -80,6 +79,42 @@ public final class SingletonMockTest {
 
             reset(singleton);
 
+            assertNull(singleton.foo());
+        }
+    }
+
+    @Test
+    public void testSingletonMockDeregisteredByClearInlineMocks() {
+        MyEnum singleton = MyEnum.A;
+
+        // Intentionally do not close the MockedSingleton to simulate a leak.
+        Mockito.mockSingleton(singleton);
+        when(singleton.foo()).thenReturn("bar");
+        assertEquals("bar", singleton.foo());
+
+        Mockito.framework().clearInlineMocks();
+
+        // After clearing, the singleton must no longer be mocked
+        assertEquals("foo", singleton.foo());
+        // and re-mocking the same instance must not throw "already registered".
+        try (MockedSingleton<MyEnum> ignored = Mockito.mockSingleton(singleton)) {
+            assertNull(singleton.foo());
+        }
+    }
+
+    @Test
+    public void testSingletonMockDeregisteredByClearInlineMock() {
+        MyEnum singleton = MyEnum.A;
+
+        // Intentionally do not close the MockedSingleton to simulate a leak.
+        Mockito.mockSingleton(singleton);
+        when(singleton.foo()).thenReturn("bar");
+        assertEquals("bar", singleton.foo());
+
+        Mockito.framework().clearInlineMock(singleton);
+
+        assertEquals("foo", singleton.foo());
+        try (MockedSingleton<MyEnum> ignored = Mockito.mockSingleton(singleton)) {
             assertNull(singleton.foo());
         }
     }


### PR DESCRIPTION
## Description

**Problem:** singleton mocks were leaking since clearInlineMocks() didn't clear their mocking state.

clearInlineMocks() and clearInlineMock(...) left singleton mocks registered, so re-mocking the same instance threw "already registered as a mock" exception. 

This PR fixes it:
- clearInlineMocks() clears the mockedSingletons registry
- ~clearInlineMock(...) removes the instance from that registry~: discussed and agreed to not cover.

Without the changes, both the newly-introduce unit tests would fail.

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style (run `./gradlew spotlessApply` for auto-formatting)
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should end with `Fixes #<issue number>` _if relevant_
