### PR TITLE
Replace constant hashcode

### DIFF
--- a/mockito-core/src/main/java/org/mockito/internal/invocation/InterceptedInvocation.java
+++ b/mockito-core/src/main/java/org/mockito/internal/invocation/InterceptedInvocation.java
@@ -168,9 +168,10 @@ public class InterceptedInvocation implements Invocation, VerificationAwareInvoc
 
     @Override
     public int hashCode() {
-        // TODO SF we need to provide hash code implementation so that there are no unexpected,
-        // slight perf issues
-        return 1;
+        int result = mockRef.get().hashCode();
+        result = 31 * result + mockitoMethod.hashCode();
+        result = 31 * result + Arrays.hashCode(arguments);
+        return result;
     }
 
     @Override

--- a/mockito-core/src/main/java/org/mockito/internal/invocation/SerializableMethod.java
+++ b/mockito-core/src/main/java/org/mockito/internal/invocation/SerializableMethod.java
@@ -94,10 +94,18 @@ public class SerializableMethod implements Serializable, MockitoMethod {
 
     @Override
     public int hashCode() {
-        int result = declaringClass == null ? 0 : declaringClass.hashCode();
+        int result = declaringClass == null ? 0 : declaringClass.getName().hashCode();
         result = 31 * result + (methodName == null ? 0 : methodName.hashCode());
-        result = 31 * result + Arrays.hashCode(parameterTypes);
-        result = 31 * result + (returnType == null ? 0 : returnType.hashCode());
+        result = 31 * result + parameterTypeNamesHashCode();
+        result = 31 * result + (returnType == null ? 0 : returnType.getName().hashCode());
+        return result;
+    }
+
+    private int parameterTypeNamesHashCode() {
+        int result = 1;
+        for (Class<?> type : parameterTypes) {
+            result = 31 * result + (type == null ? 0 : type.getName().hashCode());
+        }
         return result;
     }
 

--- a/mockito-core/src/main/java/org/mockito/internal/invocation/SerializableMethod.java
+++ b/mockito-core/src/main/java/org/mockito/internal/invocation/SerializableMethod.java
@@ -94,7 +94,11 @@ public class SerializableMethod implements Serializable, MockitoMethod {
 
     @Override
     public int hashCode() {
-        return 1;
+        int result = declaringClass == null ? 0 : declaringClass.hashCode();
+        result = 31 * result + (methodName == null ? 0 : methodName.hashCode());
+        result = 31 * result + Arrays.hashCode(parameterTypes);
+        result = 31 * result + (returnType == null ? 0 : returnType.hashCode());
+        return result;
     }
 
     @Override

--- a/mockito-core/src/main/java/org/mockito/internal/matchers/Equals.java
+++ b/mockito-core/src/main/java/org/mockito/internal/matchers/Equals.java
@@ -53,7 +53,7 @@ public class Equals implements ArgumentMatcher<Object>, ContainsExtraTypeInfo, S
 
     @Override
     public int hashCode() {
-        return 1;
+        return wanted == null ? 0 : wanted.hashCode();
     }
 
     @Override

--- a/mockito-core/src/test/java/org/mockito/internal/matchers/EqualsTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/matchers/EqualsTest.java
@@ -19,7 +19,8 @@ public class EqualsTest extends TestBase {
         assertEquals(new Equals(new Integer(2)), new Equals(new Integer(2)));
         assertFalse(new Equals(null).equals(null));
         assertFalse(new Equals(null).equals("Test"));
-        assertEquals(1, new Equals(null).hashCode());
+        assertEquals(0, new Equals(null).hashCode());
+        assertEquals(new Equals(new Integer(2)).hashCode(), new Equals(new Integer(2)).hashCode());
     }
 
     @Test


### PR DESCRIPTION
A few classes (InterceptedInvocation, SerializableMethod, Equals) returned a constant number (1) as their hashcode implementation, collapsing every instance into one bucket and degrading HashMap/HashSet lookups to linear complexity.

This PR fixes it (and removes corresponding `TODO` from the code) so that each hashcode derives from the same fields taken into consideration for their equals. 

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style (run `./gradlew spotlessApply` for auto-formatting)
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should end with `Fixes #<issue number>` _if relevant_
