### PR TITLE
docs(when-verify): fixes to explanations about redundancy

### DIFF
--- a/mockito-core/src/main/java/org/mockito/Mockito.java
+++ b/mockito-core/src/main/java/org/mockito/Mockito.java
@@ -343,7 +343,7 @@ import java.util.function.Function;
  * System.out.println(mockedList.get(999));
  *
  * //Although it is possible to verify a stubbed invocation, usually <b>it's just redundant</b>
- * //If your code cares what get(0) returns, then something else breaks (often even before verify() gets executed).
+ * //If your code cares what get(0) returns, then something else breaks (often before verify() even gets executed).
  * //If your code doesn't care what get(0) returns, then it should not be stubbed.
  * verify(mockedList).get(0);
  * </code></pre>
@@ -3104,8 +3104,8 @@ public class Mockito extends ArgumentMatchers {
      * <p>
      * Although it is possible to verify a stubbed invocation, usually <b>it's just redundant</b>.
      * Let's say you've stubbed <code>foo.bar()</code>.
-     * If your code cares what <code>foo.bar()</code> returns then something else breaks(often before even <code>verify()</code> gets executed).
-     * If your code doesn't care what <code>get(0)</code> returns then it should not be stubbed.
+     * If your code cares what <code>foo.bar()</code> returns then something else breaks (often before <code>verify()</code> even gets executed).
+     * If your code doesn't care what <code>foo.bar()</code> returns then it should not be stubbed.
      *
      * <p>
      * See examples in javadoc for {@link Mockito} class
@@ -3134,7 +3134,7 @@ public class Mockito extends ArgumentMatchers {
      * <p>
      * Although it is possible to verify a stubbed invocation, usually <b>it's just redundant</b>.
      * Let's say you've stubbed <code>foo.bar()</code>.
-     * If your code cares what <code>foo.bar()</code> returns then something else breaks(often before even <code>verify()</code> gets executed).
+     * If your code cares what <code>foo.bar()</code> returns then something else breaks (often before <code>verify()</code> even gets executed).
      * If your code doesn't care what <code>foo.bar()</code> returns then it should not be stubbed.
      *
      * <p>


### PR DESCRIPTION
Fixes #3837

* Spacing
* Example method consistency
* Placement of the word “even”

NB: In one place, the “stray `get(0)`” issue was already fixed (or was never present to begin with).


## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style (run `./gradlew spotlessApply` for auto-formatting)
 - [x] Mention `Fixes #<issue number>` in the description _if relevant_
 - [x] At least one commit should end with `Fixes #<issue number>` _if relevant_
