### PR TITLE
Migrate extensions-tests to JUnit Jupiter

### DIFF
--- a/mockito-core/build.gradle.kts
+++ b/mockito-core/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
     testFixturesImplementation(libs.assertj)
     testFixturesImplementation(libs.objenesis)
     testFixturesCompileOnly(libs.junit4)
+    testFixturesCompileOnly(libs.junit.jupiter.api)
 }
 
 mockitoJavadoc {

--- a/mockito-core/src/testFixtures/java/org/mockitoutil/TestBase5.java
+++ b/mockito-core/src/testFixtures/java/org/mockitoutil/TestBase5.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitoutil;
+
+import static org.mockito.Mockito.mock;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+
+import org.assertj.core.api.Condition;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.MockitoAnnotations;
+import org.mockito.StateMaster;
+import org.mockito.internal.MockitoCore;
+import org.mockito.internal.configuration.ConfigurationAccess;
+import org.mockito.internal.debugging.LocationFactory;
+import org.mockito.internal.invocation.InterceptedInvocation;
+import org.mockito.internal.invocation.InvocationBuilder;
+import org.mockito.internal.invocation.InvocationMatcher;
+import org.mockito.internal.invocation.SerializableMethod;
+import org.mockito.internal.invocation.mockref.MockStrongReference;
+import org.mockito.invocation.Invocation;
+
+/**
+ * JUnit 5 (Jupiter) counterpart of {@link TestBase}.
+ */
+public class TestBase5 {
+
+    /**
+     * Condition to be used with AssertJ
+     */
+    public static Condition<Throwable> hasMessageContaining(final String substring) {
+        return new Condition<Throwable>() {
+            @Override
+            public boolean matches(Throwable e) {
+                return e.getMessage().contains(substring);
+            }
+        };
+    }
+
+    @AfterEach
+    public void cleanUpConfigInAnyCase() {
+        ConfigurationAccess.getConfig().overrideCleansStackTrace(false);
+        ConfigurationAccess.getConfig().overrideDefaultAnswer(null);
+        StateMaster state = new StateMaster();
+        // catch any invalid state left over after test case run
+        // this way we can catch early if some Mockito operations leave weird state afterwards
+        state.validate();
+        // reset the state, especially, reset any ongoing stubbing for correct error messages of
+        // tests that assert unhappy paths
+        state.reset();
+    }
+
+    @BeforeEach
+    public void init() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    public static void makeStackTracesClean() {
+        ConfigurationAccess.getConfig().overrideCleansStackTrace(true);
+    }
+
+    public void resetState() {
+        new StateMaster().reset();
+    }
+
+    public static Invocation getLastInvocation() {
+        return new MockitoCore().getLastInvocation();
+    }
+
+    protected static Invocation invocationOf(Class<?> type, String methodName, Object... args)
+            throws NoSuchMethodException {
+        Class<?>[] types = new Class<?>[args.length];
+        for (int i = 0; i < args.length; i++) {
+            types[i] = args[i].getClass();
+        }
+        return new InterceptedInvocation(
+                new MockStrongReference<Object>(mock(type), false),
+                new SerializableMethod(type.getMethod(methodName, types)),
+                args,
+                InterceptedInvocation.NO_OP,
+                LocationFactory.create(),
+                1);
+    }
+
+    protected static Invocation invocationAt(String location) {
+        return new InvocationBuilder().location(location).toInvocation();
+    }
+
+    protected static InvocationMatcher invocationMatcherAt(String location) {
+        return new InvocationBuilder().location(location).toInvocationMatcher();
+    }
+
+    protected String getStackTrace(Throwable e) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        e.printStackTrace(new PrintStream(out));
+        try {
+            out.close();
+        } catch (IOException ex) {
+        }
+        return out.toString();
+    }
+
+    /**
+     * Filters out unwanted line numbers from provided stack trace String.
+     * This is useful for writing assertions for exception messages that contain line numbers.
+     *
+     * For example it turns:
+     * blah blah (UnusedStubsExceptionMessageTest.java:27)
+     * into:
+     * blah blah (UnusedStubsExceptionMessageTest.java:0)
+     */
+    public static String filterLineNo(String stackTrace) {
+        return stackTrace.replaceAll("(\\((\\w+\\.java):(\\d)+\\))", "($2:0)");
+    }
+
+    /**
+     * Filters out hashCode from the text. Useful for writing assertions that contain the String representation of mock objects
+     * @param text to filter
+     * @return filtered text
+     */
+    public static String filterHashCode(String text) {
+        return text.replaceAll("hashCode: (\\d)+\\.", "hashCode: xxx.");
+    }
+}

--- a/mockito-core/src/testFixtures/java/org/mockitoutil/TestBase5.java
+++ b/mockito-core/src/testFixtures/java/org/mockitoutil/TestBase5.java
@@ -4,8 +4,6 @@
  */
 package org.mockitoutil;
 
-import static org.mockito.Mockito.mock;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -15,15 +13,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.MockitoAnnotations;
 import org.mockito.StateMaster;
-import org.mockito.internal.MockitoCore;
 import org.mockito.internal.configuration.ConfigurationAccess;
-import org.mockito.internal.debugging.LocationFactory;
-import org.mockito.internal.invocation.InterceptedInvocation;
-import org.mockito.internal.invocation.InvocationBuilder;
-import org.mockito.internal.invocation.InvocationMatcher;
-import org.mockito.internal.invocation.SerializableMethod;
-import org.mockito.internal.invocation.mockref.MockStrongReference;
-import org.mockito.invocation.Invocation;
 
 /**
  * JUnit 5 (Jupiter) counterpart of {@link TestBase}.
@@ -68,39 +58,12 @@ public class TestBase5 {
         new StateMaster().reset();
     }
 
-    public static Invocation getLastInvocation() {
-        return new MockitoCore().getLastInvocation();
-    }
-
-    protected static Invocation invocationOf(Class<?> type, String methodName, Object... args)
-            throws NoSuchMethodException {
-        Class<?>[] types = new Class<?>[args.length];
-        for (int i = 0; i < args.length; i++) {
-            types[i] = args[i].getClass();
-        }
-        return new InterceptedInvocation(
-                new MockStrongReference<Object>(mock(type), false),
-                new SerializableMethod(type.getMethod(methodName, types)),
-                args,
-                InterceptedInvocation.NO_OP,
-                LocationFactory.create(),
-                1);
-    }
-
-    protected static Invocation invocationAt(String location) {
-        return new InvocationBuilder().location(location).toInvocation();
-    }
-
-    protected static InvocationMatcher invocationMatcherAt(String location) {
-        return new InvocationBuilder().location(location).toInvocationMatcher();
-    }
-
     protected String getStackTrace(Throwable e) {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         e.printStackTrace(new PrintStream(out));
         try {
             out.close();
-        } catch (IOException ex) {
+        } catch (IOException ignored) {
         }
         return out.toString();
     }
@@ -116,14 +79,5 @@ public class TestBase5 {
      */
     public static String filterLineNo(String stackTrace) {
         return stackTrace.replaceAll("(\\((\\w+\\.java):(\\d)+\\))", "($2:0)");
-    }
-
-    /**
-     * Filters out hashCode from the text. Useful for writing assertions that contain the String representation of mock objects
-     * @param text to filter
-     * @return filtered text
-     */
-    public static String filterHashCode(String text) {
-        return text.replaceAll("hashCode: (\\d)+\\.", "hashCode: xxx.");
     }
 }

--- a/mockito-integration-tests/extensions-tests/build.gradle.kts
+++ b/mockito-integration-tests/extensions-tests/build.gradle.kts
@@ -9,11 +9,9 @@ dependencies {
     testImplementation(project(":mockito-core"))
     testImplementation(project(":mockito-extensions:mockito-junit-jupiter"))
     testImplementation(testFixtures(project(":mockito-core")))
-    testImplementation(libs.junit4)
     testImplementation(libs.assertj)
     testImplementation(libs.junit.jupiter.api)
     testRuntimeOnly(libs.junit.jupiter.engine)
-    testRuntimeOnly(libs.junit.vintage.engine)
     testRuntimeOnly(libs.junit.platform.launcher)
 }
 
@@ -24,7 +22,6 @@ tasks {
 }
 
 configurations.configureEach {
-    //TODO SF enable when #154 is implemented
-    //let's make those tests not use hamcrest
-    //exclude group: 'org.hamcrest', module: 'hamcrest-core'
+    // Ensure these tests do not depend on hamcrest (see #154).
+    exclude(group = "org.hamcrest", module = "hamcrest-core")
 }

--- a/mockito-integration-tests/extensions-tests/build.gradle.kts
+++ b/mockito-integration-tests/extensions-tests/build.gradle.kts
@@ -20,8 +20,3 @@ tasks {
         useJUnitPlatform()
     }
 }
-
-configurations.configureEach {
-    // Ensure these tests do not depend on hamcrest (see #154).
-    exclude(group = "org.hamcrest", module = "hamcrest-core")
-}

--- a/mockito-integration-tests/extensions-tests/src/test/java/org/mockitousage/plugins/donotmockenforcer/DoNotmockEnforcerTest.java
+++ b/mockito-integration-tests/extensions-tests/src/test/java/org/mockitousage/plugins/donotmockenforcer/DoNotmockEnforcerTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.DoNotMock;
 import org.mockito.MockedStatic;
 import org.mockito.exceptions.base.MockitoException;

--- a/mockito-integration-tests/extensions-tests/src/test/java/org/mockitousage/plugins/instantiator/InstantiatorProviderTest.java
+++ b/mockito-integration-tests/extensions-tests/src/test/java/org/mockitousage/plugins/instantiator/InstantiatorProviderTest.java
@@ -4,12 +4,12 @@
  */
 package org.mockitousage.plugins.instantiator;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 public class InstantiatorProviderTest {

--- a/mockito-integration-tests/extensions-tests/src/test/java/org/mockitousage/plugins/stacktrace/PluginStackTraceFilteringTest.java
+++ b/mockito-integration-tests/extensions-tests/src/test/java/org/mockitousage/plugins/stacktrace/PluginStackTraceFilteringTest.java
@@ -4,30 +4,38 @@
  */
 package org.mockitousage.plugins.stacktrace;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.exceptions.verification.WantedButNotInvoked;
-import org.mockitousage.IMethods;
-import org.mockitoutil.TestBase;
-
-import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.verify;
 
-public class PluginStackTraceFilteringTest extends TestBase {
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.StateMaster;
+import org.mockito.exceptions.verification.WantedButNotInvoked;
+import org.mockito.internal.configuration.ConfigurationAccess;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockitousage.IMethods;
+
+@ExtendWith(MockitoExtension.class)
+public class PluginStackTraceFilteringTest {
 
     @Mock private IMethods mock;
 
-    @After
-    public void resetState() {
-        super.resetState();
+    @BeforeEach
+    public void setup() {
+        ConfigurationAccess.getConfig().overrideCleansStackTrace(true);
     }
 
-    @Before
-    public void setup() {
-        super.makeStackTracesClean();
+    @AfterEach
+    public void resetState() {
+        ConfigurationAccess.getConfig().overrideCleansStackTrace(false);
+        new StateMaster().reset();
     }
 
     @Test
@@ -52,6 +60,12 @@ public class PluginStackTraceFilteringTest extends TestBase {
             String trace = getStackTrace(e);
             assertThat(trace).contains("verifyMock_x").contains("verify_excludeMe_x");
         }
+    }
+
+    private String getStackTrace(Throwable e) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        e.printStackTrace(new PrintStream(out));
+        return out.toString();
     }
 
     private void verify_excludeMe_x() {

--- a/mockito-integration-tests/extensions-tests/src/test/java/org/mockitousage/plugins/stacktrace/PluginStackTraceFilteringTest.java
+++ b/mockito-integration-tests/extensions-tests/src/test/java/org/mockitousage/plugins/stacktrace/PluginStackTraceFilteringTest.java
@@ -8,34 +8,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.verify;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.StateMaster;
 import org.mockito.exceptions.verification.WantedButNotInvoked;
-import org.mockito.internal.configuration.ConfigurationAccess;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockitousage.IMethods;
+import org.mockitoutil.TestBase5;
 
-@ExtendWith(MockitoExtension.class)
-public class PluginStackTraceFilteringTest {
+public class PluginStackTraceFilteringTest extends TestBase5 {
 
     @Mock private IMethods mock;
 
-    @BeforeEach
-    public void setup() {
-        ConfigurationAccess.getConfig().overrideCleansStackTrace(true);
-    }
-
     @AfterEach
     public void resetState() {
-        ConfigurationAccess.getConfig().overrideCleansStackTrace(false);
-        new StateMaster().reset();
+        super.resetState();
+    }
+
+    @BeforeEach
+    public void setup() {
+        makeStackTracesClean();
     }
 
     @Test
@@ -60,12 +52,6 @@ public class PluginStackTraceFilteringTest {
             String trace = getStackTrace(e);
             assertThat(trace).contains("verifyMock_x").contains("verify_excludeMe_x");
         }
-    }
-
-    private String getStackTrace(Throwable e) {
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        e.printStackTrace(new PrintStream(out));
-        return out.toString();
     }
 
     private void verify_excludeMe_x() {

--- a/mockito-integration-tests/extensions-tests/src/test/java/org/mockitousage/plugins/switcher/PluginSwitchTest.java
+++ b/mockito-integration-tests/extensions-tests/src/test/java/org/mockitousage/plugins/switcher/PluginSwitchTest.java
@@ -4,7 +4,7 @@
  */
 package org.mockitousage.plugins.switcher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockitousage.plugins.donotmockenforcer.MyDoNotMockEnforcer;
 import org.mockitousage.plugins.instantiator.MyInstantiatorProvider2;
 import org.mockitousage.plugins.logger.MyMockitoLogger;
@@ -15,8 +15,8 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 public class PluginSwitchTest {


### PR DESCRIPTION
The extensions tests pulled hamcrest-core transitively via JUnit 4. There was a TODO to exclude it (linked to #154) that was blocked on that dependency.
This PR excludes it migrating the module's JUnit 4 unit tests to JUnit Jupiter, dropping its dependencies, and replacing the stale TODO with an active exclude of the hamcrest dependency. 