### PR TITLE
Upgrade Android Gradle Plugin to 9.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ classes
 .gradletasknamecache
 *.log
 local.properties
+.kotlin
 
 # Used to check reproducibility of Mockito jars
 checksums/

--- a/buildSrc/src/main/kotlin/mockito.publication-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/mockito.publication-conventions.gradle.kts
@@ -158,11 +158,12 @@ plugins.withType<com.android.build.gradle.LibraryPlugin>().configureEach {
     }
 
     afterEvaluate {
-        val androidExtension = extensions.getByType<com.android.build.gradle.LibraryExtension>()
+        val androidExtension =
+            extensions.getByType<com.android.build.api.dsl.LibraryExtension>()
 
         val sourcesJar by tasks.registering(Jar::class) {
             archiveClassifier.set("sources")
-            from(androidExtension.sourceSets.getByName("main").java.srcDirs)
+            from(androidExtension.sourceSets.getByName("main").java.directories)
             with(licenseSpec)
         }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ gradleplugin-aQute-bnd = "7.1.0"
 gradleplugin-errorprone = "4.3.0"
 gradleplugin-spotless = "8.0.0"
 
-gradleplugin-android = "8.13.2"
+gradleplugin-android = "9.2.1"
 
 [libraries]
 android-junit = { module = "androidx.test.ext:junit", version = "1.2.1" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=7197a12f450794931532469d4ff21a59ea2c1cd59a3ec3f89c035c3c420a6999
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/mockito-integration-tests/android-tests/build.gradle.kts
+++ b/mockito-integration-tests/android-tests/build.gradle.kts
@@ -3,7 +3,6 @@
 
 plugins {
     id("com.android.application")
-    id("kotlin-android")
     id("mockito.test-conventions")
 }
 


### PR DESCRIPTION
See:
https://developer.android.com/build/releases/agp-9-0-0-release-notes

Changes:
- exclude `.kotlin/` from git per https://kotlinlang.org/docs/whatsnew20.html#new-directory-for-kotlin-data-in-gradle-projects
- adapt to new Android Gradle DSL
- remove `kotlin-android` plugin now that Kotlin plugin is bundled per https://developer.android.com/build/migrate-to-built-in-kotlin

I verified with:
- Project sync succeeds in Android Studio
- `./gradlew connectedAndroidTest` to run Android tests on emulator
- `./gradlew :mockito-extensions:mockito-android:publishToMavenLocal` and consumed in a dummy project to verify publish flow still works