### PR TITLE
Print object fields via reflection when `toString()` is not implemented

### DIFF
--- a/mockito-core/src/main/java/org/mockito/internal/matchers/apachecommons/ReflectionEquals.java
+++ b/mockito-core/src/main/java/org/mockito/internal/matchers/apachecommons/ReflectionEquals.java
@@ -7,6 +7,7 @@ package org.mockito.internal.matchers.apachecommons;
 import java.io.Serializable;
 
 import org.mockito.ArgumentMatcher;
+import org.mockito.internal.matchers.text.ValuePrinter;
 
 public class ReflectionEquals implements ArgumentMatcher<Object>, Serializable {
 
@@ -25,6 +26,6 @@ public class ReflectionEquals implements ArgumentMatcher<Object>, Serializable {
 
     @Override
     public String toString() {
-        return "refEq(" + wanted + ")";
+        return "refEq(" + ValuePrinter.print(wanted) + ")";
     }
 }

--- a/mockito-core/src/main/java/org/mockito/internal/matchers/text/ValuePrinter.java
+++ b/mockito-core/src/main/java/org/mockito/internal/matchers/text/ValuePrinter.java
@@ -4,9 +4,17 @@
  */
 package org.mockito.internal.matchers.text;
 
+import static java.util.Comparator.comparing;
+
 import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.stream.Collectors;
+import org.mockito.internal.configuration.plugins.Plugins;
+import org.mockito.plugins.MemberAccessor;
 
 /**
  * Prints a Java object value in a way humans can read it neatly.
@@ -146,11 +154,78 @@ public class ValuePrinter {
         return sb.toString();
     }
 
+    private static final int MAX_FIELD_VALUE_LENGTH = 100;
+
+    /**
+     * Return string representation of given object.
+     * If 'value' has its own {@code toString()} method, it's called.
+     * If 'value' does not declare its own {@code toString()} then {@code Object.toString()} is useless for a
+     * human-readable diff, so fields are printed reflectively instead.
+     *
+     * @param value any java object
+     * @return String representation of this object (non-nullable)
+     */
     private static String descriptionOf(Object value) {
         try {
+            if (!declaresOwnToString(value.getClass())) {
+                return reflectiveToString(value);
+            }
             return String.valueOf(value);
         } catch (RuntimeException e) {
             return value.getClass().getName() + "@" + Integer.toHexString(value.hashCode());
         }
+    }
+
+    private static boolean declaresOwnToString(Class<?> type) {
+        try {
+            return type.getMethod("toString").getDeclaringClass() != Object.class;
+        } catch (NoSuchMethodException neverHappensBecauseObjectDeclaresToString) {
+            return false;
+        }
+    }
+
+    private static String reflectiveToString(Object value) {
+        MemberAccessor accessor = Plugins.getMemberAccessor();
+        StringBuilder result = new StringBuilder(value.getClass().getSimpleName()).append('[');
+        boolean first = true;
+        for (Class<?> type = value.getClass();
+                type != null && type != Object.class;
+                type = type.getSuperclass()) {
+            for (Field field : fields(type)) {
+                if (!first) {
+                    result.append(", ");
+                }
+                first = false;
+                result.append(field.getName())
+                        .append('=')
+                        .append(fieldValue(accessor, field, value));
+            }
+        }
+        return result.append(']').toString();
+    }
+
+    /**
+     * Sorts fields by name - this guarantees the same output every time, thus avoiding flaky tests.
+     */
+    private static Iterable<Field> fields(Class<?> type) {
+        return Arrays.stream(type.getDeclaredFields())
+                .filter(field -> !Modifier.isStatic(field.getModifiers()))
+                .filter(field -> !field.isSynthetic())
+                .sorted(comparing(Field::getName))
+                .collect(Collectors.toList());
+    }
+
+    private static String fieldValue(MemberAccessor accessor, Field field, Object target) {
+        try {
+            return truncate(String.valueOf(accessor.get(field, target)));
+        } catch (RuntimeException | IllegalAccessException fieldNotReadable) {
+            return "<unavailable>";
+        }
+    }
+
+    private static String truncate(String text) {
+        return text.length() > MAX_FIELD_VALUE_LENGTH
+                ? text.substring(0, MAX_FIELD_VALUE_LENGTH) + "..."
+                : text;
     }
 }

--- a/mockito-core/src/test/java/org/mockito/internal/matchers/apachecommons/ReflectionEqualsTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/matchers/apachecommons/ReflectionEqualsTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.matchers.apachecommons;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.mockitoutil.TestBase;
+
+public class ReflectionEqualsTest extends TestBase {
+
+    static class NoToString {
+        private final String name;
+        private final int age;
+
+        NoToString(String name, int age) {
+            this.name = name;
+            this.age = age;
+        }
+    }
+
+    static class WithToString {
+        private final String name;
+
+        WithToString(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return "WithToString(" + name + ")";
+        }
+    }
+
+    static class LongField {
+        private final String value;
+
+        LongField(String value) {
+            this.value = value;
+        }
+    }
+
+    @Test
+    public void prints_fields_reflectively_when_toString_not_overridden() {
+        ReflectionEquals matcher = new ReflectionEquals(new NoToString("john", 42));
+
+        assertThat(matcher.toString()).isEqualTo("refEq(NoToString[age=42, name=john])");
+    }
+
+    @Test
+    public void uses_declared_toString_when_present() {
+        ReflectionEquals matcher = new ReflectionEquals(new WithToString("john"));
+
+        assertThat(matcher.toString()).isEqualTo("refEq(WithToString(john))");
+    }
+
+    @Test
+    public void prints_null_as_null() {
+        ReflectionEquals matcher = new ReflectionEquals(null);
+
+        assertThat(matcher.toString()).isEqualTo("refEq(null)");
+    }
+
+    @Test
+    public void truncates_long_field_values() {
+        String longValue = "x".repeat(200);
+        ReflectionEquals matcher = new ReflectionEquals(new LongField(longValue));
+
+        assertThat(matcher.toString())
+                .isEqualTo("refEq(LongField[value=" + "x".repeat(100) + "...])");
+    }
+}

--- a/mockito-core/src/test/java/org/mockito/internal/matchers/text/ValuePrinterTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/matchers/text/ValuePrinterTest.java
@@ -4,11 +4,15 @@
  */
 package org.mockito.internal.matchers.text;
 
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.internal.matchers.text.ValuePrinter.print;
+import static org.mockito.internal.matchers.text.ValuePrinter.printValues;
 
+import java.math.BigDecimal;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.Test;
 
@@ -47,11 +51,40 @@ public class ValuePrinterTest {
     }
 
     @Test
+    public void prints_fields_reflectively_when_toString_not_overridden() {
+        assertThat(print(new NoToString("john", 42))).isEqualTo("NoToString[age=42, name=john]");
+        assertThat(print(new ChildWithoutToString("john", 42, new BigDecimal("100.99"))))
+                .isEqualTo("ChildWithoutToString[salary=100.99, age=42, name=john]");
+    }
+
+    @Test
+    public void callsToString_when_toString_is_overridden() {
+        assertThat(print(new Credentials("john", "secret")))
+                .isEqualTo("Credentials{username:joh.., password:***}");
+    }
+
+    @Test
+    public void truncates_long_field_values_when_printing_reflectively() {
+        String longValue = "x".repeat(200);
+
+        assertThat(print(new NoToString(longValue, 0)))
+                .isEqualTo("NoToString[age=0, name=" + "x".repeat(100) + "...]");
+    }
+
+    @Test
     public void prints_chars() {
         assertThat(print('a')).isEqualTo("'a'");
         assertThat(print('\n')).isEqualTo("'\\n'");
         assertThat(print('\t')).isEqualTo("'\\t'");
         assertThat(print('\r')).isEqualTo("'\\r'");
+        assertThat(print('"')).isEqualTo("'\\\"'");
+    }
+
+    @Test
+    public void printValues_withDefaultSeparator() {
+        List<Integer> values = asList(111, 222, 333);
+
+        assertThat(printValues(null, null, null, values.iterator())).isEqualTo("(111,222,333)");
     }
 
     static class ToString {
@@ -63,6 +96,42 @@ public class ValuePrinterTest {
     static class UnsafeToString {
         public String toString() {
             throw new RuntimeException("ka-boom!");
+        }
+    }
+
+    static class NoToString {
+        private static final int MIN_AGE = 23;
+        private final String name;
+        private final int age;
+
+        NoToString(String name, int age) {
+            this.name = name;
+            this.age = age;
+        }
+    }
+
+    static class ChildWithoutToString extends NoToString {
+        private final BigDecimal salary;
+
+        public ChildWithoutToString(String name, int age, BigDecimal salary) {
+            super(name, age);
+            this.salary = salary;
+        }
+    }
+
+    static class Credentials {
+        private final String username;
+        private final String password;
+
+        public Credentials(String username, String password) {
+            this.username = username;
+            this.password = password;
+        }
+
+        @Override
+        public String toString() {
+            return String.format(
+                    "Credentials{username:%s.., password:***}", username.substring(0, 3));
         }
     }
 }

--- a/mockito-core/src/test/java/org/mockitousage/matchers/ReflectionMatchersTest.java
+++ b/mockito-core/src/test/java/org/mockitousage/matchers/ReflectionMatchersTest.java
@@ -73,10 +73,10 @@ public class ReflectionMatchersTest extends TestBase {
                 .hasMessageContainingAll(
                         "Argument(s) are different! Wanted:",
                         "mockMe.run(",
-                        "    refEq(org.mockitousage.matchers.ReflectionMatchersTest",
+                        "    refEq(Child[childFieldOne=2, childFieldTwo=bar XXX, parentField=1, protectedParentField=foo])",
                         "Actual invocations have different arguments:",
                         "mockMe.run(",
-                        "    org.mockitousage.matchers.ReflectionMatchersTest");
+                        "    Child[childFieldOne=2, childFieldTwo=bar, parentField=1, protectedParentField=foo]");
     }
 
     @Test
@@ -90,10 +90,10 @@ public class ReflectionMatchersTest extends TestBase {
                 .hasMessageContainingAll(
                         "Argument(s) are different! Wanted:",
                         "mockMe.run(",
-                        "    refEq(org.mockitousage.matchers.ReflectionMatchersTest",
+                        "    refEq(Child[childFieldOne=999, childFieldTwo=bar, parentField=1, protectedParentField=foo])",
                         "Actual invocations have different arguments:",
                         "mockMe.run(",
-                        "    org.mockitousage.matchers.ReflectionMatchersTest");
+                        "    Child[childFieldOne=2, childFieldTwo=bar, parentField=1, protectedParentField=foo]");
     }
 
     @Test
@@ -107,10 +107,10 @@ public class ReflectionMatchersTest extends TestBase {
                 .hasMessageContainingAll(
                         "Argument(s) are different! Wanted:",
                         "mockMe.run(",
-                        "    refEq(org.mockitousage.matchers.ReflectionMatchersTest",
+                        "    refEq(Child[childFieldOne=2, childFieldTwo=bar, parentField=1, protectedParentField=XXXXX])",
                         "Actual invocations have different arguments:",
                         "mockMe.run(",
-                        "    org.mockitousage.matchers.ReflectionMatchersTest");
+                        "    Child[childFieldOne=2, childFieldTwo=bar, parentField=1, protectedParentField=foo]");
     }
 
     @Test
@@ -124,10 +124,10 @@ public class ReflectionMatchersTest extends TestBase {
                 .hasMessageContainingAll(
                         "Argument(s) are different! Wanted:",
                         "mockMe.run(",
-                        "    refEq(org.mockitousage.matchers.ReflectionMatchersTest",
+                        "    refEq(Child[childFieldOne=2, childFieldTwo=bar, parentField=234234, protectedParentField=foo])",
                         "Actual invocations have different arguments:",
                         "mockMe.run(",
-                        "    org.mockitousage.matchers.ReflectionMatchersTest");
+                        "    Child[childFieldOne=2, childFieldTwo=bar, parentField=1, protectedParentField=foo]");
     }
 
     @Test
@@ -154,9 +154,9 @@ public class ReflectionMatchersTest extends TestBase {
                 .hasMessageContainingAll(
                         "Argument(s) are different! Wanted:",
                         "mockMe.run(",
-                        "    refEq(org.mockitousage.matchers.ReflectionMatchersTest",
+                        "    refEq(Child[childFieldOne=2, childFieldTwo=excluded, parentField=234234, protectedParentField=foo])",
                         "Actual invocations have different arguments:",
                         "mockMe.run(",
-                        "    org.mockitousage.matchers.ReflectionMatchersTest");
+                        "    Child[childFieldOne=2, childFieldTwo=bar, parentField=1, protectedParentField=foo]");
     }
 }

--- a/mockito-core/src/test/java/org/mockitousage/matchers/ReflectivePrintingTest.java
+++ b/mockito-core/src/test/java/org/mockitousage/matchers/ReflectivePrintingTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage.matchers;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.refEq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+import org.mockitoutil.TestBase;
+
+@SuppressWarnings("all")
+public class ReflectivePrintingTest extends TestBase {
+
+    /**
+     * Class without own "toString()" method
+     */
+    class Credentials {
+        private final String username;
+        private final String password;
+
+        Credentials(String username, String password) {
+            this.username = username;
+            this.password = password;
+        }
+    }
+
+    interface LoginService {
+        void run(Credentials credentials);
+    }
+
+    private final Credentials actual = new Credentials("usr", "pwd");
+    private final Credentials expected = new Credentials("john", "secret");
+    private final LoginService mock = mock();
+
+    @Test
+    public void printsObjectFieldsUsingReflection() {
+        mock.run(actual);
+
+        assertThatThrownBy(() -> verify(mock).run(expected))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Argument(s) are different! Wanted:")
+                .hasMessageContaining("Credentials[password=secret, username=john]")
+                .hasMessageContaining("Actual invocations have different arguments:")
+                .hasMessageContaining("Credentials[password=pwd, username=usr]");
+    }
+
+    @Test
+    public void eq_printsObjectFieldsUsingReflection() {
+        mock.run(actual);
+
+        assertThatThrownBy(() -> verify(mock).run(eq(expected)))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Argument(s) are different! Wanted:")
+                .hasMessageContaining("Credentials[password=secret, username=john]")
+                .hasMessageContaining("Actual invocations have different arguments:")
+                .hasMessageContaining("Credentials[password=pwd, username=usr]");
+    }
+
+    @Test
+    public void refEq_printsObjectFieldsUsingReflection() {
+        mock.run(actual);
+
+        assertThatThrownBy(() -> verify(mock).run(refEq(expected)))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Argument(s) are different! Wanted:")
+                .hasMessageContaining("refEq(Credentials[password=secret, username=john])")
+                .hasMessageContaining("Actual invocations have different arguments:")
+                .hasMessageContaining("Credentials[password=pwd, username=usr]");
+    }
+
+    @Test
+    public void same_printsObjectFieldsUsingReflection() {
+        mock.run(actual);
+
+        assertThatThrownBy(() -> verify(mock).run(same(expected)))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Argument(s) are different! Wanted:")
+                .hasMessageContaining("same(Credentials[password=secret, username=john])")
+                .hasMessageContaining("Actual invocations have different arguments:")
+                .hasMessageContaining("Credentials[password=pwd, username=usr]");
+    }
+}


### PR DESCRIPTION
### Motivation
In my project, it often happens that value object doesn't have its own `toString()` method. And comes from a JAR that I cannot easily change. 

For such objects, it's highly inconvenient to debug failing tests showing just `MyClass@12345` in failure message.

@TimvdLippe  @raphw 

### The problem
In verification failure messages, Mockito uses `toString()` method to print out the argument object. For objects not having their own `toString()`, the useless description like "MyClass@12345" was generated (the default `Object.toString()` implementation).

### The solution
Now, ValuePrinter reflects over an object's declared fields when its class doesn't override `toString()`, thus producing readable description of the object. Too long field values are truncated.

Example of error message:

```java
Argument(s) are different! Wanted:
mock.run(
    Credentials[username=john, password=secret]
);
-> at org.mockitousage.matchers.ReflectivePrintingTest.refEq_printsObjectFieldsUsingReflection(CustomToStringTest.java:53)
Actual invocations have different arguments:
mock.run(
    Credentials[username=usr, password=pwd]
);
-> at org.mockitousage.matchers.ReflectivePrintingTest.refEq_printsObjectFieldsUsingReflection(CustomToStringTest.java:51)
```

Where
```java
/**
 * Class without own "toString()" method
 */
 class Credentials {
     private String username;
     private String password;
}
```

## Checklist

 - [x] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [x] PR should be motivated, i.e. what does it fix, why, and if relevant how
 - [x] If possible / relevant include an example in the description, that could help all readers
       including project members to get a better picture of the change
 - [x] Avoid other runtime dependencies
 - [x] Meaningful commit history ; intention is important please rebase your commit history so that each
       commit is meaningful and help the people that will explore a change in 2 years
 - [x] The pull request follows coding style (run `./gradlew spotlessApply` for auto-formatting)
 - [ ] Mention `Fixes #<issue number>` in the description _if relevant_
 - [ ] At least one commit should end with `Fixes #<issue number>` _if relevant_
